### PR TITLE
Move reusable release workflow into this repo

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,18 @@
+# Workflows
+
+## Naming convention
+
+- **Caller workflows:** `{name}.yaml` — repo-specific workflows that trigger on events (e.g., `workflow_dispatch`) and delegate to a reusable workflow.
+- **Reusable workflows:** `{name}-workflow.yaml` — shared workflows invoked via `workflow_call`. These can be consumed by this repo (via relative path) or by other repos (via full reference).
+
+## Versioning
+
+Each reusable workflow is versioned independently using a workflow-prefixed tag: `{name}-workflow-v{major}`.
+
+For example, `release-workflow.yaml` is tagged as `release-workflow-v1`. A breaking change would produce `release-workflow-v2`.
+
+This repo references its own reusable workflows via relative path (`./.github/workflows/release-workflow.yaml`), so it is not affected by tag changes. External consumers reference by tag:
+
+```yaml
+uses: williamthorsen/node-monorepo-tools/.github/workflows/release-workflow.yaml@release-workflow-v1
+```

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -1,0 +1,113 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Release
+
+# Reusable release workflow for projects using @williamthorsen/release-kit.
+#
+# Runs `npx @williamthorsen/release-kit prepare` to bump versions and generate
+# changelogs. The CLI writes computed tag names to `/tmp/release-kit/.release-tags`.
+# This workflow reads that file instead of deriving tags independently,
+# so `tagPrefix` in the release config is the single source of truth.
+#
+# pnpm install is intentionally omitted: release-kit runs git-cliff and prettier
+# via `npx`, so no local dependencies are needed.
+#
+# Usage:
+#   jobs:
+#     release:
+#       uses: williamthorsen/node-monorepo-tools/.github/workflows/release-workflow.yaml@release-workflow-v1
+#       with:
+#         node-version: '24'
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        type: string
+        default: '24'
+      prepare-command:
+        description: 'Command to run for release preparation (override for repos that need custom logic)'
+        type: string
+        default: 'npx @williamthorsen/release-kit prepare'
+      only:
+        description: 'Components to release (comma-separated, monorepo only)'
+        type: string
+        default: ''
+      bump:
+        description: 'Override version bump type'
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+  packages: read
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Run release preparation
+        run: |
+          ARGS=""
+          if [ -n "${{ inputs.only }}" ]; then
+            ARGS="$ARGS --only=${{ inputs.only }}"
+          fi
+          if [ -n "${{ inputs.bump }}" ]; then
+            ARGS="$ARGS --bump=${{ inputs.bump }}"
+          fi
+          ${{ inputs.prepare-command }} $ARGS
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No release-worthy changes found."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine tags
+        if: steps.check.outputs.changed == 'true'
+        id: tags
+        run: |
+          TAGS_FILE="/tmp/release-kit/.release-tags"
+          if [ ! -f "$TAGS_FILE" ]; then
+            echo "Error: $TAGS_FILE not found" >&2
+            exit 1
+          fi
+          TAGS=$(tr '\n' ' ' < "$TAGS_FILE" | xargs)
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+          echo "Releasing: $TAGS"
+
+      - name: Commit, tag, and push
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          TAGS="${{ steps.tags.outputs.tags }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "release: ${TAGS}"
+
+          for TAG in $TAGS; do
+            git tag "$TAG"
+          done
+
+          git push origin main $TAGS

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   release:
-    uses: williamthorsen/.github/.github/workflows/release-pnpm.yaml@v3
+    uses: ./.github/workflows/release-workflow.yaml
     with:
       only: ${{ inputs.only }}
       bump: ${{ inputs.bump }}

