### PR TITLE
#27 Auto-detect Prettier for CHANGELOG formatting

### DIFF
--- a/packages/release-kit/src/__tests__/hasPrettierConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/hasPrettierConfig.unit.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+}));
+
+import { hasPrettierConfig } from '../hasPrettierConfig.ts';
+
+describe(hasPrettierConfig, () => {
+  afterEach(() => {
+    mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
+  });
+
+  it('returns true when .prettierrc exists', () => {
+    mockExistsSync.mockImplementation((filePath: string) => filePath.endsWith('.prettierrc'));
+
+    expect(hasPrettierConfig()).toBe(true);
+  });
+
+  it('returns true when prettier.config.mjs exists', () => {
+    mockExistsSync.mockImplementation((filePath: string) => filePath.endsWith('prettier.config.mjs'));
+
+    expect(hasPrettierConfig()).toBe(true);
+  });
+
+  it('returns true when package.json has a "prettier" key', () => {
+    mockExistsSync.mockImplementation((filePath: string) => filePath.endsWith('package.json'));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'my-app', prettier: { singleQuote: true } }));
+
+    expect(hasPrettierConfig()).toBe(true);
+  });
+
+  it('returns false when no prettier config exists', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    expect(hasPrettierConfig()).toBe(false);
+  });
+
+  it('returns false when package.json exists but has no "prettier" key', () => {
+    mockExistsSync.mockImplementation((filePath: string) => filePath.endsWith('package.json'));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'my-app' }));
+
+    expect(hasPrettierConfig()).toBe(false);
+  });
+
+  it('returns false when package.json is malformed', () => {
+    mockExistsSync.mockImplementation((filePath: string) => filePath.endsWith('package.json'));
+    mockReadFileSync.mockReturnValue('not json');
+
+    expect(hasPrettierConfig()).toBe(false);
+  });
+});

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -4,6 +4,7 @@ const mockExecFileSync = vi.hoisted(() => vi.fn());
 const mockExecSync = vi.hoisted(() => vi.fn());
 const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockHasPrettierConfig = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,
