### PR TITLE
#30 Allow git-cliff to be used without config

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -5,7 +5,7 @@ name: Release
 #
 # Installs `@williamthorsen/release-kit` globally and runs `release-kit prepare`
 # to bump versions and generate changelogs. The CLI writes computed tag names to
-# `/tmp/release-kit/.release-tags`. This workflow reads that file instead of
+# `tmp/.release-tags` (relative to the project root). This workflow reads that file instead of
 # deriving tags independently, so `tagPrefix` in the release config is the
 # single source of truth.
 #
@@ -100,7 +100,7 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         id: tags
         run: |
-          TAGS_FILE="/tmp/release-kit/.release-tags"
+          TAGS_FILE="tmp/.release-tags"
           if [ ! -f "$TAGS_FILE" ]; then
             echo "Error: $TAGS_FILE not found" >&2
             exit 1

--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -28,7 +28,7 @@ That's it for most repos. The CLI auto-discovers workspaces and applies sensible
 2. **Config loading**: loads `.config/release-kit.config.ts` (if present) via [jiti](https://github.com/unjs/jiti) and merges it with discovered defaults.
 3. **Commit analysis**: for each component, finds commits since the last version tag, parses them for type and scope, and determines the appropriate version bump.
 4. **Version bump + changelog**: bumps `package.json` versions and generates changelogs via `git-cliff`.
-5. **Release tags file**: writes computed tags to `/tmp/release-kit/.release-tags` for CI consumption.
+5. **Release tags file**: writes computed tags to `tmp/.release-tags` for the release workflow to read when tagging and pushing.
 
 ## CLI reference
 
@@ -258,7 +258,7 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         id: tags
         run: |
-          TAGS=$(cat /tmp/release-kit/.release-tags | tr '\n' ' ')
+          TAGS=$(cat tmp/.release-tags | tr '\n' ' ')
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
           echo "Releasing: $TAGS"
 
@@ -296,7 +296,7 @@ And the tag step with:
   if: steps.check.outputs.changed == 'true'
   id: tags
   run: |
-    TAG=$(cat /tmp/release-kit/.release-tags)
+    TAG=$(cat tmp/.release-tags)
     echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 ```
 

--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -13,17 +13,14 @@ pnpm add -D @williamthorsen/release-kit
 ## Quick start
 
 ```bash
-# 1. Set up release-kit in your repo (scaffolds workflow + optional config)
+# 1. Set up release-kit in your repo (scaffolds the release workflow)
 npx @williamthorsen/release-kit init
 
 # 2. Preview what a release would do
 npx @williamthorsen/release-kit prepare --dry-run
-
-# 3. Copy cliff.toml.template to your repo root (if init didn't create one)
-cp node_modules/@williamthorsen/release-kit/cliff.toml.template cliff.toml
 ```
 
-That's it for most repos. The CLI auto-discovers workspaces and applies sensible defaults. Customize only what you need via `.config/release-kit.config.ts`.
+That's it for most repos. The CLI auto-discovers workspaces and applies sensible defaults. The bundled `cliff.toml.template` is used automatically — no need to copy it. Customize only what you need via `.config/release-kit.config.ts`.
 
 ## How it works
 
@@ -59,21 +56,23 @@ node packages/release-kit/dist/esm/bin/release-kit.js prepare --dry-run
 
 ### `release-kit init`
 
-Initialize release-kit in the current repository. Scaffolds a GitHub Actions workflow and an optional config file.
+Initialize release-kit in the current repository. By default, scaffolds only the GitHub Actions workflow file. Use `--with-config` to also scaffold configuration files.
 
 ```
 Usage: release-kit init [options]
 
 Options:
-  --dry-run     Preview changes without writing files
-  --help, -h    Show help
+  --with-config    Also scaffold .config/release-kit.config.ts and .config/git-cliff.toml
+  --force          Overwrite existing files instead of skipping them
+  --dry-run        Preview changes without writing files
+  --help, -h       Show help
 ```
 
 Scaffolded files:
 
-- `.config/release-kit.config.ts` — starter config with commented-out customization examples
 - `.github/workflows/release.yaml` — workflow that delegates to a reusable release workflow
-- `cliff.toml` — copied from the bundled template (prompted if missing)
+- `.config/release-kit.config.ts` — starter config with commented-out customization examples (with `--with-config`)
+- `.config/git-cliff.toml` — copied from the bundled template (with `--with-config`)
 
 ## Configuration
 
@@ -105,14 +104,14 @@ The config file supports both `export default config` and `export const config =
 
 ### `ReleaseKitConfig` reference
 
-| Field              | Type                             | Description                                                                                    |
-| ------------------ | -------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `cliffConfigPath`  | `string`                         | Path to `cliff.toml` (defaults to `'cliff.toml'`)                                              |
-| `components`       | `ComponentOverride[]`            | Override or exclude discovered components (matched by `dir`)                                   |
-| `formatCommand`    | `string`                         | Shell command to run after changelog generation; modified file paths are appended as arguments |
-| `versionPatterns`  | `VersionPatterns`                | Rules for which commit types trigger major/minor bumps                                         |
-| `workspaceAliases` | `Record<string, string>`         | Maps shorthand workspace names to canonical names in commits                                   |
-| `workTypes`        | `Record<string, WorkTypeConfig>` | Work type definitions, merged with defaults by key                                             |
+| Field              | Type                             | Description                                                                                                                   |
+| ------------------ | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `cliffConfigPath`  | `string`                         | Explicit path to cliff config. If omitted, resolved automatically: `.config/git-cliff.toml` → `cliff.toml` → bundled template |
+| `components`       | `ComponentOverride[]`            | Override or exclude discovered components (matched by `dir`)                                                                  |
+| `formatCommand`    | `string`                         | Shell command to run after changelog generation; modified file paths are appended as arguments                                |
+| `versionPatterns`  | `VersionPatterns`                | Rules for which commit types trigger major/minor bumps                                                                        |
+| `workspaceAliases` | `Record<string, string>`         | Maps shorthand workspace names to canonical names in commits                                                                  |
+| `workTypes`        | `Record<string, WorkTypeConfig>` | Work type definitions, merged with defaults by key                                                                            |
 
 All fields are optional.
 
@@ -316,19 +315,20 @@ Or use the GitHub UI: Actions > Release > Run workflow.
 
 ## cliff.toml setup
 
-The package includes a `cliff.toml.template` with a generic git-cliff configuration that:
+The package includes a bundled `cliff.toml.template` that is used automatically when no custom config is found. The resolution order is:
+
+1. Explicit `cliffConfigPath` in `.config/release-kit.config.ts`
+2. `.config/git-cliff.toml`
+3. `cliff.toml` (repo root)
+4. Bundled `cliff.toml.template` (automatic fallback)
+
+The bundled template provides a generic git-cliff configuration that:
 
 - Strips issue-ticket prefixes matching `^[A-Z]+-\d+\s+` (e.g., `TOOL-123 `, `AFG-456 `)
 - Handles both `type: description` and `workspace|type: description` commit formats
 - Groups commits by work type into changelog sections
 
-Copy it to your repo root:
-
-```bash
-cp node_modules/@williamthorsen/release-kit/cliff.toml.template cliff.toml
-```
-
-Then customize as needed for your project.
+To customize, scaffold a local copy with `release-kit init --with-config` and edit `.config/git-cliff.toml`.
 
 ## External dependencies
 
@@ -386,5 +386,6 @@ If your format command does not accept file arguments, update it to one that doe
 3. Delete the `.changeset/` directory.
 4. Run `npx @williamthorsen/release-kit init` to scaffold workflow and config files.
 5. Remove `changeset:*` scripts from `package.json` (no replacement needed — the CLI handles everything).
-6. Copy `cliff.toml.template` to your repo root as `cliff.toml` (if `init` didn't create one).
-7. Create an initial version tag for each package (e.g., `git tag v1.0.0` or `git tag arrays-v1.0.0`).
+6. Create an initial version tag for each package (e.g., `git tag v1.0.0` or `git tag arrays-v1.0.0`).
+
+No cliff config copy is needed — the bundled template is used automatically. To customize, run `release-kit init --with-config`.

--- a/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockExecFileSync = vi.hoisted(() => vi.fn());
+const mockResolveCliffConfigPath = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,
+}));
+
+vi.mock('../resolveCliffConfigPath.ts', () => ({
+  resolveCliffConfigPath: mockResolveCliffConfigPath,
 }));
 
 import { generateChangelog, generateChangelogs } from '../generateChangelogs.ts';
