### PR TITLE
#41 Remove tagPrefix customization from component config

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -114,7 +114,6 @@ All fields are optional.
 ```typescript
 interface ComponentOverride {
   dir: string; // Package directory name (e.g., 'arrays')
-  tagPrefix?: string; // Custom git tag prefix (defaults to '${dir}-v')
   shouldExclude?: boolean; // If true, exclude from release processing
 }
 ```
@@ -178,12 +177,9 @@ component('packages/arrays');
 //   changelogPaths: ['packages/arrays'],
 //   paths: ['packages/arrays/**'],
 // }
-
-// Custom tag prefix
-component('libs/core', 'core-v');
 ```
 
-The `dir` field is derived from `path.basename()`, so `packages/arrays` and `libs/arrays` both produce `dir: 'arrays'`.
+The `dir` field is derived from `path.basename()`, so `packages/arrays` and `libs/arrays` both produce `dir: 'arrays'`. The `tagPrefix` is always `${dir}-v` — it cannot be customized.
 
 ## GitHub Actions workflow
 

--- a/packages/release-kit/src/__tests__/component.unit.test.ts
+++ b/packages/release-kit/src/__tests__/component.unit.test.ts
@@ -13,16 +13,6 @@ describe(component, () => {
     });
   });
 
-  it('uses a custom tag prefix when provided', () => {
-    expect(component('packages/basic', 'my-lib-v')).toStrictEqual({
-      dir: 'basic',
-      tagPrefix: 'my-lib-v',
-      packageFiles: ['packages/basic/package.json'],
-      changelogPaths: ['packages/basic'],
-      paths: ['packages/basic/**'],
-    });
-  });
-
   it('works with non-standard workspace paths', () => {
     expect(component('libs/core')).toStrictEqual({
       dir: 'core',

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -142,14 +142,6 @@ describe(mergeMonorepoConfig, () => {
     expect(result.components[0]?.tagPrefix).toBe('arrays-v');
   });
 
-  it('applies tagPrefix override to a matched component', () => {
-    const result = mergeMonorepoConfig(discoveredPaths, {
-      components: [{ dir: 'arrays', tagPrefix: 'my-arrays-v' }],
-    });
-
-    expect(result.components[0]?.tagPrefix).toBe('my-arrays-v');
-  });
-
   it('merges custom workTypes with defaults', () => {
     const result = mergeMonorepoConfig(discoveredPaths, {
       workTypes: { perf: { header: 'Performance' } },

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -21,7 +21,7 @@ describe(validateConfig, () => {
   describe('components', () => {
     it('validates a valid components array', () => {
       const { config, errors } = validateConfig({
-        components: [{ dir: 'arrays' }, { dir: 'strings', tagPrefix: 'str-v', shouldExclude: false }],
+        components: [{ dir: 'arrays' }, { dir: 'strings', shouldExclude: false }],
       });
       expect(errors).toStrictEqual([]);
       expect(config.components).toHaveLength(2);
@@ -33,7 +33,7 @@ describe(validateConfig, () => {
     });
 
     it('returns an error when dir is missing', () => {
-      const { errors } = validateConfig({ components: [{ tagPrefix: 'test-v' }] });
+      const { errors } = validateConfig({ components: [{ shouldExclude: true }] });
       expect(errors).toContain("components[0]: 'dir' is required");
     });
 

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -43,6 +43,22 @@ describe(validateConfig, () => {
       });
       expect(errors).toContain("components[0]: 'shouldExclude' must be a boolean");
     });
+
+    it('returns a deprecation error when tagPrefix is present', () => {
+      const { errors } = validateConfig({
+        components: [{ dir: 'arrays', tagPrefix: 'my-v' }],
+      });
+      expect(errors).toContain(
+        "components[0]: 'tagPrefix' is no longer supported; remove it to use the default 'arrays-v'",
+      );
+    });
+
+    it('returns an error for unknown component fields', () => {
+      const { errors } = validateConfig({
+        components: [{ dir: 'arrays', bogusField: true }],
+      });
+      expect(errors).toContain("components[0]: unknown field 'bogusField'");
+    });
   });
 
   describe('versionPatterns', () => {

--- a/packages/release-kit/src/component.ts
+++ b/packages/release-kit/src/component.ts
@@ -7,17 +7,13 @@ import type { ComponentConfig } from './types.ts';
  *
  * Derives all fields from the workspace path so that the same rule governs both
  * tag creation and tag lookup. The `dir` field is the basename of the path; the
- * `tagPrefix` defaults to `${dir}-v`.
- *
- * @param workspacePath - The workspace-relative path (e.g., 'packages/arrays' or 'libs/core').
- * @param tagPrefix - Optional custom tag prefix. Defaults to `${basename}-v`.
+ * `tagPrefix` is always `${dir}-v`.
  */
-export function component(workspacePath: string, tagPrefix?: string): ComponentConfig {
+export function component(workspacePath: string): ComponentConfig {
   const dir = basename(workspacePath);
-  const prefix = tagPrefix ?? `${dir}-v`;
   return {
     dir,
-    tagPrefix: prefix,
+    tagPrefix: `${dir}-v`,
     packageFiles: [`${workspacePath}/package.json`],
     changelogPaths: [workspacePath],
     paths: [`${workspacePath}/**`],

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -62,18 +62,10 @@ export function mergeMonorepoConfig(
   if (userConfig?.components !== undefined) {
     const overrides = new Map(userConfig.components.map((c) => [c.dir, c]));
 
-    components = components
-      .filter((c) => {
-        const override = overrides.get(c.dir);
-        return override?.shouldExclude !== true;
-      })
-      .map((c) => {
-        const override = overrides.get(c.dir);
-        if (override?.tagPrefix !== undefined) {
-          return { ...c, tagPrefix: override.tagPrefix };
-        }
-        return c;
-      });
+    components = components.filter((c) => {
+      const override = overrides.get(c.dir);
+      return override?.shouldExclude !== true;
+    });
   }
 
   // Merge workTypes

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -45,8 +45,8 @@ export async function loadConfig(): Promise<unknown> {
  * Resolves a final monorepo config from discovered workspaces and an optional user config overlay.
  *
  * Merging rules:
- * - `components`: match overlay entries by `dir` against discovered list; `shouldExclude` removes;
- *   other fields override; unlisted packages keep defaults.
+ * - `components`: match overlay entries by `dir` against discovered list; `shouldExclude: true`
+ *   removes the component; unlisted packages keep defaults.
  * - `workTypes`: shallow merge — consumer entries override or add to defaults by key.
  * - `versionPatterns`: consumer value replaces defaults entirely.
  * - `formatCommand`, `cliffConfigPath`, `workspaceAliases`: consumer value wins.

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -55,8 +55,6 @@ export interface ReleaseKitConfig {
 export interface ComponentOverride {
   /** The package directory name (e.g., 'arrays'). */
   dir: string;
