### PR TITLE
#28 Add tag-creation command

### DIFF
--- a/packages/release-kit/src/__tests__/createTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createTags.unit.test.ts
@@ -16,6 +16,7 @@ import { createTags } from '../createTags.ts';
 describe(createTags, () => {
   beforeEach(() => {
     vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -134,5 +135,45 @@ describe(createTags, () => {
     const result = createTags({ dryRun: false, noGitChecks: true });
 
     expect(result).toEqual(['alpha-v1.0.0', 'beta-v2.0.0']);
+  });
+
+  it('skips the dirty-tree check when the tags file is empty', () => {
+    mockReadFileSync.mockReturnValue('');
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('dirty');
+    });
+
+    const result = createTags({ dryRun: false, noGitChecks: false });
+
+    expect(result).toEqual([]);
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('reports successfully created tags when a subsequent tag fails', () => {
+    mockReadFileSync.mockReturnValue('tag-a\ntag-b\ntag-c\n');
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes('tag-b')) {
+        throw new Error('tag already exists');
+      }
+    });
+
+    expect(() => createTags({ dryRun: false, noGitChecks: true })).toThrow('tag already exists');
+
+    expect(console.warn).toHaveBeenCalledWith('Tags created before failure:');
+    expect(console.warn).toHaveBeenCalledWith('  tag-a');
+  });
+
+  it('re-throws spawn errors from assertCleanWorkingTree without masking', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+    const spawnError = Object.assign(new Error('spawn git ENOENT'), {
+      errno: -2,
+      code: 'ENOENT',
+      syscall: 'spawn git',
+    });
+    mockExecFileSync.mockImplementation(() => {
+      throw spawnError;
+    });
+
+    expect(() => createTags({ dryRun: false, noGitChecks: false })).toThrow('spawn git ENOENT');
   });
 });

--- a/packages/release-kit/src/__tests__/createTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createTags.unit.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  readFileSync: mockReadFileSync,
+}));
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+import { createTags } from '../createTags.ts';
+
+describe(createTags, () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockReadFileSync.mockReset();
+    mockExecFileSync.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('throws when the tags file is missing', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(() => createTags({ dryRun: false, noGitChecks: false })).toThrow(
+      'No tags file found. Run `release-kit prepare` first.',
+    );
+  });
+
+  it('returns an empty array when the tags file is empty', () => {
+    mockReadFileSync.mockReturnValue('');
+
+    const result = createTags({ dryRun: false, noGitChecks: false });
+
+    expect(result).toEqual([]);
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty array when the tags file contains only whitespace', () => {
+    mockReadFileSync.mockReturnValue('  \n  \n  ');
+
+    const result = createTags({ dryRun: false, noGitChecks: false });
+
+    expect(result).toEqual([]);
+  });
+
+  it('creates annotated tags for each entry in the tags file', () => {
+    mockReadFileSync.mockReturnValue('release-kit-v2.1.0\ncore-v1.3.0\n');
+
+    const result = createTags({ dryRun: false, noGitChecks: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', [
+      'tag',
+      '-a',
+      'release-kit-v2.1.0',
+      '-m',
+      'release-kit-v2.1.0',
+    ]);
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['tag', '-a', 'core-v1.3.0', '-m', 'core-v1.3.0']);
+    expect(result).toEqual(['release-kit-v2.1.0', 'core-v1.3.0']);
+  });
+
+  it('prints the created tags heading in normal mode', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+
+    createTags({ dryRun: false, noGitChecks: true });
+
+    expect(console.info).toHaveBeenCalledWith('Created tags:');
+    expect(console.info).toHaveBeenCalledWith('🏷️ v1.0.0');
+  });
+
+  it('prints the dry-run heading and does not create tags in dry-run mode', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\nv2.0.0\n');
+
+    const result = createTags({ dryRun: true, noGitChecks: false });
+
+    expect(console.info).toHaveBeenCalledWith('[dry-run] Would create tags:');
+    expect(console.info).toHaveBeenCalledWith('🏷️ v1.0.0');
+    expect(console.info).toHaveBeenCalledWith('🏷️ v2.0.0');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(result).toEqual(['v1.0.0', 'v2.0.0']);
+  });
+
+  it('checks for a clean working tree when not in dry-run or noGitChecks mode', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+
+    createTags({ dryRun: false, noGitChecks: false });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['diff', '--quiet']);
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['diff', '--quiet', '--cached']);
+  });
+
+  it('throws when the working tree is dirty', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'diff') {
+        throw new Error('exit code 1');
+      }
+    });
+
+    expect(() => createTags({ dryRun: false, noGitChecks: false })).toThrow('Working tree is dirty');
+  });
+
+  it('skips the dirty check when noGitChecks is true', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+
+    createTags({ dryRun: false, noGitChecks: true });
+
+    // Only git tag calls, no git diff calls
+    const diffCalls = mockExecFileSync.mock.calls.filter(
+      (call: unknown[]) => Array.isArray(call[1]) && call[1][0] === 'diff',
+    );
+    expect(diffCalls).toHaveLength(0);
+  });
+
+  it('skips the dirty check when dryRun is true', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+
+    createTags({ dryRun: true, noGitChecks: false });
+
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('returns the list of tag names', () => {
+    mockReadFileSync.mockReturnValue('alpha-v1.0.0\nbeta-v2.0.0\n');
+
+    const result = createTags({ dryRun: false, noGitChecks: true });
+
+    expect(result).toEqual(['alpha-v1.0.0', 'beta-v2.0.0']);
+  });
+});

