### PR TITLE
#7 Slim down release workflow by removing unnecessary pnpm install

### DIFF
--- a/.config/release-kit.config.ts
+++ b/.config/release-kit.config.ts
@@ -1,7 +1,7 @@
 import type { ReleaseKitConfig } from '@williamthorsen/release-kit';
 
 const config: ReleaseKitConfig = {
-  formatCommand: 'pnpm run fmt',
+  formatCommand: 'npx prettier --write',
 };
 
 export default config;

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,9 +24,7 @@ permissions:
 
 jobs:
   release:
-    uses: williamthorsen/.github/.github/workflows/release-pnpm.yaml@v2
+    uses: williamthorsen/.github/.github/workflows/release-pnpm.yaml@v3
     with:
-      node-version: '24.14.0'
-      pnpm-version: '10.32.1'
       only: ${{ inputs.only }}
       bump: ${{ inputs.bump }}

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "esbuild": "0.27.4",
     "eslint": "9.39.4",
     "eslint-plugin-import": "2.32.0",
-    "git-cliff": "2.12.0",
     "glob": "13.0.6",
     "js-yaml": "4.1.1",
     "lefthook": "2.1.4",

--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -362,6 +362,23 @@ runReleasePrepare(config);
 
 The key difference: the script-based approach requires manually listing every component, while the CLI auto-discovers them from `pnpm-workspace.yaml`.
 
+## Breaking changes
+
+### v1.1.0: `formatCommand` receives file paths as trailing arguments
+
+Previously, `formatCommand` was executed as-is (e.g., `pnpm run fmt` would run without arguments). Now, the paths of all modified files (package.json files and changelogs) are appended as trailing arguments.
+
+If your format command does not accept file arguments, update it to one that does:
+
+```diff
+-formatCommand: 'pnpm run fmt',
++formatCommand: 'npx prettier --write',
+```
+
+### v1.1.0: `git-cliff` is no longer a required dev dependency
+
+`git-cliff` is now invoked via `npx --yes git-cliff` instead of requiring it as a dev dependency. You can remove it from your `devDependencies`. The version is not pinned, so `npx` downloads and caches the latest version on first invocation. To pin a specific version, use `npx --yes git-cliff@2.12.0` by wrapping the call in a custom script.
+
 ## Migration from changesets
 
 1. Add `@williamthorsen/release-kit` as a dev dependency.

--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -7,7 +7,7 @@ Provides a self-contained CLI that auto-discovers workspaces from `pnpm-workspac
 ## Installation
 
 ```bash
-pnpm add -D @williamthorsen/release-kit git-cliff
+pnpm add -D @williamthorsen/release-kit
 ```
 
 ## Quick start
@@ -88,8 +88,8 @@ const config: ReleaseKitConfig = {
   // Exclude a component from release processing
   components: [{ dir: 'internal-tools', shouldExclude: true }],
 
-  // Run a formatter after changelog generation
-  formatCommand: 'pnpm run fmt',
+  // Run a formatter after changelog generation (modified file paths are appended as arguments)
+  formatCommand: 'npx prettier --write',
 
   // Override the default version patterns
   versionPatterns: { major: ['!'], minor: ['feat', 'feature'] },
@@ -105,14 +105,14 @@ The config file supports both `export default config` and `export const config =
 
 ### `ReleaseKitConfig` reference
 
-| Field              | Type                             | Description                                                  |
-| ------------------ | -------------------------------- | ------------------------------------------------------------ |
-| `cliffConfigPath`  | `string`                         | Path to `cliff.toml` (defaults to `'cliff.toml'`)            |
-| `components`       | `ComponentOverride[]`            | Override or exclude discovered components (matched by `dir`) |
-| `formatCommand`    | `string`                         | Shell command to run after changelog generation              |
-| `versionPatterns`  | `VersionPatterns`                | Rules for which commit types trigger major/minor bumps       |
-| `workspaceAliases` | `Record<string, string>`         | Maps shorthand workspace names to canonical names in commits |
-| `workTypes`        | `Record<string, WorkTypeConfig>` | Work type definitions, merged with defaults by key           |
+| Field              | Type                             | Description                                                                                    |
+| ------------------ | -------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `cliffConfigPath`  | `string`                         | Path to `cliff.toml` (defaults to `'cliff.toml'`)                                              |
+| `components`       | `ComponentOverride[]`            | Override or exclude discovered components (matched by `dir`)                                   |
+| `formatCommand`    | `string`                         | Shell command to run after changelog generation; modified file paths are appended as arguments |
+| `versionPatterns`  | `VersionPatterns`                | Rules for which commit types trigger major/minor bumps                                         |
+| `workspaceAliases` | `Record<string, string>`         | Maps shorthand workspace names to canonical names in commits                                   |
+| `workTypes`        | `Record<string, WorkTypeConfig>` | Work type definitions, merged with defaults by key                                             |
 
 All fields are optional.
 
@@ -230,14 +230,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'pnpm'
-
-      - run: pnpm install
+          node-version: '24'
 
       - name: Run release preparation
         run: |
