### PR TITLE
#3 Add --quiet flag to nmr CLI

### DIFF
--- a/packages/core/__tests__/cli.test.ts
+++ b/packages/core/__tests__/cli.test.ts
@@ -7,24 +7,28 @@ const MONOREPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
 const CORE_PACKAGE_DIR = path.resolve(MONOREPO_ROOT, 'packages', 'core');
 const CLI_PATH = path.join(CORE_PACKAGE_DIR, 'dist', 'esm', 'cli.js');
 
-function runNmr(args: string, options: { cwd?: string } = {}): { stdout: string; exitCode: number } {
+function runNmr(args: string, options: { cwd?: string } = {}): { stdout: string; stderr: string; exitCode: number } {
   try {
     const stdout = execSync(`node ${CLI_PATH} ${args}`, {
       cwd: options.cwd ?? MONOREPO_ROOT,
       encoding: 'utf8',
       timeout: 10_000,
     });
-    return { stdout, exitCode: 0 };
+    return { stdout, stderr: '', exitCode: 0 };
   } catch (error: unknown) {
     const stdout =
       error !== null && typeof error === 'object' && 'stdout' in error && typeof error.stdout === 'string'
         ? error.stdout
         : '';
+    const stderr =
+      error !== null && typeof error === 'object' && 'stderr' in error && typeof error.stderr === 'string'
+        ? error.stderr
+        : '';
     const exitCode =
       error !== null && typeof error === 'object' && 'status' in error && typeof error.status === 'number'
         ? error.status
         : 1;
-    return { stdout, exitCode };
+    return { stdout, stderr, exitCode };
   }
 }
 
@@ -52,5 +56,29 @@ describe('nmr CLI', () => {
   it('exits with error for unknown command', () => {
     const { exitCode } = runNmr('nonexistent-command');
     expect(exitCode).toBe(1);
+  });
+
+  describe('--quiet flag', () => {
+    it('accepts -q flag without parse errors', () => {
+      const { stdout, exitCode } = runNmr('-q --help');
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Usage: nmr');
+    });
+
+    it('accepts --quiet flag without parse errors', () => {
+      const { stdout, exitCode } = runNmr('--quiet --help');
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Usage: nmr');
+    });
+
+    it('shows -q, --quiet in help output', () => {
+      const { stdout } = runNmr('--help');
+      expect(stdout).toContain('-q, --quiet');
+    });
+
+    it('still exits with error for unknown command when quiet', () => {
+      const { exitCode } = runNmr('--quiet nonexistent-command');
+      expect(exitCode).toBe(1);
+    });
   });
 });

--- a/packages/core/__tests__/cli.test.ts
+++ b/packages/core/__tests__/cli.test.ts
@@ -76,9 +76,17 @@ describe('nmr CLI', () => {
       expect(stdout).toContain('-q, --quiet');
     });
 
+    it('suppresses output on successful command in quiet mode', () => {
+      const { stdout, stderr, exitCode } = runNmr('-q typecheck', { cwd: CORE_PACKAGE_DIR });
+      expect(exitCode).toBe(0);
+      expect(stdout).toBe('');
+      expect(stderr).toBe('');
+    });
+
     it('still exits with error for unknown command when quiet', () => {
-      const { exitCode } = runNmr('--quiet nonexistent-command');
+      const { stderr, exitCode } = runNmr('--quiet nonexistent-command');
       expect(exitCode).toBe(1);
+      expect(stderr).toContain('Unknown command');
     });
   });
 });

