### PR TITLE
#34 Report up-to-date status for unchanged init files

### DIFF
--- a/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
@@ -76,8 +76,9 @@ describe('scaffold', () => {
       );
     });
 
-    it('skips files that already exist when overwrite is false', () => {
+    it('skips files that already exist with different content when overwrite is false', () => {
       mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('different content');
 
       scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false, withConfig: false });
 
@@ -94,18 +95,18 @@ describe('scaffold', () => {
       expect(mockPrintSkip).not.toHaveBeenCalled();
     });
 
-    it('skips cliff template when withConfig is true and overwrite is false and target exists', () => {
-      // All files exist
+    it('skips all files when withConfig is true, overwrite is false, and all targets have different content', () => {
       mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue('template content');
+      mockReadFileSync.mockImplementation((path: string) => {
+        // Return template content for the bundled template read; return different content for file-existence reads.
+        if (path.includes('cliff.toml.template')) return '[changelog]\nbody = "template"';
+        return 'different content';
+      });
 
       scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false, withConfig: true });
 
-      // Workflow file should be skipped
       expect(mockPrintSkip).toHaveBeenCalledWith(expect.stringContaining('.github/workflows/release.yaml'));
-      // Config file should be skipped
       expect(mockPrintSkip).toHaveBeenCalledWith(expect.stringContaining('.config/release-kit.config.ts'));
-      // Cliff template target should be skipped
       expect(mockPrintSkip).toHaveBeenCalledWith(expect.stringContaining('.config/git-cliff.toml'));
       expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
@@ -146,6 +147,73 @@ describe('scaffold', () => {
       scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: false, withConfig: false });
 
       expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('Failed to create directory for'));
+    });
+  });
+
+  describe('content-aware skip reporting', () => {
+    it('reports up to date when existing file matches the intended content', () => {
+      // Template file exists, target file exists with same content
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('same content');
+
+      copyCliffTemplate(false, false);
+
+      expect(mockPrintSuccess).toHaveBeenCalledWith(expect.stringContaining('(up to date)'));
+      expect(mockPrintSkip).not.toHaveBeenCalled();
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('reports already exists when existing file differs from intended content', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.includes('cliff.toml.template')) return 'template content';
+        return 'different content on disk';
+      });
+
+      copyCliffTemplate(false, false);
+
+      expect(mockPrintSkip).toHaveBeenCalledWith(expect.stringContaining('(already exists)'));
+      expect(mockPrintSuccess).not.toHaveBeenCalled();
+    });
+
+    it('treats files as identical when they differ only in trailing whitespace', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.includes('cliff.toml.template')) return 'line one\nline two\n';
+        return 'line one  \nline two  \n\n';
+      });
+
+      copyCliffTemplate(false, false);
+
+      expect(mockPrintSuccess).toHaveBeenCalledWith(expect.stringContaining('(up to date)'));
+      expect(mockPrintSkip).not.toHaveBeenCalled();
+    });
+
+    it('falls back to already exists when reading the existing file throws', () => {
+      let callCount = 0;
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.includes('cliff.toml.template')) return 'template content';
+        callCount++;
+        if (callCount === 1) throw new Error('EACCES: permission denied');
+        return 'unreachable';
+      });
+
+      copyCliffTemplate(false, false);
+
+      expect(mockPrintSkip).toHaveBeenCalledWith(expect.stringContaining('(already exists)'));
+      expect(mockPrintSuccess).not.toHaveBeenCalled();
+    });
+
+    it('reports up to date in dry-run mode when existing file matches', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('same content');
+
+      copyCliffTemplate(true, false);
+
+      expect(mockPrintSuccess).toHaveBeenCalledWith(expect.stringContaining('(up to date)'));
+      expect(mockPrintSkip).not.toHaveBeenCalled();
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/release-kit/src/init/scaffold.ts
+++ b/packages/release-kit/src/init/scaffold.ts
@@ -25,9 +25,27 @@ function tryWriteFile(filePath: string, content: string): boolean {
   }
 }
 
+/** Strip trailing whitespace from each line and from EOF. */
+function normalizeTrailingWhitespace(content: string): string {
+  return content
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n')
+    .trimEnd();
+}
+
 /** Write a file, creating parent directories as needed. Skips if the file already exists and overwrite is false. */
 function writeIfAbsent(filePath: string, content: string, dryRun: boolean, overwrite: boolean): void {
   if (existsSync(filePath) && !overwrite) {
+    try {
+      const existing = readFileSync(filePath, 'utf8');
+      if (normalizeTrailingWhitespace(existing) === normalizeTrailingWhitespace(content)) {
+        printSuccess(`${filePath} (up to date)`);
+        return;
+      }
+    } catch {
+      // Fall through to skip message if reading fails.
+    }
     printSkip(`${filePath} (already exists)`);
     return;
   }


### PR DESCRIPTION
Closes #34 

## What

`release-kit init` now compares existing file content against the default before reporting status. When an existing file is identical to the default (after normalizing trailing whitespace), it reports `✅ (up to date)` instead of the misleading `⚠️ (already exists)`.

## Why

Idempotent re-runs of `release-kit init` previously showed warnings for every existing file, even when nothing was wrong. This made it hard to distinguish genuinely conflicting files from files that were already correct, creating unnecessary noise and concern.

## Details

### Features

- Added content comparison in `writeIfAbsent()` that reads existing files and compares against intended content using trailing-whitespace normalization
- New `normalizeTrailingWhitespace()` helper strips trailing whitespace per line and at EOF before comparison, tolerating formatter-introduced differences
- Falls back to `⚠️ (already exists)` if reading the existing file fails

### Tests

- Updated 2 existing tests to properly mock `readFileSync` for the new content-comparison path
- Added 5 new tests covering: exact content match, different content, trailing whitespace normalization, read-error fallback, and dry-run with matching file