### PR TITLE
#6 Clean up release-kit post-migration issues

### DIFF
--- a/packages/release-kit/src/__tests__/bumpAllVersions.unit.test.ts
+++ b/packages/release-kit/src/__tests__/bumpAllVersions.unit.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), () => ({
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+import { bumpAllVersions } from '../bumpAllVersions.ts';
+
+describe(bumpAllVersions, () => {
+  afterEach(() => {
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('reads the first file only once when packageFiles has a single entry', () => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '1.0.0' }));
+
+    bumpAllVersions(['packages/a/package.json'], 'patch', false);
+
+    expect(mockReadFileSync).toHaveBeenCalledTimes(1);
+    expect(mockReadFileSync).toHaveBeenCalledWith('packages/a/package.json', 'utf8');
+  });
+
+  it('reads each additional file exactly once without re-reading the first', () => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath === 'packages/a/package.json') {
+        return JSON.stringify({ name: 'a', version: '2.1.0' });
+      }
+      if (filePath === 'packages/b/package.json') {
+        return JSON.stringify({ name: 'b', version: '2.1.0' });
+      }
+      if (filePath === 'packages/c/package.json') {
+        return JSON.stringify({ name: 'c', version: '2.1.0' });
+      }
+      throw new Error(`Unexpected read: ${filePath}`);
+    });
+
+    bumpAllVersions(['packages/a/package.json', 'packages/b/package.json', 'packages/c/package.json'], 'minor', false);
+
+    // First file is read once (before the loop). The loop reuses it for the first entry,
+    // so only two additional reads for b and c.
+    expect(mockReadFileSync).toHaveBeenCalledTimes(3);
+    expect(mockReadFileSync).toHaveBeenCalledWith('packages/a/package.json', 'utf8');
+    expect(mockReadFileSync).toHaveBeenCalledWith('packages/b/package.json', 'utf8');
+    expect(mockReadFileSync).toHaveBeenCalledWith('packages/c/package.json', 'utf8');
+  });
+
+  it('writes the bumped version to all files', () => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '1.2.3' }));
+
+    const result = bumpAllVersions(['packages/a/package.json', 'packages/b/package.json'], 'patch', false);
+
+    expect(result).toBe('1.2.4');
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
+    expect(mockWriteFileSync).toHaveBeenNthCalledWith(
+      1,
+      'packages/a/package.json',
+      expect.stringContaining('"version": "1.2.4"'),
+      'utf8',
+    );
+    expect(mockWriteFileSync).toHaveBeenNthCalledWith(
+      2,
+      'packages/b/package.json',
+      expect.stringContaining('"version": "1.2.4"'),
+      'utf8',
+    );
+  });
+
+  it('skips writing in dry-run mode', () => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '0.5.0' }));
+
+    const result = bumpAllVersions(['packages/a/package.json'], 'major', true);
+
+    expect(result).toBe('1.0.0');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('throws when no package files are specified', () => {
+    expect(() => bumpAllVersions([], 'patch', false)).toThrow('No package files specified');
+  });
+});