-  /** Custom git tag prefix. Defaults to `${dir}-v`. */
-  tagPrefix?: string;
   /** If true, exclude this component from release processing. */
   shouldExclude?: boolean;
 }

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -67,13 +67,6 @@ function validateComponents(value: unknown, config: ReleaseKitConfig, errors: st
 
     const component: NonNullable<ReleaseKitConfig['components']>[number] = { dir: entry.dir };
 
-    if (entry.tagPrefix !== undefined) {
-      if (typeof entry.tagPrefix === 'string') {
-        component.tagPrefix = entry.tagPrefix;
-      } else {
-        errors.push(`components[${i}]: 'tagPrefix' must be a string`);
-      }
-    }
     if (entry.shouldExclude !== undefined) {
       if (typeof entry.shouldExclude === 'boolean') {
         component.shouldExclude = entry.shouldExclude;

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -55,6 +55,7 @@ function validateComponents(value: unknown, config: ReleaseKitConfig, errors: st
   }
 
   const components: NonNullable<ReleaseKitConfig['components']> = [];
+  const knownComponentFields = new Set(['dir', 'shouldExclude']);
   for (const [i, entry] of value.entries()) {
     if (!isRecord(entry)) {
       errors.push(`components[${i}]: must be an object`);
@@ -66,7 +67,6 @@ function validateComponents(value: unknown, config: ReleaseKitConfig, errors: st
     }
 
     // Detect unknown or removed fields
-    const knownComponentFields = new Set(['dir', 'shouldExclude']);
     for (const key of Object.keys(entry)) {
       if (!knownComponentFields.has(key)) {
         if (key === 'tagPrefix') {

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -65,6 +65,20 @@ function validateComponents(value: unknown, config: ReleaseKitConfig, errors: st
       continue;
     }
 
+    // Detect unknown or removed fields
+    const knownComponentFields = new Set(['dir', 'shouldExclude']);
+    for (const key of Object.keys(entry)) {
+      if (!knownComponentFields.has(key)) {
+        if (key === 'tagPrefix') {
+          errors.push(
+            `components[${i}]: 'tagPrefix' is no longer supported; remove it to use the default '${entry.dir}-v'`,
+          );
+        } else {
+          errors.push(`components[${i}]: unknown field '${key}'`);
+        }
+      }
+    }
+
     const component: NonNullable<ReleaseKitConfig['components']>[number] = { dir: entry.dir };
 
     if (entry.shouldExclude !== undefined) {


### PR DESCRIPTION
Closes #41 

## What

Removes the ability to customize `tagPrefix` per component, enforcing the deterministic `{dir}-v` convention universally. The internal `tagPrefix` property on `ComponentConfig` and `ReleaseConfig` is preserved — only the override/customization entry points are removed. Existing configs that still include `tagPrefix` now receive a clear deprecation error.

## Why

The `tagPrefix` override adds complexity for no practical benefit — directory names are already unique within the monorepo, and the `{dir}-v` convention is deterministic. Discovered during design of the `publish` command (#29), which derives packages from git tags using the `{dir}-v{version}` pattern; supporting custom prefixes would require loading the config file, adding unnecessary complexity.

## Details

### Features

- `ComponentOverride` no longer accepts `tagPrefix`
- `component()` no longer accepts a `tagPrefix` parameter — it always derives `${dir}-v`
- `mergeMonorepoConfig()` no longer applies `tagPrefix` overrides from user config
- `validateComponents()` now detects unknown fields in component entries, including a specific deprecation error for `tagPrefix`: `'tagPrefix' is no longer supported; remove it to use the default '${dir}-v'`

### Refactoring

- Simplified `mergeMonorepoConfig()` by removing the `.map()` chain that applied tagPrefix overrides
- Hoisted `knownComponentFields` set outside the validation loop in `validateComponents()`
- Updated `mergeMonorepoConfig` JSDoc to reflect current merging behavior

### Tests

- Removed tests for custom `tagPrefix` parameter in `component()` and override merging in `mergeMonorepoConfig()`
- Added tests for tagPrefix deprecation error and generic unknown-field error in `validateConfig`
- Updated existing test fixtures to remove `tagPrefix` usage

### Documentation

- Removed `tagPrefix` from `ComponentOverride` interface block in README
- Removed custom tag prefix example from `component()` usage section
- Updated prose to state that `tagPrefix` is always `${dir}-v` and cannot be customized