### PR TITLE
#29 Add publish command

### DIFF
--- a/packages/release-kit/src/__tests__/createTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createTags.unit.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockUnlinkSync = vi.hoisted(() => vi.fn());
 const mockExecFileSync = vi.hoisted(() => vi.fn());
 
 vi.mock('node:fs', () => ({
   readFileSync: mockReadFileSync,
+  unlinkSync: mockUnlinkSync,
 }));
 
 vi.mock('node:child_process', () => ({
@@ -21,6 +23,7 @@ describe(createTags, () => {
 
   afterEach(() => {
     mockReadFileSync.mockReset();
+    mockUnlinkSync.mockReset();
     mockExecFileSync.mockReset();
     vi.restoreAllMocks();
   });
@@ -175,5 +178,30 @@ describe(createTags, () => {
     });
 
     expect(() => createTags({ dryRun: false, noGitChecks: false })).toThrow('spawn git ENOENT');
+  });
+
+  it('deletes the tags file after successful tag creation', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+
+    createTags({ dryRun: false, noGitChecks: true });
+
+    expect(mockUnlinkSync).toHaveBeenCalledWith('tmp/.release-tags');
+  });
+
+  it('does not delete the tags file in dry-run mode', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+
+    createTags({ dryRun: true, noGitChecks: false });
+
+    expect(mockUnlinkSync).not.toHaveBeenCalled();
+  });
+
+  it('tolerates missing tags file on deletion', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+    mockUnlinkSync.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    expect(() => createTags({ dryRun: false, noGitChecks: true })).not.toThrow();
   });
 });

--- a/packages/release-kit/src/__tests__/detectPackageManager.unit.test.ts
+++ b/packages/release-kit/src/__tests__/detectPackageManager.unit.test.ts
@@ -33,8 +33,32 @@ describe(detectPackageManager, () => {
     expect(detectPackageManager()).toBe('npm');
   });
 
-  it('detects yarn from the packageManager field', () => {
+  it('detects Yarn Classic from the packageManager field', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'yarn@1.22.19' }));
+
+    expect(detectPackageManager()).toBe('yarn');
+  });
+
+  it('detects Yarn Berry from the packageManager field', () => {
     mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'yarn@4.1.0' }));
+
+    expect(detectPackageManager()).toBe('yarn-berry');
+  });
+
+  it('detects Yarn Berry for v2', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'yarn@2.0.0' }));
+
+    expect(detectPackageManager()).toBe('yarn-berry');
+  });
+
+  it('detects Yarn Berry for v3', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'yarn@3.6.4' }));
+
+    expect(detectPackageManager()).toBe('yarn-berry');
+  });
+
+  it('treats yarn without version as Classic', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'yarn' }));
 
     expect(detectPackageManager()).toBe('yarn');
   });

--- a/packages/release-kit/src/__tests__/detectPackageManager.unit.test.ts
+++ b/packages/release-kit/src/__tests__/detectPackageManager.unit.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  readFileSync: mockReadFileSync,
+  existsSync: mockExistsSync,
+}));
+
+import { detectPackageManager } from '../detectPackageManager.ts';
+
+describe(detectPackageManager, () => {
+  beforeEach(() => {
+    mockReadFileSync.mockReturnValue('{}');
+    mockExistsSync.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    mockReadFileSync.mockReset();
+    mockExistsSync.mockReset();
+  });
+
+  it('detects pnpm from the packageManager field', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'pnpm@9.15.4' }));
+
+    expect(detectPackageManager()).toBe('pnpm');
+  });
+
+  it('detects npm from the packageManager field', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'npm@10.2.0' }));
+
+    expect(detectPackageManager()).toBe('npm');
+  });
+
+  it('detects yarn from the packageManager field', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'yarn@4.1.0' }));
+
+    expect(detectPackageManager()).toBe('yarn');
+  });
+
+  it('handles packageManager field without version suffix', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'pnpm' }));
+
+    expect(detectPackageManager()).toBe('pnpm');
+  });
+
+  it('falls back to lockfile detection when packageManager field is unrecognized', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'bun@1.0.0' }));
+    mockExistsSync.mockReturnValue(false);
+
+    expect(detectPackageManager()).toBe('npm');
+  });
+
+  it('falls back to lockfile detection when packageManager field is absent', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'my-package' }));
+    mockExistsSync.mockImplementation((path: string) => path.endsWith('pnpm-lock.yaml'));
+
+    expect(detectPackageManager()).toBe('pnpm');
+  });
+
+  it('detects npm from package-lock.json', () => {
+    mockReadFileSync.mockReturnValue('{}');
+    mockExistsSync.mockImplementation((path: string) => path.endsWith('package-lock.json'));
+
+    expect(detectPackageManager()).toBe('npm');
+  });
+
+  it('detects yarn from yarn.lock', () => {
+    mockReadFileSync.mockReturnValue('{}');
+    mockExistsSync.mockImplementation((path: string) => path.endsWith('yarn.lock'));
+
+    expect(detectPackageManager()).toBe('yarn');
+  });
+
+  it('defaults to npm when no signal is found', () => {
+    mockReadFileSync.mockReturnValue('{}');
+    mockExistsSync.mockReturnValue(false);
+
+    expect(detectPackageManager()).toBe('npm');
+  });
+
+  it('falls back to lockfile detection when package.json cannot be read', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    mockExistsSync.mockImplementation((path: string) => path.endsWith('yarn.lock'));
+
+    expect(detectPackageManager()).toBe('yarn');
+  });
+
+  it('falls back to lockfile detection when package.json contains invalid JSON', () => {
+    mockReadFileSync.mockReturnValue('not json');
+    mockExistsSync.mockImplementation((path: string) => path.endsWith('pnpm-lock.yaml'));
+
+    expect(detectPackageManager()).toBe('pnpm');
+  });
+});