--- a/packages/release-kit/src/__tests__/tagCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/tagCommand.unit.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreateTags = vi.hoisted(() => vi.fn());
+
+vi.mock('../createTags.ts', () => ({
+  createTags: mockCreateTags,
+}));
+
+import { tagCommand } from '../tagCommand.ts';
+
+/** Sentinel error thrown by the mocked process.exit. */
+class ExitError extends Error {
+  constructor(public readonly code: number | undefined) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe(tagCommand, () => {
+  beforeEach(() => {
+    mockCreateTags.mockReturnValue([]);
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new ExitError(typeof code === 'number' ? code : undefined);
+    });
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockCreateTags.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('delegates to createTags with default options', () => {
+    tagCommand([]);
+
+    expect(mockCreateTags).toHaveBeenCalledWith({ dryRun: false, noGitChecks: false });
+  });
+
+  it('passes dryRun when --dry-run is provided', () => {
+    tagCommand(['--dry-run']);
+
+    expect(mockCreateTags).toHaveBeenCalledWith({ dryRun: true, noGitChecks: false });
+  });
+
+  it('passes noGitChecks when --no-git-checks is provided', () => {
+    tagCommand(['--no-git-checks']);
+
+    expect(mockCreateTags).toHaveBeenCalledWith({ dryRun: false, noGitChecks: true });
+  });
+
+  it('passes both flags when both are provided', () => {
+    tagCommand(['--dry-run', '--no-git-checks']);
+
+    expect(mockCreateTags).toHaveBeenCalledWith({ dryRun: true, noGitChecks: true });
+  });
+
+  it('exits with code 1 on unknown flags', () => {
+    expect(() => tagCommand(['--unknown'])).toThrow(ExitError);
+
+    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
+    expect(mockCreateTags).not.toHaveBeenCalled();
+  });
+
+  it('exits with code 1 when createTags throws', () => {
+    mockCreateTags.mockImplementation(() => {
+      throw new Error('No tags file found. Run `release-kit prepare` first.');
+    });
+
+    expect(() => tagCommand([])).toThrow(ExitError);
+
+    expect(console.error).toHaveBeenCalledWith('No tags file found. Run `release-kit prepare` first.');
+  });
+});

--- a/packages/release-kit/src/__tests__/tagCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/tagCommand.unit.test.ts
@@ -55,8 +55,17 @@ describe(tagCommand, () => {
   });
 
   it('exits with code 1 on unknown flags', () => {
-    expect(() => tagCommand(['--unknown'])).toThrow(ExitError);
+    let thrown: ExitError | undefined;
+    try {
+      tagCommand(['--unknown']);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
 
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
     expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
     expect(mockCreateTags).not.toHaveBeenCalled();
   });
@@ -66,8 +75,17 @@ describe(tagCommand, () => {
       throw new Error('No tags file found. Run `release-kit prepare` first.');
     });
 
-    expect(() => tagCommand([])).toThrow(ExitError);
+    let thrown: ExitError | undefined;
+    try {
+      tagCommand([]);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
 
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
     expect(console.error).toHaveBeenCalledWith('No tags file found. Run `release-kit prepare` first.');
   });
 });

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -7,6 +7,7 @@ import { prepareCommand } from '../prepareCommand.ts';
 import { generateCommand } from '../sync-labels/generateCommand.ts';
 import { syncLabelsInitCommand } from '../sync-labels/initCommand.ts';
 import { syncLabelsCommand } from '../sync-labels/syncCommand.ts';