@@ -17,6 +18,10 @@ vi.mock('node:fs', () => ({
 
 vi.mock('../resolveCliffConfigPath.ts', () => ({
   resolveCliffConfigPath: () => 'cliff.toml',
+}));
+
+vi.mock('../hasPrettierConfig.ts', () => ({
+  hasPrettierConfig: mockHasPrettierConfig,
 }));
 
 import { releasePrepare } from '../releasePrepare.ts';
@@ -43,6 +48,7 @@ describe(releasePrepare, () => {
     mockExecSync.mockReset();
     mockReadFileSync.mockReset();
     mockWriteFileSync.mockReset();
+    mockHasPrettierConfig.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -117,6 +123,49 @@ describe(releasePrepare, () => {
     const result = releasePrepare(config, { dryRun: false });
 
     expect(result).toStrictEqual([]);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('defaults to prettier when no formatCommand is set and prettier config exists', () => {
+    const config = makeConfig();
+    mockHasPrettierConfig.mockReturnValue(true);
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'feat: add feature\u001Fabc123';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    releasePrepare(config, { dryRun: false });
+
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(mockExecSync).toHaveBeenCalledWith('npx prettier --write package.json ./CHANGELOG.md', {
+      stdio: 'inherit',
+    });
+  });
+
+  it('skips formatting when no formatCommand is set and no prettier config exists', () => {
+    const config = makeConfig();
+    mockHasPrettierConfig.mockReturnValue(false);
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'feat: add feature\u001Fabc123';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    releasePrepare(config, { dryRun: false });
+
     expect(mockExecSync).not.toHaveBeenCalled();
   });
 });

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -4,6 +4,7 @@ const mockExecFileSync = vi.hoisted(() => vi.fn());
 const mockExecSync = vi.hoisted(() => vi.fn());
 const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockHasPrettierConfig = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,
@@ -17,6 +18,10 @@ vi.mock('node:fs', () => ({
 
 vi.mock('../resolveCliffConfigPath.ts', () => ({
   resolveCliffConfigPath: () => 'cliff.toml',
+}));
+
+vi.mock('../hasPrettierConfig.ts', () => ({
+  hasPrettierConfig: mockHasPrettierConfig,
 }));
 
 import { releasePrepareMono } from '../releasePrepareMono.ts';
@@ -58,6 +63,7 @@ describe(releasePrepareMono, () => {
     mockExecSync.mockReset();
     mockReadFileSync.mockReset();
     mockWriteFileSync.mockReset();
+    mockHasPrettierConfig.mockReset();
   });
 
   it('processes a component that has commits', () => {
@@ -482,6 +488,70 @@ describe(releasePrepareMono, () => {
     const result = releasePrepareMono(config, { dryRun: false });
 
     expect(result).toStrictEqual([]);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('defaults to prettier when no formatCommand is set and prettier config exists', () => {
+    const config = makeConfig({
+      components: [
+        {
+          dir: 'arrays',
+          tagPrefix: 'arrays-v',
+          packageFiles: ['packages/arrays/package.json'],
+          changelogPaths: ['packages/arrays'],
+          paths: ['packages/arrays/**'],
+        },
+      ],
+    });
+    mockHasPrettierConfig.mockReturnValue(true);
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'arrays-v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'feat: add feature\u001Fabc123';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    releasePrepareMono(config, { dryRun: false });
+
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      'npx prettier --write packages/arrays/package.json packages/arrays/CHANGELOG.md',
+      { stdio: 'inherit' },
+    );
+  });
+
+  it('skips formatting when no formatCommand is set and no prettier config exists', () => {
+    const config = makeConfig({
+      components: [
+        {
+          dir: 'arrays',
+          tagPrefix: 'arrays-v',
+          packageFiles: ['packages/arrays/package.json'],
+          changelogPaths: ['packages/arrays'],
+          paths: ['packages/arrays/**'],
+        },
+      ],
+    });
+    mockHasPrettierConfig.mockReturnValue(false);
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'arrays-v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'feat: add feature\u001Fabc123';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    releasePrepareMono(config, { dryRun: false });
+
     expect(mockExecSync).not.toHaveBeenCalled();
   });
 });

--- a/packages/release-kit/src/hasPrettierConfig.ts
+++ b/packages/release-kit/src/hasPrettierConfig.ts
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { isRecord } from './typeGuards.ts';
+
+/**
+ * Detects whether the repo has a Prettier configuration.
+ *
+ * Checks for config files in the working directory and for a `"prettier"` key
+ * in the root `package.json`. Returns `true` if any indicator is found.
+ */
+export function hasPrettierConfig(): boolean {
+  const cwd = process.cwd();
+
+  for (const file of PRETTIER_CONFIG_FILES) {
+    if (existsSync(path.join(cwd, file))) {
+      return true;
+    }
+  }
+
+  return hasPrettierKeyInPackageJson(path.join(cwd, 'package.json'));
+}
+
+/** Returns true if `package.json` contains a top-level `"prettier"` key. */
+function hasPrettierKeyInPackageJson(packageJsonPath: string): boolean {
+  if (!existsSync(packageJsonPath)) {
+    return false;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    return isRecord(parsed) && 'prettier' in parsed;
+  } catch {
+    return false;
+  }
+}
+
+/** Config file names that indicate a project uses prettier. */
+const PRETTIER_CONFIG_FILES = [
+  '.prettierrc',
+  '.prettierrc.cjs',
+  '.prettierrc.js',
+  '.prettierrc.json',
+  '.prettierrc.json5',
+  '.prettierrc.mjs',
+  '.prettierrc.toml',
+  '.prettierrc.ts',
+  '.prettierrc.yaml',
+  '.prettierrc.yml',
+  'prettier.config.cjs',
+  'prettier.config.js',
+  'prettier.config.mjs',
+  'prettier.config.ts',
+];

--- a/packages/release-kit/src/init/templates.ts
+++ b/packages/release-kit/src/init/templates.ts
@@ -15,8 +15,7 @@ const config: ReleaseKitConfig = {
   //   { dir: 'my-package', shouldExclude: true },
   // ],
 
-  // TODO: Uncomment and adjust if you have a format command
-  // formatCommand: 'npx prettier --write',
+  // Formatting: prettier is auto-detected. Set formatCommand to override.
 
   // Uncomment to override the default version patterns:
   // versionPatterns: { major: ['!'], minor: ['feat', 'feature'] },
@@ -32,8 +31,7 @@ export default config;
   return `import type { ReleaseKitConfig } from '@williamthorsen/release-kit';
 
 const config: ReleaseKitConfig = {
-  // TODO: Uncomment and adjust if you have a format command
-  // formatCommand: 'npx prettier --write',
+  // Formatting: prettier is auto-detected. Set formatCommand to override.
 
   // Uncomment to override the default version patterns:
   // versionPatterns: { major: ['!'], minor: ['feat', 'feature'] },

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -5,6 +5,7 @@ import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpType } from './determineBumpType.ts';
 import { generateChangelogs } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
+import { hasPrettierConfig } from './hasPrettierConfig.ts';
 import { parseCommitMessage } from './parseCommitMessage.ts';
 import type { ParsedCommit, ReleaseConfig, ReleaseType } from './types.ts';
 
@@ -69,10 +70,11 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   console.info('Generating changelogs...');
   generateChangelogs(config, newTag, dryRun);
 
-  // 5. Run format command if configured, appending modified file paths
-  if (config.formatCommand !== undefined) {
+  // 5. Run format command, appending modified file paths
+  const formatCommand = config.formatCommand ?? (hasPrettierConfig() ? 'npx prettier --write' : undefined);
+  if (formatCommand !== undefined) {
     const modifiedFiles = [...config.packageFiles, ...config.changelogPaths.map((p) => `${p}/CHANGELOG.md`)];
-    const fullCommand = `${config.formatCommand} ${modifiedFiles.join(' ')}`;
+    const fullCommand = `${formatCommand} ${modifiedFiles.join(' ')}`;
     if (dryRun) {
       console.info(`  [dry-run] Would run format command: ${fullCommand}`);
     } else {

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -5,6 +5,7 @@ import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpType } from './determineBumpType.ts';
 import { generateChangelog } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
+import { hasPrettierConfig } from './hasPrettierConfig.ts';
 import { parseCommitMessage } from './parseCommitMessage.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
 import type { MonorepoReleaseConfig, ParsedCommit, ReleaseType } from './types.ts';
@@ -89,8 +90,9 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
   }
 
   // 5. Run format command once after all components are processed, appending modified file paths
-  if (tags.length > 0 && config.formatCommand !== undefined) {
-    const fullCommand = `${config.formatCommand} ${modifiedFiles.join(' ')}`;
+  const formatCommand = config.formatCommand ?? (hasPrettierConfig() ? 'npx prettier --write' : undefined);
+  if (tags.length > 0 && formatCommand !== undefined) {
+    const fullCommand = `${formatCommand} ${modifiedFiles.join(' ')}`;
     if (dryRun) {
       console.info(`\n  [dry-run] Would run format command: ${fullCommand}`);
     } else {


### PR DESCRIPTION
Closes #27 

## What

When `formatCommand` is not configured, release-kit now auto-detects whether the repo uses Prettier by checking for config files (`.prettierrc*`, `prettier.config.*`) or a `"prettier"` key in root `package.json`. If found, it defaults to `npx prettier --write` on generated files. If not found, formatting is skipped.

## Why

Release commits that introduce formatting violations force every subsequent branch to fix them. Repos with Prettier should have their generated CHANGELOGs formatted automatically, without requiring explicit `formatCommand` configuration or a full dependency install.

## Details

### Features

- Added `hasPrettierConfig()` detection function that checks 14 config file patterns and the `package.json` `"prettier"` key
- `releasePrepare` and `releasePrepareMono` now resolve an effective format command via `config.formatCommand ?? (hasPrettierConfig() ? 'npx prettier --write' : undefined)`
- Updated init template to replace commented-out `formatCommand` boilerplate with a note about auto-detection

### Tests

- Added 6 unit tests for `hasPrettierConfig` covering config file detection, `package.json` key detection, and negative cases
- Added 2 tests each to `releasePrepare` and `releasePrepareMono` for auto-detection (prettier present) and no-op (prettier absent) behaviors

## Test plan

- [ ] Run release-kit `prepare` in a repo with a `.prettierrc` and no `formatCommand` — verify prettier runs
- [ ] Run release-kit `prepare` in a repo with no prettier config and no `formatCommand` — verify no formatting step
- [ ] Run release-kit `prepare` with an explicit `formatCommand` — verify it takes precedence