### PR TITLE
#43 Replace dist bin targets with thin wrapper scripts

### DIFF
--- a/packages/core/bin/nmr-report-overrides.js
+++ b/packages/core/bin/nmr-report-overrides.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import('../dist/esm/cli-report-overrides.js');

--- a/packages/core/bin/nmr-sync-pnpm-version.js
+++ b/packages/core/bin/nmr-sync-pnpm-version.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import('../dist/esm/cli-sync-pnpm-version.js');

--- a/packages/core/bin/nmr.js
+++ b/packages/core/bin/nmr.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import('../dist/esm/cli.js');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,11 +17,12 @@
     "./tests": "./dist/esm/tests/consistency.js"
   },
   "bin": {
-    "nmr": "dist/esm/cli.js",
-    "nmr-report-overrides": "dist/esm/cli-report-overrides.js",
-    "nmr-sync-pnpm-version": "dist/esm/cli-sync-pnpm-version.js"
+    "nmr": "bin/nmr.js",
+    "nmr-report-overrides": "bin/nmr-report-overrides.js",
+    "nmr-sync-pnpm-version": "bin/nmr-sync-pnpm-version.js"
   },
   "files": [
+    "bin",
     "dist"
   ],
   "scripts": {

--- a/packages/release-kit/bin/release-kit.js
+++ b/packages/release-kit/bin/release-kit.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import('../dist/esm/bin/release-kit.js');

--- a/packages/release-kit/package.json
+++ b/packages/release-kit/package.json
@@ -21,9 +21,10 @@
     }
   },
   "bin": {
-    "release-kit": "./dist/esm/bin/release-kit.js"
+    "release-kit": "./bin/release-kit.js"
   },
   "files": [
+    "bin",
     "dist/*",
     "cliff.toml.template",
     "presets/**",


### PR DESCRIPTION
Closes #43 

## What

Replace `dist/esm/` bin targets in `packages/core` and `packages/release-kit` with thin wrapper scripts in committed `bin/` directories. Each wrapper is a two-line script (shebang + dynamic `import()`) that forwards to the real entry point under `dist/esm/`.

## Why

When `pnpm install` runs in a fresh worktree or clone, it validates that bin targets exist. Since `dist/` is gitignored and only created at build time, every bin entry emitted a "Failed to create bin" warning. The wrapper scripts exist at install time, eliminating the warnings.

## Details

### Fixes

- Add `packages/core/bin/nmr.js`, `nmr-report-overrides.js`, and `nmr-sync-pnpm-version.js` as wrappers forwarding to `dist/esm/cli*.js`
- Add `packages/release-kit/bin/release-kit.js` as a wrapper forwarding to `dist/esm/bin/release-kit.js`
- Update `bin` entries in both `package.json` files to point to the wrappers
- Add `bin` to the `files` array in both packages so wrappers ship in the published tarball

## Test plan

- Run `pnpm install` in a fresh worktree and confirm no "Failed to create bin" warnings
- After building, confirm all bin commands (`nmr`, `nmr-report-overrides`, `nmr-sync-pnpm-version`, `release-kit`) execute correctly