### PR TITLE
#47 Enable strict linting of monorepo root

### DIFF
--- a/packages/core/__tests__/registries.test.ts
+++ b/packages/core/__tests__/registries.test.ts
@@ -49,4 +49,10 @@ describe('getDefaultRootScripts', () => {
     expect(scripts.test).toBe('nmr root:test && pnpm --recursive exec nmr test');
     expect(scripts.typecheck).toBe('nmr root:typecheck && pnpm --recursive exec nmr typecheck');
   });
+
+  it('runs strict-lint against the monorepo root, excluding packages', () => {
+    const scripts = getDefaultRootScripts();
+
+    expect(scripts['root:lint:strict']).toBe("strict-lint --ignore-pattern 'packages/**' .");
+  });
 });

--- a/packages/core/src/registries.ts
+++ b/packages/core/src/registries.ts
@@ -62,8 +62,7 @@ function getDefaultRootScripts(): ScriptRegistry {
     'report-overrides': 'nmr-report-overrides',
     'root:lint': "eslint --fix --ignore-pattern 'packages/**' .",
     'root:lint:check': "eslint --ignore-pattern 'packages/**' .",
-    'root:lint:strict':
-      'echo "Strict linting for the workspace root cannot be enabled until a pattern is accepted as an argument. Falling back to normal linting." && nmr root:lint:check',
+    'root:lint:strict': "strict-lint --ignore-pattern 'packages/**' .",
     'root:test': 'vitest --config ./vitest.root.config.ts',
     'root:typecheck': 'tsgo --noEmit',
     'sync-pnpm-version': 'nmr-sync-pnpm-version',


### PR DESCRIPTION
Closes #47 

## What

Replaces the `root:lint:strict` echo fallback with a direct `strict-lint --ignore-pattern 'packages/**' .` invocation, now that the `strict-lint` package supports the full `eslint` CLI API.

## Why

The `root:lint:strict` script previously fell back to normal linting because `strict-lint` did not accept `--ignore-pattern`. With that limitation removed, the monorepo root can now be strict-linted like any workspace package.

## Details

### Features

- `root:lint:strict` now runs `strict-lint` against the monorepo root, excluding the `packages/` directory. This applies both to this project and to consumers of `nmr` who inherit the default script registry.

### Tests

- Added assertion verifying the new `root:lint:strict` script value in `getDefaultRootScripts`.