+import { tagCommand } from '../tagCommand.ts';
 
 function showUsage(): void {
   console.info(`
@@ -14,6 +15,7 @@ Usage: release-kit <command> [options]
 
 Commands:
   prepare       Run release preparation (auto-discovers workspaces)
+  tag           Create annotated git tags from the tags file
   init          Initialize release-kit in the current repository
   sync-labels   Manage GitHub label synchronization
 
@@ -104,6 +106,19 @@ Options:
 `);
 }
 
+function showTagHelp(): void {
+  console.info(`
+Usage: release-kit tag [options]
+
+Create annotated git tags from the tags file produced by \`prepare\`.
+
+Options:
+  --dry-run          Preview without creating tags
+  --no-git-checks    Skip dirty working tree check
+  --help, -h         Show this help message
+`);
+}
+
 const args = process.argv.slice(2);
 const command = args[0];
 const flags = args.slice(1);
@@ -120,6 +135,16 @@ if (command === 'prepare') {
   }
 
   await prepareCommand(flags);
+  process.exit(0);
+}
+
+if (command === 'tag') {
+  if (flags.some((f) => f === '--help' || f === '-h')) {
+    showTagHelp();
+    process.exit(0);
+  }
+
+  tagCommand(flags);
   process.exit(0);
 }
 

--- a/packages/release-kit/src/createTags.ts
+++ b/packages/release-kit/src/createTags.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+import { RELEASE_TAGS_FILE } from './runReleasePrepare.ts';
+
+export interface CreateTagsOptions {
+  dryRun: boolean;
+  noGitChecks: boolean;
+}
+
+/**
+ * Read tag names from the tags file produced by `prepare` and create annotated git tags.
+ *
+ * Returns the list of tag names that were created (or would be created in dry-run mode).
+ */
+export function createTags(options: CreateTagsOptions): string[] {
+  const { dryRun, noGitChecks } = options;
+
+  let content: string;
+  try {
+    content = readFileSync(RELEASE_TAGS_FILE, 'utf8');
+  } catch {
+    throw new Error('No tags file found. Run `release-kit prepare` first.');
+  }
+
+  const tags = content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (tags.length === 0) {
+    return [];
+  }
+
+  if (!dryRun && !noGitChecks) {
+    assertCleanWorkingTree();
+  }
+
+  if (dryRun) {
+    console.info('[dry-run] Would create tags:');
+  } else {
+    for (const tag of tags) {
+      execFileSync('git', ['tag', '-a', tag, '-m', tag]);
+    }
+    console.info('Created tags:');
+  }
+
+  for (const tag of tags) {
+    console.info(`🏷️ ${tag}`);
+  }
+
+  return tags;
+}
+
+/** Throw if the git working tree has uncommitted changes. */
+function assertCleanWorkingTree(): void {
+  try {
+    execFileSync('git', ['diff', '--quiet']);
+    execFileSync('git', ['diff', '--quiet', '--cached']);
+  } catch {
+    throw new Error(
+      'Working tree is dirty. Commit or stash changes before tagging, or use `--no-git-checks` to skip this check.',
+    );
+  }
+}