@@ -340,7 +335,7 @@ Then customize as needed for your project.
 This package shells out to two external tools:
 
 - **`git`** — must be available on `PATH`. Used to find tags and retrieve commit history.
-- **`git-cliff`** — must be available on `PATH`. Add `git-cliff` as a dev dependency to make it available in CI.
+- **`git-cliff`** — automatically downloaded and cached via `npx` on first invocation. No need to install it as a dev dependency.
 
 ## Legacy script-based approach
 
@@ -353,7 +348,7 @@ import { component } from '@williamthorsen/release-kit';
 
 export const config: MonorepoReleaseConfig = {
   components: [component('packages/arrays'), component('packages/strings')],
-  formatCommand: 'pnpm run fmt',
+  formatCommand: 'npx prettier --write',
 };
 ```
 
@@ -369,7 +364,7 @@ The key difference: the script-based approach requires manually listing every co
 
 ## Migration from changesets
 
-1. Add `@williamthorsen/release-kit` and `git-cliff` as dev dependencies.
+1. Add `@williamthorsen/release-kit` as a dev dependency.
 2. Remove `@changesets/cli` from dev dependencies.
 3. Delete the `.changeset/` directory.
 4. Run `npx @williamthorsen/release-kit init` to scaffold workflow and config files.

--- a/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
@@ -21,7 +21,7 @@ describe(generateChangelog, () => {
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'npx',
-      ['git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      ['--yes', 'git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
       { stdio: 'inherit' },
     );
   });
@@ -36,6 +36,7 @@ describe(generateChangelog, () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'npx',
       [
+        '--yes',
         'git-cliff',
         '--config',
         'cliff.toml',
@@ -60,6 +61,7 @@ describe(generateChangelog, () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'npx',
       [
+        '--yes',
         'git-cliff',
         '--config',
         'cliff.toml',
@@ -83,7 +85,7 @@ describe(generateChangelog, () => {
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'npx',
-      ['git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      ['--yes', 'git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
       { stdio: 'inherit' },
     );
   });
@@ -106,7 +108,7 @@ describe(generateChangelog, () => {
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'npx',
-      ['git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      ['--yes', 'git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
       { stdio: 'inherit' },
     );
   });
@@ -131,12 +133,12 @@ describe(generateChangelogs, () => {
     expect(mockExecFileSync).toHaveBeenCalledTimes(2);
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'npx',
-      ['git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      ['--yes', 'git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
       { stdio: 'inherit' },
     );
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'npx',
-      ['git-cliff', '--config', 'cliff.toml', '--output', 'packages/strings/CHANGELOG.md', '--tag', 'v1.0.0'],
+      ['--yes', 'git-cliff', '--config', 'cliff.toml', '--output', 'packages/strings/CHANGELOG.md', '--tag', 'v1.0.0'],
       { stdio: 'inherit' },
     );
   });

--- a/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
@@ -20,8 +20,8 @@ describe(generateChangelog, () => {
     generateChangelog(config, 'packages/arrays', 'v1.0.0', false);
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
-      'git-cliff',
-      ['--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      'npx',
+      ['git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
       { stdio: 'inherit' },
     );
   });
@@ -34,8 +34,9 @@ describe(generateChangelog, () => {
     });
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
-      'git-cliff',
+      'npx',
       [
+        'git-cliff',
         '--config',
         'cliff.toml',
         '--output',
@@ -57,8 +58,9 @@ describe(generateChangelog, () => {
     });
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
-      'git-cliff',
+      'npx',
       [
+        'git-cliff',
         '--config',
         'cliff.toml',
         '--output',
@@ -80,8 +82,8 @@ describe(generateChangelog, () => {
     generateChangelog(config, 'packages/arrays', 'v1.0.0', false, { includePaths: [] });
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
-      'git-cliff',
-      ['--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      'npx',
+      ['git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
       { stdio: 'inherit' },
     );
   });
@@ -103,8 +105,8 @@ describe(generateChangelog, () => {
     generateChangelog(config, 'packages/arrays', 'v1.0.0', false);
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
-      'git-cliff',
-      ['--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      'npx',
+      ['git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
       { stdio: 'inherit' },
     );
   });
@@ -128,13 +130,13 @@ describe(generateChangelogs, () => {
 
     expect(mockExecFileSync).toHaveBeenCalledTimes(2);
     expect(mockExecFileSync).toHaveBeenCalledWith(
-      'git-cliff',
-      ['--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      'npx',
+      ['git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
       { stdio: 'inherit' },
     );
     expect(mockExecFileSync).toHaveBeenCalledWith(
-      'git-cliff',
-      ['--config', 'cliff.toml', '--output', 'packages/strings/CHANGELOG.md', '--tag', 'v1.0.0'],
+      'npx',
+      ['git-cliff', '--config', 'cliff.toml', '--output', 'packages/strings/CHANGELOG.md', '--tag', 'v1.0.0'],
       { stdio: 'inherit' },
     );
   });

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+const mockExecSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+  execSync: mockExecSync,
+}));
+
+vi.mock('node:fs', () => ({
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+import { releasePrepare } from '../releasePrepare.ts';
+import type { ReleaseConfig, WorkTypeConfig } from '../types.ts';
+
+const workTypes: Record<string, WorkTypeConfig> = {
+  feat: { header: 'Features' },
+  fix: { header: 'Bug fixes' },
+};
+
+function makeConfig(overrides?: Partial<ReleaseConfig>): ReleaseConfig {
+  return {
+    tagPrefix: 'v',
+    packageFiles: ['package.json'],
+    changelogPaths: ['.'],
+    workTypes,
+    ...overrides,
+  };
+}
+
+describe(releasePrepare, () => {
+  afterEach(() => {
+    mockExecFileSync.mockReset();
+    mockExecSync.mockReset();
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('runs format command with package files and changelog paths appended', () => {
+    const config = makeConfig({
+      formatCommand: 'npx prettier --write',
+      packageFiles: ['package.json', 'packages/core/package.json'],
+      changelogPaths: ['.', 'packages/core'],
+    });
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'feat: add feature\u001Fabc123';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    releasePrepare(config, { dryRun: false });
+
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      'npx prettier --write package.json packages/core/package.json ./CHANGELOG.md packages/core/CHANGELOG.md',
+      { stdio: 'inherit' },
+    );
+  });
+
+  it('logs full command with file paths in dry-run mode', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const config = makeConfig({
+      formatCommand: 'npx prettier --write',
+      packageFiles: ['package.json'],
+      changelogPaths: ['.'],
+    });
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'feat: add feature\u001Fabc123';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    releasePrepare(config, { dryRun: true });
+
+    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('npx prettier --write package.json ./CHANGELOG.md'));
+  });
+
+  it('does not run format command when no release-worthy changes exist', () => {
+    const config = makeConfig({
+      formatCommand: 'npx prettier --write',
+    });
+
+    // Return a commit whose type (chore) is not in workTypes (only feat, fix)
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'chore: update deps\u001Fabc123';
+      }
+      return '';
+    });
+
+    const result = releasePrepare(config, { dryRun: false });
+
+    expect(result).toStrictEqual([]);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -31,19 +31,21 @@ function makeConfig(overrides?: Partial<MonorepoReleaseConfig>): MonorepoRelease
   };
 }
 
-/** Find the first git-cliff call's args from the mock call history. */
+/** Find the first npx git-cliff call's args from the mock call history. */
 function findCliffCallArgs(): readonly unknown[] {
   for (const call of mockExecFileSync.mock.calls) {
-    if (call[0] === 'git-cliff' && Array.isArray(call[1])) {
+    if (call[0] === 'npx' && Array.isArray(call[1]) && call[1][0] === 'git-cliff') {
       return call[1];
     }
   }
-  throw new Error('No git-cliff call found in mock history');
+  throw new Error('No npx git-cliff call found in mock history');
 }
 
-/** Count how many git-cliff calls occurred. */
+/** Count how many npx git-cliff calls occurred. */
 function countCliffCalls(): number {
-  return mockExecFileSync.mock.calls.filter((call: unknown[]) => call[0] === 'git-cliff').length;
+  return mockExecFileSync.mock.calls.filter(
+    (call: unknown[]) => call[0] === 'npx' && Array.isArray(call[1]) && call[1][0] === 'git-cliff',
+  ).length;
 }
 
 describe(releasePrepareMono, () => {
@@ -253,7 +255,10 @@ describe(releasePrepareMono, () => {
     releasePrepareMono(config, { dryRun: false });
 
     expect(mockExecSync).toHaveBeenCalledTimes(1);
-    expect(mockExecSync).toHaveBeenCalledWith('pnpm run fmt', { stdio: 'inherit' });
+    expect(mockExecSync).toHaveBeenCalledWith(
+      'pnpm run fmt packages/arrays/package.json packages/arrays/CHANGELOG.md packages/strings/package.json packages/strings/CHANGELOG.md',
+      { stdio: 'inherit' },
+    );
   });
 
   it('uses bumpOverride instead of commit-derived bump type', () => {

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -34,7 +34,7 @@ function makeConfig(overrides?: Partial<MonorepoReleaseConfig>): MonorepoRelease
 /** Find the first npx git-cliff call's args from the mock call history. */
 function findCliffCallArgs(): readonly unknown[] {
   for (const call of mockExecFileSync.mock.calls) {
-    if (call[0] === 'npx' && Array.isArray(call[1]) && call[1][0] === 'git-cliff') {
+    if (call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff')) {
       return call[1];
     }
   }
@@ -44,7 +44,7 @@ function findCliffCallArgs(): readonly unknown[] {
 /** Count how many npx git-cliff calls occurred. */
 function countCliffCalls(): number {
   return mockExecFileSync.mock.calls.filter(
-    (call: unknown[]) => call[0] === 'npx' && Array.isArray(call[1]) && call[1][0] === 'git-cliff',
+    (call: unknown[]) => call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff'),
   ).length;
 }
 
@@ -186,6 +186,7 @@ describe(releasePrepareMono, () => {
   });
 
   it('does not write files or run formatCommand when dryRun is true', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const config = makeConfig({
       formatCommand: 'pnpm run fmt',
       components: [
@@ -216,6 +217,12 @@ describe(releasePrepareMono, () => {
     expect(mockWriteFileSync).not.toHaveBeenCalled();
     expect(countCliffCalls()).toBe(0);
     expect(mockExecSync).not.toHaveBeenCalled();
+
+    // Verify the dry-run log includes modified file paths
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('pnpm run fmt packages/arrays/package.json packages/arrays/CHANGELOG.md'),
+    );
+    infoSpy.mockRestore();
   });
 
   it('runs formatCommand once after all components are processed', () => {

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -188,7 +188,7 @@ describe(releasePrepareMono, () => {
   it('does not write files or run formatCommand when dryRun is true', () => {
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const config = makeConfig({
-      formatCommand: 'pnpm run fmt',
+      formatCommand: 'npx prettier --write',
       components: [
         {
           dir: 'arrays',
@@ -220,14 +220,14 @@ describe(releasePrepareMono, () => {
 
     // Verify the dry-run log includes modified file paths
     expect(infoSpy).toHaveBeenCalledWith(
-      expect.stringContaining('pnpm run fmt packages/arrays/package.json packages/arrays/CHANGELOG.md'),
+      expect.stringContaining('npx prettier --write packages/arrays/package.json packages/arrays/CHANGELOG.md'),
     );
     infoSpy.mockRestore();
   });
 
   it('runs formatCommand once after all components are processed', () => {
     const config = makeConfig({
-      formatCommand: 'pnpm run fmt',
+      formatCommand: 'npx prettier --write',
       components: [
         {
           dir: 'arrays',
@@ -263,7 +263,7 @@ describe(releasePrepareMono, () => {
 
     expect(mockExecSync).toHaveBeenCalledTimes(1);
     expect(mockExecSync).toHaveBeenCalledWith(
-      'pnpm run fmt packages/arrays/package.json packages/arrays/CHANGELOG.md packages/strings/package.json packages/strings/CHANGELOG.md',
+      'npx prettier --write packages/arrays/package.json packages/arrays/CHANGELOG.md packages/strings/package.json packages/strings/CHANGELOG.md',
       { stdio: 'inherit' },
     );
   });
@@ -341,7 +341,7 @@ describe(releasePrepareMono, () => {
 
   it('does not run formatCommand when no components have commits', () => {
     const config = makeConfig({
-      formatCommand: 'pnpm run fmt',
+      formatCommand: 'npx prettier --write',
       components: [
         {
           dir: 'arrays',

--- a/packages/release-kit/src/generateChangelogs.ts
+++ b/packages/release-kit/src/generateChangelogs.ts
@@ -11,9 +11,9 @@ export interface GenerateChangelogOptions {
 /**
  * Generates a single changelog using git-cliff.
  *
- * Invokes the `git-cliff` binary via `execFileSync` with an argument array,
- * avoiding shell interpretation of paths. The `git-cliff` tool and a
- * `cliff.toml` configuration file must be available in the environment.
+ * Invokes `git-cliff` via `npx` using `execFileSync` with an argument array,
+ * avoiding shell interpretation of paths. The `npx` command downloads
+ * `git-cliff` on first invocation and caches it for subsequent calls.
  *
  * @param config - Object containing the optional `cliffConfigPath` (defaults to 'cliff.toml').
  * @param changelogPath - Directory in which to write the CHANGELOG.md file.
@@ -38,13 +38,13 @@ export function generateChangelog(
   }
 
   if (dryRun) {
-    console.info(`  [dry-run] Would run: git-cliff ${args.join(' ')}`);
+    console.info(`  [dry-run] Would run: npx git-cliff ${args.join(' ')}`);
     return;
   }
 
   console.info(`  Generating changelog: ${outputFile}`);
   try {
-    execFileSync('git-cliff', args, { stdio: 'inherit' });
+    execFileSync('npx', ['git-cliff', ...args], { stdio: 'inherit' });
   } catch (error: unknown) {
     throw new Error(
       `Failed to generate changelog for ${outputFile}: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/release-kit/src/generateChangelogs.ts