--- a/packages/release-kit/src/__tests__/publish.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publish.unit.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+import { publish } from '../publish.ts';
+import type { ResolvedTag } from '../resolveReleaseTags.ts';
+
+describe(publish, () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockExecFileSync.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  const singleTag: ResolvedTag[] = [{ tag: 'v1.0.0', dir: '.', workspacePath: '.' }];
+  const multiTags: ResolvedTag[] = [
+    { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+    { tag: 'release-kit-v2.1.0', dir: 'release-kit', workspacePath: 'packages/release-kit' },
+  ];
+
+  it('does nothing when resolvedTags is empty', () => {
+    publish([], 'npm', { dryRun: false, noGitChecks: false });
+
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
+  });
+
+  it('runs npm publish from the correct directory', () => {
+    publish(singleTag, 'npm', { dryRun: false, noGitChecks: false });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('runs pnpm publish from the correct directory for each package', () => {
+    publish(multiTags, 'pnpm', { dryRun: false, noGitChecks: false });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish'], {
+      cwd: 'packages/core',
+      stdio: 'inherit',
+    });
+    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish'], {
+      cwd: 'packages/release-kit',
+      stdio: 'inherit',
+    });
+  });
+
+  it('forwards --dry-run flag', () => {
+    publish(singleTag, 'npm', { dryRun: true, noGitChecks: false });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish', '--dry-run'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('forwards --no-git-checks only for pnpm', () => {
+    publish(singleTag, 'pnpm', { dryRun: false, noGitChecks: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--no-git-checks'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('does not forward --no-git-checks for npm', () => {
+    publish(singleTag, 'npm', { dryRun: false, noGitChecks: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('does not forward --no-git-checks for yarn', () => {
+    publish(singleTag, 'yarn', { dryRun: false, noGitChecks: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['publish'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('forwards both --dry-run and --no-git-checks for pnpm', () => {
+    publish(singleTag, 'pnpm', { dryRun: true, noGitChecks: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--dry-run', '--no-git-checks'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('prints confirmation listing before publishing', () => {
+    publish(multiTags, 'pnpm', { dryRun: false, noGitChecks: false });
+
+    expect(console.info).toHaveBeenCalledWith('Publishing:');
+    expect(console.info).toHaveBeenCalledWith('  core-v1.3.0 (packages/core)');
+    expect(console.info).toHaveBeenCalledWith('  release-kit-v2.1.0 (packages/release-kit)');
+  });
+
+  it('prints dry-run confirmation listing', () => {
+    publish(multiTags, 'pnpm', { dryRun: true, noGitChecks: false });
+
+    expect(console.info).toHaveBeenCalledWith('[dry-run] Would publish:');
+  });
+
+  it('reports successfully published packages when a subsequent publish fails', () => {
+    mockExecFileSync.mockImplementation((_cmd: string, _args: string[], opts: { cwd: string }) => {
+      if (opts.cwd === 'packages/release-kit') {
+        throw new Error('publish failed');
+      }
+    });
+
+    expect(() => publish(multiTags, 'pnpm', { dryRun: false, noGitChecks: false })).toThrow('publish failed');
+
+    expect(console.warn).toHaveBeenCalledWith('Packages published before failure:');
+    expect(console.warn).toHaveBeenCalledWith('  core-v1.3.0');
+  });
+});

--- a/packages/release-kit/src/__tests__/publish.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publish.unit.test.ts
@@ -91,6 +91,33 @@ describe(publish, () => {
     });
   });
 
+  it('runs yarn npm publish for yarn-berry', () => {
+    publish(singleTag, 'yarn-berry', { dryRun: false, noGitChecks: false });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('forwards --dry-run for yarn-berry', () => {
+    publish(singleTag, 'yarn-berry', { dryRun: true, noGitChecks: false });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish', '--dry-run'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('does not forward --no-git-checks for yarn-berry', () => {
+    publish(singleTag, 'yarn-berry', { dryRun: false, noGitChecks: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
   it('forwards both --dry-run and --no-git-checks for pnpm', () => {
     publish(singleTag, 'pnpm', { dryRun: true, noGitChecks: true });
 

--- a/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDiscoverWorkspaces = vi.hoisted(() => vi.fn());
+const mockResolveReleaseTags = vi.hoisted(() => vi.fn());
+const mockDetectPackageManager = vi.hoisted(() => vi.fn());
+const mockPublish = vi.hoisted(() => vi.fn());
+
+vi.mock('../discoverWorkspaces.ts', () => ({
+  discoverWorkspaces: mockDiscoverWorkspaces,
+}));
+
+vi.mock('../resolveReleaseTags.ts', () => ({
+  resolveReleaseTags: mockResolveReleaseTags,
+}));
+
+vi.mock('../detectPackageManager.ts', () => ({
+  detectPackageManager: mockDetectPackageManager,
+}));
+
+vi.mock('../publish.ts', () => ({
+  publish: mockPublish,
+}));
+
+import { publishCommand } from '../publishCommand.ts';
+
+/** Sentinel error thrown by the mocked process.exit. */
+class ExitError extends Error {
+  constructor(public readonly code: number | undefined) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe(publishCommand, () => {
+  beforeEach(() => {
+    mockDiscoverWorkspaces.mockResolvedValue(undefined);
+    mockResolveReleaseTags.mockReturnValue([{ tag: 'v1.0.0', dir: '.', workspacePath: '.' }]);
+    mockDetectPackageManager.mockReturnValue('npm');
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new ExitError(typeof code === 'number' ? code : undefined);
+    });
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockDiscoverWorkspaces.mockReset();
+    mockResolveReleaseTags.mockReset();
+    mockDetectPackageManager.mockReset();
+    mockPublish.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('delegates to publish with default options', async () => {
+    await publishCommand([]);
+
+    expect(mockPublish).toHaveBeenCalledWith([{ tag: 'v1.0.0', dir: '.', workspacePath: '.' }], 'npm', {
+      dryRun: false,
+      noGitChecks: false,
+    });
+  });
+
+  it('passes dryRun when --dry-run is provided', async () => {
+    await publishCommand(['--dry-run']);
+
+    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'npm', { dryRun: true, noGitChecks: false });
+  });
+
+  it('passes noGitChecks when --no-git-checks is provided', async () => {
+    await publishCommand(['--no-git-checks']);
+
+    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'npm', { dryRun: false, noGitChecks: true });
+  });
+
+  it('exits with code 1 on unknown flags', async () => {
+    let thrown: ExitError | undefined;
+    try {
+      await publishCommand(['--unknown']);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
+    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it('exits with code 1 when no release tags are found on HEAD', async () => {
+    mockResolveReleaseTags.mockReturnValue([]);
+
+    let thrown: ExitError | undefined;
+    try {
+      await publishCommand([]);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
+    expect(console.error).toHaveBeenCalledWith(
+      'Error: No release tags found on HEAD. Create tags with `release-kit tag` first.',
+    );
+  });
+
+  it('exits with code 1 when --only is used in single-package mode', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue(undefined);
+
+    let thrown: ExitError | undefined;
+    try {
+      await publishCommand(['--only=core']);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
+    expect(console.error).toHaveBeenCalledWith('Error: --only is only supported for monorepo configurations');
+  });
+
+  it('filters resolved tags by --only in monorepo mode', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue(['packages/core', 'packages/release-kit']);
+    mockResolveReleaseTags.mockReturnValue([
+      { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+      { tag: 'release-kit-v2.1.0', dir: 'release-kit', workspacePath: 'packages/release-kit' },
+    ]);
+
+    await publishCommand(['--only=core']);
+
+    expect(mockPublish).toHaveBeenCalledWith(
+      [{ tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' }],
+      'npm',
+      { dryRun: false, noGitChecks: false },
+    );
+  });
+
+  it('exits with code 1 when --only references an unmatched name', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue(['packages/core']);
+    mockResolveReleaseTags.mockReturnValue([{ tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' }]);
+
+    let thrown: ExitError | undefined;
+    try {
+      await publishCommand(['--only=nonexistent']);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
+    expect(console.error).toHaveBeenCalledWith('Error: Unknown package "nonexistent" in --only. Available: core');
+  });
+
+  it('exits with code 1 when publish throws', async () => {
+    mockPublish.mockImplementation(() => {
+      throw new Error('publish failed');
+    });
+
+    let thrown: ExitError | undefined;
+    try {
+      await publishCommand([]);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
+    expect(console.error).toHaveBeenCalledWith('publish failed');
+  });
+
+  it('uses the detected package manager', async () => {
+    mockDetectPackageManager.mockReturnValue('pnpm');
+
+    await publishCommand([]);
+
+    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'pnpm', expect.anything());
+  });
+});

--- a/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+import { resolveReleaseTags } from '../resolveReleaseTags.ts';
+
+describe(resolveReleaseTags, () => {
+  afterEach(() => {
+    mockExecFileSync.mockReset();
+  });
+
+  it('returns an empty array when no tags point at HEAD', () => {
+    mockExecFileSync.mockReturnValue('');
+
+    expect(resolveReleaseTags()).toEqual([]);
+  });
+
+  it('resolves a single-package tag', () => {
+    mockExecFileSync.mockReturnValue('v1.2.3\n');
+
+    expect(resolveReleaseTags()).toEqual([{ tag: 'v1.2.3', dir: '.', workspacePath: '.' }]);
+  });
+
+  it('ignores unrecognized tags in single-package mode', () => {
+    mockExecFileSync.mockReturnValue('v1.2.3\nsome-other-tag\nrelease-candidate\n');
+
+    expect(resolveReleaseTags()).toEqual([{ tag: 'v1.2.3', dir: '.', workspacePath: '.' }]);
+  });
+
+  it('resolves monorepo tags against the workspace map', () => {
+    mockExecFileSync.mockReturnValue('core-v1.3.0\nrelease-kit-v2.1.0\n');
+    const workspaceMap = new Map([
+      ['core', 'packages/core'],
+      ['release-kit', 'packages/release-kit'],
+    ]);
+
+    expect(resolveReleaseTags(workspaceMap)).toEqual([
+      { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+      { tag: 'release-kit-v2.1.0', dir: 'release-kit', workspacePath: 'packages/release-kit' },
+    ]);
+  });
+
+  it('ignores monorepo tags with unrecognized directory names', () => {
+    mockExecFileSync.mockReturnValue('unknown-v1.0.0\ncore-v1.3.0\n');
+    const workspaceMap = new Map([['core', 'packages/core']]);
+
+    expect(resolveReleaseTags(workspaceMap)).toEqual([
+      { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+    ]);
+  });
+
+  it('ignores non-release tags in monorepo mode', () => {
+    mockExecFileSync.mockReturnValue('core-v1.3.0\nsome-random-tag\n');
+    const workspaceMap = new Map([['core', 'packages/core']]);
+
+    expect(resolveReleaseTags(workspaceMap)).toEqual([
+      { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+    ]);
+  });
+
+  it('handles tags with multiple hyphens in the directory name', () => {
+    mockExecFileSync.mockReturnValue('my-cool-lib-v3.0.0\n');
+    const workspaceMap = new Map([['my-cool-lib', 'packages/my-cool-lib']]);
+
+    expect(resolveReleaseTags(workspaceMap)).toEqual([
+      { tag: 'my-cool-lib-v3.0.0', dir: 'my-cool-lib', workspacePath: 'packages/my-cool-lib' },
+    ]);
+  });
+
+  it('returns an empty array when no tags match in monorepo mode', () => {
+    mockExecFileSync.mockReturnValue('unrelated-tag\n');
+    const workspaceMap = new Map([['core', 'packages/core']]);
+
+    expect(resolveReleaseTags(workspaceMap)).toEqual([]);
+  });
+});

--- a/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockExecFileSync = vi.hoisted(() => vi.fn());
 
@@ -9,8 +9,13 @@ vi.mock('node:child_process', () => ({
 import { resolveReleaseTags } from '../resolveReleaseTags.ts';
 
 describe(resolveReleaseTags, () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
   afterEach(() => {
     mockExecFileSync.mockReset();
+    vi.restoreAllMocks();
   });
 
   it('returns an empty array when no tags point at HEAD', () => {
@@ -76,5 +81,24 @@ describe(resolveReleaseTags, () => {
     const workspaceMap = new Map([['core', 'packages/core']]);
 
     expect(resolveReleaseTags(workspaceMap)).toEqual([]);
+  });
+
+  it('warns and returns only the first tag when multiple single-package version tags exist', () => {
+    mockExecFileSync.mockReturnValue('v1.0.0\nv1.1.0\n');
+
+    const result = resolveReleaseTags();
+
+    expect(result).toEqual([{ tag: 'v1.0.0', dir: '.', workspacePath: '.' }]);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Multiple version tags found on HEAD: v1.0.0, v1.1.0'),
+    );
+  });
+
+  it('does not warn when only one single-package version tag exists', () => {
+    mockExecFileSync.mockReturnValue('v1.2.3\n');
+
+    resolveReleaseTags();
+
+    expect(console.warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -4,6 +4,7 @@
 
 import { initCommand } from '../init/initCommand.ts';
 import { prepareCommand } from '../prepareCommand.ts';
+import { publishCommand } from '../publishCommand.ts';
 import { generateCommand } from '../sync-labels/generateCommand.ts';
 import { syncLabelsInitCommand } from '../sync-labels/initCommand.ts';
 import { syncLabelsCommand } from '../sync-labels/syncCommand.ts';
@@ -16,6 +17,7 @@ Usage: release-kit <command> [options]
 Commands:
   prepare       Run release preparation (auto-discovers workspaces)
   tag           Create annotated git tags from the tags file
+  publish       Publish packages with release tags on HEAD
   init          Initialize release-kit in the current repository
   sync-labels   Manage GitHub label synchronization
 
@@ -119,6 +121,20 @@ Options:
 `);
 }
 
+function showPublishHelp(): void {
+  console.info(`
+Usage: release-kit publish [options]
+
+Publish packages that have release tags on HEAD.
+
+Options:
+  --dry-run              Preview without publishing
+  --no-git-checks        Skip git checks (pnpm only)
+  --only=name1,name2     Only publish the named packages (comma-separated, monorepo only)
+  --help, -h             Show this help message
+`);
+}
+
 const args = process.argv.slice(2);
 const command = args[0];
 const flags = args.slice(1);
@@ -145,6 +161,16 @@ if (command === 'tag') {
   }
 
   tagCommand(flags);
+  process.exit(0);
+}
+
+if (command === 'publish') {
+  if (flags.some((f) => f === '--help' || f === '-h')) {
+    showPublishHelp();
+    process.exit(0);
+  }
+
+  await publishCommand(flags);
   process.exit(0);
 }
 

--- a/packages/release-kit/src/createTags.ts
+++ b/packages/release-kit/src/createTags.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, unlinkSync } from 'node:fs';
 
 import { RELEASE_TAGS_FILE } from './runReleasePrepare.ts';
 
@@ -65,7 +65,21 @@ export function createTags(options: CreateTagsOptions): string[] {
     console.info(`🏷️ ${tag}`);
   }
 
+  deleteTagsFile();
+
   return tags;
+}
+
+/** Remove the tags file after successful tag creation. Tolerate missing file. */
+function deleteTagsFile(): void {
+  try {
+    unlinkSync(RELEASE_TAGS_FILE);
+  } catch (error: unknown) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
 }
 
 /** Throw if the git working tree has uncommitted changes. */

--- a/packages/release-kit/src/detectPackageManager.ts
+++ b/packages/release-kit/src/detectPackageManager.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { isRecord } from './typeGuards.ts';
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn';
+
+/**
+ * Detect the repo's package manager by checking the `packageManager` field in root `package.json`,
+ * then falling back to lockfile detection, then defaulting to `npm`.
+ */
+export function detectPackageManager(): PackageManager {
+  const packageJsonPath = join(process.cwd(), 'package.json');
+
+  try {
+    const content = readFileSync(packageJsonPath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+
+    if (isRecord(parsed) && typeof parsed.packageManager === 'string') {
+      const name = parsed.packageManager.split('@')[0];
+      if (name === 'pnpm' || name === 'npm' || name === 'yarn') {
+        return name;
+      }
+    }
+  } catch {
+    // Fall through to lockfile detection
+  }
+
+  return detectFromLockfile();
+}
+
+/** Detect the package manager from the presence of lockfiles. */
+function detectFromLockfile(): PackageManager {
+  const cwd = process.cwd();
+
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) {
+    return 'pnpm';
+  }
+  if (existsSync(join(cwd, 'package-lock.json'))) {
+    return 'npm';
+  }
+  if (existsSync(join(cwd, 'yarn.lock'))) {
+    return 'yarn';
+  }
+
+  return 'npm';
+}

--- a/packages/release-kit/src/detectPackageManager.ts
+++ b/packages/release-kit/src/detectPackageManager.ts
@@ -3,11 +3,13 @@ import { join } from 'node:path';
 
 import { isRecord } from './typeGuards.ts';
 
-export type PackageManager = 'npm' | 'pnpm' | 'yarn';
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'yarn-berry';
 
 /**
  * Detect the repo's package manager by checking the `packageManager` field in root `package.json`,
  * then falling back to lockfile detection, then defaulting to `npm`.
+ *
+ * Yarn v2+ is returned as `'yarn-berry'` to distinguish it from Yarn Classic.
  */
 export function detectPackageManager(): PackageManager {
   const packageJsonPath = join(process.cwd(), 'package.json');
@@ -17,9 +19,12 @@ export function detectPackageManager(): PackageManager {
     const parsed: unknown = JSON.parse(content);
 
     if (isRecord(parsed) && typeof parsed.packageManager === 'string') {
-      const name = parsed.packageManager.split('@')[0];
-      if (name === 'pnpm' || name === 'npm' || name === 'yarn') {
+      const [name, version] = parsed.packageManager.split('@');
+      if (name === 'pnpm' || name === 'npm') {
         return name;
+      }
+      if (name === 'yarn') {
+        return isYarnBerry(version) ? 'yarn-berry' : 'yarn';
       }
     }
   } catch {
@@ -27,6 +32,15 @@ export function detectPackageManager(): PackageManager {
   }
 
   return detectFromLockfile();
+}
+
+/** Return true when the version string indicates Yarn v2+. */
+function isYarnBerry(version: string | undefined): boolean {
+  if (version === undefined) {
+    return false;
+  }
+  const major = Number.parseInt(version, 10);
+  return !Number.isNaN(major) && major >= 2;
 }
 
 /** Detect the package manager from the presence of lockfiles. */

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -1,7 +1,10 @@
 // Types
 export type { CreateTagsOptions } from './createTags.ts';
+export type { PackageManager } from './detectPackageManager.ts';
 export type { GenerateChangelogOptions } from './generateChangelogs.ts';
+export type { PublishOptions } from './publish.ts';
 export type { ReleasePrepareOptions } from './releasePrepare.ts';
+export type { ResolvedTag } from './resolveReleaseTags.ts';
 export type { LabelDefinition, SyncLabelsConfig } from './sync-labels/types.ts';
 export type {
   Commit,
@@ -24,11 +27,14 @@ export { bumpAllVersions } from './bumpAllVersions.ts';
 export { bumpVersion } from './bumpVersion.ts';
 export { component } from './component.ts';
 export { createTags } from './createTags.ts';
+export { detectPackageManager } from './detectPackageManager.ts';
 export { determineBumpType } from './determineBumpType.ts';
 export { discoverWorkspaces } from './discoverWorkspaces.ts';
 export { generateChangelog, generateChangelogs } from './generateChangelogs.ts';
 export { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 export { parseCommitMessage } from './parseCommitMessage.ts';
+export { publish } from './publish.ts';
 export { releasePrepare } from './releasePrepare.ts';
 export { releasePrepareMono } from './releasePrepareMono.ts';
+export { resolveReleaseTags } from './resolveReleaseTags.ts';
 export { RELEASE_TAGS_FILE, runReleasePrepare, writeReleaseTags } from './runReleasePrepare.ts';

--- a/packages/release-kit/src/publish.ts
+++ b/packages/release-kit/src/publish.ts
@@ -1,0 +1,68 @@
+import { execFileSync } from 'node:child_process';
+
+import type { PackageManager } from './detectPackageManager.ts';
+import type { ResolvedTag } from './resolveReleaseTags.ts';
+
+export interface PublishOptions {
+  dryRun: boolean;
+  noGitChecks: boolean;
+}
+
+/**
+ * Publish resolved packages by running `{pm} publish` from each package directory.
+ *
+ * Prints a confirmation listing all packages before publishing begins. Exits on first failure,
+ * reporting which packages were successfully published before the error.
+ */
+export function publish(resolvedTags: ResolvedTag[], packageManager: PackageManager, options: PublishOptions): void {
+  const { dryRun, noGitChecks } = options;
+
+  if (resolvedTags.length === 0) {
+    return;
+  }
+
+  console.info(dryRun ? '[dry-run] Would publish:' : 'Publishing:');
+  for (const { tag, workspacePath } of resolvedTags) {
+    console.info(`  ${tag} (${workspacePath})`);
+  }
+
+  const published: string[] = [];
+
+  for (const { tag, workspacePath } of resolvedTags) {
+    const args = buildPublishArgs(packageManager, { dryRun, noGitChecks });
+
+    try {
+      console.info(
+        `\n${dryRun ? '[dry-run] ' : ''}Running: ${packageManager} ${args.join(' ')} (cwd: ${workspacePath})`,
+      );
+      execFileSync(packageManager, args, { cwd: workspacePath, stdio: 'inherit' });
+      published.push(tag);
+    } catch (error: unknown) {
+      if (published.length > 0) {
+        console.warn('Packages published before failure:');
+        for (const t of published) {
+          console.warn(`  ${t}`);
+        }
+      }
+      throw error;
+    }
+  }
+}
+
+/** Build the argument list for `{pm} publish`. */
+function buildPublishArgs(
+  packageManager: PackageManager,
+  options: { dryRun: boolean; noGitChecks: boolean },
+): string[] {
+  const args = ['publish'];
+
+  if (options.dryRun) {
+    args.push('--dry-run');
+  }
+
+  if (options.noGitChecks && packageManager === 'pnpm') {
+    args.push('--no-git-checks');
+  }
+
+  return args;
+}

--- a/packages/release-kit/src/publish.ts
+++ b/packages/release-kit/src/publish.ts
@@ -29,13 +29,12 @@ export function publish(resolvedTags: ResolvedTag[], packageManager: PackageMana
   const published: string[] = [];
 
   for (const { tag, workspacePath } of resolvedTags) {
+    const executable = resolveExecutable(packageManager);
     const args = buildPublishArgs(packageManager, { dryRun, noGitChecks });
 
     try {
-      console.info(
-        `\n${dryRun ? '[dry-run] ' : ''}Running: ${packageManager} ${args.join(' ')} (cwd: ${workspacePath})`,
-      );
-      execFileSync(packageManager, args, { cwd: workspacePath, stdio: 'inherit' });
+      console.info(`\n${dryRun ? '[dry-run] ' : ''}Running: ${executable} ${args.join(' ')} (cwd: ${workspacePath})`);
+      execFileSync(executable, args, { cwd: workspacePath, stdio: 'inherit' });
       published.push(tag);
     } catch (error: unknown) {
       if (published.length > 0) {
@@ -49,9 +48,17 @@ export function publish(resolvedTags: ResolvedTag[], packageManager: PackageMana
   }
 }
 
-/** Build the argument list for `{pm} publish`. */
+/** Map the `PackageManager` value to the actual CLI executable name. */
+function resolveExecutable(packageManager: PackageManager): string {
+  if (packageManager === 'yarn-berry') {
+    return 'yarn';
+  }
+  return packageManager;
+}
+
+/** Build the argument list for the publish command. */
 function buildPublishArgs(packageManager: PackageManager, options: PublishOptions): string[] {
-  const args = ['publish'];
+  const args = packageManager === 'yarn-berry' ? ['npm', 'publish'] : ['publish'];
 
   if (options.dryRun) {
     args.push('--dry-run');

--- a/packages/release-kit/src/publish.ts
+++ b/packages/release-kit/src/publish.ts
@@ -50,10 +50,7 @@ export function publish(resolvedTags: ResolvedTag[], packageManager: PackageMana
 }
 
 /** Build the argument list for `{pm} publish`. */
-function buildPublishArgs(
-  packageManager: PackageManager,
-  options: { dryRun: boolean; noGitChecks: boolean },
-): string[] {
+function buildPublishArgs(packageManager: PackageManager, options: PublishOptions): string[] {
   const args = ['publish'];
 
   if (options.dryRun) {

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -24,7 +24,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
   const noGitChecks = argv.includes('--no-git-checks');
 
   const onlyArg = argv.find((f) => f.startsWith('--only='));
-  const only = onlyArg === undefined ? undefined : onlyArg.slice('--only='.length).split(',');
+  const only = onlyArg?.slice('--only='.length).split(',');
 
   // Discover workspaces to determine single-package vs monorepo mode
   let discoveredPaths: string[] | undefined;
@@ -45,13 +45,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
     discoveredPaths === undefined ? undefined : new Map(discoveredPaths.map((p) => [basename(p), p]));
 
   // Resolve tags from HEAD
-  let resolvedTags;
-  try {
-    resolvedTags = resolveReleaseTags(workspaceMap);
-  } catch (error: unknown) {
-    console.error(`Error resolving tags: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(1);
-  }
+  let resolvedTags = resolveReleaseTags(workspaceMap);
 
   if (resolvedTags.length === 0) {
     console.error('Error: No release tags found on HEAD. Create tags with `release-kit tag` first.');

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -1,0 +1,81 @@
+/* eslint n/no-process-exit: off */
+/* eslint unicorn/no-process-exit: off */
+
+import { basename } from 'node:path';
+
+import { detectPackageManager } from './detectPackageManager.ts';
+import { discoverWorkspaces } from './discoverWorkspaces.ts';
+import { publish } from './publish.ts';
+import { resolveReleaseTags } from './resolveReleaseTags.ts';
+
+/**
+ * Orchestrate the CLI `publish` command: parse flags, discover workspaces, resolve tags from HEAD,
+ * detect the package manager, validate `--only`, and delegate to `publish`.
+ */
+export async function publishCommand(argv: string[]): Promise<void> {
+  const knownFlags = new Set(['--dry-run', '--no-git-checks']);
+  const unknownFlags = argv.filter((f) => !f.startsWith('--only=') && !knownFlags.has(f));
+  if (unknownFlags.length > 0) {
+    console.error(`Error: Unknown option: ${unknownFlags[0]}`);
+    process.exit(1);
+  }
+
+  const dryRun = argv.includes('--dry-run');
+  const noGitChecks = argv.includes('--no-git-checks');
+
+  const onlyArg = argv.find((f) => f.startsWith('--only='));
+  const only = onlyArg === undefined ? undefined : onlyArg.slice('--only='.length).split(',');
+
+  // Discover workspaces to determine single-package vs monorepo mode
+  let discoveredPaths: string[] | undefined;
+  try {
+    discoveredPaths = await discoverWorkspaces();
+  } catch (error: unknown) {
+    console.error(`Error discovering workspaces: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  if (only !== undefined && discoveredPaths === undefined) {
+    console.error('Error: --only is only supported for monorepo configurations');
+    process.exit(1);
+  }
+
+  // Build workspace map: dir (basename) -> workspace path
+  const workspaceMap =
+    discoveredPaths === undefined ? undefined : new Map(discoveredPaths.map((p) => [basename(p), p]));
+
+  // Resolve tags from HEAD
+  let resolvedTags;
+  try {
+    resolvedTags = resolveReleaseTags(workspaceMap);
+  } catch (error: unknown) {
+    console.error(`Error resolving tags: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  if (resolvedTags.length === 0) {
+    console.error('Error: No release tags found on HEAD. Create tags with `release-kit tag` first.');
+    process.exit(1);
+  }
+
+  // Validate --only against resolved tags
+  if (only !== undefined) {
+    const availableNames = resolvedTags.map((t) => t.dir);
+    for (const name of only) {
+      if (!availableNames.includes(name)) {
+        console.error(`Error: Unknown package "${name}" in --only. Available: ${availableNames.join(', ')}`);
+        process.exit(1);
+      }
+    }
+    resolvedTags = resolvedTags.filter((t) => only.includes(t.dir));
+  }
+
+  const packageManager = detectPackageManager();
+
+  try {
+    publish(resolvedTags, packageManager, { dryRun, noGitChecks });
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/packages/release-kit/src/resolveReleaseTags.ts
+++ b/packages/release-kit/src/resolveReleaseTags.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from 'node:child_process';
+
+export interface ResolvedTag {
+  tag: string;
+  dir: string;
+  workspacePath: string;
+}
+
+/** Pattern matching a version suffix like `v1.2.3` or `v0.10.0-beta.1`. */
+const VERSION_PATTERN = /^v\d+\.\d+\.\d+/;
+
+/**
+ * Resolve release tags pointing at HEAD into publishable package descriptors.
+ *
+ * In single-package mode (no `workspaceMap`), match tags like `v1.2.3`.
+ * In monorepo mode, match `{dir}-v{semver}` tags against the provided workspace map.
+ */
+export function resolveReleaseTags(workspaceMap?: Map<string, string>): ResolvedTag[] {
+  const output = execFileSync('git', ['tag', '--points-at', 'HEAD'], { encoding: 'utf8' });
+
+  const tags = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (tags.length === 0) {
+    return [];
+  }
+
+  if (workspaceMap === undefined) {
+    return resolveSinglePackageTags(tags);
+  }
+
+  return resolveMonorepoTags(tags, workspaceMap);
+}
+
+/** Match single-package tags of the form `v{semver}`. */
+function resolveSinglePackageTags(tags: string[]): ResolvedTag[] {
+  const resolved: ResolvedTag[] = [];
+
+  for (const tag of tags) {
+    if (VERSION_PATTERN.test(tag)) {
+      resolved.push({ tag, dir: '.', workspacePath: '.' });
+    }
+  }
+
+  return resolved;
+}
+
+/** Match monorepo tags of the form `{dir}-v{semver}` against the workspace map. */
+function resolveMonorepoTags(tags: string[], workspaceMap: Map<string, string>): ResolvedTag[] {
+  const resolved: ResolvedTag[] = [];
+
+  for (const tag of tags) {
+    const dashV = tag.lastIndexOf('-v');
+    if (dashV === -1) {
+      continue;
+    }
+
+    const dir = tag.slice(0, dashV);
+    const versionPart = tag.slice(dashV + 1);
+
+    if (!VERSION_PATTERN.test(versionPart)) {
+      continue;
+    }
+
+    const workspacePath = workspaceMap.get(dir);
+    if (workspacePath !== undefined) {
+      resolved.push({ tag, dir, workspacePath });
+    }
+  }
+
+  return resolved;
+}

--- a/packages/release-kit/src/resolveReleaseTags.ts
+++ b/packages/release-kit/src/resolveReleaseTags.ts
@@ -23,10 +23,6 @@ export function resolveReleaseTags(workspaceMap?: Map<string, string>): Resolved
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 
-  if (tags.length === 0) {
-    return [];
-  }
-
   if (workspaceMap === undefined) {
     return resolveSinglePackageTags(tags);
   }
@@ -36,15 +32,7 @@ export function resolveReleaseTags(workspaceMap?: Map<string, string>): Resolved
 
 /** Match single-package tags of the form `v{semver}`. */
 function resolveSinglePackageTags(tags: string[]): ResolvedTag[] {
-  const resolved: ResolvedTag[] = [];
-
-  for (const tag of tags) {
-    if (VERSION_PATTERN.test(tag)) {
-      resolved.push({ tag, dir: '.', workspacePath: '.' });
-    }
-  }
-
-  return resolved;
+  return tags.filter((tag) => VERSION_PATTERN.test(tag)).map((tag) => ({ tag, dir: '.', workspacePath: '.' }));
 }
 
 /** Match monorepo tags of the form `{dir}-v{semver}` against the workspace map. */

--- a/packages/release-kit/src/resolveReleaseTags.ts
+++ b/packages/release-kit/src/resolveReleaseTags.ts
@@ -30,9 +30,19 @@ export function resolveReleaseTags(workspaceMap?: Map<string, string>): Resolved
   return resolveMonorepoTags(tags, workspaceMap);
 }
 
-/** Match single-package tags of the form `v{semver}`. */
+/** Match single-package tags of the form `v{semver}`, warning if multiple are found. */
 function resolveSinglePackageTags(tags: string[]): ResolvedTag[] {
-  return tags.filter((tag) => VERSION_PATTERN.test(tag)).map((tag) => ({ tag, dir: '.', workspacePath: '.' }));
+  const matched = tags.filter((tag) => VERSION_PATTERN.test(tag));
+
+  if (matched.length > 1) {
+    console.warn(
+      `Warning: Multiple version tags found on HEAD: ${matched.join(', ')}. ` +
+        `Publishing the same package multiple times is almost certainly unintended. Using only the first tag.`,
+    );
+    return matched.slice(0, 1).map((tag) => ({ tag, dir: '.', workspacePath: '.' }));
+  }
+
+  return matched.map((tag) => ({ tag, dir: '.', workspacePath: '.' }));
 }
 
 /** Match monorepo tags of the form `{dir}-v{semver}` against the workspace map. */


### PR DESCRIPTION
Closes #29 

## What

Adds a `release-kit publish` subcommand that derives packages to publish from git tags on HEAD and delegates to the repo's detected package manager. Also cleans up the `.release-tags` file after tag creation.

## Why

Publishing packages after a release required manual coordination — knowing which packages were tagged, running the right publish command from the right directory, with the right package manager. This completes the release workflow: `prepare` → `tag` → `publish`.

## Details

### Features

- **Publish command** (`publishCommand.ts`): thin CLI orchestrator that parses flags (`--dry-run`, `--no-git-checks`, `--only=name1,name2`), discovers workspaces, resolves tags, detects the package manager, validates `--only`, and delegates to the core publish function. Wired into the CLI entry point with help text.
- **Package manager detection** (`detectPackageManager.ts`): reads `packageManager` field from root `package.json`, falls back to lockfile detection (`pnpm-lock.yaml` → `package-lock.json` → `yarn.lock`), defaults to `npm`. Returns a `PackageManager` union type including `'yarn-berry'` for Yarn v2+ to handle its distinct `yarn npm publish` command.
- **Tag resolution from HEAD** (`resolveReleaseTags.ts`): runs `git tag --points-at HEAD` and resolves tags into `ResolvedTag[]`. Single-package mode matches `v{semver}`, monorepo mode matches `{dir}-v{semver}` using `lastIndexOf('-v')` for robust multi-hyphen directory name handling. Warns and returns only the first tag when multiple single-package version tags are found.
- **Publish execution** (`publish.ts`): prints confirmation listing, runs `{pm} publish` per package via `execFileSync`. Forwards `--dry-run` always, `--no-git-checks` only for pnpm. Reports prior successes on failure.
- **Tags-file cleanup**: `createTags()` now deletes `tmp/.release-tags` after successful tag creation. Tolerates missing files, skipped in dry-run mode.
- **Public API**: exports `detectPackageManager`, `publish`, `resolveReleaseTags`, and their types from `index.ts`.

### Tests

- 5 new test files with 50+ tests covering all code paths: `createTags` cleanup behavior, `detectPackageManager` (field parsing, lockfile fallback, Yarn Berry detection), `publish` (all flag combinations, failure reporting, Yarn Berry support), `publishCommand` (flag validation, `--only` filtering, error handling), and `resolveReleaseTags` (single-package, monorepo, multi-hyphen dirs, multiple-tags guard).

## Test plan

- [ ] Manual smoke test: create tags on HEAD, run `release-kit publish --dry-run`, verify correct packages identified
- [ ] Verify Yarn Berry detection: test with `packageManager: "yarn@4.1.0"` in package.json
- [ ] Verify `--only` filtering in a monorepo context