### PR TITLE
#17 Cover multi-changelogPaths and error paths

### DIFF
--- a/packages/release-kit/src/__tests__/getCommitsSinceTarget.unit.test.ts
+++ b/packages/release-kit/src/__tests__/getCommitsSinceTarget.unit.test.ts
@@ -134,4 +134,31 @@ describe(getCommitsSinceTarget, () => {
     const logArgs = findLogCallArgs();
     expect(logArgs[1]).toBe('HEAD');
   });
+
+  it('propagates git describe errors with a non-128 status', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        throw Object.assign(new Error('permission denied'), { status: 1 });
+      }
+      return '';
+    });
+
+    expect(() => getCommitsSinceTarget('v')).toThrow("Failed to run 'git describe': permission denied");
+  });
+
+  it('wraps and re-throws git log failures', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        throw new Error('spawn git ENOENT');
+      }
+      return '';
+    });
+
+    expect(() => getCommitsSinceTarget('v')).toThrow(
+      "Failed to run 'git log' for range 'v1.0.0..HEAD': spawn git ENOENT",
+    );
+  });
 });

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -57,6 +57,22 @@ function countCliffCalls(): number {
   ).length;
 }
 
+/** Collect the --output path from every npx git-cliff call. */
+function findAllCliffOutputPaths(): string[] {
+  const paths: string[] = [];
+  for (const call of mockExecFileSync.mock.calls) {
+    if (call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff')) {
+      const args = call[1];
+      const outputIndex = args.indexOf('--output');
+      const outputPath = outputIndex === -1 ? undefined : args[outputIndex + 1];
+      if (typeof outputPath === 'string') {
+        paths.push(outputPath);
+      }
+    }
+  }
+  return paths;
+}
+
 describe(releasePrepareMono, () => {
   afterEach(() => {
     mockExecFileSync.mockReset();
@@ -553,5 +569,39 @@ describe(releasePrepareMono, () => {
     releasePrepareMono(config, { dryRun: false });
 
     expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('generates a changelog for each entry in changelogPaths', () => {
+    const config = makeConfig({
+      components: [
+        {
+          dir: 'arrays',
+          tagPrefix: 'arrays-v',
+          packageFiles: ['packages/arrays/package.json'],
+          changelogPaths: ['packages/arrays', 'packages/arrays/docs'],
+          paths: ['packages/arrays/**'],
+        },
+      ],
+    });
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'arrays-v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'feat: add utility\u001Fabc123';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    const result = releasePrepareMono(config, { dryRun: false });
+
+    expect(result).toStrictEqual(['arrays-v1.1.0']);
+    expect(countCliffCalls()).toBe(2);
+    expect(findAllCliffOutputPaths()).toStrictEqual([
+      'packages/arrays/CHANGELOG.md',
+      'packages/arrays/docs/CHANGELOG.md',
+    ]);
   });
 });


### PR DESCRIPTION
Closes #17 

## What

Adds three unit tests covering previously untested code paths in `releasePrepareMono` and `getCommitsSinceTarget`. Also adds a `findAllCliffOutputPaths()` test helper for asserting per-call `git-cliff` output targets.

## Why

Issue #17 identified two test coverage gaps: the multi-`changelogPaths` iteration loop in `releasePrepareMono` was exercised only with single-entry arrays, and two error-handling branches in `getCommitsSinceTarget` (non-128 `git describe` failures and `git log` failures) had no test coverage.

## Details

### Tests

- `releasePrepareMono`: test with a component having two `changelogPaths` entries, asserting `git-cliff` is called once per path and each call targets the correct `--output` path.
- `getCommitsSinceTarget`: test that a `git describe` error with non-128 status propagates as a wrapped error rather than being treated as "no tag found".
- `getCommitsSinceTarget`: test that a `git log` failure is wrapped and re-thrown with the commit range in the error message.
- New `findAllCliffOutputPaths()` helper collects the `--output` arg from every `git-cliff` mock call, complementing the existing `findCliffCallArgs()` and `countCliffCalls()` helpers.