--- a/packages/release-kit/src/createTags.ts
+++ b/packages/release-kit/src/createTags.ts
@@ -38,25 +38,29 @@ export function createTags(options: CreateTagsOptions): string[] {
 
   if (dryRun) {
     console.info('[dry-run] Would create tags:');
-  } else {
-    const created: string[] = [];
     for (const tag of tags) {
-      try {
-        execFileSync('git', ['tag', '-a', tag, '-m', tag]);
-        created.push(tag);
-      } catch (error: unknown) {
-        if (created.length > 0) {
-          console.warn('Tags created before failure:');
-          for (const t of created) {
-            console.warn(`  ${t}`);
-          }
-        }
-        throw error;
-      }
+      console.info(`🏷️ ${tag}`);
     }
-    console.info('Created tags:');
+    return tags;
   }
 
+  const created: string[] = [];
+  for (const tag of tags) {
+    try {
+      execFileSync('git', ['tag', '-a', tag, '-m', tag]);
+      created.push(tag);
+    } catch (error: unknown) {
+      if (created.length > 0) {
+        console.warn('Tags created before failure:');
+        for (const t of created) {
+          console.warn(`  ${t}`);
+        }
+      }
+      throw error;
+    }
+  }
+
+  console.info('Created tags:');
   for (const tag of tags) {
     console.info(`🏷️ ${tag}`);
   }
@@ -70,16 +74,11 @@ function assertCleanWorkingTree(): void {
     execFileSync('git', ['diff', '--quiet']);
     execFileSync('git', ['diff', '--quiet', '--cached']);
   } catch (error: unknown) {
-    if (isSpawnError(error)) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
       throw error;
     }
     throw new Error(
       'Working tree is dirty. Commit or stash changes before tagging, or use `--no-git-checks` to skip this check.',
     );
   }
-}
-
-/** Detect errors from spawning the process itself (e.g. `ENOENT` when git is not on PATH). */
-function isSpawnError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && 'errno' in error;
 }

--- a/packages/release-kit/src/createTags.ts
+++ b/packages/release-kit/src/createTags.ts
@@ -39,8 +39,20 @@ export function createTags(options: CreateTagsOptions): string[] {
   if (dryRun) {
     console.info('[dry-run] Would create tags:');
   } else {
+    const created: string[] = [];
     for (const tag of tags) {
-      execFileSync('git', ['tag', '-a', tag, '-m', tag]);
+      try {
+        execFileSync('git', ['tag', '-a', tag, '-m', tag]);
+        created.push(tag);
+      } catch (error: unknown) {
+        if (created.length > 0) {
+          console.warn('Tags created before failure:');
+          for (const t of created) {
+            console.warn(`  ${t}`);
+          }
+        }
+        throw error;
+      }
     }
     console.info('Created tags:');
   }
@@ -57,9 +69,17 @@ function assertCleanWorkingTree(): void {
   try {
     execFileSync('git', ['diff', '--quiet']);
     execFileSync('git', ['diff', '--quiet', '--cached']);
-  } catch {
+  } catch (error: unknown) {
+    if (isSpawnError(error)) {
+      throw error;
+    }
     throw new Error(
       'Working tree is dirty. Commit or stash changes before tagging, or use `--no-git-checks` to skip this check.',
     );
   }
+}
+
+/** Detect errors from spawning the process itself (e.g. `ENOENT` when git is not on PATH). */
+function isSpawnError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'errno' in error;
 }

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -1,4 +1,5 @@
 // Types
+export type { CreateTagsOptions } from './createTags.ts';
 export type { GenerateChangelogOptions } from './generateChangelogs.ts';
 export type { ReleasePrepareOptions } from './releasePrepare.ts';
 export type { LabelDefinition, SyncLabelsConfig } from './sync-labels/types.ts';