--- a/packages/release-kit/src/init/__tests__/templates.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/templates.unit.test.ts
@@ -39,7 +39,7 @@ describe(releaseWorkflow, () => {
   it('generates a monorepo workflow with only input but no monorepo flag', () => {
     const workflow = releaseWorkflow('monorepo');
 
-    expect(workflow).toContain('release-pnpm.yaml@v3');
+    expect(workflow).toContain('release-workflow.yaml@release-workflow-v1');
     expect(workflow).not.toContain('monorepo:');
     expect(workflow).toContain('only:');
     expect(workflow).toContain('inputs.only');
@@ -48,7 +48,7 @@ describe(releaseWorkflow, () => {
   it('generates a single-package workflow without only input', () => {
     const workflow = releaseWorkflow('single-package');
 
-    expect(workflow).toContain('release-pnpm.yaml@v3');
+    expect(workflow).toContain('release-workflow.yaml@release-workflow-v1');
     expect(workflow).not.toContain('monorepo:');
     expect(workflow).not.toContain('inputs.only');
   });

--- a/packages/release-kit/src/init/templates.ts
+++ b/packages/release-kit/src/init/templates.ts
@@ -14,12 +14,15 @@ const config: ReleaseKitConfig = {
   // components: [
   //   { dir: 'my-package', shouldExclude: true },
   // ],
-  // Uncomment to override the default version patterns:
-  // versionPatterns: { major: ['!'], minor: ['feat', 'feature'] },
-  // Uncomment to add custom work types (merged with defaults):
-  // workTypes: { perf: { header: 'Performance' } },
+
   // TODO: Uncomment and adjust if you have a format command
   // formatCommand: 'npx prettier --write',
+
+  // Uncomment to override the default version patterns:
+  // versionPatterns: { major: ['!'], minor: ['feat', 'feature'] },
+
+  // Uncomment to add custom work types (merged with defaults):
+  // workTypes: { perf: { header: 'Performance' } },
 };
 
 export default config;
@@ -29,12 +32,14 @@ export default config;
   return `import type { ReleaseKitConfig } from '@williamthorsen/release-kit';
 
 const config: ReleaseKitConfig = {
-  // Uncomment to override the default version patterns:
-  // versionPatterns: { major: ['!'], minor: ['feat', 'feature'] },
-  // Uncomment to add custom work types (merged with defaults):
-  // workTypes: { perf: { header: 'Performance' } },
   // TODO: Uncomment and adjust if you have a format command
   // formatCommand: 'npx prettier --write',
+
+  // Uncomment to override the default version patterns:
+  // versionPatterns: { major: ['!'], minor: ['feat', 'feature'] },
+
+  // Uncomment to add custom work types (merged with defaults):
+  // workTypes: { perf: { header: 'Performance' } },
 };
 
 export default config;
@@ -70,7 +75,7 @@ permissions:
 
 jobs:
   release:
-    uses: williamthorsen/.github/.github/workflows/release-pnpm.yaml@v3
+    uses: williamthorsen/node-monorepo-tools/.github/workflows/release-workflow.yaml@release-workflow-v1
     with:
       only: \${{ inputs.only }}
       bump: \${{ inputs.bump }}
@@ -99,7 +104,7 @@ permissions:
 
 jobs:
   release:
-    uses: williamthorsen/.github/.github/workflows/release-pnpm.yaml@v3
+    uses: williamthorsen/node-monorepo-tools/.github/workflows/release-workflow.yaml@release-workflow-v1
     with:
       bump: \${{ inputs.bump }}
 `;


### PR DESCRIPTION
Closes #20

## What

Moves the reusable release workflow from `williamthorsen/.github` into this repo as `release-workflow.yaml`, stripping all pnpm-related steps since release-kit now runs git-cliff and prettier via `npx` internally. Updates this repo's caller workflow to use a relative path and update init templates to reference the new location. Establishes a naming convention (`{name}-workflow.yaml` for reusable, `{name}.yaml` for callers) and independent versioning strategy (`{name}-workflow-v{major}` tags), documented in `.github/workflows/README.md`.

## Why

The reusable release workflow was tightly coupled to `release-kit` but lived in a separate repo (`williamthorsen/.github`), splitting coupled concerns across linked release cycles. Co-locating the workflow with its dependency eliminates this coupling. The pnpm steps were made unnecessary by #7, which made release-kit self-contained via `npx`.

## Details

### Features

- Created `.github/workflows/release-workflow.yaml` as a reusable `workflow_call` workflow with `node-version`, `prepare-command`, `only`, and `bump` inputs — no pnpm setup or dependency installation
- Established `{name}-workflow.yaml` naming convention and `{name}-workflow-v{major}` tag-based versioning for independent workflow evolution
- Created `.github/workflows/README.md` documenting the naming and versioning conventions
- Updated init templates to generate workflow references pointing to `williamthorsen/node-monorepo-tools/.github/workflows/release-workflow.yaml@release-workflow-v1`
- Sorted config template keys alphabetically with blank line separators
- Created cross-repo tickets for downstream migration: williamthorsen/.github#6, williamthorsen/codeassembly#308, williamthorsen/templates.node-monorepo#11

### Refactoring

- Changed `release.yaml` from external reference (`williamthorsen/.github/...@v3`) to local relative path (`./.github/workflows/release-workflow.yaml`)

## Test plan

- [ ] Validate workflow YAML syntax
- [ ] After merge, tag as `release-workflow-v1` and trigger a test release via `workflow_dispatch`