### PR TITLE
#22 Add --force flag to release-kit prepare

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,5 +34,5 @@ jobs:
       only: ${{ inputs.only }}
       bump: ${{ inputs.bump }}
       # TODO: The reusable workflow (release-pnpm.yaml@v3) does not yet accept `force`.
-      # Update williamthorsen/.github to declare and forward this input before it takes effect.
-      force: ${{ inputs.force }}
+      # After updating williamthorsen/.github to declare and forward this input,
+      # add `force: ${{ inputs.force }}` here.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,4 +33,6 @@ jobs:
     with:
       only: ${{ inputs.only }}
       bump: ${{ inputs.bump }}
+      # TODO: The reusable workflow (release-pnpm.yaml@v3) does not yet accept `force`.
+      # Update williamthorsen/.github to declare and forward this input before it takes effect.
       force: ${{ inputs.force }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,11 @@ on:
           - patch
           - minor
           - major
+      force:
+        description: 'Bypass "no commits since last tag" check (requires bump)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -28,3 +33,4 @@ jobs:
     with:
       only: ${{ inputs.only }}
       bump: ${{ inputs.bump }}
+      force: ${{ inputs.force }}

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -99,6 +99,16 @@ describe(prepareCommand, () => {
     });
   });
 
+  it('passes force from --force flag', async () => {
+    await prepareCommand(['--force', '--bump=patch']);
+
+    expect(mockReleasePrepareMono).toHaveBeenCalledWith(expect.any(Object), {
+      dryRun: false,
+      force: true,
+      bumpOverride: 'patch',
+    });
+  });
+
   it('filters components when --only is provided', async () => {
     await prepareCommand(['--only=arrays']);
 

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -72,7 +72,7 @@ describe(prepareCommand, () => {
       expect.objectContaining({
         components: expect.arrayContaining([expect.objectContaining({ tagPrefix: 'arrays-v' })]),
       }),
-      { dryRun: false },
+      { dryRun: false, force: false },
     );
   });
 
@@ -81,13 +81,19 @@ describe(prepareCommand, () => {
 
     await prepareCommand([]);
 
-    expect(mockReleasePrepare).toHaveBeenCalledWith(expect.objectContaining({ tagPrefix: 'v' }), { dryRun: false });
+    expect(mockReleasePrepare).toHaveBeenCalledWith(expect.objectContaining({ tagPrefix: 'v' }), {
+      dryRun: false,
+      force: false,
+    });
   });
 
   it('passes dryRun from --dry-run flag', async () => {
     await prepareCommand(['--dry-run']);
 
-    expect(mockReleasePrepareMono).toHaveBeenCalledWith(expect.any(Object), { dryRun: true });
+    expect(mockReleasePrepareMono).toHaveBeenCalledWith(expect.any(Object), {
+      dryRun: true,
+      force: false,
+    });
   });
 
   it('passes bumpOverride from --bump flag', async () => {
@@ -95,6 +101,7 @@ describe(prepareCommand, () => {
 
     expect(mockReleasePrepareMono).toHaveBeenCalledWith(expect.any(Object), {
       dryRun: false,
+      force: false,
       bumpOverride: 'minor',
     });
   });

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -374,7 +374,7 @@ describe(releasePrepareMono, () => {
     expect(countCliffCalls()).toBe(1);
   });
 
-  it('force-bumps one component while skipping another with no commits', () => {
+  it('force-bumps a component with no commits while also bumping one with commits', () => {
     const config = makeConfig({
       components: [
         {
@@ -416,8 +416,39 @@ describe(releasePrepareMono, () => {
 
     const result = releasePrepareMono(config, { dryRun: false, force: true, bumpOverride: 'patch' });
 
-    // Both components should be bumped: arrays via force, strings via commits
+    // arrays is bumped via --force (0 commits); strings is bumped via commits; both use bumpOverride: 'patch'
     expect(result).toStrictEqual(['arrays-v1.0.1', 'strings-v2.0.1']);
+  });
+
+  it('does not write files when force and dryRun are both true', () => {
+    const config = makeConfig({
+      components: [
+        {
+          dir: 'arrays',
+          tagPrefix: 'arrays-v',
+          packageFiles: ['packages/arrays/package.json'],
+          changelogPaths: ['packages/arrays'],
+          paths: ['packages/arrays/**'],
+        },
+      ],
+    });
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'arrays-v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return '';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    const result = releasePrepareMono(config, { dryRun: true, force: true, bumpOverride: 'patch' });
+
+    expect(result).toStrictEqual(['arrays-v1.0.1']);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(countCliffCalls()).toBe(0);
   });
 
   it('does not run formatCommand when no components have commits', () => {

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -339,6 +339,87 @@ describe(releasePrepareMono, () => {
     expect(countCliffCalls()).toBe(0);
   });
 
+  it('bypasses the no-commits check when force is true', () => {
+    const config = makeConfig({
+      components: [
+        {
+          dir: 'arrays',
+          tagPrefix: 'arrays-v',
+          packageFiles: ['packages/arrays/package.json'],
+          changelogPaths: ['packages/arrays'],
+          paths: ['packages/arrays/**'],
+        },
+      ],
+    });
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'arrays-v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return '';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    const result = releasePrepareMono(config, { dryRun: false, force: true, bumpOverride: 'patch' });
+
+    expect(result).toStrictEqual(['arrays-v1.0.1']);
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      'packages/arrays/package.json',
+      expect.stringContaining('"version": "1.0.1"'),
+      'utf8',
+    );
+    expect(countCliffCalls()).toBe(1);
+  });
+
+  it('force-bumps one component while skipping another with no commits', () => {
+    const config = makeConfig({
+      components: [
+        {
+          dir: 'arrays',
+          tagPrefix: 'arrays-v',
+          packageFiles: ['packages/arrays/package.json'],
+          changelogPaths: ['packages/arrays'],
+          paths: ['packages/arrays/**'],
+        },
+        {
+          dir: 'strings',
+          tagPrefix: 'strings-v',
+          packageFiles: ['packages/strings/package.json'],
+          changelogPaths: ['packages/strings'],
+          paths: ['packages/strings/**'],
+        },
+      ],
+    });
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        const matchArg = args.find((a: string) => a.startsWith('--match='));
+        if (matchArg?.includes('arrays-v')) return 'arrays-v1.0.0\n';
+        if (matchArg?.includes('strings-v')) return 'strings-v2.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        const hasStringsPath = args.includes('packages/strings/**');
+        if (hasStringsPath) {
+          return 'feat: add string helper\u001Fabc123';
+        }
+        return '';
+      }
+      return '';
+    });
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath.includes('arrays')) return JSON.stringify({ version: '1.0.0' });
+      return JSON.stringify({ version: '2.0.0' });
+    });
+
+    const result = releasePrepareMono(config, { dryRun: false, force: true, bumpOverride: 'patch' });
+
+    // Both components should be bumped: arrays via force, strings via commits
+    expect(result).toStrictEqual(['arrays-v1.0.1', 'strings-v2.0.1']);
+  });
+
   it('does not run formatCommand when no components have commits', () => {
     const config = makeConfig({
       formatCommand: 'npx prettier --write',

--- a/packages/release-kit/src/__tests__/runReleasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/runReleasePrepare.unit.test.ts
@@ -162,6 +162,26 @@ describe(runReleasePrepare, () => {
     );
   });
 
+  it('passes force true when --force and --bump are provided', () => {
+    process.argv = ['node', 'script.ts', '--force', '--bump=patch'];
+
+    runReleasePrepare(makeConfig());
+
+    expect(mockReleasePrepareMono).toHaveBeenCalledWith(expect.any(Object), {
+      dryRun: false,
+      force: true,
+      bumpOverride: 'patch',
+    });
+  });
+
+  it('exits with code 1 when --force is used without --bump', () => {
+    process.argv = ['node', 'script.ts', '--force'];
+
+    expect(() => runReleasePrepare(makeConfig())).toThrow(ExitError);
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--force requires --bump'));
+  });
+
   it('exits with code 1 for an invalid bump type', () => {
     process.argv = ['node', 'script.ts', '--bump=invalid'];
 

--- a/packages/release-kit/src/__tests__/runReleasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/runReleasePrepare.unit.test.ts
@@ -100,6 +100,7 @@ describe(runReleasePrepare, () => {
 
     expect(mockReleasePrepareMono).toHaveBeenCalledWith(expect.objectContaining({ components: expect.any(Array) }), {
       dryRun: false,
+      force: false,
     });
   });
 
@@ -108,7 +109,10 @@ describe(runReleasePrepare, () => {
 
     runReleasePrepare(makeConfig());
 
-    expect(mockReleasePrepareMono).toHaveBeenCalledWith(expect.any(Object), { dryRun: true });
+    expect(mockReleasePrepareMono).toHaveBeenCalledWith(expect.any(Object), {
+      dryRun: true,
+      force: false,
+    });
   });
 
   it('passes bumpOverride when --bump is provided', () => {
@@ -118,6 +122,7 @@ describe(runReleasePrepare, () => {
 
     expect(mockReleasePrepareMono).toHaveBeenCalledWith(expect.any(Object), {
       dryRun: false,
+      force: false,
       bumpOverride: 'major',
     });
   });
@@ -129,6 +134,7 @@ describe(runReleasePrepare, () => {
 
     expect(mockReleasePrepareMono).toHaveBeenCalledWith(expect.any(Object), {
       dryRun: true,
+      force: false,
       bumpOverride: 'patch',
     });
   });
@@ -297,7 +303,10 @@ describe(runReleasePrepare, () => {
 
       runReleasePrepare(makeSingleConfig());
 
-      expect(mockReleasePrepare).toHaveBeenCalledWith(expect.objectContaining({ tagPrefix: 'v' }), { dryRun: false });
+      expect(mockReleasePrepare).toHaveBeenCalledWith(expect.objectContaining({ tagPrefix: 'v' }), {
+        dryRun: false,
+        force: false,
+      });
       expect(mockReleasePrepareMono).not.toHaveBeenCalled();
     });
 
@@ -308,6 +317,7 @@ describe(runReleasePrepare, () => {
 
       expect(mockReleasePrepare).toHaveBeenCalledWith(expect.any(Object), {
         dryRun: true,
+        force: false,
         bumpOverride: 'minor',
       });
     });

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -22,7 +22,7 @@ export async function prepareCommand(argv: string[]): Promise<void> {
   const { dryRun, force, bumpOverride, only } = parseArgs(argv);
   const options = {
     dryRun,
-    ...(force ? { force } : {}),
+    force,
     ...(bumpOverride === undefined ? {} : { bumpOverride }),
   };
 

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -19,8 +19,12 @@ import { validateConfig } from './validateConfig.ts';
  * 5. Writes `.release-tags` for CI consumption.
  */
 export async function prepareCommand(argv: string[]): Promise<void> {
-  const { dryRun, bumpOverride, only } = parseArgs(argv);
-  const options = { dryRun, ...(bumpOverride === undefined ? {} : { bumpOverride }) };
+  const { dryRun, force, bumpOverride, only } = parseArgs(argv);
+  const options = {
+    dryRun,
+    ...(force ? { force } : {}),
+    ...(bumpOverride === undefined ? {} : { bumpOverride }),
+  };
 
   // 1. Load config file
   let rawConfig: unknown;

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -12,6 +12,8 @@ import type { ParsedCommit, ReleaseConfig, ReleaseType } from './types.ts';
 export interface ReleasePrepareOptions {
   /** If true, logs actions without modifying files. */
   dryRun: boolean;
+  /** Bypass the "no commits since last tag" check. Requires `bumpOverride`. */
+  force?: boolean;
   /** Override the bump type instead of determining it from commits. */
   bumpOverride?: ReleaseType;
 }

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -12,7 +12,7 @@ import type { ParsedCommit, ReleaseConfig, ReleaseType } from './types.ts';
 export interface ReleasePrepareOptions {
   /** If true, logs actions without modifying files. */
   dryRun: boolean;
-  /** Bypass the "no commits since last tag" check. Requires `bumpOverride`. */
+  /** Bypass the "no commits since last tag" check (monorepo only). Requires `bumpOverride`. */
   force?: boolean;
   /** Override the bump type instead of determining it from commits. */
   bumpOverride?: ReleaseType;

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -28,7 +28,7 @@ import type { MonorepoReleaseConfig, ParsedCommit, ReleaseType } from './types.t
  * @param options - Options controlling dry-run mode and optional bump override.
  */
 export function releasePrepareMono(config: MonorepoReleaseConfig, options: ReleasePrepareOptions): string[] {
-  const { dryRun, bumpOverride } = options;
+  const { dryRun, force, bumpOverride } = options;
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
   const tags: string[] = [];
@@ -44,11 +44,11 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     const since = tag === undefined ? '(no previous release found)' : `since ${tag}`;
     console.info(`  Found ${commits.length} commits ${since}`);
 
-    // Skip components with no changes. "No changes" means no commits touched
-    // paths matching the component's glob patterns. Root-level or cross-cutting
-    // commits not captured by the component's path globs are not counted and
-    // may cause a skip even when those changes semantically apply.
-    if (commits.length === 0) {
+    // Skip components with no changes unless --force is set. "No changes" means
+    // no commits touched paths matching the component's glob patterns. Root-level
+    // or cross-cutting commits not captured by the component's path globs are not
+    // counted and may cause a skip even when those changes semantically apply.
+    if (commits.length === 0 && !force) {
       console.info(`  No changes for ${name} ${since}. Skipping.`);
       continue;
     }

--- a/packages/release-kit/src/runReleasePrepare.ts
+++ b/packages/release-kit/src/runReleasePrepare.ts
@@ -35,7 +35,7 @@ Legacy entry point for release preparation. Prefer the CLI:
 Options:
   --dry-run             Run without modifying any files
   --bump=major|minor|patch  Override the bump type for all components
-  --force               Bypass the "no commits since last tag" check (requires --bump)
+  --force               Bypass the "no commits since last tag" check (monorepo only, requires --bump)
   --only=name1,name2    Only process the named components (comma-separated, monorepo only)
   --help                Show this help message
 `);

--- a/packages/release-kit/src/runReleasePrepare.ts
+++ b/packages/release-kit/src/runReleasePrepare.ts
@@ -107,7 +107,7 @@ export function runReleasePrepare(config: MonorepoReleaseConfig | ReleaseConfig)
   const { dryRun, force, bumpOverride, only } = parseArgs(process.argv.slice(2));
   const options = {
     dryRun,
-    ...(force ? { force } : {}),
+    force,
     ...(bumpOverride === undefined ? {} : { bumpOverride }),
   };
 

--- a/packages/release-kit/src/runReleasePrepare.ts
+++ b/packages/release-kit/src/runReleasePrepare.ts
@@ -35,6 +35,7 @@ Legacy entry point for release preparation. Prefer the CLI:
 Options:
   --dry-run             Run without modifying any files
   --bump=major|minor|patch  Override the bump type for all components
+  --force               Bypass the "no commits since last tag" check (requires --bump)
   --only=name1,name2    Only process the named components (comma-separated, monorepo only)
   --help                Show this help message
 `);
@@ -43,16 +44,20 @@ Options:
 /** Parse CLI arguments into structured options. */
 export function parseArgs(argv: string[]): {
   dryRun: boolean;
+  force: boolean;
   bumpOverride: ReleaseType | undefined;
   only: string[] | undefined;
 } {
   let dryRun = false;
+  let force = false;
   let bumpOverride: ReleaseType | undefined;
   let only: string[] | undefined;
 
   for (const arg of argv) {
     if (arg === '--dry-run') {
       dryRun = true;
+    } else if (arg === '--force') {
+      force = true;
     } else if (arg.startsWith('--bump=')) {
       const value = arg.slice('--bump='.length);
       if (!isReleaseType(value)) {
@@ -76,7 +81,12 @@ export function parseArgs(argv: string[]): {
     }
   }
 
-  return { dryRun, bumpOverride, only };
+  if (force && bumpOverride === undefined) {
+    console.error('Error: --force requires --bump to specify the version bump type');
+    process.exit(1);
+  }
+
+  return { dryRun, force, bumpOverride, only };
 }
 
 /**
@@ -94,8 +104,12 @@ export function parseArgs(argv: string[]): {
  * @param config - A monorepo or single-package release configuration.
  */
 export function runReleasePrepare(config: MonorepoReleaseConfig | ReleaseConfig): void {
-  const { dryRun, bumpOverride, only } = parseArgs(process.argv.slice(2));
-  const options = { dryRun, ...(bumpOverride === undefined ? {} : { bumpOverride }) };
+  const { dryRun, force, bumpOverride, only } = parseArgs(process.argv.slice(2));
+  const options = {
+    dryRun,
+    ...(force ? { force } : {}),
+    ...(bumpOverride === undefined ? {} : { bumpOverride }),
+  };
 
   if (!isMonorepoConfig(config)) {
     if (only !== undefined) {


### PR DESCRIPTION
Closes #22 

## What

Add a `--force` flag to `release-kit prepare` that bypasses the "no commits since last tag" check in monorepo mode, allowing version bumping and changelog generation to proceed even when no new commits are found since the last release tag. The flag requires `--bump` since there are no commits to infer bump type from. The local release workflow gains a `force` boolean input for future use.

## Why

When migrating packages from GitHub Package Registry to the NPM registry, existing release tags prevent `release-kit prepare` from creating new releases. The CLI skips components when it finds 0 commits since the last tag, even with `--bump=patch`, making it impossible to publish packages under updated versions without a code change.

## Details

### Features

- `--force` flag in `parseArgs` with validation that it requires `--bump`
- `force?: boolean` on `ReleasePrepareOptions`, threaded through both `prepareCommand` and `runReleasePrepare`
- Monorepo guard changed from `commits.length === 0` to `commits.length === 0 && !force`
- Help text documents `--force` as monorepo-only
- `workflow_dispatch` gains a `force` boolean input (not yet wired to the reusable workflow; TODO comment documents the dependency)

### Tests

- `--force --bump=patch` parsing returns `{ force: true, bumpOverride: 'patch' }`
- `--force` without `--bump` exits with error mentioning `--bump`
- Force bypass with zero commits bumps version and generates changelog
- Mixed-component scenario: one force-bumped (0 commits), one commit-bumped
- `force: true` + `dryRun: true` does not write files or run git-cliff
- `prepareCommand` passes `force` through to prepare functions

### CI

- `release.yaml` declares `force` input on `workflow_dispatch` with a TODO for wiring to the reusable workflow after `williamthorsen/.github` is updated