--- a/packages/core/__tests__/runner.test.ts
+++ b/packages/core/__tests__/runner.test.ts
@@ -1,0 +1,117 @@
+import { execSync } from 'node:child_process';
+import process from 'node:process';
+
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runCommand } from '../src/runner.js';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+const mockedExecSync = vi.mocked(execSync);
+
+describe(runCommand, () => {
+  let stderrWriteSpy: MockInstance;
+  let stdoutWriteSpy: MockInstance;
+
+  beforeEach(() => {
+    stderrWriteSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('without quiet option', () => {
+    it('calls execSync with stdio inherit', () => {
+      mockedExecSync.mockReturnValue(Buffer.from(''));
+
+      const code = runCommand('echo hello', '/tmp');
+
+      expect(code).toBe(0);
+      expect(mockedExecSync).toHaveBeenCalledWith('echo hello', {
+        stdio: 'inherit',
+        cwd: '/tmp',
+      });
+    });
+
+    it('returns the exit code on failure', () => {
+      const error = Object.assign(new Error('command failed'), { status: 2 });
+      mockedExecSync.mockImplementation(() => {
+        throw error;
+      });
+
+      const code = runCommand('failing-command');
+
+      expect(code).toBe(2);
+    });
+  });
+
+  describe('with quiet option', () => {
+    it('calls execSync with stdio pipe', () => {
+      mockedExecSync.mockReturnValue(Buffer.from('some output'));
+
+      const code = runCommand('echo hello', '/tmp', { quiet: true });
+
+      expect(code).toBe(0);
+      expect(mockedExecSync).toHaveBeenCalledWith('echo hello', {
+        stdio: 'pipe',
+        cwd: '/tmp',
+      });
+    });
+
+    it('does not write any output on success', () => {
+      mockedExecSync.mockReturnValue(Buffer.from('some output'));
+
+      runCommand('echo hello', undefined, { quiet: true });
+
+      expect(stderrWriteSpy).not.toHaveBeenCalled();
+      expect(stdoutWriteSpy).not.toHaveBeenCalled();
+    });
+
+    it('writes captured stdout and stderr to process.stderr on failure', () => {
+      const stdout = Buffer.from('lint errors\n');
+      const stderr = Buffer.from('error details\n');
+      const error = Object.assign(new Error('command failed'), { status: 1, stdout, stderr });
+      mockedExecSync.mockImplementation(() => {
+        throw error;
+      });
+
+      const code = runCommand('lint', undefined, { quiet: true });
+
+      expect(code).toBe(1);
+      expect(stderrWriteSpy).toHaveBeenCalledWith(stdout);
+      expect(stderrWriteSpy).toHaveBeenCalledWith(stderr);
+    });
+
+    it('handles null stdout and stderr buffers on the error object', () => {
+      const error = Object.assign(new Error('command failed'), { status: 1, stdout: null, stderr: null });
+      mockedExecSync.mockImplementation(() => {
+        throw error;
+      });
+
+      const code = runCommand('lint', undefined, { quiet: true });
+
+      expect(code).toBe(1);
+      expect(stderrWriteSpy).not.toHaveBeenCalled();
+    });
+
+    it('handles empty buffers on the error object', () => {
+      const error = Object.assign(new Error('command failed'), {
+        status: 1,
+        stdout: Buffer.from(''),
+        stderr: Buffer.from(''),
+      });
+      mockedExecSync.mockImplementation(() => {
+        throw error;
+      });
+
+      const code = runCommand('lint', undefined, { quiet: true });
+
+      expect(code).toBe(1);
+      expect(stderrWriteSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/__tests__/runner.test.ts
+++ b/packages/core/__tests__/runner.test.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
 import process from 'node:process';
 
-import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 import { runCommand } from '../src/runner.js';
 
@@ -112,6 +112,21 @@ describe(runCommand, () => {
 
       expect(code).toBe(1);
       expect(stderrWriteSpy).not.toHaveBeenCalled();
+    });
+
+    it('writes captured output even when error lacks a status property', () => {
+      const stdout = Buffer.from('partial output\n');
+      const stderr = Buffer.from('crash details\n');
+      const error = Object.assign(new Error('unexpected error'), { stdout, stderr });
+      mockedExecSync.mockImplementation(() => {
+        throw error;
+      });
+
+      const code = runCommand('lint', undefined, { quiet: true });
+
+      expect(code).toBe(1);
+      expect(stderrWriteSpy).toHaveBeenCalledWith(stdout);
+      expect(stderrWriteSpy).toHaveBeenCalledWith(stderr);
     });
   });
 });

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -133,7 +133,7 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  if (resolved.source === 'package') {
+  if (resolved.source === 'package' && !parsed.quiet) {
     console.info(`Using override script: ${resolved.command}`);
   }
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -6,7 +6,6 @@ import process from 'node:process';
 import { resolveContext } from './context.js';
 import { generateHelp } from './help.js';
 import { buildRootRegistry, buildWorkspaceRegistry, resolveScript } from './resolver.js';
-import type { RunCommandOptions } from './runner.js';
 import { runCommand } from './runner.js';
 
 /**
@@ -101,7 +100,7 @@ async function main(): Promise<void> {
 
   const { command } = parsed;
   const passthrough = parsed.passthrough.length > 0 ? ' ' + parsed.passthrough.map(shellQuote).join(' ') : '';
-  const runOptions: RunCommandOptions = { quiet: parsed.quiet };
+  const runOptions = { quiet: parsed.quiet };
 
   // -F: delegate to pnpm --filter
   if (parsed.filter) {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -129,7 +129,9 @@ async function main(): Promise<void> {
   }
 
   if (resolved.command === '') {
-    console.info('Override script is defined but empty. Skipping.');
+    if (!parsed.quiet) {
+      console.info('Override script is defined but empty. Skipping.');
+    }
     process.exit(0);
   }
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -6,6 +6,7 @@ import process from 'node:process';
 import { resolveContext } from './context.js';
 import { generateHelp } from './help.js';
 import { buildRootRegistry, buildWorkspaceRegistry, resolveScript } from './resolver.js';
+import type { RunCommandOptions } from './runner.js';
 import { runCommand } from './runner.js';
 
 /**
@@ -18,6 +19,7 @@ function shellQuote(arg: string): string {
 
 interface ParsedArgs {
   filter?: string;
+  quiet: boolean;
   recursive: boolean;
   workspaceRoot: boolean;
   help: boolean;
@@ -29,6 +31,7 @@ interface ParsedArgs {
 function parseArgs(argv: string[]): ParsedArgs {
   const args = argv.slice(2);
   const result: ParsedArgs = {
+    quiet: false,
     recursive: false,
     workspaceRoot: false,
     help: false,
@@ -67,6 +70,11 @@ function parseArgs(argv: string[]): ParsedArgs {
       i++;
       continue;
     }
+    if (arg === '-q' || arg === '--quiet') {
+      result.quiet = true;
+      i++;
+      continue;
+    }
     if (arg === '--int-test') {
       result.intTest = true;
       i++;
@@ -93,18 +101,19 @@ async function main(): Promise<void> {
 
   const { command } = parsed;
   const passthrough = parsed.passthrough.length > 0 ? ' ' + parsed.passthrough.map(shellQuote).join(' ') : '';
+  const runOptions: RunCommandOptions = { quiet: parsed.quiet };
 
   // -F: delegate to pnpm --filter
   if (parsed.filter) {
     const delegateCmd = `pnpm --filter ${shellQuote(parsed.filter)} exec nmr ${command}${passthrough}`;
-    const code = runCommand(delegateCmd, context.monorepoRoot);
+    const code = runCommand(delegateCmd, context.monorepoRoot, runOptions);
     process.exit(code);
   }
 
   // -R: delegate to pnpm --recursive
   if (parsed.recursive) {
     const delegateCmd = `pnpm --recursive exec nmr ${command}${passthrough}`;
-    const code = runCommand(delegateCmd, context.monorepoRoot);
+    const code = runCommand(delegateCmd, context.monorepoRoot, runOptions);
     process.exit(code);
   }
 
@@ -129,7 +138,7 @@ async function main(): Promise<void> {
   }
 
   const fullCommand = resolved.command + passthrough;
-  const code = runCommand(fullCommand);
+  const code = runCommand(fullCommand, undefined, runOptions);
   process.exit(code);
 }
 

--- a/packages/core/src/help.ts
+++ b/packages/core/src/help.ts
@@ -15,6 +15,7 @@ export function generateHelp(config: NmrConfig): string {
     '  -F, --filter <pattern>   Run command in matching packages',
     '  -R, --recursive          Run command in all packages',
     '  -w, --workspace-root     Run root command regardless of cwd',
+    '  -q, --quiet              Suppress output on success; show full output on failure',
     '  -?, --help               Show this help',
     '      --int-test           Use integration test scripts',
     '',

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -23,12 +23,14 @@ export function runCommand(command: string, cwd?: string, options?: RunCommandOp
   } catch (error) {
     // execSync throws on non-zero exit code.
     // The error object has a `status` property with the exit code.
-    if (error !== null && typeof error === 'object' && 'status' in error) {
+    if (error !== null && typeof error === 'object') {
       if (quiet) {
         writeErrorOutput(error);
       }
-      const { status } = error;
-      return typeof status === 'number' ? status : 1;
+      if ('status' in error) {
+        const { status } = error;
+        return typeof status === 'number' ? status : 1;
+      }
     }
     return 1;
   }

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -1,23 +1,51 @@
 import { execSync } from 'node:child_process';
+import process from 'node:process';
+
+export interface RunCommandOptions {
+  /** When true, suppress output on success and write captured output to stderr on failure. */
+  quiet?: boolean;
+}
 
 /**
- * Executes a command synchronously with inherited stdio.
+ * Executes a command synchronously.
  * Returns the exit code of the command.
+ *
+ * In quiet mode, output is captured (piped) instead of inherited.
+ * On success, captured output is discarded. On failure, it is written to stderr.
  */
-export function runCommand(command: string, cwd?: string): number {
+export function runCommand(command: string, cwd?: string, options?: RunCommandOptions): number {
+  const quiet = options?.quiet === true;
+  const stdio = quiet ? 'pipe' : 'inherit';
+
   try {
-    execSync(command, {
-      stdio: 'inherit',
-      cwd,
-    });
+    execSync(command, { stdio, cwd });
     return 0;
   } catch (error) {
     // execSync throws on non-zero exit code.
     // The error object has a `status` property with the exit code.
     if (error !== null && typeof error === 'object' && 'status' in error) {
+      if (quiet) {
+        writeErrorOutput(error);
+      }
       const { status } = error;
       return typeof status === 'number' ? status : 1;
     }
     return 1;
+  }
+}
+
+/** Writes captured stdout and stderr buffers from an execSync error to `process.stderr`. */
+function writeErrorOutput(error: object): void {
+  if ('stdout' in error) {
+    const { stdout } = error;
+    if (Buffer.isBuffer(stdout) && stdout.length > 0) {
+      process.stderr.write(stdout);
+    }
+  }
+  if ('stderr' in error) {
+    const { stderr } = error;
+    if (Buffer.isBuffer(stderr) && stderr.length > 0) {
+      process.stderr.write(stderr);
+    }
   }
 }


### PR DESCRIPTION
Closes #3

## What

Adds a `-q`/`--quiet` flag to the `nmr` CLI that suppresses command output on success while preserving full output on failure. When quiet mode is active, `runCommand()` uses `stdio: 'pipe'` to capture child process output, discards it on success, and writes captured stdout and stderr to `process.stderr` on failure. All informational messages on success paths (`console.info` calls for override script notifications) are also suppressed.

## Why

Agents run `nmr lint`, `nmr typecheck`, and similar commands as quality gates. The full output (especially ESLint) floods the agent's context window with noise even when the command succeeds and no action is needed. The quiet flag lets agents suppress this noise while still seeing diagnostic output when a command fails.

## Details

### Features

- Added `RunCommandOptions` interface with optional `quiet` property to `runner.ts`
- Added `writeErrorOutput` helper that writes captured stdout/stderr buffers to `process.stderr`, guarding against null and empty buffers using `Buffer.isBuffer()`
- Added `-q`/`--quiet` flag parsing in `cli.ts`, threaded to all three `runCommand()` call sites (filter delegation, recursive delegation, direct execution)
- Guarded `console.info` messages for override script notifications with `!parsed.quiet` checks
- Added `-q, --quiet` to help text with description "Suppress output on success; show full output on failure"

### Tests

- Created `runner.test.ts` with 8 unit tests covering: default stdio inherit, failure exit code, quiet stdio pipe, no output on quiet success, stderr writes on quiet failure, null buffer handling, empty buffer handling, and statusless error output
- Extended `cli.test.ts` with 5 integration tests: `-q` accepted, `--quiet` accepted, help output includes flag, quiet suppresses output on successful command end-to-end, and error message reaches stderr on failure
- Updated `runNmr` test helper to capture stderr

## Test plan

- [ ] `nmr -q typecheck` succeeds silently (no output)
- [ ] `nmr -q lint` with errors dumps output to stderr
- [ ] `nmr --help` shows `-q, --quiet` flag
- [ ] `nmr typecheck` (without `-q`) still streams output normally