--- a/packages/release-kit/src/__tests__/bumpAllVersions.unit.test.ts
+++ b/packages/release-kit/src/__tests__/bumpAllVersions.unit.test.ts
@@ -44,8 +44,7 @@ describe(bumpAllVersions, () => {
 
     bumpAllVersions(['packages/a/package.json', 'packages/b/package.json', 'packages/c/package.json'], 'minor', false);
 
-    // First file is read once (before the loop). The loop reuses it for the first entry,
-    // so only two additional reads for b and c.
+    // One read per file: the first file is read before the loop and reused inside it.
     expect(mockReadFileSync).toHaveBeenCalledTimes(3);
     expect(mockReadFileSync).toHaveBeenCalledWith('packages/a/package.json', 'utf8');
     expect(mockReadFileSync).toHaveBeenCalledWith('packages/b/package.json', 'utf8');

--- a/packages/release-kit/src/__tests__/typeGuards.unit.test.ts
+++ b/packages/release-kit/src/__tests__/typeGuards.unit.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { isRecord } from '../typeGuards.ts';
+
+describe(isRecord, () => {
+  it.each([
+    ['plain object', {}, true],
+    ['object with properties', { a: 1, b: 'two' }, true],
+    ['null', null, false],
+    ['undefined', undefined, false],
+    ['array', [1, 2, 3], false],
+    ['empty array', [], false],
+    ['string', 'hello', false],
+    ['number', 42, false],
+    ['boolean', true, false],
+  ])('returns %s for %s', (_label, value, expected) => {
+    expect(isRecord(value)).toBe(expected);
+  });
+
+  it('returns true for Object.create(null)', () => {
+    // Object.create(null) produces a prototype-less object, tested separately
+    // to avoid a type assertion in the parameterized array.
+    const nullProto: unknown = Object.create(null);
+    expect(isRecord(nullProto)).toBe(true);
+  });
+});

--- a/packages/release-kit/src/bumpAllVersions.ts
+++ b/packages/release-kit/src/bumpAllVersions.ts
@@ -41,7 +41,6 @@ export function bumpAllVersions(packageFiles: readonly string[], releaseType: Re
       continue;
     }
 
-    // Reuse the already-parsed first file instead of reading it again.
     const pkg = filePath === firstFile ? firstPkg : readPackageJson(filePath);
     pkg.version = newVersion;
 

--- a/packages/release-kit/src/bumpAllVersions.ts
+++ b/packages/release-kit/src/bumpAllVersions.ts
@@ -41,7 +41,8 @@ export function bumpAllVersions(packageFiles: readonly string[], releaseType: Re
       continue;
     }
 
-    const pkg = readPackageJson(filePath);
+    // Reuse the already-parsed first file instead of reading it again.
+    const pkg = filePath === firstFile ? firstPkg : readPackageJson(filePath);
     pkg.version = newVersion;
 
     try {

--- a/packages/release-kit/src/defaults.ts
+++ b/packages/release-kit/src/defaults.ts
@@ -17,5 +17,5 @@ export const DEFAULT_WORK_TYPES: Record<string, WorkTypeConfig> = {
 /** Default version bump patterns. */
 export const DEFAULT_VERSION_PATTERNS: VersionPatterns = {
   major: ['!'],
-  minor: ['feat', 'feature'],
+  minor: ['feat'],
 };

--- a/packages/release-kit/src/discoverWorkspaces.ts
+++ b/packages/release-kit/src/discoverWorkspaces.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 import { glob } from 'glob';
 import { load } from 'js-yaml';
 
+import { isRecord } from './typeGuards.ts';
+
 /**
  * Reads `pnpm-workspace.yaml` and resolves its `packages` globs to discover workspace directories.
  *
@@ -60,8 +62,4 @@ export async function discoverWorkspaces(): Promise<string[] | undefined> {
 
   // eslint-disable-next-line unicorn/no-array-sort -- toSorted requires Node 20+; engine target is >=18.17.0
   return directories.length > 0 ? [...directories].sort() : undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/release-kit/src/init/__tests__/checks.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/checks.unit.test.ts
@@ -86,6 +86,15 @@ describe('checks', () => {
       const result = usesPnpm();
       expect(result.ok).toBe(false);
     });
+
+    it('throws when readFileSync throws', () => {
+      mockExistsSync.mockReturnValue(false);
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+      expect(() => usesPnpm()).toThrow('EACCES: permission denied');
+    });
   });
 
   describe(hasCliffToml, () => {

--- a/packages/release-kit/src/init/__tests__/checks.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/checks.unit.test.ts
@@ -94,6 +94,7 @@ describe('checks', () => {
       });
 
       expect(() => usesPnpm()).toThrow('EACCES: permission denied');
+      expect(mockReadFileSync).toHaveBeenCalledWith('package.json', 'utf8');
     });
   });
 

--- a/packages/release-kit/src/init/__tests__/scaffold.int.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.int.test.ts
@@ -48,7 +48,7 @@ describe('copyCliffTemplate (integration)', () => {
       expect(existsSync(cliffTomlPath)).toBe(true);
 
       const content = readFileSync(cliffTomlPath, 'utf8');
-      expect(content.length).toBeGreaterThan(0);
+      expect(content).toContain('# git-cliff configuration');
     } finally {
       process.chdir(originalCwd);
       rmSync(tempDir, { recursive: true, force: true });

--- a/packages/release-kit/src/init/__tests__/scaffold.int.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.int.test.ts
@@ -1,0 +1,55 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const distScaffoldPath = join(__dirname, '..', '..', '..', 'dist', 'esm', 'init', 'scaffold.js');
+
+interface ScaffoldModule {
+  copyCliffTemplate: (dryRun: boolean) => void;
+}
+
+/** Check whether a dynamic import result exports `copyCliffTemplate` as a function. */
+function isScaffoldModule(value: unknown): value is ScaffoldModule {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'copyCliffTemplate' in value &&
+    typeof value.copyCliffTemplate === 'function'
+  );
+}
+
+describe('copyCliffTemplate (integration)', () => {
+  it('resolves cliff.toml.template from the built output and writes cliff.toml', async () => {
+    if (!existsSync(distScaffoldPath)) {
+      throw new Error(
+        `Built output not found at ${distScaffoldPath}. Run \`pnpm run ws build\` before running integration tests.`,
+      );
+    }
+
+    const tempDir = mkdtempSync(join(tmpdir(), 'scaffold-int-'));
+    const originalCwd = process.cwd();
+
+    try {
+      process.chdir(tempDir);
+
+      // Import from the compiled JS so that `import.meta.url` points to dist/esm/init/scaffold.js.
+      const mod: unknown = await import(distScaffoldPath);
+      if (!isScaffoldModule(mod)) {
+        throw new Error('Module does not export `copyCliffTemplate` as a function');
+      }
+
+      mod.copyCliffTemplate(false);
+
+      const cliffTomlPath = join(tempDir, 'cliff.toml');
+      expect(existsSync(cliffTomlPath)).toBe(true);
+
+      const content = readFileSync(cliffTomlPath, 'utf8');
+      expect(content.length).toBeGreaterThan(0);
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/release-kit/src/init/__tests__/scaffold.int.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.int.test.ts
@@ -1,10 +1,12 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-const distScaffoldPath = join(__dirname, '..', '..', '..', 'dist', 'esm', 'init', 'scaffold.js');
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const distScaffoldPath = join(thisDir, '..', '..', '..', 'dist', 'esm', 'init', 'scaffold.js');
 
 interface ScaffoldModule {
   copyCliffTemplate: (dryRun: boolean) => void;

--- a/packages/release-kit/src/init/checks.ts
+++ b/packages/release-kit/src/init/checks.ts
@@ -33,14 +33,10 @@ export function usesPnpm(): CheckResult {
     return { ok: true };
   }
 
-  try {
-    const raw = readFileSync('package.json', 'utf8');
-    const pkg = parseJsonRecord(raw);
-    if (pkg !== undefined && typeof pkg.packageManager === 'string' && pkg.packageManager.startsWith('pnpm')) {
-      return { ok: true };
-    }
-  } catch {
-    // Fall through to failure
+  const raw = readFileSync('package.json', 'utf8');
+  const pkg = parseJsonRecord(raw);
+  if (pkg !== undefined && typeof pkg.packageManager === 'string' && pkg.packageManager.startsWith('pnpm')) {
+    return { ok: true };
   }
 
   return {

--- a/packages/release-kit/src/init/initCommand.ts
+++ b/packages/release-kit/src/init/initCommand.ts
@@ -29,15 +29,7 @@ async function checkEligibility(dryRun: boolean): Promise<EligibilityResult> {
 
   if (!runRequiredCheck('Git repository detected', isGitRepo())) return { status: 'fail', overwrite: false };
   if (!runRequiredCheck('package.json found', hasPackageJson())) return { status: 'fail', overwrite: false };
-
-  let pnpmResult: CheckResult;
-  try {
-    pnpmResult = usesPnpm();
-  } catch (error: unknown) {
-    printError(`Failed to check pnpm usage: ${error instanceof Error ? error.message : String(error)}`);
-    return { status: 'fail', overwrite: false };
-  }
-  if (!runRequiredCheck('pnpm detected', pnpmResult)) return { status: 'fail', overwrite: false };
+  if (!runRequiredCheck('pnpm detected', usesPnpm())) return { status: 'fail', overwrite: false };
 
   const cliffCheck = hasCliffToml();
   if (cliffCheck.ok) {
@@ -78,7 +70,13 @@ export async function initCommand({ dryRun }: InitOptions): Promise<number> {
     console.info('[dry-run mode]');
   }
 
-  const eligibility = await checkEligibility(dryRun);
+  let eligibility: EligibilityResult;
+  try {
+    eligibility = await checkEligibility(dryRun);
+  } catch (error: unknown) {
+    printError(`Eligibility check failed: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
   if (eligibility.status === 'fail') return 1;
   if (eligibility.status === 'abort') return 0;
 

--- a/packages/release-kit/src/init/initCommand.ts
+++ b/packages/release-kit/src/init/initCommand.ts
@@ -29,7 +29,15 @@ async function checkEligibility(dryRun: boolean): Promise<EligibilityResult> {
 
   if (!runRequiredCheck('Git repository detected', isGitRepo())) return { status: 'fail', overwrite: false };
   if (!runRequiredCheck('package.json found', hasPackageJson())) return { status: 'fail', overwrite: false };
-  if (!runRequiredCheck('pnpm detected', usesPnpm())) return { status: 'fail', overwrite: false };
+
+  let pnpmResult: CheckResult;
+  try {
+    pnpmResult = usesPnpm();
+  } catch (error: unknown) {
+    printError(`Failed to check pnpm usage: ${error instanceof Error ? error.message : String(error)}`);
+    return { status: 'fail', overwrite: false };
+  }
+  if (!runRequiredCheck('pnpm detected', pnpmResult)) return { status: 'fail', overwrite: false };
 
   const cliffCheck = hasCliffToml();
   if (cliffCheck.ok) {

--- a/packages/release-kit/src/init/parseJsonRecord.ts
+++ b/packages/release-kit/src/init/parseJsonRecord.ts
@@ -1,6 +1,4 @@
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+import { isRecord } from '../typeGuards.ts';
 
 /**
  * Parse a JSON string and return the result if it is a plain object (Record<string, unknown>).

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { component } from './component.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
+import { isRecord } from './typeGuards.ts';
 import type { ComponentConfig, MonorepoReleaseConfig, ReleaseConfig, ReleaseKitConfig } from './types.ts';
 
 /** The path where the consumer-facing config file is expected. */
@@ -38,10 +39,6 @@ export async function loadConfig(): Promise<unknown> {
   }
 
   return resolved;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/packages/release-kit/src/typeGuards.ts
+++ b/packages/release-kit/src/typeGuards.ts
@@ -1,0 +1,4 @@
+/** Check whether a value is a plain object (non-null, non-array). */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -1,3 +1,4 @@
+import { isRecord } from './typeGuards.ts';
 import type { ReleaseKitConfig } from './types.ts';
 
 /**
@@ -39,10 +40,6 @@ export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors
   validateWorkspaceAliases(raw.workspaceAliases, config, errors);
 
   return { config, errors };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function isStringArray(value: unknown): value is string[] {


### PR DESCRIPTION
Closes #6

## What

Addresses five code quality issues and a test coverage gap identified during the release-kit migration (#5). Extracts a duplicated `isRecord` type guard into a shared module, eliminates a double-read in `bumpAllVersions`, improves error handling in `usesPnpm` by replacing a silent catch with a structured error boundary, removes an unreachable `'feature'` pattern from version defaults, and adds an integration test for scaffold template path resolution.

## Why

These issues were intentionally deferred during the #5 migration to keep that PR's scope clean. Fixing them now removes duplicated code, prevents a class of silent failures in the init CLI, eliminates dead code, and adds build-time regression coverage for the template path resolution that depends on relative paths from the compiled output location.

## Details

### Refactoring

- Extracted the `isRecord` type guard from `loadConfig.ts`, `validateConfig.ts`, `discoverWorkspaces.ts`, and `init/parseJsonRecord.ts` into a shared `src/typeGuards.ts` module.
- Fixed `bumpAllVersions` double-read: the first `package.json` is now read once before the loop and reused via a ternary when the loop encounters the first file path.
- Removed dead `'feature'` entry from `DEFAULT_VERSION_PATTERNS.minor` — alias resolution normalizes `feature` → `feat` before pattern matching, so it could never match.

### Fixes

- Removed the empty catch block in `usesPnpm` that swallowed all `readFileSync` errors (EACCES, etc.), making them indistinguishable from a legitimate "pnpm not detected" outcome.
- Added a try/catch error boundary in `initCommand` around the `checkEligibility()` call so I/O errors surface through the structured `printError` path rather than as raw stack traces.

### Tests

- Added `typeGuards.unit.test.ts` covering plain objects, null, undefined, arrays, primitives, and prototype-less objects.
- Added `bumpAllVersions.unit.test.ts` verifying read counts (no re-read of first file), version bumping, dry-run behavior, and empty-array error handling.
- Added `scaffold.int.test.ts` integration test that imports from `dist/esm/init/scaffold.js` and verifies `copyCliffTemplate` resolves and copies the correct template. Gated behind `--int-test`.
- Added `usesPnpm` throw test verifying error propagation with argument assertion.
- Strengthened scaffold integration test to assert template content header rather than just non-empty content.