@@ -12,9 +17,11 @@ import type { ReleaseConfig } from '../types.ts';
 describe(generateChangelog, () => {
   afterEach(() => {
     mockExecFileSync.mockReset();
+    mockResolveCliffConfigPath.mockReset();
   });
 
   it('calls git-cliff with base args when no includePaths are provided', () => {
+    mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
     const config = { cliffConfigPath: 'cliff.toml' };
 
     generateChangelog(config, 'packages/arrays', 'v1.0.0', false);
@@ -27,6 +34,7 @@ describe(generateChangelog, () => {
   });
 
   it('appends --include-path flags when includePaths are provided', () => {
+    mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
     const config = { cliffConfigPath: 'cliff.toml' };
 
     generateChangelog(config, 'packages/arrays', 'arrays-v1.0.0', false, {
@@ -52,6 +60,7 @@ describe(generateChangelog, () => {
   });
 
   it('appends multiple --include-path flags for multiple paths', () => {
+    mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
     const config = { cliffConfigPath: 'cliff.toml' };
 
     generateChangelog(config, '.', 'v2.0.0', false, {
@@ -79,6 +88,7 @@ describe(generateChangelog, () => {
   });
 
   it('does not append --include-path flags when includePaths is an empty array', () => {
+    mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
     const config = { cliffConfigPath: 'cliff.toml' };
 
     generateChangelog(config, 'packages/arrays', 'v1.0.0', false, { includePaths: [] });
@@ -91,6 +101,7 @@ describe(generateChangelog, () => {
   });
 
   it('does not call execFileSync when dryRun is true', () => {
+    mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const config = { cliffConfigPath: 'cliff.toml' };
 
@@ -101,14 +112,25 @@ describe(generateChangelog, () => {
     infoSpy.mockRestore();
   });
 
-  it('defaults cliffConfigPath to cliff.toml when absent', () => {
+  it('uses the path returned by resolveCliffConfigPath when cliffConfigPath is absent', () => {
+    mockResolveCliffConfigPath.mockReturnValue('/bundled/cliff.toml.template');
     const config = {};
 
     generateChangelog(config, 'packages/arrays', 'v1.0.0', false);
 
+    expect(mockResolveCliffConfigPath).toHaveBeenCalledWith(undefined, expect.any(String));
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'npx',
-      ['--yes', 'git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      [
+        '--yes',
+        'git-cliff',
+        '--config',
+        '/bundled/cliff.toml.template',
+        '--output',
+        'packages/arrays/CHANGELOG.md',
+        '--tag',
+        'v1.0.0',
+      ],
       { stdio: 'inherit' },
     );
   });
@@ -117,9 +139,11 @@ describe(generateChangelog, () => {
 describe(generateChangelogs, () => {
   afterEach(() => {
     mockExecFileSync.mockReset();
+    mockResolveCliffConfigPath.mockReset();
   });
 
   it('calls git-cliff for each configured changelog path', () => {
+    mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
     const config = {
       tagPrefix: 'v',
       packageFiles: [],

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -15,6 +15,10 @@ vi.mock('node:fs', () => ({
   writeFileSync: mockWriteFileSync,
 }));
 
+vi.mock('../resolveCliffConfigPath.ts', () => ({
+  resolveCliffConfigPath: () => 'cliff.toml',
+}));
+
 import { releasePrepare } from '../releasePrepare.ts';
 import type { ReleaseConfig, WorkTypeConfig } from '../types.ts';
 

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -15,6 +15,10 @@ vi.mock('node:fs', () => ({
   writeFileSync: mockWriteFileSync,
 }));
 
+vi.mock('../resolveCliffConfigPath.ts', () => ({
+  resolveCliffConfigPath: () => 'cliff.toml',
+}));
+
 import { releasePrepareMono } from '../releasePrepareMono.ts';
 import type { MonorepoReleaseConfig, WorkTypeConfig } from '../types.ts';
 

--- a/packages/release-kit/src/__tests__/resolveCliffConfigPath.int.test.ts
+++ b/packages/release-kit/src/__tests__/resolveCliffConfigPath.int.test.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const distResolverPath = join(thisDir, '..', '..', 'dist', 'esm', 'resolveCliffConfigPath.js');
+
+interface ResolverModule {
+  resolveCliffConfigPath: (cliffConfigPath: string | undefined, metaUrl: string) => string;
+}
+
+/** Check whether a dynamic import result exports `resolveCliffConfigPath` as a function. */
+function isResolverModule(value: unknown): value is ResolverModule {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'resolveCliffConfigPath' in value &&
+    typeof value.resolveCliffConfigPath === 'function'
+  );
+}
+
+describe('resolveCliffConfigPath (integration)', () => {
+  it('resolves the bundled cliff.toml.template from the built output', async () => {
+    if (!existsSync(distResolverPath)) {
+      throw new Error(
+        `Built output not found at ${distResolverPath}. Run \`pnpm run ws build\` before running integration tests.`,
+      );
+    }
+
+    // Import from the compiled JS so that import.meta.url resolution uses dist/esm/ paths.
+    const mod: unknown = await import(distResolverPath);
+    if (!isResolverModule(mod)) {
+      throw new Error('Module does not export `resolveCliffConfigPath` as a function');
+    }
+
+    // Pass the compiled module's URL so the bundled template resolves from dist/esm/resolveCliffConfigPath.js.
+    const moduleUrl = new URL(`file://${distResolverPath}`).href;
+    const result = mod.resolveCliffConfigPath(undefined, moduleUrl);
+
+    expect(result).toContain('cliff.toml.template');
+    expect(existsSync(result)).toBe(true);
+  });
+});

--- a/packages/release-kit/src/__tests__/resolveCliffConfigPath.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveCliffConfigPath.unit.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockFileURLToPath = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), () => ({
+  existsSync: mockExistsSync,
+}));
+
+vi.mock(import('node:url'), () => ({
+  fileURLToPath: mockFileURLToPath,
+}));
+
+import { resolveCliffConfigPath } from '../resolveCliffConfigPath.ts';
+
+describe(resolveCliffConfigPath, () => {
+  afterEach(() => {
+    mockExistsSync.mockReset();
+    mockFileURLToPath.mockReset();
+  });
+
+  it('returns the explicit path when cliffConfigPath is provided', () => {
+    const result = resolveCliffConfigPath('custom/cliff.toml', 'file:///fake/src/resolveCliffConfigPath.ts');
+
+    expect(result).toBe('custom/cliff.toml');
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+
+  it('returns .config/git-cliff.toml when it exists', () => {
+    mockExistsSync.mockImplementation((path: string) => path === '.config/git-cliff.toml');
+
+    const result = resolveCliffConfigPath(undefined, 'file:///fake/src/resolveCliffConfigPath.ts');
+
+    expect(result).toBe('.config/git-cliff.toml');
+  });
+
+  it('returns cliff.toml when .config/git-cliff.toml does not exist', () => {
+    mockExistsSync.mockImplementation((path: string) => path === 'cliff.toml');
+
+    const result = resolveCliffConfigPath(undefined, 'file:///fake/src/resolveCliffConfigPath.ts');
+
+    expect(result).toBe('cliff.toml');
+  });
+
+  it('returns the bundled template path when no local config exists', () => {
+    mockFileURLToPath.mockReturnValue('/fake/dist/esm/resolveCliffConfigPath.js');
+    // Convention candidates don't exist; bundled template does.
+    mockExistsSync.mockImplementation((path: string) => path.endsWith('cliff.toml.template'));
+
+    const result = resolveCliffConfigPath(undefined, 'file:///fake/dist/esm/resolveCliffConfigPath.js');
+
+    expect(result).toContain('cliff.toml.template');
+  });
+
+  it('throws when no config file can be found', () => {
+    mockFileURLToPath.mockReturnValue('/fake/dist/esm/resolveCliffConfigPath.js');
+    mockExistsSync.mockReturnValue(false);
+
+    expect(() => resolveCliffConfigPath(undefined, 'file:///fake/dist/esm/resolveCliffConfigPath.js')).toThrow(
+      'Could not resolve a git-cliff config file',
+    );
+  });
+
+  it('prefers .config/git-cliff.toml over cliff.toml when both exist', () => {
+    mockExistsSync.mockReturnValue(true);
+
+    const result = resolveCliffConfigPath(undefined, 'file:///fake/src/resolveCliffConfigPath.ts');
+
+    expect(result).toBe('.config/git-cliff.toml');
+  });
+});

--- a/packages/release-kit/src/__tests__/resolveCliffConfigPath.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveCliffConfigPath.unit.test.ts
@@ -49,7 +49,7 @@ describe(resolveCliffConfigPath, () => {
 
     const result = resolveCliffConfigPath(undefined, 'file:///fake/dist/esm/resolveCliffConfigPath.js');
 
-    expect(result).toContain('cliff.toml.template');
+    expect(result).toBe('/fake/cliff.toml.template');
   });
 
   it('throws when no config file can be found', () => {

--- a/packages/release-kit/src/__tests__/runReleasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/runReleasePrepare.unit.test.ts
@@ -240,8 +240,8 @@ describe(runReleasePrepare, () => {
   });
 
   describe('release-tags file', () => {
-    it('writes to /tmp, not the project root', () => {
-      expect(RELEASE_TAGS_FILE).toMatch(/^\/tmp\//);
+    it('writes to tmp/ relative to the project root', () => {
+      expect(RELEASE_TAGS_FILE).toBe('tmp/.release-tags');
     });
 
     it('creates the parent directory before writing', () => {
@@ -250,7 +250,7 @@ describe(runReleasePrepare, () => {
 
       runReleasePrepare(makeConfig());
 
-      expect(mockMkdirSync).toHaveBeenCalledWith('/tmp/release-kit', { recursive: true });
+      expect(mockMkdirSync).toHaveBeenCalledWith('tmp', { recursive: true });
 
       // Verify mkdir was called before writeFileSync
       const mkdirOrder = mockMkdirSync.mock.invocationCallOrder[0];

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -24,11 +24,13 @@ function showInitHelp(): void {
 Usage: release-kit init [options]
 
 Initialize release-kit in the current repository.
-Scaffolds workflow and config files.
+By default, scaffolds only the GitHub Actions workflow file.
 
 Options:
-  --dry-run     Preview changes without writing files
-  --help, -h    Show this help message
+  --with-config   Also scaffold .config/release-kit.config.ts and .config/git-cliff.toml
+  --force         Overwrite existing files instead of skipping them
+  --dry-run       Preview changes without writing files
+  --help, -h      Show this help message
 `);
 }
 
@@ -71,14 +73,17 @@ if (command === 'init') {
     process.exit(0);
   }
 
-  const unknownFlags = flags.filter((f) => f !== '--dry-run' && f !== '--help' && f !== '-h');
+  const knownInitFlags = new Set(['--dry-run', '--force', '--with-config', '--help', '-h']);
+  const unknownFlags = flags.filter((f) => !knownInitFlags.has(f));
   if (unknownFlags.length > 0) {
     console.error(`Error: Unknown option: ${unknownFlags[0]}`);
     process.exit(1);
   }
 
   const dryRun = flags.includes('--dry-run');
-  const exitCode = await initCommand({ dryRun });
+  const force = flags.includes('--force');
+  const withConfig = flags.includes('--with-config');
+  const exitCode = initCommand({ dryRun, force, withConfig });
   process.exit(exitCode);
 }
 

--- a/packages/release-kit/src/generateChangelogs.ts
+++ b/packages/release-kit/src/generateChangelogs.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 
+import { resolveCliffConfigPath } from './resolveCliffConfigPath.ts';
 import type { ReleaseConfig } from './types.ts';
 
 /** Options for single-changelog generation. */
@@ -17,7 +18,7 @@ export interface GenerateChangelogOptions {
  * The `npx` command downloads `git-cliff` on first invocation and caches it for
  * subsequent calls.
  *
- * @param config - Object containing the optional `cliffConfigPath` (defaults to 'cliff.toml').
+ * @param config - Object containing the optional `cliffConfigPath`.
  * @param changelogPath - Directory in which to write the CHANGELOG.md file.
  * @param tag - The git tag to generate the changelog up to (e.g., 'v1.2.3').
  * @param dryRun - If true, logs the command without executing it.
@@ -30,7 +31,7 @@ export function generateChangelog(
   dryRun: boolean,
   options?: GenerateChangelogOptions,
 ): void {
-  const cliffConfigPath = config.cliffConfigPath ?? 'cliff.toml';
+  const cliffConfigPath = resolveCliffConfigPath(config.cliffConfigPath, import.meta.url);
   const outputFile = `${changelogPath}/CHANGELOG.md`;
   const args = ['--config', cliffConfigPath, '--output', outputFile, '--tag', tag];
 

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -28,4 +28,5 @@ export { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 export { parseCommitMessage } from './parseCommitMessage.ts';
 export { releasePrepare } from './releasePrepare.ts';
 export { releasePrepareMono } from './releasePrepareMono.ts';
+export { resolveCliffConfigPath } from './resolveCliffConfigPath.ts';
 export { RELEASE_TAGS_FILE, runReleasePrepare, writeReleaseTags } from './runReleasePrepare.ts';

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -28,5 +28,4 @@ export { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 export { parseCommitMessage } from './parseCommitMessage.ts';
 export { releasePrepare } from './releasePrepare.ts';
 export { releasePrepareMono } from './releasePrepareMono.ts';
-export { resolveCliffConfigPath } from './resolveCliffConfigPath.ts';
 export { RELEASE_TAGS_FILE, runReleasePrepare, writeReleaseTags } from './runReleasePrepare.ts';

--- a/packages/release-kit/src/init/__tests__/checks.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/checks.unit.test.ts
@@ -13,7 +13,7 @@ vi.mock(import('node:fs'), () => ({
   readFileSync: mockReadFileSync,
 }));
 
-import { hasCliffToml, hasPackageJson, isGitRepo, notAlreadyInitialized, usesPnpm } from '../checks.ts';
+import { hasPackageJson, isGitRepo, usesPnpm } from '../checks.ts';
 
 describe('checks', () => {
   afterEach(() => {
@@ -95,38 +95,6 @@ describe('checks', () => {
 
       expect(() => usesPnpm()).toThrow('EACCES: permission denied');
       expect(mockReadFileSync).toHaveBeenCalledWith('package.json', 'utf8');
-    });
-  });
-
-  describe(hasCliffToml, () => {
-    it('returns ok when cliff.toml exists', () => {
-      mockExistsSync.mockReturnValue(true);
-
-      expect(hasCliffToml()).toStrictEqual({ ok: true });
-    });
-
-    it('returns not ok when cliff.toml is missing', () => {
-      mockExistsSync.mockReturnValue(false);
-
-      const result = hasCliffToml();
-      expect(result.ok).toBe(false);
-      expect(result.message).toContain('cliff.toml');
-    });
-  });
-
-  describe(notAlreadyInitialized, () => {
-    it('returns ok when release.config.ts does not exist', () => {
-      mockExistsSync.mockReturnValue(false);
-
-      expect(notAlreadyInitialized()).toStrictEqual({ ok: true });
-    });
-
-    it('returns not ok when release.config.ts exists', () => {
-      mockExistsSync.mockReturnValue(true);
-
-      const result = notAlreadyInitialized();
-      expect(result.ok).toBe(false);
-      expect(result.message).toContain('already initialized');
     });
   });
 });

--- a/packages/release-kit/src/init/__tests__/initCommand.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/initCommand.unit.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockIsGitRepo = vi.hoisted(() => vi.fn());
+const mockHasPackageJson = vi.hoisted(() => vi.fn());
+const mockUsesPnpm = vi.hoisted(() => vi.fn());
+const mockDetectRepoType = vi.hoisted(() => vi.fn());
+const mockScaffoldFiles = vi.hoisted(() => vi.fn());
+const mockPrintError = vi.hoisted(() => vi.fn());
+const mockPrintStep = vi.hoisted(() => vi.fn());
+const mockPrintSuccess = vi.hoisted(() => vi.fn());
+vi.mock(import('../checks.ts'), () => ({
+  isGitRepo: mockIsGitRepo,
+  hasPackageJson: mockHasPackageJson,
+  usesPnpm: mockUsesPnpm,
+}));
+
+vi.mock(import('../detectRepoType.ts'), () => ({
+  detectRepoType: mockDetectRepoType,
+}));
+
+vi.mock(import('../scaffold.ts'), () => ({
+  scaffoldFiles: mockScaffoldFiles,
+}));
+
+vi.mock(import('../prompt.ts'), () => ({
+  printError: mockPrintError,
+  printStep: mockPrintStep,
+  printSuccess: mockPrintSuccess,
+}));
+
+import { initCommand } from '../initCommand.ts';
+
+/** Configure all eligibility checks to pass and repo type to single-package. */
+function setupPassingChecks(): void {
+  mockIsGitRepo.mockReturnValue({ ok: true });
+  mockHasPackageJson.mockReturnValue({ ok: true });
+  mockUsesPnpm.mockReturnValue({ ok: true });
+  mockDetectRepoType.mockReturnValue('single-package');
+}
+
+describe(initCommand, () => {
+  afterEach(() => {
+    mockIsGitRepo.mockReset();
+    mockHasPackageJson.mockReset();
+    mockUsesPnpm.mockReset();
+    mockDetectRepoType.mockReset();
+    mockScaffoldFiles.mockReset();
+    mockPrintError.mockReset();
+    mockPrintStep.mockReset();
+    mockPrintSuccess.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('returns 0 on success', () => {
+    setupPassingChecks();
+
+    const exitCode = initCommand({ dryRun: false, force: false, withConfig: false });
+
+    expect(exitCode).toBe(0);
+    expect(mockScaffoldFiles).toHaveBeenCalledOnce();
+  });
+
+  it('returns 1 when eligibility check fails', () => {
+    mockIsGitRepo.mockReturnValue({ ok: false, message: 'Not a git repo' });
+
+    const exitCode = initCommand({ dryRun: false, force: false, withConfig: false });
+
+    expect(exitCode).toBe(1);
+    expect(mockScaffoldFiles).not.toHaveBeenCalled();
+  });
+
+  it('returns 1 when an eligibility check throws', () => {
+    mockIsGitRepo.mockImplementation(() => {
+      throw new Error('unexpected filesystem error');
+    });
+
+    const exitCode = initCommand({ dryRun: false, force: false, withConfig: false });
+
+    expect(exitCode).toBe(1);
+    expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('unexpected filesystem error'));
+    expect(mockScaffoldFiles).not.toHaveBeenCalled();
+  });
+
+  it('returns 1 when detectRepoType throws', () => {
+    setupPassingChecks();
+    mockDetectRepoType.mockImplementation(() => {
+      throw new Error('Cannot read package.json');
+    });
+
+    const exitCode = initCommand({ dryRun: false, force: false, withConfig: false });
+
+    expect(exitCode).toBe(1);
+    expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('Cannot read package.json'));
+    expect(mockScaffoldFiles).not.toHaveBeenCalled();
+  });
+
+  it('returns 1 when scaffoldFiles throws', () => {
+    setupPassingChecks();
+    mockScaffoldFiles.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    const exitCode = initCommand({ dryRun: false, force: false, withConfig: false });
+
+    expect(exitCode).toBe(1);
+    expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('EACCES: permission denied'));
+  });
+
+  it('passes force as overwrite to scaffoldFiles', () => {
+    setupPassingChecks();
+
+    initCommand({ dryRun: false, force: true, withConfig: false });
+
+    expect(mockScaffoldFiles).toHaveBeenCalledWith(expect.objectContaining({ overwrite: true }));
+  });
+
+  it('passes withConfig to scaffoldFiles', () => {
+    setupPassingChecks();
+
+    initCommand({ dryRun: false, force: false, withConfig: true });
+
+    expect(mockScaffoldFiles).toHaveBeenCalledWith(expect.objectContaining({ withConfig: true }));
+  });
+
+  it('passes dryRun to scaffoldFiles', () => {
+    setupPassingChecks();
+
+    initCommand({ dryRun: true, force: false, withConfig: false });
+
+    expect(mockScaffoldFiles).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
+  });
+
+  it('prints dry-run banner when dryRun is true', () => {
+    setupPassingChecks();
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    initCommand({ dryRun: true, force: false, withConfig: false });
+
+    expect(spy).toHaveBeenCalledWith('[dry-run mode]');
+  });
+
+  it('passes detected repoType to scaffoldFiles', () => {
+    setupPassingChecks();
+    mockDetectRepoType.mockReturnValue('monorepo');
+
+    initCommand({ dryRun: false, force: false, withConfig: false });
+
+    expect(mockScaffoldFiles).toHaveBeenCalledWith(expect.objectContaining({ repoType: 'monorepo' }));
+  });
+});

--- a/packages/release-kit/src/init/__tests__/scaffold.int.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.int.test.ts
@@ -9,7 +9,7 @@ const thisDir = dirname(fileURLToPath(import.meta.url));
 const distScaffoldPath = join(thisDir, '..', '..', '..', 'dist', 'esm', 'init', 'scaffold.js');
 
 interface ScaffoldModule {
-  copyCliffTemplate: (dryRun: boolean) => void;
+  copyCliffTemplate: (dryRun: boolean, overwrite: boolean) => void;
 }
 
 /** Check whether a dynamic import result exports `copyCliffTemplate` as a function. */
@@ -23,7 +23,7 @@ function isScaffoldModule(value: unknown): value is ScaffoldModule {
 }
 
 describe('copyCliffTemplate (integration)', () => {
-  it('resolves cliff.toml.template from the built output and writes cliff.toml', async () => {
+  it('resolves cliff.toml.template from the built output and writes .config/git-cliff.toml', async () => {
     if (!existsSync(distScaffoldPath)) {
       throw new Error(
         `Built output not found at ${distScaffoldPath}. Run \`pnpm run ws build\` before running integration tests.`,
@@ -42,9 +42,9 @@ describe('copyCliffTemplate (integration)', () => {
         throw new Error('Module does not export `copyCliffTemplate` as a function');
       }
 
-      mod.copyCliffTemplate(false);
+      mod.copyCliffTemplate(false, false);
 
-      const cliffTomlPath = join(tempDir, 'cliff.toml');
+      const cliffTomlPath = join(tempDir, '.config', 'git-cliff.toml');
       expect(existsSync(cliffTomlPath)).toBe(true);
 
       const content = readFileSync(cliffTomlPath, 'utf8');

--- a/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
@@ -57,7 +57,16 @@ describe('scaffold', () => {
 
     it('creates workflow and config files when withConfig is true', () => {
       mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
-      mockExistsSync.mockReturnValue(false);
+      // existsSync calls: workflow file (false), config file (false), template path (true), git-cliff.toml (false)
+      mockExistsSync.mockReturnValue(false).mockReturnValueOnce(false).mockReturnValueOnce(false);
+      // After the two writeIfAbsent existsSync calls, copyCliffTemplate calls existsSync for template (true), then for target (false)
+      mockExistsSync.mockReset();
+      mockExistsSync
+        .mockReturnValueOnce(false) // workflow file exists?
+        .mockReturnValueOnce(false) // config file exists?
+        .mockReturnValueOnce(true) // template path exists?
+        .mockReturnValueOnce(false); // .config/git-cliff.toml exists?
+      mockReadFileSync.mockReturnValue('[changelog]\nbody = "template"');
 
       scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false, withConfig: true });
 
@@ -65,6 +74,11 @@ describe('scaffold', () => {
       expect(mockMkdirSync).toHaveBeenCalledWith('.config', { recursive: true });
       expect(mockWriteFileSync).toHaveBeenCalledWith('.github/workflows/release.yaml', expect.any(String), 'utf8');
       expect(mockWriteFileSync).toHaveBeenCalledWith('.config/release-kit.config.ts', expect.any(String), 'utf8');
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        '.config/git-cliff.toml',
+        '[changelog]\nbody = "template"',
+        'utf8',
+      );
     });
 
     it('skips files that already exist when overwrite is false', () => {
@@ -82,6 +96,41 @@ describe('scaffold', () => {
       scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: true, withConfig: false });
 
       expect(mockWriteFileSync).toHaveBeenCalledWith('.github/workflows/release.yaml', expect.any(String), 'utf8');
+      expect(mockPrintSkip).not.toHaveBeenCalled();
+    });
+
+    it('skips cliff template when withConfig is true and overwrite is false and target exists', () => {
+      mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
+      // All files exist
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('template content');
+
+      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false, withConfig: true });
+
+      // Workflow file should be skipped
+      expect(mockPrintSkip).toHaveBeenCalledWith(expect.stringContaining('.github/workflows/release.yaml'));
+      // Config file should be skipped
+      expect(mockPrintSkip).toHaveBeenCalledWith(expect.stringContaining('.config/release-kit.config.ts'));
+      // Cliff template target should be skipped
+      expect(mockPrintSkip).toHaveBeenCalledWith(expect.stringContaining('.config/git-cliff.toml'));
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('overwrites cliff template when withConfig is true and overwrite is true', () => {
+      mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
+      // existsSync: workflow (true), template path (true), git-cliff.toml target (true)
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('[changelog]\nbody = "overwritten"');
+
+      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: true, withConfig: true });
+
+      expect(mockWriteFileSync).toHaveBeenCalledWith('.github/workflows/release.yaml', expect.any(String), 'utf8');
+      expect(mockWriteFileSync).toHaveBeenCalledWith('.config/release-kit.config.ts', expect.any(String), 'utf8');
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        '.config/git-cliff.toml',
+        '[changelog]\nbody = "overwritten"',
+        'utf8',
+      );
       expect(mockPrintSkip).not.toHaveBeenCalled();
     });
 

--- a/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
@@ -41,34 +41,46 @@ describe('scaffold', () => {
   });
 
   describe(scaffoldFiles, () => {
-    it('creates scaffold files when they do not exist', () => {
+    it('creates only the workflow file by default', () => {
       mockExistsSync.mockReturnValue(false);
 
-      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false });
+      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false, withConfig: false });
 
-      expect(mockMkdirSync).toHaveBeenCalledWith('.config', { recursive: true });
       expect(mockMkdirSync).toHaveBeenCalledWith('.github/workflows', { recursive: true });
-      expect(mockWriteFileSync).toHaveBeenCalledWith('.config/release-kit.config.ts', expect.any(String), 'utf8');
       expect(mockWriteFileSync).toHaveBeenCalledWith('.github/workflows/release.yaml', expect.any(String), 'utf8');
+      expect(mockWriteFileSync).not.toHaveBeenCalledWith(
+        '.config/release-kit.config.ts',
+        expect.any(String),
+        expect.any(String),
+      );
+    });
+
+    it('creates workflow and config files when withConfig is true', () => {
+      mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
+      mockExistsSync.mockReturnValue(false);
+
+      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false, withConfig: true });
+
+      expect(mockMkdirSync).toHaveBeenCalledWith('.github/workflows', { recursive: true });
+      expect(mockMkdirSync).toHaveBeenCalledWith('.config', { recursive: true });
+      expect(mockWriteFileSync).toHaveBeenCalledWith('.github/workflows/release.yaml', expect.any(String), 'utf8');
+      expect(mockWriteFileSync).toHaveBeenCalledWith('.config/release-kit.config.ts', expect.any(String), 'utf8');
     });
 
     it('skips files that already exist when overwrite is false', () => {
       mockExistsSync.mockReturnValue(true);
 
-      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false });
+      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false, withConfig: false });
 
-      // writeIfAbsent should skip, not write
       expect(mockWriteFileSync).not.toHaveBeenCalled();
-      expect(mockPrintSkip).toHaveBeenCalledTimes(2);
+      expect(mockPrintSkip).toHaveBeenCalledTimes(1);
     });
 
     it('overwrites existing files when overwrite is true', () => {
       mockExistsSync.mockReturnValue(true);
 
-      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: true });
+      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: true, withConfig: false });
 
-      // Should write files even though they exist
-      expect(mockWriteFileSync).toHaveBeenCalledWith('.config/release-kit.config.ts', expect.any(String), 'utf8');
       expect(mockWriteFileSync).toHaveBeenCalledWith('.github/workflows/release.yaml', expect.any(String), 'utf8');
       expect(mockPrintSkip).not.toHaveBeenCalled();
     });
@@ -76,9 +88,8 @@ describe('scaffold', () => {
     it('logs but does not write in dry-run mode', () => {
       mockExistsSync.mockReturnValue(false);
 
-      scaffoldFiles({ repoType: 'single-package', dryRun: true, overwrite: false });
+      scaffoldFiles({ repoType: 'single-package', dryRun: true, overwrite: false, withConfig: false });
 
-      // mkdirSync and writeFileSync should not be called for the scaffold files
       expect(mockMkdirSync).not.toHaveBeenCalled();
       expect(mockWriteFileSync).not.toHaveBeenCalled();
       expect(mockPrintSuccess).toHaveBeenCalledWith(expect.stringContaining('[dry-run]'));
@@ -90,7 +101,7 @@ describe('scaffold', () => {
         throw new Error('EACCES: permission denied');
       });
 
-      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false });
+      scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false, withConfig: false });
 
       expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('Failed to create directory for'));
     });
@@ -101,21 +112,25 @@ describe('scaffold', () => {
       mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
       mockExistsSync.mockReturnValue(false);
 
-      copyCliffTemplate(false);
+      copyCliffTemplate(false, false);
 
       expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('Could not find cliff.toml.template'));
     });
 
-    it('reads the template and writes cliff.toml when template exists', () => {
+    it('reads the template and writes .config/git-cliff.toml when template exists', () => {
       mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
-      // First call: existsSync for templatePath (true), second call: existsSync for cliff.toml (false)
+      // First call: existsSync for templatePath (true), second: existsSync for .config/git-cliff.toml (false)
       mockExistsSync.mockReturnValueOnce(true).mockReturnValueOnce(false);
       mockReadFileSync.mockReturnValue('[changelog]\nbody = "template content"');
 
-      copyCliffTemplate(false);
+      copyCliffTemplate(false, false);
 
       expect(mockReadFileSync).toHaveBeenCalledWith(expect.stringContaining('cliff.toml.template'), 'utf8');
-      expect(mockWriteFileSync).toHaveBeenCalledWith('cliff.toml', '[changelog]\nbody = "template content"', 'utf8');
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        '.config/git-cliff.toml',
+        '[changelog]\nbody = "template content"',
+        'utf8',
+      );
     });
 
     it('prints an error when readFileSync fails for the template', () => {
@@ -125,7 +140,7 @@ describe('scaffold', () => {
         throw new Error('EACCES: permission denied');
       });
 
-      copyCliffTemplate(false);
+      copyCliffTemplate(false, false);
 
       expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('Failed to read cliff.toml.template'));
       expect(mockWriteFileSync).not.toHaveBeenCalled();
@@ -136,7 +151,7 @@ describe('scaffold', () => {
       mockExistsSync.mockReturnValueOnce(true).mockReturnValueOnce(false);
       mockReadFileSync.mockReturnValue('template content');
 
-      copyCliffTemplate(true);
+      copyCliffTemplate(true, false);
 
       expect(mockWriteFileSync).not.toHaveBeenCalled();
       expect(mockPrintSuccess).toHaveBeenCalledWith(expect.stringContaining('[dry-run]'));

--- a/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
@@ -57,10 +57,6 @@ describe('scaffold', () => {
 
     it('creates workflow and config files when withConfig is true', () => {
       mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
-      // existsSync calls: workflow file (false), config file (false), template path (true), git-cliff.toml (false)
-      mockExistsSync.mockReturnValue(false).mockReturnValueOnce(false).mockReturnValueOnce(false);
-      // After the two writeIfAbsent existsSync calls, copyCliffTemplate calls existsSync for template (true), then for target (false)
-      mockExistsSync.mockReset();
       mockExistsSync
         .mockReturnValueOnce(false) // workflow file exists?
         .mockReturnValueOnce(false) // config file exists?
@@ -157,13 +153,12 @@ describe('scaffold', () => {
   });
 
   describe(copyCliffTemplate, () => {
-    it('prints an error and returns false when the template file is not found', () => {
+    it('prints an error when the template file is not found', () => {
       mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
       mockExistsSync.mockReturnValue(false);
 
-      const result = copyCliffTemplate(false, false);
+      copyCliffTemplate(false, false);
 
-      expect(result).toBe(false);
       expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('Could not find cliff.toml.template'));
     });
 
@@ -173,9 +168,8 @@ describe('scaffold', () => {
       mockExistsSync.mockReturnValueOnce(true).mockReturnValueOnce(false);
       mockReadFileSync.mockReturnValue('[changelog]\nbody = "template content"');
 
-      const result = copyCliffTemplate(false, false);
+      copyCliffTemplate(false, false);
 
-      expect(result).toBe(true);
       expect(mockReadFileSync).toHaveBeenCalledWith(expect.stringContaining('cliff.toml.template'), 'utf8');
       expect(mockWriteFileSync).toHaveBeenCalledWith(
         '.config/git-cliff.toml',
@@ -184,16 +178,15 @@ describe('scaffold', () => {
       );
     });
 
-    it('prints an error and returns false when readFileSync fails for the template', () => {
+    it('prints an error when readFileSync fails for the template', () => {
       mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
       mockExistsSync.mockReturnValueOnce(true);
       mockReadFileSync.mockImplementation(() => {
         throw new Error('EACCES: permission denied');
       });
 
-      const result = copyCliffTemplate(false, false);
+      copyCliffTemplate(false, false);
 
-      expect(result).toBe(false);
       expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('Failed to read cliff.toml.template'));
       expect(mockWriteFileSync).not.toHaveBeenCalled();
     });

--- a/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
@@ -157,12 +157,13 @@ describe('scaffold', () => {
   });
 
   describe(copyCliffTemplate, () => {
-    it('prints an error when the template file is not found', () => {
+    it('prints an error and returns false when the template file is not found', () => {
       mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
       mockExistsSync.mockReturnValue(false);
 
-      copyCliffTemplate(false, false);
+      const result = copyCliffTemplate(false, false);
 
+      expect(result).toBe(false);
       expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('Could not find cliff.toml.template'));
     });
 
@@ -172,8 +173,9 @@ describe('scaffold', () => {
       mockExistsSync.mockReturnValueOnce(true).mockReturnValueOnce(false);
       mockReadFileSync.mockReturnValue('[changelog]\nbody = "template content"');
 
-      copyCliffTemplate(false, false);
+      const result = copyCliffTemplate(false, false);
 
+      expect(result).toBe(true);
       expect(mockReadFileSync).toHaveBeenCalledWith(expect.stringContaining('cliff.toml.template'), 'utf8');
       expect(mockWriteFileSync).toHaveBeenCalledWith(
         '.config/git-cliff.toml',
@@ -182,15 +184,16 @@ describe('scaffold', () => {
       );
     });
 
-    it('prints an error when readFileSync fails for the template', () => {
+    it('prints an error and returns false when readFileSync fails for the template', () => {
       mockFileURLToPath.mockReturnValue('/fake/dist/esm/init/scaffold.js');
       mockExistsSync.mockReturnValueOnce(true);
       mockReadFileSync.mockImplementation(() => {
         throw new Error('EACCES: permission denied');
       });
 
-      copyCliffTemplate(false, false);
+      const result = copyCliffTemplate(false, false);
 
+      expect(result).toBe(false);
       expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('Failed to read cliff.toml.template'));
       expect(mockWriteFileSync).not.toHaveBeenCalled();
     });

--- a/packages/release-kit/src/init/checks.ts
+++ b/packages/release-kit/src/init/checks.ts
@@ -44,23 +44,3 @@ export function usesPnpm(): CheckResult {
     message: 'This project does not appear to use pnpm. A pnpm-lock.yaml or packageManager field is required.',
   };
 }
-
-/** Verify that cliff.toml exists in the current directory. */
-export function hasCliffToml(): CheckResult {
-  if (existsSync('cliff.toml')) {
-    return { ok: true };
-  }
-  return { ok: false, message: 'No cliff.toml found. This file is required for changelog generation.' };
-}
-
-/** Verify that release-kit has not already been initialized. */
-export function notAlreadyInitialized(): CheckResult {
-  // Check both old and new config locations
-  if (!existsSync('.config/release-kit.config.ts') && !existsSync('.github/scripts/release.config.ts')) {
-    return { ok: true };
-  }
-  return {
-    ok: false,
-    message: 'release-kit appears to be already initialized.',
-  };
-}

--- a/packages/release-kit/src/init/initCommand.ts
+++ b/packages/release-kit/src/init/initCommand.ts
@@ -53,12 +53,23 @@ export function initCommand({ dryRun, force, withConfig }: InitOptions): number 
 
   // Detect repo type
   printStep('Detecting repo type');
-  const repoType = detectRepoType();
+  let repoType: ReturnType<typeof detectRepoType>;
+  try {
+    repoType = detectRepoType();
+  } catch (error: unknown) {
+    printError(`Failed to detect repo type: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
   printSuccess(`Detected: ${repoType}`);
 
   // Scaffold files
   printStep('Scaffolding files');
-  scaffoldFiles({ repoType, dryRun, overwrite: force, withConfig });
+  try {
+    scaffoldFiles({ repoType, dryRun, overwrite: force, withConfig });
+  } catch (error: unknown) {
+    printError(`Failed to scaffold files: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
 
   // Print next steps
   printStep('Next steps');

--- a/packages/release-kit/src/init/initCommand.ts
+++ b/packages/release-kit/src/init/initCommand.ts
@@ -1,5 +1,6 @@
 import type { CheckResult } from './checks.ts';
 import { hasPackageJson, isGitRepo, usesPnpm } from './checks.ts';
+import type { RepoType } from './detectRepoType.ts';
 import { detectRepoType } from './detectRepoType.ts';
 import { printError, printStep, printSuccess } from './prompt.ts';
 import { scaffoldFiles } from './scaffold.ts';
@@ -53,7 +54,7 @@ export function initCommand({ dryRun, force, withConfig }: InitOptions): number 
 
   // Detect repo type
   printStep('Detecting repo type');
-  let repoType: ReturnType<typeof detectRepoType>;
+  let repoType: RepoType;
   try {
     repoType = detectRepoType();
   } catch (error: unknown) {

--- a/packages/release-kit/src/init/initCommand.ts
+++ b/packages/release-kit/src/init/initCommand.ts
@@ -1,11 +1,13 @@
 import type { CheckResult } from './checks.ts';
-import { hasCliffToml, hasPackageJson, isGitRepo, notAlreadyInitialized, usesPnpm } from './checks.ts';
+import { hasPackageJson, isGitRepo, usesPnpm } from './checks.ts';
 import { detectRepoType } from './detectRepoType.ts';
-import { confirm, printError, printStep, printSuccess } from './prompt.ts';
-import { copyCliffTemplate, scaffoldFiles } from './scaffold.ts';
+import { printError, printStep, printSuccess } from './prompt.ts';
+import { scaffoldFiles } from './scaffold.ts';
 
 interface InitOptions {
   dryRun: boolean;
+  force: boolean;
+  withConfig: boolean;
 }
 
 /** Run a required check and print the result. Returns false if the check failed. */
@@ -18,45 +20,15 @@ function runRequiredCheck(label: string, result: CheckResult): boolean {
   return false;
 }
 
-interface EligibilityResult {
-  status: 'pass' | 'abort' | 'fail';
-  overwrite: boolean;
-}
-
-/** Run all eligibility checks. Returns the check status and whether overwrite was confirmed. */
-async function checkEligibility(dryRun: boolean): Promise<EligibilityResult> {
+/** Run all eligibility checks. Returns true if all checks pass. */
+function checkEligibility(): boolean {
   printStep('Checking eligibility');
 
-  if (!runRequiredCheck('Git repository detected', isGitRepo())) return { status: 'fail', overwrite: false };
-  if (!runRequiredCheck('package.json found', hasPackageJson())) return { status: 'fail', overwrite: false };
-  if (!runRequiredCheck('pnpm detected', usesPnpm())) return { status: 'fail', overwrite: false };
+  if (!runRequiredCheck('Git repository detected', isGitRepo())) return false;
+  if (!runRequiredCheck('package.json found', hasPackageJson())) return false;
+  if (!runRequiredCheck('pnpm detected', usesPnpm())) return false;
 
-  const cliffCheck = hasCliffToml();
-  if (cliffCheck.ok) {
-    printSuccess('cliff.toml found');
-  } else {
-    console.info('');
-    const shouldCreate = await confirm('No cliff.toml found. Create one from the bundled template?');
-    if (shouldCreate) {
-      copyCliffTemplate(dryRun);
-    } else {
-      printError('cliff.toml is required for changelog generation. Aborting.');
-      return { status: 'fail', overwrite: false };
-    }
-  }
-
-  const initCheck = notAlreadyInitialized();
-  if (!initCheck.ok) {
-    console.info('');
-    const shouldOverwrite = await confirm('release-kit appears to be already initialized. Overwrite existing files?');
-    if (!shouldOverwrite) {
-      console.info('Aborting.');
-      return { status: 'abort', overwrite: false };
-    }
-    return { status: 'pass', overwrite: true };
-  }
-
-  return { status: 'pass', overwrite: false };
+  return true;
 }
 
 /**
@@ -65,20 +37,19 @@ async function checkEligibility(dryRun: boolean): Promise<EligibilityResult> {
  * Checks eligibility, detects repo type, scaffolds files, and prints next steps.
  * Returns the process exit code (0 for success, 1 for failure).
  */
-export async function initCommand({ dryRun }: InitOptions): Promise<number> {
+export function initCommand({ dryRun, force, withConfig }: InitOptions): number {
   if (dryRun) {
     console.info('[dry-run mode]');
   }
 
-  let eligibility: EligibilityResult;
+  let eligible: boolean;
   try {
-    eligibility = await checkEligibility(dryRun);
+    eligible = checkEligibility();
   } catch (error: unknown) {
     printError(`Eligibility check failed: ${error instanceof Error ? error.message : String(error)}`);
     return 1;
   }
-  if (eligibility.status === 'fail') return 1;
-  if (eligibility.status === 'abort') return 0;
+  if (!eligible) return 1;
 
   // Detect repo type
   printStep('Detecting repo type');
@@ -87,14 +58,17 @@ export async function initCommand({ dryRun }: InitOptions): Promise<number> {
 
   // Scaffold files
   printStep('Scaffolding files');
-  scaffoldFiles({ repoType, dryRun, overwrite: eligibility.overwrite });
+  scaffoldFiles({ repoType, dryRun, overwrite: force, withConfig });
 
   // Print next steps
   printStep('Next steps');
+  const configHint = withConfig
+    ? '1. (Optional) Customize .config/release-kit.config.ts and .config/git-cliff.toml.'
+    : '1. (Optional) Run again with --with-config to scaffold config files.';
   console.info(`
-  1. (Optional) Customize .config/release-kit.config.ts to exclude components, override version patterns, add custom work types, etc.
+  ${configHint}
   2. Test by running: npx @williamthorsen/release-kit prepare --dry-run
-  3. Commit the generated workflow file (and config file if created).
+  3. Commit the generated files.
 `);
 
   return 0;

--- a/packages/release-kit/src/init/prompt.ts
+++ b/packages/release-kit/src/init/prompt.ts
@@ -1,16 +1,3 @@
-import { createInterface } from 'node:readline/promises';
-
-/** Prompt the user for a yes/no answer. Returns `true` for yes, `false` for no. */
-export async function confirm(question: string): Promise<boolean> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  try {
-    const answer = await rl.question(`${question} (y/n) `);
-    return answer.trim().toLowerCase().startsWith('y');
-  } finally {
-    rl.close();
-  }
-}
-
 /** Print a step label with a right-arrow prefix. */
 export function printStep(message: string): void {
   console.info(`\n> ${message}`);

--- a/packages/release-kit/src/init/prompt.ts
+++ b/packages/release-kit/src/init/prompt.ts
@@ -16,17 +16,17 @@ export function printStep(message: string): void {
   console.info(`\n> ${message}`);
 }
 
-/** Print a success message with a checkmark prefix. */
+/** Print a success message with a checkmark emoji prefix. */
 export function printSuccess(message: string): void {
-  console.info(`  [ok] ${message}`);
+  console.info(`  ✅ ${message}`);
 }
 
-/** Print a skip message to stdout. */
+/** Print a skip/warning message to stdout. */
 export function printSkip(message: string): void {
-  console.info(`  [skip] ${message}`);
+  console.info(`  ⚠️ ${message}`);
 }
 
 /** Print an error message to stderr. */
 export function printError(message: string): void {
-  console.error(`  [error] ${message}`);
+  console.error(`  ❌ ${message}`);
 }

--- a/packages/release-kit/src/init/scaffold.ts
+++ b/packages/release-kit/src/init/scaffold.ts
@@ -50,8 +50,8 @@ function writeIfAbsent(filePath: string, content: string, dryRun: boolean, overw
   }
 }
 
-/** Copy the bundled cliff.toml.template to `.config/git-cliff.toml` in the target repo. */
-export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): void {
+/** Copy the bundled cliff.toml.template to `.config/git-cliff.toml` in the target repo. Returns true on success. */
+export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): boolean {
   // Resolve the template relative to this file's compiled location.
   // From dist/esm/init/scaffold.js, the template is at ../../../cliff.toml.template.
   const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -59,7 +59,7 @@ export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): void {
 
   if (!existsSync(templatePath)) {
     printError(`Could not find cliff.toml.template at ${templatePath}`);
-    return;
+    return false;
   }
 
   let content: string;
@@ -68,9 +68,10 @@ export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): void {
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     printError(`Failed to read cliff.toml.template: ${message}`);
-    return;
+    return false;
   }
   writeIfAbsent('.config/git-cliff.toml', content, dryRun, overwrite);
+  return true;
 }
 
 /** Scaffold release-kit files for the target repo. */

--- a/packages/release-kit/src/init/scaffold.ts
+++ b/packages/release-kit/src/init/scaffold.ts
@@ -10,6 +10,7 @@ interface ScaffoldOptions {
   repoType: RepoType;
   dryRun: boolean;
   overwrite: boolean;
+  withConfig: boolean;
 }
 
 interface FileToWrite {
@@ -54,8 +55,8 @@ function writeIfAbsent(filePath: string, content: string, dryRun: boolean, overw
   }
 }
 
-/** Copy the bundled cliff.toml.template to cliff.toml in the target repo. */
-export function copyCliffTemplate(dryRun: boolean): void {
+/** Copy the bundled cliff.toml.template to `.config/git-cliff.toml` in the target repo. */
+export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): void {
   // Resolve the template relative to this file's compiled location.
   // From dist/esm/init/scaffold.js, the template is at ../../../cliff.toml.template.
   const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -74,17 +75,22 @@ export function copyCliffTemplate(dryRun: boolean): void {
     printError(`Failed to read cliff.toml.template: ${message}`);
     return;
   }
-  writeIfAbsent('cliff.toml', content, dryRun, false);
+  writeIfAbsent('.config/git-cliff.toml', content, dryRun, overwrite);
 }
 
-/** Scaffold all release-kit files for the target repo. */
-export function scaffoldFiles({ repoType, dryRun, overwrite }: ScaffoldOptions): void {
-  const files: FileToWrite[] = [
-    { path: '.config/release-kit.config.ts', content: releaseConfigScript(repoType) },
-    { path: '.github/workflows/release.yaml', content: releaseWorkflow(repoType) },
-  ];
+/** Scaffold release-kit files for the target repo. */
+export function scaffoldFiles({ repoType, dryRun, overwrite, withConfig }: ScaffoldOptions): void {
+  const files: FileToWrite[] = [{ path: '.github/workflows/release.yaml', content: releaseWorkflow(repoType) }];
+
+  if (withConfig) {
+    files.push({ path: '.config/release-kit.config.ts', content: releaseConfigScript(repoType) });
+  }
 
   for (const file of files) {
     writeIfAbsent(file.path, file.content, dryRun, overwrite);
+  }
+
+  if (withConfig) {
+    copyCliffTemplate(dryRun, overwrite);
   }
 }

--- a/packages/release-kit/src/init/scaffold.ts
+++ b/packages/release-kit/src/init/scaffold.ts
@@ -13,11 +13,6 @@ interface ScaffoldOptions {
   withConfig: boolean;
 }
 
-interface FileToWrite {
-  path: string;
-  content: string;
-}
-
 /** Attempt to write a file, printing a user-friendly error on failure. Returns true on success. */
 function tryWriteFile(filePath: string, content: string): boolean {
   try {
@@ -80,17 +75,10 @@ export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): void {
 
 /** Scaffold release-kit files for the target repo. */
 export function scaffoldFiles({ repoType, dryRun, overwrite, withConfig }: ScaffoldOptions): void {
-  const files: FileToWrite[] = [{ path: '.github/workflows/release.yaml', content: releaseWorkflow(repoType) }];
+  writeIfAbsent('.github/workflows/release.yaml', releaseWorkflow(repoType), dryRun, overwrite);
 
   if (withConfig) {
-    files.push({ path: '.config/release-kit.config.ts', content: releaseConfigScript(repoType) });
-  }
-
-  for (const file of files) {
-    writeIfAbsent(file.path, file.content, dryRun, overwrite);
-  }
-
-  if (withConfig) {
+    writeIfAbsent('.config/release-kit.config.ts', releaseConfigScript(repoType), dryRun, overwrite);
     copyCliffTemplate(dryRun, overwrite);
   }
 }

--- a/packages/release-kit/src/init/scaffold.ts
+++ b/packages/release-kit/src/init/scaffold.ts
@@ -50,8 +50,8 @@ function writeIfAbsent(filePath: string, content: string, dryRun: boolean, overw
   }
 }
 
-/** Copy the bundled cliff.toml.template to `.config/git-cliff.toml` in the target repo. Returns true on success. */
-export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): boolean {
+/** Copy the bundled cliff.toml.template to `.config/git-cliff.toml` in the target repo. */
+export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): void {
   // Resolve the template relative to this file's compiled location.
   // From dist/esm/init/scaffold.js, the template is at ../../../cliff.toml.template.
   const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -59,7 +59,7 @@ export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): boolean 
 
   if (!existsSync(templatePath)) {
     printError(`Could not find cliff.toml.template at ${templatePath}`);
-    return false;
+    return;
   }
 
   let content: string;
@@ -68,10 +68,9 @@ export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): boolean 
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     printError(`Failed to read cliff.toml.template: ${message}`);
-    return false;
+    return;
   }
   writeIfAbsent('.config/git-cliff.toml', content, dryRun, overwrite);
-  return true;
 }
 
 /** Scaffold release-kit files for the target repo. */

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -42,7 +42,7 @@ export async function prepareCommand(argv: string[]): Promise<void> {
     if (errors.length > 0) {
       console.error('Invalid config:');
       for (const err of errors) {
-        console.error(`  - ${err}`);
+        console.error(`  ❌ ${err}`);
       }
       process.exit(1);
     }

--- a/packages/release-kit/src/resolveCliffConfigPath.ts
+++ b/packages/release-kit/src/resolveCliffConfigPath.ts
@@ -1,0 +1,40 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Resolve the git-cliff configuration file path.
+ *
+ * Checks candidates in order: explicit `cliffConfigPath` -> `.config/git-cliff.toml` ->
+ * `cliff.toml` -> bundled `cliff.toml.template`. Returns the first path that exists,
+ * or throws if even the bundled template cannot be found.
+ *
+ * When an explicit `cliffConfigPath` is provided, it is returned as-is without checking
+ * existence, preserving current behavior (git-cliff reports the error if the file is missing).
+ */
+export function resolveCliffConfigPath(cliffConfigPath: string | undefined, metaUrl: string): string {
+  // Explicit path: return without checking existence.
+  if (cliffConfigPath !== undefined) {
+    return cliffConfigPath;
+  }
+
+  // Convention-based candidates in priority order.
+  const candidates = ['.config/git-cliff.toml', 'cliff.toml'];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Bundled template fallback.
+  // From dist/esm/resolveCliffConfigPath.js the template is at ../../cliff.toml.template.
+  const thisDir = dirname(fileURLToPath(metaUrl));
+  const bundledPath = resolve(thisDir, '..', '..', 'cliff.toml.template');
+  if (existsSync(bundledPath)) {
+    return bundledPath;
+  }
+
+  throw new Error(
+    `Could not resolve a git-cliff config file. Searched: ${candidates.join(', ')}, and bundled template at ${bundledPath}`,
+  );
+}

--- a/packages/release-kit/src/runReleasePrepare.ts
+++ b/packages/release-kit/src/runReleasePrepare.ts
@@ -10,9 +10,9 @@ import type { MonorepoReleaseConfig, ReleaseConfig, ReleaseType } from './types.
 
 /**
  * File written by the release preparation step, containing one tag per line.
- * Located in `/tmp` because it only needs to survive within a single CI job.
+ * Relative to the project root so it works identically in CI and local runs.
  */
-export const RELEASE_TAGS_FILE = '/tmp/release-kit/.release-tags';
+export const RELEASE_TAGS_FILE = 'tmp/.release-tags';
 
 const VALID_BUMP_TYPES: readonly string[] = ['major', 'minor', 'patch'];
 


### PR DESCRIPTION
Closes #30 

## What

Adds a `resolveCliffConfigPath()` function that searches for a git-cliff config in a 4-step cascade (explicit path → `.config/git-cliff.toml` → `cliff.toml` → bundled `cliff.toml.template`), eliminating the requirement for consuming repos to maintain a cliff config copy. Restructures the `init` command to scaffold only the workflow file by default, with new `--with-config` and `--force` flags. Moves `.release-tags` from `/tmp/release-kit/` to project-local `tmp/` for predictable behavior in local runs.

## Why

Every repo using `release-kit` had to maintain an identical `cliff.toml` copy. The bundled template fallback means repos that don't need customization can delete their cliff config entirely. The `init` restructuring separates the common case (workflow scaffolding) from the optional case (config customization), and the release-tags path change avoids collisions between concurrent jobs on shared CI runners.

## Details

### Features

- New `resolveCliffConfigPath()` resolves git-cliff config via 4-step cascade: explicit `cliffConfigPath` → `.config/git-cliff.toml` → `cliff.toml` → bundled `cliff.toml.template`
- `release-kit init` now scaffolds only `.github/workflows/release.yaml` by default; `--with-config` also scaffolds `.config/release-kit.config.ts` and `.config/git-cliff.toml`
- `--force` flag overwrites existing files instead of skipping
- CLI output uses emoji prefixes (✅, ⚠️, ❌) instead of text brackets

### Fixes

- `RELEASE_TAGS_FILE` moved from `/tmp/release-kit/.release-tags` to project-local `tmp/.release-tags`, avoiding cross-job collisions on shared CI runners and unpredictable behavior in local runs
- `detectRepoType()` and `scaffoldFiles()` wrapped in try/catch in `initCommand` to prevent unhandled exceptions
- Release workflow updated to read tags from the new project-local path

### Refactoring

- `initCommand` converted from async/interactive to sync/flag-based; `confirm()` prompt removed
- Dead code removed: `hasCliffToml()`, `notAlreadyInitialized()`, `confirm()`, `FileToWrite` interface
- `copyCliffTemplate` simplified to `void` return type (no caller used the boolean)
- `resolveCliffConfigPath` kept internal (not exported from `index.ts`) since its `metaUrl` parameter is coupled to the package structure

### Tests

- New `resolveCliffConfigPath` unit tests covering all 4 cascade branches plus error case
- New integration test importing from compiled `dist/esm/` to verify bundled template path resolution
- New `initCommand` unit tests (10 cases) covering success, eligibility failures, exception handling, and flag passthrough
- Expanded `scaffoldFiles` tests for `withConfig`/`overwrite` matrix and cliff template behavior

## Test plan

- [ ] Verify `release-kit init` scaffolds only the workflow file by default
- [ ] Verify `release-kit init --with-config` also scaffolds config files
- [ ] Verify `release-kit prepare --dry-run` works without any cliff config in the repo
- [ ] Verify the release workflow reads tags from `tmp/.release-tags`