+++ b/packages/release-kit/src/generateChangelogs.ts
@@ -11,9 +11,11 @@ export interface GenerateChangelogOptions {
 /**
  * Generates a single changelog using git-cliff.
  *
- * Invokes `git-cliff` via `npx` using `execFileSync` with an argument array,
- * avoiding shell interpretation of paths. The `npx` command downloads
- * `git-cliff` on first invocation and caches it for subsequent calls.
+ * Invokes `git-cliff` via `npx --yes` using `execFileSync` with an argument array,
+ * avoiding shell interpretation of paths. The `--yes` flag auto-accepts the
+ * download prompt so the command does not hang in non-interactive CI environments.
+ * The `npx` command downloads `git-cliff` on first invocation and caches it for
+ * subsequent calls.
  *
  * @param config - Object containing the optional `cliffConfigPath` (defaults to 'cliff.toml').
  * @param changelogPath - Directory in which to write the CHANGELOG.md file.
@@ -38,13 +40,13 @@ export function generateChangelog(
   }
 
   if (dryRun) {
-    console.info(`  [dry-run] Would run: npx git-cliff ${args.join(' ')}`);
+    console.info(`  [dry-run] Would run: npx --yes git-cliff ${args.join(' ')}`);
     return;
   }
 
   console.info(`  Generating changelog: ${outputFile}`);
   try {
-    execFileSync('npx', ['git-cliff', ...args], { stdio: 'inherit' });
+    execFileSync('npx', ['--yes', 'git-cliff', ...args], { stdio: 'inherit' });
   } catch (error: unknown) {
     throw new Error(
       `Failed to generate changelog for ${outputFile}: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/release-kit/src/init/__tests__/templates.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/templates.unit.test.ts
@@ -39,7 +39,7 @@ describe(releaseWorkflow, () => {
   it('generates a monorepo workflow with only input but no monorepo flag', () => {
     const workflow = releaseWorkflow('monorepo');
 
-    expect(workflow).toContain('release-pnpm.yaml@v2');
+    expect(workflow).toContain('release-pnpm.yaml@v3');
     expect(workflow).not.toContain('monorepo:');
     expect(workflow).toContain('only:');
     expect(workflow).toContain('inputs.only');
@@ -48,18 +48,18 @@ describe(releaseWorkflow, () => {
   it('generates a single-package workflow without only input', () => {
     const workflow = releaseWorkflow('single-package');
 
-    expect(workflow).toContain('release-pnpm.yaml@v2');
+    expect(workflow).toContain('release-pnpm.yaml@v3');
     expect(workflow).not.toContain('monorepo:');
     expect(workflow).not.toContain('inputs.only');
   });
 
-  it('includes TODO for node and pnpm versions in both types', () => {
+  it('does not include version inputs', () => {
     const mono = releaseWorkflow('monorepo');
     const single = releaseWorkflow('single-package');
 
-    expect(mono).toContain('# TODO:');
-    expect(single).toContain('# TODO:');
-    expect(mono).toContain('node-version:');
-    expect(single).toContain('node-version:');
+    expect(mono).not.toContain('node-version:');
+    expect(single).not.toContain('node-version:');
+    expect(mono).not.toContain('pnpm-version:');
+    expect(single).not.toContain('pnpm-version:');
   });
 });

--- a/packages/release-kit/src/init/templates.ts
+++ b/packages/release-kit/src/init/templates.ts
@@ -19,7 +19,7 @@ const config: ReleaseKitConfig = {
   // Uncomment to add custom work types (merged with defaults):
   // workTypes: { perf: { header: 'Performance' } },
   // TODO: Uncomment and adjust if you have a format command
-  // formatCommand: 'pnpm run fmt',
+  // formatCommand: 'npx prettier --write',
 };
 
 export default config;
@@ -34,7 +34,7 @@ const config: ReleaseKitConfig = {
   // Uncomment to add custom work types (merged with defaults):
   // workTypes: { perf: { header: 'Performance' } },
   // TODO: Uncomment and adjust if you have a format command
-  // formatCommand: 'pnpm run fmt',
+  // formatCommand: 'npx prettier --write',
 };
 
 export default config;
@@ -70,11 +70,8 @@ permissions:
 
 jobs:
   release:
-    uses: williamthorsen/.github/.github/workflows/release-pnpm.yaml@v2
+    uses: williamthorsen/.github/.github/workflows/release-pnpm.yaml@v3
     with:
-      # TODO: Set the Node.js and pnpm versions for your project
-      node-version: '24'
-      pnpm-version: '10.32.1'
       only: \${{ inputs.only }}
       bump: \${{ inputs.bump }}
 `;
@@ -102,11 +99,8 @@ permissions:
 
 jobs:
   release:
-    uses: williamthorsen/.github/.github/workflows/release-pnpm.yaml@v2
+    uses: williamthorsen/.github/.github/workflows/release-pnpm.yaml@v3
     with:
-      # TODO: Set the Node.js and pnpm versions for your project
-      node-version: '24'
-      pnpm-version: '10.32.1'
       bump: \${{ inputs.bump }}
 `;
 }

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -67,17 +67,19 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   console.info('Generating changelogs...');
   generateChangelogs(config, newTag, dryRun);
 
-  // 5. Run format command if configured
+  // 5. Run format command if configured, appending modified file paths
   if (config.formatCommand !== undefined) {
+    const modifiedFiles = [...config.packageFiles, ...config.changelogPaths.map((p) => `${p}/CHANGELOG.md`)];
+    const fullCommand = `${config.formatCommand} ${modifiedFiles.join(' ')}`;
     if (dryRun) {
-      console.info(`  [dry-run] Would run format command: ${config.formatCommand}`);
+      console.info(`  [dry-run] Would run format command: ${fullCommand}`);
     } else {
-      console.info(`  Running format command: ${config.formatCommand}`);
+      console.info(`  Running format command: ${fullCommand}`);
       try {
-        execSync(config.formatCommand, { stdio: 'inherit' });
+        execSync(fullCommand, { stdio: 'inherit' });
       } catch (error: unknown) {
         throw new Error(
-          `Format command failed ('${config.formatCommand}'): ${error instanceof Error ? error.message : String(error)}`,
+          `Format command failed ('${fullCommand}'): ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -32,6 +32,7 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
   const tags: string[] = [];
+  const modifiedFiles: string[] = [];
 
   for (const component of config.components) {
     const name = component.dir;
@@ -77,6 +78,7 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     const newVersion = bumpAllVersions(component.packageFiles, releaseType, dryRun);
     const newTag = `${component.tagPrefix}${newVersion}`;
     tags.push(newTag);
+    modifiedFiles.push(...component.packageFiles, ...component.changelogPaths.map((p) => `${p}/CHANGELOG.md`));
 
     // 4. Generate changelogs for each configured path with include-path filtering
     console.info('  Generating changelogs...');
@@ -86,17 +88,18 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     console.info(`  Component release prepared: ${newTag}`);
   }
 
-  // 5. Run format command once after all components are processed
+  // 5. Run format command once after all components are processed, appending modified file paths
   if (tags.length > 0 && config.formatCommand !== undefined) {
+    const fullCommand = `${config.formatCommand} ${modifiedFiles.join(' ')}`;
     if (dryRun) {
-      console.info(`\n  [dry-run] Would run format command: ${config.formatCommand}`);
+      console.info(`\n  [dry-run] Would run format command: ${fullCommand}`);
     } else {
-      console.info(`\n  Running format command: ${config.formatCommand}`);
+      console.info(`\n  Running format command: ${fullCommand}`);
       try {
-        execSync(config.formatCommand, { stdio: 'inherit' });
+        execSync(fullCommand, { stdio: 'inherit' });
       } catch (error: unknown) {
         throw new Error(
-          `Format command failed ('${config.formatCommand}'): ${error instanceof Error ? error.message : String(error)}`,
+          `Format command failed ('${fullCommand}'): ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -35,7 +35,11 @@ export interface ReleaseKitConfig {
   versionPatterns?: VersionPatterns;
   /** Work type overrides. Merged with defaults by key. */
   workTypes?: Record<string, WorkTypeConfig>;
-  /** Shell command to run after all changelogs are generated (e.g., 'pnpm run fmt'). */
+  /**
+   * Shell command to run after all changelogs are generated (e.g., 'pnpm run fmt').
+   * Modified file paths (package.json files and CHANGELOGs) are appended as space-separated
+   * arguments. Paths are repo-relative; file paths containing spaces are not supported.
+   */
   formatCommand?: string;
   /** Path to the cliff.toml file; defaults to 'cliff.toml' when absent. */
   cliffConfigPath?: string;
@@ -103,7 +107,11 @@ export interface MonorepoReleaseConfig {
   workTypes?: Record<string, WorkTypeConfig>;
   /** Version bump patterns. Defaults to `DEFAULT_VERSION_PATTERNS`. */
   versionPatterns?: VersionPatterns;
-  /** Shell command to run after all changelogs are generated (e.g., 'pnpm run fmt'). */
+  /**
+   * Shell command to run after all changelogs are generated (e.g., 'pnpm run fmt').
+   * Modified file paths (package.json files and CHANGELOGs) are appended as space-separated
+   * arguments. Paths are repo-relative; file paths containing spaces are not supported.
+   */
   formatCommand?: string;
   /** Path to the cliff.toml file; defaults to 'cliff.toml' when absent. */
   cliffConfigPath?: string;
@@ -127,7 +135,11 @@ export interface ReleaseConfig {
   workTypes?: Record<string, WorkTypeConfig>;
   /** Version bump patterns. Defaults to `DEFAULT_VERSION_PATTERNS`. */
   versionPatterns?: VersionPatterns;
-  /** Shell command to run after changelog generation (e.g., 'pnpm run fmt'). */
+  /**
+   * Shell command to run after changelog generation (e.g., 'pnpm run fmt').
+   * Modified file paths (package.json files and CHANGELOGs) are appended as space-separated
+   * arguments. Paths are repo-relative; file paths containing spaces are not supported.
+   */
   formatCommand?: string;
   /** Path to the cliff.toml file; defaults to 'cliff.toml' when absent. */
   cliffConfigPath?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       eslint-plugin-import:
         specifier: 2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
-      git-cliff:
-        specifier: 2.12.0
-        version: 2.12.0
       glob:
         specifier: 13.0.6
         version: 13.0.6
@@ -557,13 +554,6 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
-
-  '@sec-ant/readable-stream@0.4.1':
-    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
-
-  '@sindresorhus/merge-streams@4.0.0':
-    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
-    engines: {node: '>=18'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1221,10 +1211,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  execa@9.6.1:
-    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
-    engines: {node: ^18.19.0 || >=20.5.0}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1246,10 +1232,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  figures@6.1.0:
-    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
-    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1297,51 +1279,12 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stream@9.0.1:
-    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
-    engines: {node: '>=18'}
-
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
-
-  git-cliff-darwin-arm64@2.12.0:
-    resolution: {integrity: sha512-k3jzFDmkjc+6MjpnqvRenzMWRbZN5J+w3iQ8WNt9pSmPewNJIm92O/G6AbAxQaCbSfzQapeZ0e+5wSacVc62GA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  git-cliff-darwin-x64@2.12.0:
-    resolution: {integrity: sha512-Kkoe+nfmXM/WMcZuC+OaIGA5vj847Ima6NEaaHnyb7Xsri+OAJryPXlABV7q6UeGfiiN2MlL8UsoHgnIEIQLqQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  git-cliff-linux-arm64@2.12.0:
-    resolution: {integrity: sha512-eTp2gZjV4LmfzdlhFsYFYuWf5mojALU03X/37r3VmnpuabaijuTEQo/zm/0BKP8gPiLKLR4ofdUvE1OSisCE1A==}
-    cpu: [arm64]
-    os: [linux]
-
-  git-cliff-linux-x64@2.12.0:
-    resolution: {integrity: sha512-abidFG6dH2N5hPUF245/kRYdwViP11Pz7ZwIW/a86CJLZ/WSE7dJt0f2cUIkxTcFSsp11OwuLc5k1hAbwmiIRw==}
-    cpu: [x64]
-    os: [linux]
-
-  git-cliff-windows-arm64@2.12.0:
-    resolution: {integrity: sha512-rFuI+D/3Yq3jqafazZw5E68HsXEvcwI/B/5IPDIZD+QqZh8vETf4IXs7wVxYWWtHQJDC+G9ZrR3vE5648mdG3A==}
-    cpu: [arm64]
-    os: [win32]
-
-  git-cliff-windows-x64@2.12.0:
-    resolution: {integrity: sha512-jskb3nyVGr4dekHSCDM/J6iho45t37wnmMGkPNq42kOoUp04JS96yMBrNRdXfXV9ViZsaZq3NaNu1e3QkhFlyA==}
-    cpu: [x64]
-    os: [win32]
-
-  git-cliff@2.12.0:
-    resolution: {integrity: sha512-kjTm5439LsvMs/xRxndWBUetrA4aQfLE8DTbR/ER5H7fGn7ioeFG9YNAK1V7dpTtNi6k2uKYY4f3EvT8J1d+1Q==}
-    engines: {node: '>=18.19 || >=20.6 || >=21'}
-    hasBin: true
 
   git-hooks-list@4.2.1:
     resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
@@ -1425,10 +1368,6 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
-
-  human-signals@8.0.1:
-    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
-    engines: {node: '>=18.18.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1537,10 +1476,6 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
-  is-stream@4.0.1:
-    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
-    engines: {node: '>=18'}
-
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -1552,10 +1487,6 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
-
-  is-unicode-supported@2.1.0:
-    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
-    engines: {node: '>=18'}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -1820,10 +1751,6 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  npm-run-path@6.0.0:
-    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
-    engines: {node: '>=18'}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -1875,10 +1802,6 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
-  parse-ms@4.0.0:
-    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
-    engines: {node: '>=18'}
-
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -1889,10 +1812,6 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -1931,10 +1850,6 @@ packages:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
-
-  pretty-ms@9.3.0:
-    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
-    engines: {node: '>=18'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2041,10 +1956,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
   sort-object-keys@2.1.0:
     resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
 
@@ -2101,10 +2012,6 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-
-  strip-final-newline@4.0.0:
-    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
-    engines: {node: '>=18'}
 
   strip-indent@4.1.1:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
@@ -2232,10 +2139,6 @@ packages:
   undici@7.24.2:
     resolution: {integrity: sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==}
     engines: {node: '>=20.18.1'}
-
-  unicorn-magic@0.3.0:
-    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
-    engines: {node: '>=18'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2396,10 +2299,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yoctocolors@2.1.2:
-    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
-    engines: {node: '>=18'}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -2731,10 +2630,6 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.9': {}
 
   '@rtsao/scc@1.1.0': {}
-
-  '@sec-ant/readable-stream@0.4.1': {}
-
-  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -3613,21 +3508,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  execa@9.6.1:
-    dependencies:
-      '@sindresorhus/merge-streams': 4.0.0
-      cross-spawn: 7.0.6
-      figures: 6.1.0
-      get-stream: 9.0.1
-      human-signals: 8.0.1
-      is-plain-obj: 4.1.0
-      is-stream: 4.0.1
-      npm-run-path: 6.0.0
-      pretty-ms: 9.3.0
-      signal-exit: 4.1.0
-      strip-final-newline: 4.0.0
-      yoctocolors: 2.1.2
-
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -3639,10 +3519,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
-
-  figures@6.1.0:
-    dependencies:
-      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -3700,11 +3576,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@9.0.1:
-    dependencies:
-      '@sec-ant/readable-stream': 0.4.1
-      is-stream: 4.0.1
-
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -3714,35 +3585,6 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  git-cliff-darwin-arm64@2.12.0:
-    optional: true
-
-  git-cliff-darwin-x64@2.12.0:
-    optional: true
-
-  git-cliff-linux-arm64@2.12.0:
-    optional: true
-
-  git-cliff-linux-x64@2.12.0:
-    optional: true
-
-  git-cliff-windows-arm64@2.12.0:
-    optional: true
-
-  git-cliff-windows-x64@2.12.0:
-    optional: true
-
-  git-cliff@2.12.0:
-    dependencies:
-      execa: 9.6.1
-    optionalDependencies:
-      git-cliff-darwin-arm64: 2.12.0
-      git-cliff-darwin-x64: 2.12.0
-      git-cliff-linux-arm64: 2.12.0
-      git-cliff-linux-x64: 2.12.0
-      git-cliff-windows-arm64: 2.12.0
-      git-cliff-windows-x64: 2.12.0
 
   git-hooks-list@4.2.1: {}
 
@@ -3821,8 +3663,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
-
-  human-signals@8.0.1: {}
 
   ignore@5.3.2: {}
 
@@ -3931,8 +3771,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
-  is-stream@4.0.1: {}
-
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -3947,8 +3785,6 @@ snapshots:
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.19
-
-  is-unicode-supported@2.1.0: {}
 
   is-weakmap@2.0.2: {}
 
@@ -4180,11 +4016,6 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  npm-run-path@6.0.0:
-    dependencies:
-      path-key: 4.0.0
-      unicorn-magic: 0.3.0
-
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -4253,8 +4084,6 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
-  parse-ms@4.0.0: {}
-
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -4263,8 +4092,6 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
-
-  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -4292,10 +4119,6 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
-
-  pretty-ms@9.3.0:
-    dependencies:
-      parse-ms: 4.0.0
 
   punycode@2.3.1: {}
 
@@ -4445,8 +4268,6 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@4.1.0: {}
-
   sort-object-keys@2.1.0: {}
 
   sort-package-json@3.6.1:
@@ -4517,8 +4338,6 @@ snapshots:
       es-object-atoms: 1.1.1
 
   strip-bom@3.0.0: {}
-
-  strip-final-newline@4.0.0: {}
 
   strip-indent@4.1.1: {}
 
@@ -4663,8 +4482,6 @@ snapshots:
 
   undici@7.24.2:
     optional: true
-
-  unicorn-magic@0.3.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -4814,7 +4631,5 @@ snapshots:
   yaml@2.8.0: {}
 
   yocto-queue@0.1.0: {}
-
-  yoctocolors@2.1.2: {}
 
   zod@4.3.6: {}


### PR DESCRIPTION
Closes #7 

## What

Make release-kit self-contained by invoking git-cliff via `npx --yes` instead of requiring it on PATH, and by appending modified file paths to the format command so lightweight formatters like `npx prettier --write` work without a full `pnpm install`. Update init templates, README, and consuming repo config/workflow to reference workflow v3.

## Why

The reusable release workflow ran a full `pnpm install` before executing `npx @williamthorsen/release-kit prepare`, even though release-kit only performs git history analysis and package.json file operations. The install was needed solely because git-cliff had to be on PATH as a dev dependency and the format command (`pnpm run fmt`) required the project's dependency tree. Removing this install significantly reduces CI time and complexity.

## Details

### Features

- `generateChangelogs.ts` invokes git-cliff via `execFileSync('npx', ['--yes', 'git-cliff', ...args])` — no external binary required on PATH
- `releasePrepare.ts` and `releasePrepareMono.ts` collect modified file paths (package.json + CHANGELOG.md) and append them as trailing arguments to the format command
- Init templates reference `release-pnpm.yaml@v3` with no version inputs; config template uses `npx prettier --write`

### Fixes

- Added `--yes` flag to `npx` invocation to prevent interactive prompts hanging CI
- Regenerated `pnpm-lock.yaml` after removing `git-cliff` from devDependencies
- Documented breaking change to `formatCommand` semantics in README
- Documented file-path space limitation in `formatCommand` JSDoc across all three config interfaces

### Tests

- Created `releasePrepare.unit.test.ts` with tests for format-command file-path passing, dry-run logging, and early-return behavior
- Updated `generateChangelog.unit.test.ts` assertions for `npx --yes` invocation
- Updated `releasePrepareMono.unit.test.ts` cliff-call helpers and dry-run log assertion
- Updated `templates.unit.test.ts` for v3 references and removed version inputs
- Updated format command in tests to `npx prettier --write` for accuracy

### Tooling

- `.config/release-kit.config.ts` uses `npx prettier --write`
- `git-cliff` removed from root devDependencies
- `.github/workflows/release.yaml` references `@v3` without `node-version` or `pnpm-version` inputs

### Documentation

- README updated: installation no longer includes git-cliff, external dependencies section notes automatic npx download, format command documentation notes file-path appending, workflow examples match v3 shape, "Breaking changes" section added with migration guidance and version-pinning information