@@ -22,6 +23,7 @@ export { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 export { bumpAllVersions } from './bumpAllVersions.ts';
 export { bumpVersion } from './bumpVersion.ts';
 export { component } from './component.ts';
+export { createTags } from './createTags.ts';
 export { determineBumpType } from './determineBumpType.ts';
 export { discoverWorkspaces } from './discoverWorkspaces.ts';
 export { generateChangelog, generateChangelogs } from './generateChangelogs.ts';

--- a/packages/release-kit/src/tagCommand.ts
+++ b/packages/release-kit/src/tagCommand.ts
@@ -1,0 +1,27 @@
+/* eslint n/no-process-exit: off */
+/* eslint unicorn/no-process-exit: off */
+
+import { createTags } from './createTags.ts';
+
+const KNOWN_FLAGS = new Set(['--dry-run', '--no-git-checks', '--help', '-h']);
+
+/**
+ * Orchestrate the CLI `tag` command: parse flags and delegate to `createTags`.
+ */
+export function tagCommand(argv: string[]): void {
+  const unknownFlags = argv.filter((f) => !KNOWN_FLAGS.has(f));
+  if (unknownFlags.length > 0) {
+    console.error(`Error: Unknown option: ${unknownFlags[0]}`);
+    process.exit(1);
+  }
+
+  const dryRun = argv.includes('--dry-run');
+  const noGitChecks = argv.includes('--no-git-checks');
+
+  try {
+    createTags({ dryRun, noGitChecks });
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/packages/release-kit/src/tagCommand.ts
+++ b/packages/release-kit/src/tagCommand.ts
@@ -3,14 +3,13 @@
 
 import { createTags } from './createTags.ts';
 
-// Help flags are handled upstream in the CLI entry point (bin/release-kit.ts).
-const KNOWN_FLAGS = new Set(['--dry-run', '--no-git-checks']);
-
 /**
  * Orchestrate the CLI `tag` command: parse flags and delegate to `createTags`.
  */
 export function tagCommand(argv: string[]): void {
-  const unknownFlags = argv.filter((f) => !KNOWN_FLAGS.has(f));
+  // Help flags are handled upstream in the CLI entry point (bin/release-kit.ts).
+  const knownFlags = new Set(['--dry-run', '--no-git-checks']);
+  const unknownFlags = argv.filter((f) => !knownFlags.has(f));
   if (unknownFlags.length > 0) {
     console.error(`Error: Unknown option: ${unknownFlags[0]}`);
     process.exit(1);

--- a/packages/release-kit/src/tagCommand.ts
+++ b/packages/release-kit/src/tagCommand.ts
@@ -3,7 +3,8 @@
 
 import { createTags } from './createTags.ts';
 
-const KNOWN_FLAGS = new Set(['--dry-run', '--no-git-checks', '--help', '-h']);
+// Help flags are handled upstream in the CLI entry point (bin/release-kit.ts).
+const KNOWN_FLAGS = new Set(['--dry-run', '--no-git-checks']);
 
 /**
  * Orchestrate the CLI `tag` command: parse flags and delegate to `createTags`.


### PR DESCRIPTION
Closes #28 

## What

Add a `release-kit tag` CLI command that reads computed tag names from the `tmp/.release-tags` file produced by `prepare` and creates annotated git tags. The command supports `--dry-run` (preview without creating tags) and `--no-git-checks` (skip dirty working tree validation). The `createTags` function and its options type are exported for programmatic use.

## Why

The reusable release workflow currently creates tags in an inline shell step, duplicating logic that belongs in release-kit. Moving tag creation into `release-kit tag` keeps the full release lifecycle in one tool, respects annotated-tag conventions automatically, and simplifies both the workflow and manual local releases.

## Details

### Features

- `createTags` core function: reads the tags file, validates the working tree is clean (both staged and unstaged changes), creates annotated git tags, and returns the list of created tag names
- `tagCommand` CLI handler: parses `--dry-run` and `--no-git-checks` flags, rejects unknown flags with exit code 1
- CLI entry point wiring: `release-kit tag` command with `--help` support
- Package exports: `createTags` and `CreateTagsOptions` available for library consumers

### Fixes

- Partial tag creation failures report which tags were already created before propagating the error
- Spawn errors (e.g., git not on PATH) are distinguished from dirty-tree exit codes and propagated with their original message

### Tests

- Unit tests for `createTags`: tags file reading, empty file early return, dirty tree detection, dry-run mode, tag creation, partial failure warning, spawn error passthrough
- Unit tests for `tagCommand`: flag parsing, unknown flag rejection with exit code verification, delegation to `createTags`