### PR TITLE
#51 Add preflight-check package

### DIFF
--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import type { PreflightConfig } from '../src/types.ts';
+
+const mockLoadPreflightConfig = vi.hoisted(() => vi.fn());
+const mockRunPreflight = vi.hoisted(() => vi.fn());
+const mockReportPreflight = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/config.ts', () => ({
+  loadPreflightConfig: mockLoadPreflightConfig,
+}));
+
+vi.mock('../src/runPreflight.ts', () => ({
+  runPreflight: mockRunPreflight,
+}));
+
+vi.mock('../src/reportPreflight.ts', () => ({
+  reportPreflight: mockReportPreflight,
+}));
+
+import { main, parseArgs } from '../src/cli.ts';
+
+/** Sentinel error thrown by the mocked `process.exit` so tests can detect early termination. */
+class ExitError extends Error {
+  code: number;
+  constructor(code: number) {
+    super(`process.exit(${code})`);
+    this.code = code;
+  }
+}
+
+function makeConfig(overrides?: Partial<PreflightConfig>): PreflightConfig {
+  return {
+    checklists: [
+      { name: 'deploy', checks: [{ name: 'a', check: () => true }] },
+      { name: 'infra', checks: [{ name: 'b', check: () => true }] },
+    ],
+    ...overrides,
+  };
+}
+
+describe(parseArgs, () => {
+  it('parses positional names', () => {
+    const result = parseArgs(['node', 'preflight', 'deploy', 'infra']);
+
+    expect(result.names).toStrictEqual(['deploy', 'infra']);
+    expect(result.configPath).toBeUndefined();
+  });
+
+  it('parses --config flag', () => {
+    const result = parseArgs(['node', 'preflight', '--config', 'custom/path.ts']);
+
+    expect(result.configPath).toBe('custom/path.ts');
+    expect(result.names).toStrictEqual([]);
+  });
+
+  it('parses --config= syntax', () => {
+    const result = parseArgs(['node', 'preflight', '--config=custom/path.ts']);
+
+    expect(result.configPath).toBe('custom/path.ts');
+  });
+
+  it('parses -c flag', () => {
+    const result = parseArgs(['node', 'preflight', '-c', 'custom/path.ts']);
+
+    expect(result.configPath).toBe('custom/path.ts');
+  });
+
+  it('parses mixed flags and names', () => {
+    const result = parseArgs(['node', 'preflight', '-c', 'config.ts', 'deploy']);
+
+    expect(result.configPath).toBe('config.ts');
+    expect(result.names).toStrictEqual(['deploy']);
+  });
+
+  it('throws when --config has no value', () => {
+    expect(() => parseArgs(['node', 'preflight', '--config'])).toThrow('--config requires a path argument');
+  });
+
+  it('throws when -c has no value', () => {
+    expect(() => parseArgs(['node', 'preflight', '-c'])).toThrow('--config requires a path argument');
+  });
+
+  it('throws when --config= has an empty value', () => {
+    expect(() => parseArgs(['node', 'preflight', '--config='])).toThrow('--config requires a path argument');
+  });
+
+  it('throws on unknown flags', () => {
+    expect(() => parseArgs(['node', 'preflight', '--unknown'])).toThrow("unknown flag '--unknown'");
+  });
+});
+
+describe(main, () => {
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+  let originalArgv: string[];
+  let lastExitCode: number | undefined;
+
+  beforeEach(() => {
+    lastExitCode = undefined;
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      lastExitCode = code;
+      throw new ExitError(code);
+    });
+    originalArgv = process.argv;
+    mockReportPreflight.mockReturnValue('report output');
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.restoreAllMocks();
+    mockLoadPreflightConfig.mockReset();
+    mockRunPreflight.mockReset();
+    mockReportPreflight.mockReset();
+  });
+
+  /** Run main, catching ExitError so tests can inspect the exit code. */
+  async function runMain(): Promise<void> {
+    try {
+      await main();
+    } catch (error: unknown) {
+      if (!(error instanceof ExitError)) throw error;
+    }
+  }
+
+  it('runs all checklists when no names are given', async () => {
+    process.argv = ['node', 'preflight'];
+    const config = makeConfig();
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runMain();
+
+    expect(mockRunPreflight).toHaveBeenCalledTimes(2);
+    expect(lastExitCode).toBe(0);
+  });
+
+  it('filters to named checklists only', async () => {
+    process.argv = ['node', 'preflight', 'deploy'];
+    const config = makeConfig();
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runMain();
+
+    expect(mockRunPreflight).toHaveBeenCalledTimes(1);
+    expect(mockRunPreflight).toHaveBeenCalledWith(config.checklists[0]);
+  });
+
+  it('errors when an unknown checklist name is given', async () => {
+    process.argv = ['node', 'preflight', 'nonexistent'];
+    const config = makeConfig();
+    mockLoadPreflightConfig.mockResolvedValue(config);
+
+    await runMain();
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unknown checklist(s): nonexistent'));
+    expect(lastExitCode).toBe(1);
+  });
+
+  it('exits with code 1 when any checklist fails', async () => {
+    process.argv = ['node', 'preflight'];
+    const config = makeConfig();
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight
+      .mockResolvedValueOnce({ results: [], passed: true, durationMs: 0 })
+      .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
+
+    await runMain();
+
+    expect(lastExitCode).toBe(1);
+  });
+
+  it('passes --config flag to config loader', async () => {
+    process.argv = ['node', 'preflight', '--config', 'custom/path.ts'];
+    const config = makeConfig();
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runMain();
+
+    expect(mockLoadPreflightConfig).toHaveBeenCalledWith('custom/path.ts');
+  });
+
+  it('shows headers when running multiple checklists', async () => {
+    process.argv = ['node', 'preflight'];
+    const config = makeConfig();
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runMain();
+
+    const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(allOutput).toContain('--- deploy ---');
+    expect(allOutput).toContain('--- infra ---');
+  });
+
+  it('does not show headers for a single checklist', async () => {
+    process.argv = ['node', 'preflight', 'deploy'];
+    const config = makeConfig();
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runMain();
+
+    const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(allOutput).not.toContain('---');
+  });
+
+  it('uses per-checklist fixLocation over config default', async () => {
+    process.argv = ['node', 'preflight'];
+    const config = makeConfig({
+      fixLocation: 'END',
+      checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }], fixLocation: 'INLINE' }],
+    });
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runMain();
+
+    expect(mockReportPreflight).toHaveBeenCalledWith(expect.anything(), { fixLocation: 'INLINE' });
+  });
+
+  it('falls back to config-level fixLocation when checklist has none', async () => {
+    process.argv = ['node', 'preflight'];
+    const config = makeConfig({
+      fixLocation: 'END',
+      checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }],
+    });
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runMain();
+
+    expect(mockReportPreflight).toHaveBeenCalledWith(expect.anything(), { fixLocation: 'END' });
+  });
+
+  it('reports config loading errors to stderr', async () => {
+    process.argv = ['node', 'preflight'];
+    mockLoadPreflightConfig.mockRejectedValue(new Error('Config not found'));
+
+    await runMain();
+
+    expect(stderrSpy).toHaveBeenCalledWith('Error: Config not found\n');
+    expect(lastExitCode).toBe(1);
+  });
+});

--- a/packages/preflight/__tests__/config.test.ts
+++ b/packages/preflight/__tests__/config.test.ts
@@ -1,0 +1,150 @@
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockJitiImport = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), () => ({
+  existsSync: mockExistsSync,
+}));
+
+vi.mock('jiti', () => ({
+  createJiti: () => ({ import: mockJitiImport }),
+}));
+
+import {
+  CONFIG_FILE_PATH,
+  definePreflightCheckList,
+  definePreflightConfig,
+  defineStagedPreflightCheckList,
+  loadPreflightConfig,
+} from '../src/config.ts';
+
+describe(loadPreflightConfig, () => {
+  afterEach(() => {
+    mockExistsSync.mockReset();
+    mockJitiImport.mockReset();
+  });
+
+  it('throws when the config file does not exist', async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    await expect(loadPreflightConfig()).rejects.toThrow('Preflight config not found');
+  });
+
+  it('resolves the default config path against process.cwd()', async () => {
+    const expectedPath = path.resolve(process.cwd(), CONFIG_FILE_PATH);
+    const validConfig = {
+      checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
+    };
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ default: validConfig });
+
+    await loadPreflightConfig();
+
+    expect(mockExistsSync).toHaveBeenCalledWith(expectedPath);
+  });
+
+  it('uses a custom config path when provided', async () => {
+    const customPath = 'custom/config.ts';
+    const expectedPath = path.resolve(process.cwd(), customPath);
+    const validConfig = {
+      checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
+    };
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ default: validConfig });
+
+    await loadPreflightConfig(customPath);
+
+    expect(mockExistsSync).toHaveBeenCalledWith(expectedPath);
+  });
+
+  it('throws when jiti returns a non-object', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue('not-an-object');
+
+    await expect(loadPreflightConfig()).rejects.toThrow('Config file must export an object, got string');
+  });
+
+  it('throws when no default or config export exists', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ unrelated: true });
+
+    await expect(loadPreflightConfig()).rejects.toThrow('must have a default export or a named `config` export');
+  });
+
+  it('throws when checklists is missing', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ default: {} });
+
+    await expect(loadPreflightConfig()).rejects.toThrow("must have a 'checklists' array");
+  });
+
+  it('throws when a checklist has neither checks nor groups', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ default: { checklists: [{ name: 'bad' }] } });
+
+    await expect(loadPreflightConfig()).rejects.toThrow("must have either 'checks' or 'groups'");
+  });
+
+  it('throws when a checklist has both checks and groups', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({
+      default: { checklists: [{ name: 'bad', checks: [], groups: [] }] },
+    });
+
+    await expect(loadPreflightConfig()).rejects.toThrow("cannot have both 'checks' and 'groups'");
+  });
+
+  it('returns a valid config with flat checklists', async () => {
+    const validConfig = {
+      checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
+    };
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ default: validConfig });
+
+    const config = await loadPreflightConfig();
+
+    expect(config.checklists).toHaveLength(1);
+    expect(config.checklists[0]?.name).toBe('test');
+  });
+
+  it('returns a valid config via named config export', async () => {
+    const validConfig = {
+      checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
+    };
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ config: validConfig });
+
+    const config = await loadPreflightConfig();
+
+    expect(config.checklists).toHaveLength(1);
+  });
+});
+
+describe(definePreflightConfig, () => {
+  it('returns its input unchanged', () => {
+    const config = {
+      checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
+    };
+
+    expect(definePreflightConfig(config)).toBe(config);
+  });
+});
+
+describe(definePreflightCheckList, () => {
+  it('returns its input unchanged', () => {
+    const checklist = { name: 'test', checks: [{ name: 'a', check: () => true }] };
+
+    expect(definePreflightCheckList(checklist)).toBe(checklist);
+  });
+});
+
+describe(defineStagedPreflightCheckList, () => {
+  it('returns its input unchanged', () => {
+    const checklist = { name: 'test', groups: [[{ name: 'a', check: () => true }]] };
+
+    expect(defineStagedPreflightCheckList(checklist)).toBe(checklist);
+  });
+});

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -87,6 +87,25 @@ describe(reportPreflight, () => {
       expect(errorLineIndex).toBe(checkLineIndex + 1);
     });
 
+    it('shows fix without error when error is absent', () => {
+      const report = makeReport({
+        results: [
+          {
+            name: 'broken',
+            status: 'failed',
+            fix: 'Run npm install',
+            durationMs: 5,
+          },
+        ],
+        passed: false,
+      });
+
+      const output = reportPreflight(report, { fixLocation: 'INLINE' });
+
+      expect(output).toContain('Fix: Run npm install');
+      expect(output).not.toContain('Error:');
+    });
+
     it('shows error without fix when fix is absent', () => {
       const report = makeReport({
         results: [

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+
+import { reportPreflight } from '../src/reportPreflight.ts';
+import type { PreflightReport } from '../src/types.ts';
+
+function makeReport(overrides?: Partial<PreflightReport>): PreflightReport {
+  return {
+    results: [],
+    passed: true,
+    durationMs: 100,
+    ...overrides,
+  };
+}
+
+describe(reportPreflight, () => {
+  it('shows passed checks with checkmark icon', () => {
+    const report = makeReport({
+      results: [{ name: 'check-a', status: 'passed', durationMs: 10 }],
+    });
+
+    const output = reportPreflight(report);
+
+    expect(output).toContain('\u2705 check-a (10ms)');
+  });
+
+  it('shows failed checks with cross icon', () => {
+    const report = makeReport({
+      results: [{ name: 'check-b', status: 'failed', durationMs: 5 }],
+      passed: false,
+    });
+
+    const output = reportPreflight(report);
+
+    expect(output).toContain('\u274C check-b (5ms)');
+  });
+
+  it('shows skipped checks with circle icon', () => {
+    const report = makeReport({
+      results: [{ name: 'check-c', status: 'skipped', durationMs: 0 }],
+    });
+
+    const output = reportPreflight(report);
+
+    expect(output).toContain('\u26AA check-c (0ms)');
+  });
+
+  it('renders the summary line', () => {
+    const report = makeReport({
+      results: [
+        { name: 'a', status: 'passed', durationMs: 10 },
+        { name: 'b', status: 'failed', durationMs: 20 },
+        { name: 'c', status: 'skipped', durationMs: 0 },
+      ],
+      passed: false,
+      durationMs: 142,
+    });
+
+    const output = reportPreflight(report);
+
+    expect(output).toContain('1 passed, 1 failed, 1 skipped (142ms)');
+  });
+
+  describe('INLINE mode', () => {
+    it('shows error and fix below failed check', () => {
+      const report = makeReport({
+        results: [
+          {
+            name: 'broken',
+            status: 'failed',
+            error: new Error('Something went wrong'),
+            fix: 'Run npm install',
+            durationMs: 5,
+          },
+        ],
+        passed: false,
+      });
+
+      const output = reportPreflight(report, { fixLocation: 'INLINE' });
+      const lines = output.split('\n');
+
+      expect(output).toContain('Error: Something went wrong');
+      expect(output).toContain('Fix: Run npm install');
+
+      // Error line must immediately follow the check line (no blank line)
+      const checkLineIndex = lines.findIndex((l) => l.includes('broken'));
+      const errorLineIndex = lines.findIndex((l) => l.includes('Error: Something went wrong'));
+      expect(errorLineIndex).toBe(checkLineIndex + 1);
+    });
+
+    it('shows error without fix when fix is absent', () => {
+      const report = makeReport({
+        results: [
+          {
+            name: 'broken',
+            status: 'failed',
+            error: new Error('Missing file'),
+            durationMs: 5,
+          },
+        ],
+        passed: false,
+      });
+
+      const output = reportPreflight(report, { fixLocation: 'INLINE' });
+
+      expect(output).toContain('Error: Missing file');
+      expect(output).not.toContain('Fix:');
+    });
+  });
+
+  describe('END mode', () => {
+    it('shows error inline and collects fixes at the bottom', () => {
+      const report = makeReport({
+        results: [
+          {
+            name: 'broken',
+            status: 'failed',
+            error: new Error('Bad config'),
+            fix: 'Update config file',
+            durationMs: 5,
+          },
+        ],
+        passed: false,
+      });
+
+      const output = reportPreflight(report, { fixLocation: 'END' });
+
+      // Error should appear right after the check line
+      const lines = output.split('\n');
+      const errorLineIndex = lines.findIndex((l) => l.includes('Error: Bad config'));
+      const checkLineIndex = lines.findIndex((l) => l.includes('broken'));
+      expect(errorLineIndex).toBe(checkLineIndex + 1);
+
+      // Fix should appear in a Fixes section at the bottom
+      expect(output).toContain('Fixes:');
+      expect(output).toContain('  Update config file');
+    });
+
+    it('omits Fixes section when no fixes are present', () => {
+      const report = makeReport({
+        results: [
+          {
+            name: 'broken',
+            status: 'failed',
+            error: new Error('Unknown error'),
+            durationMs: 5,
+          },
+        ],
+        passed: false,
+      });
+
+      const output = reportPreflight(report, { fixLocation: 'END' });
+
+      expect(output).toContain('Error: Unknown error');
+      expect(output).not.toContain('Fixes:');
+    });
+  });
+
+  it('defaults to END mode when no options are provided', () => {
+    const report = makeReport({
+      results: [
+        {
+          name: 'broken',
+          status: 'failed',
+          error: new Error('Oops'),
+          fix: 'Fix it',
+          durationMs: 5,
+        },
+      ],
+      passed: false,
+    });
+
+    const output = reportPreflight(report);
+
+    expect(output).toContain('Fixes:');
+    expect(output).toContain('  Fix it');
+    expect(output).not.toContain('Fix: Fix it');
+  });
+});

--- a/packages/preflight/__tests__/runPreflight.test.ts
+++ b/packages/preflight/__tests__/runPreflight.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+
+import { runPreflight } from '../src/runPreflight.ts';
+import type { PreflightCheckList, StagedPreflightCheckList } from '../src/types.ts';
+
+describe(runPreflight, () => {
+  describe('flat checklists', () => {
+    it('marks passing checks as passed', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'basic',
+        checks: [{ name: 'always-true', check: () => true }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(true);
+      expect(report.results).toHaveLength(1);
+      expect(report.results[0]?.status).toBe('passed');
+      expect(report.results[0]?.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('marks failing checks as failed', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'basic',
+        checks: [{ name: 'always-false', check: () => false, fix: 'Do something' }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(false);
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.fix).toBe('Do something');
+    });
+
+    it('captures errors from throwing checks', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'throws',
+            check: () => {
+              throw new Error('boom');
+            },
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(false);
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.error?.message).toBe('boom');
+    });
+
+    it('handles async check functions', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'async',
+        checks: [{ name: 'async-true', check: () => Promise.resolve(true) }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(true);
+      expect(report.results[0]?.status).toBe('passed');
+    });
+
+    it('runs all checks concurrently', async () => {
+      const order: string[] = [];
+      const checklist: PreflightCheckList = {
+        name: 'concurrent',
+        checks: [
+          {
+            name: 'slow',
+            check: async () => {
+              await new Promise((resolve) => setTimeout(resolve, 20));
+              order.push('slow');
+              return true;
+            },
+          },
+          {
+            name: 'fast',
+            check: () => {
+              order.push('fast');
+              return true;
+            },
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(true);
+      expect(order).toStrictEqual(['fast', 'slow']);
+    });
+  });
+
+  describe('preconditions', () => {
+    it('skips all checks when a precondition fails', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'gated',
+        preconditions: [{ name: 'pre-fail', check: () => false }],
+        checks: [{ name: 'should-skip', check: () => true }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(false);
+      expect(report.results).toHaveLength(2);
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[1]?.status).toBe('skipped');
+    });
+
+    it('runs checks when all preconditions pass', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'gated',
+        preconditions: [{ name: 'pre-pass', check: () => true }],
+        checks: [{ name: 'runs', check: () => true }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(true);
+      expect(report.results).toHaveLength(2);
+      expect(report.results[0]?.status).toBe('passed');
+      expect(report.results[1]?.status).toBe('passed');
+    });
+  });
+
+  describe('staged checklists', () => {
+    it('skips subsequent groups when a group fails', async () => {
+      const checklist: StagedPreflightCheckList = {
+        name: 'staged',
+        groups: [[{ name: 'g1-fail', check: () => false }], [{ name: 'g2-skip', check: () => true }]],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(false);
+      expect(report.results).toHaveLength(2);
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[1]?.status).toBe('skipped');
+    });
+
+    it('runs all groups when earlier groups pass', async () => {
+      const checklist: StagedPreflightCheckList = {
+        name: 'staged',
+        groups: [[{ name: 'g1-pass', check: () => true }], [{ name: 'g2-pass', check: () => true }]],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(true);
+      expect(report.results).toHaveLength(2);
+      expect(report.results.every((r) => r.status === 'passed')).toBe(true);
+    });
+
+    it('skips all groups when preconditions fail', async () => {
+      const checklist: StagedPreflightCheckList = {
+        name: 'staged-gated',
+        preconditions: [{ name: 'pre-fail', check: () => false }],
+        groups: [[{ name: 'g1', check: () => true }], [{ name: 'g2', check: () => true }]],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(false);
+      expect(report.results).toHaveLength(3);
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[1]?.status).toBe('skipped');
+      expect(report.results[2]?.status).toBe('skipped');
+    });
+  });
+
+  it('computes total duration', async () => {
+    const checklist: PreflightCheckList = {
+      name: 'timing',
+      checks: [{ name: 'quick', check: () => true }],
+    };
+
+    const report = await runPreflight(checklist);
+
+    expect(report.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/preflight/__tests__/runPreflight.test.ts
+++ b/packages/preflight/__tests__/runPreflight.test.ts
@@ -52,6 +52,28 @@ describe(runPreflight, () => {
       expect(report.results[0]?.error?.message).toBe('boom');
     });
 
+    it('wraps non-Error thrown values in an Error', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'throwing-string',
+        checks: [
+          {
+            name: 'throws-string',
+            check: () => {
+              // eslint-disable-next-line no-throw-literal
+              throw 'a plain string';
+            },
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(false);
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.error).toBeInstanceOf(Error);
+      expect(report.results[0]?.error?.message).toBe('a plain string');
+    });
+
     it('handles async check functions', async () => {
       const checklist: PreflightCheckList = {
         name: 'async',

--- a/packages/preflight/__tests__/runPreflight.test.ts
+++ b/packages/preflight/__tests__/runPreflight.test.ts
@@ -59,7 +59,7 @@ describe(runPreflight, () => {
           {
             name: 'throws-string',
             check: () => {
-              // eslint-disable-next-line no-throw-literal
+              // eslint-disable-next-line @typescript-eslint/only-throw-error
               throw 'a plain string';
             },
           },

--- a/packages/preflight/bin/preflight.js
+++ b/packages/preflight/bin/preflight.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-import('../dist/esm/bin/preflight.js').catch((err) => {
-  process.stderr.write(`preflight: failed to load: ${err.message}\n`);
+try {
+  await import('../dist/esm/bin/preflight.js');
+} catch (error) {
+  process.stderr.write(`preflight: failed to load: ${error.message}\n`);
   process.exit(1);
-});
+}

--- a/packages/preflight/bin/preflight.js
+++ b/packages/preflight/bin/preflight.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import('../dist/esm/bin/preflight.js').catch((err) => {
+  process.stderr.write(`preflight: failed to load: ${err.message}\n`);
+  process.exit(1);
+});

--- a/packages/preflight/package.json
+++ b/packages/preflight/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@williamthorsen/preflight",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Run pre-deployment checks to verify environment and configuration",
+  "keywords": [
+    "checks",
+    "deploy",
+    "preflight",
+    "verification"
+  ],
+  "homepage": "https://github.com/williamthorsen/node-monorepo-tools/tree/main/packages/preflight#readme",
+  "bugs": {
+    "url": "https://github.com/williamthorsen/node-monorepo-tools/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/williamthorsen/node-monorepo-tools.git",
+    "directory": "packages/preflight"
+  },
+  "license": "MIT",
+  "author": "William Thorsen <william@thorsen.dev> (https://github.com/williamthorsen)",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "bin": {
+    "preflight": "bin/preflight.js"
+  },
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "scripts": {
+    "prepare": "tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json"
+  },
+  "dependencies": {
+    "jiti": "2.6.1"
+  },
+  "engines": {
+    "node": ">=18.17.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/preflight/src/bin/preflight.ts
+++ b/packages/preflight/src/bin/preflight.ts
@@ -2,8 +2,10 @@ import process from 'node:process';
 
 import { main } from '../cli.ts';
 
-main().catch((error: unknown) => {
+try {
+  await main();
+} catch (error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   process.stderr.write(`preflight: unexpected error: ${message}\n`);
   process.exit(1);
-});
+}

--- a/packages/preflight/src/bin/preflight.ts
+++ b/packages/preflight/src/bin/preflight.ts
@@ -1,0 +1,9 @@
+import process from 'node:process';
+
+import { main } from '../cli.ts';
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`preflight: unexpected error: ${message}\n`);
+  process.exit(1);
+});

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -1,0 +1,115 @@
+/* eslint n/no-process-exit: off */
+/* eslint unicorn/no-process-exit: off */
+
+import process from 'node:process';
+
+import { loadPreflightConfig } from './config.ts';
+import { reportPreflight } from './reportPreflight.ts';
+import { runPreflight } from './runPreflight.ts';
+import type { FixLocation, PreflightCheckList, PreflightConfig, StagedPreflightCheckList } from './types.ts';
+
+interface ParsedArgs {
+  configPath?: string;
+  names: string[];
+}
+
+/** Parse CLI arguments into a structured object. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const args = argv.slice(2);
+  const result: ParsedArgs = { names: [] };
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === undefined) break;
+
+    if (arg === '--config' || arg === '-c') {
+      i++;
+      const configValue = args[i];
+      if (configValue === undefined) {
+        throw new Error('--config requires a path argument');
+      }
+      result.configPath = configValue;
+    } else if (arg.startsWith('--config=')) {
+      const configValue = arg.slice('--config='.length);
+      if (configValue === '') {
+        throw new Error('--config requires a path argument');
+      }
+      result.configPath = configValue;
+    } else if (arg.startsWith('-')) {
+      throw new Error(`unknown flag '${arg}'`);
+    } else {
+      result.names.push(arg);
+    }
+
+    i++;
+  }
+
+  return result;
+}
+
+/** Resolve the effective fixLocation for a checklist, falling back to the config-level default. */
+function resolveFixLocation(
+  checklist: PreflightCheckList | StagedPreflightCheckList,
+  configDefault?: FixLocation,
+): FixLocation {
+  return checklist.fixLocation ?? configDefault ?? 'END';
+}
+
+/** Load config, handling errors with a message to stderr and process exit. */
+async function loadConfigOrExit(configPath?: string): Promise<PreflightConfig> {
+  try {
+    return await loadPreflightConfig(configPath);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return process.exit(1);
+  }
+}
+
+/** Entry point for the preflight CLI. */
+export async function main(): Promise<void> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(process.argv);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    process.exit(1);
+  }
+  const config = await loadConfigOrExit(parsed.configPath);
+
+  // Determine which checklists to run
+  let checklists = config.checklists;
+  if (parsed.names.length > 0) {
+    const availableNames = new Set(config.checklists.map((c) => c.name));
+    const unknownNames = parsed.names.filter((n) => !availableNames.has(n));
+    if (unknownNames.length > 0) {
+      const available = [...availableNames].join(', ');
+      process.stderr.write(`Error: unknown checklist(s): ${unknownNames.join(', ')}. Available: ${available}\n`);
+      process.exit(1);
+    }
+    const requestedNames = new Set(parsed.names);
+    checklists = config.checklists.filter((c) => requestedNames.has(c.name));
+  }
+
+  const showHeader = checklists.length > 1;
+  let allPassed = true;
+
+  for (const checklist of checklists) {
+    if (showHeader) {
+      process.stdout.write(`\n--- ${checklist.name} ---\n\n`);
+    }
+
+    const report = await runPreflight(checklist);
+    const fixLocation = resolveFixLocation(checklist, config.fixLocation);
+    const output = reportPreflight(report, { fixLocation });
+    process.stdout.write(output + '\n');
+
+    if (!report.passed) {
+      allPassed = false;
+    }
+  }
+
+  process.exit(allPassed ? 0 : 1);
+}

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -18,9 +18,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const args = argv.slice(2);
   const result: ParsedArgs = { names: [] };
 
-  let i = 0;
-  let arg: string | undefined;
-  while ((arg = args[i]) !== undefined) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) break;
     if (arg === '--config' || arg === '-c') {
       i++;
       const configValue = args[i];
@@ -39,8 +39,6 @@ export function parseArgs(argv: string[]): ParsedArgs {
     } else {
       result.names.push(arg);
     }
-
-    i++;
   }
 
   return result;

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -19,10 +19,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const result: ParsedArgs = { names: [] };
 
   let i = 0;
-  while (i < args.length) {
-    const arg = args[i];
-    if (arg === undefined) break;
-
+  let arg: string | undefined;
+  while ((arg = args[i]) !== undefined) {
     if (arg === '--config' || arg === '-c') {
       i++;
       const configValue = args[i];
@@ -56,17 +54,6 @@ function resolveFixLocation(
   return checklist.fixLocation ?? configDefault ?? 'END';
 }
 
-/** Load config, handling errors with a message to stderr and process exit. */
-async function loadConfigOrExit(configPath?: string): Promise<PreflightConfig> {
-  try {
-    return await loadPreflightConfig(configPath);
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return process.exit(1);
-  }
-}
-
 /** Entry point for the preflight CLI. */
 export async function main(): Promise<void> {
   let parsed: ParsedArgs;
@@ -77,7 +64,15 @@ export async function main(): Promise<void> {
     process.stderr.write(`Error: ${message}\n`);
     process.exit(1);
   }
-  const config = await loadConfigOrExit(parsed.configPath);
+
+  let config: PreflightConfig;
+  try {
+    config = await loadPreflightConfig(parsed.configPath);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    process.exit(1);
+  }
 
   // Determine which checklists to run
   let checklists = config.checklists;

--- a/packages/preflight/src/config.ts
+++ b/packages/preflight/src/config.ts
@@ -1,0 +1,93 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import type { PreflightCheckList, PreflightConfig, StagedPreflightCheckList } from './types.ts';
+
+/** The default config file path, resolved relative to `process.cwd()`. */
+export const CONFIG_FILE_PATH = '.config/preflight.config.ts';
+
+/** Type-safe identity function for defining a preflight config in a config file. */
+export function definePreflightConfig(config: PreflightConfig): PreflightConfig {
+  return config;
+}
+
+/** Type-safe identity function for defining a flat checklist. */
+export function definePreflightCheckList(checklist: PreflightCheckList): PreflightCheckList {
+  return checklist;
+}
+
+/** Type-safe identity function for defining a staged checklist. */
+export function defineStagedPreflightCheckList(checklist: StagedPreflightCheckList): StagedPreflightCheckList {
+  return checklist;
+}
+
+/** Check whether a value is a plain object (non-null, non-array). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validate that a raw value conforms to the PreflightConfig shape.
+ *
+ * Throws on invalid input. When it returns without throwing, the value is a valid PreflightConfig.
+ * Because jiti loads the actual TypeScript module, the config objects retain their original types
+ * including function-valued properties like `check`.
+ */
+function assertIsPreflightConfig(raw: unknown): asserts raw is PreflightConfig {
+  if (!isRecord(raw)) {
+    throw new TypeError(`Preflight config must be an object, got ${Array.isArray(raw) ? 'array' : typeof raw}`);
+  }
+
+  if (!Array.isArray(raw.checklists)) {
+    throw new TypeError("Preflight config must have a 'checklists' array");
+  }
+
+  for (const [i, entry] of raw.checklists.entries()) {
+    if (!isRecord(entry)) {
+      throw new Error(`checklists[${i}]: must be an object`);
+    }
+    if (typeof entry.name !== 'string' || entry.name === '') {
+      throw new Error(`checklists[${i}]: 'name' is required and must be a non-empty string`);
+    }
+    const hasChecks = 'checks' in entry;
+    const hasGroups = 'groups' in entry;
+    if (!hasChecks && !hasGroups) {
+      throw new Error(`checklists[${i}]: must have either 'checks' or 'groups'`);
+    }
+    if (hasChecks && hasGroups) {
+      throw new Error(`checklists[${i}]: cannot have both 'checks' and 'groups'`);
+    }
+  }
+}
+
+/**
+ * Load and validate a preflight config file.
+ *
+ * Searches `.config/preflight.config.ts` by default, or a custom path if provided.
+ * Uses jiti to load TypeScript config files at runtime.
+ */
+export async function loadPreflightConfig(configPath?: string): Promise<PreflightConfig> {
+  const resolvedPath = path.resolve(process.cwd(), configPath ?? CONFIG_FILE_PATH);
+
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`Preflight config not found: ${resolvedPath}`);
+  }
+
+  const { createJiti } = await import('jiti');
+  const jiti = createJiti(import.meta.url);
+  const imported: unknown = await jiti.import(resolvedPath);
+
+  if (!isRecord(imported)) {
+    throw new Error(`Config file must export an object, got ${Array.isArray(imported) ? 'array' : typeof imported}`);
+  }
+
+  const resolved = imported.default ?? imported.config;
+  if (resolved === undefined) {
+    throw new Error(
+      'Config file must have a default export or a named `config` export (e.g., `export default definePreflightConfig({ ... })`)',
+    );
+  }
+
+  assertIsPreflightConfig(resolved);
+  return resolved;
+}

--- a/packages/preflight/src/index.ts
+++ b/packages/preflight/src/index.ts
@@ -1,0 +1,23 @@
+// Types
+export type {
+  FixLocation,
+  PreflightCheck,
+  PreflightCheckList,
+  PreflightConfig,
+  PreflightReport,
+  PreflightResult,
+  ReportOptions,
+  StagedPreflightCheckList,
+} from './types.ts';
+
+// Type guard
+export { isFlatCheckList } from './types.ts';
+
+// Config helpers
+export { definePreflightCheckList, definePreflightConfig, defineStagedPreflightCheckList } from './config.ts';
+
+// Runner
+export { runPreflight } from './runPreflight.ts';
+
+// Reporter
+export { reportPreflight } from './reportPreflight.ts';

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -1,0 +1,73 @@
+import type { PreflightReport, PreflightResult, ReportOptions } from './types.ts';
+
+const ICON_PASSED = '\u2705';
+const ICON_FAILED = '\u274C';
+const ICON_SKIPPED = '\u26AA';
+
+/** Format a duration in milliseconds for display. */
+function formatDuration(ms: number): string {
+  return `${Math.round(ms)}ms`;
+}
+
+/** Return the status icon for a result. */
+function getIcon(status: PreflightResult['status']): string {
+  if (status === 'passed') return ICON_PASSED;
+  if (status === 'failed') return ICON_FAILED;
+  return ICON_SKIPPED;
+}
+
+/** Collect inline detail lines (error and/or fix) for a failed result. */
+function collectInlineDetails(result: PreflightResult, includeFix: boolean): string[] {
+  const details: string[] = [];
+  if (result.error !== undefined) {
+    details.push(`  Error: ${result.error.message}`);
+  }
+  if (includeFix && result.fix !== undefined) {
+    details.push(`  Fix: ${result.fix}`);
+  }
+  return details;
+}
+
+/**
+ * Format a preflight report as a human-readable string for terminal output.
+ *
+ * In `END` mode (default), errors appear inline but fix messages are collected in a "Fixes" section at the bottom.
+ * In `INLINE` mode, error and fix messages appear directly below each failed check.
+ */
+export function reportPreflight(report: PreflightReport, options?: ReportOptions): string {
+  const fixLocation = options?.fixLocation ?? 'END';
+  const lines: string[] = [];
+  const collectedFixes: string[] = [];
+
+  for (const result of report.results) {
+    const icon = getIcon(result.status);
+    lines.push(`${icon} ${result.name} (${formatDuration(result.durationMs)})`);
+
+    if (result.status === 'failed') {
+      if (fixLocation === 'INLINE') {
+        lines.push(...collectInlineDetails(result, true));
+      } else {
+        // END mode: show error inline, collect fixes separately
+        if (result.error !== undefined) {
+          lines.push(`  Error: ${result.error.message}`);
+        }
+        if (result.fix !== undefined) {
+          collectedFixes.push(result.fix);
+        }
+      }
+    }
+  }
+
+  // Summary
+  const passed = report.results.filter((r) => r.status === 'passed').length;
+  const failed = report.results.filter((r) => r.status === 'failed').length;
+  const skipped = report.results.filter((r) => r.status === 'skipped').length;
+  lines.push('', `${passed} passed, ${failed} failed, ${skipped} skipped (${formatDuration(report.durationMs)})`);
+
+  // Collected fixes section for END mode
+  if (fixLocation === 'END' && collectedFixes.length > 0) {
+    lines.push('', 'Fixes:', ...collectedFixes.map((fix) => `  ${fix}`));
+  }
+
+  return lines.join('\n');
+}

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -44,24 +44,24 @@ export function reportPreflight(report: PreflightReport, options?: ReportOptions
     lines.push(`${icon} ${result.name} (${formatDuration(result.durationMs)})`);
 
     if (result.status === 'failed') {
-      if (fixLocation === 'INLINE') {
-        lines.push(...collectInlineDetails(result, true));
-      } else {
-        // END mode: show error inline, collect fixes separately
-        if (result.error !== undefined) {
-          lines.push(`  Error: ${result.error.message}`);
-        }
-        if (result.fix !== undefined) {
-          collectedFixes.push(result.fix);
-        }
+      const includeFix = fixLocation === 'INLINE';
+      lines.push(...collectInlineDetails(result, includeFix));
+
+      if (!includeFix && result.fix !== undefined) {
+        collectedFixes.push(result.fix);
       }
     }
   }
 
   // Summary
-  const passed = report.results.filter((r) => r.status === 'passed').length;
-  const failed = report.results.filter((r) => r.status === 'failed').length;
-  const skipped = report.results.filter((r) => r.status === 'skipped').length;
+  let passed = 0;
+  let failed = 0;
+  let skipped = 0;
+  for (const r of report.results) {
+    if (r.status === 'passed') passed++;
+    else if (r.status === 'failed') failed++;
+    else skipped++;
+  }
   lines.push('', `${passed} passed, ${failed} failed, ${skipped} skipped (${formatDuration(report.durationMs)})`);
 
   // Collected fixes section for END mode

--- a/packages/preflight/src/runPreflight.ts
+++ b/packages/preflight/src/runPreflight.ts
@@ -1,0 +1,124 @@
+import { performance } from 'node:perf_hooks';
+
+import type {
+  PreflightCheck,
+  PreflightCheckList,
+  PreflightReport,
+  PreflightResult,
+  StagedPreflightCheckList,
+} from './types.ts';
+import { isFlatCheckList } from './types.ts';
+
+/** Build a result object, only including optional fields when defined. */
+function buildResult(
+  name: string,
+  status: PreflightResult['status'],
+  durationMs: number,
+  fix?: string,
+  error?: Error,
+): PreflightResult {
+  const result: PreflightResult = { name, status, durationMs };
+  if (fix !== undefined) {
+    result.fix = fix;
+  }
+  if (error !== undefined) {
+    result.error = error;
+  }
+  return result;
+}
+
+/** Execute a single check and return its result. */
+async function executeCheck(check: PreflightCheck): Promise<PreflightResult> {
+  const start = performance.now();
+  try {
+    const passed = await check.check();
+    const durationMs = performance.now() - start;
+    return buildResult(check.name, passed ? 'passed' : 'failed', durationMs, check.fix);
+  } catch (error_: unknown) {
+    const durationMs = performance.now() - start;
+    const error = error_ instanceof Error ? error_ : new Error(String(error_));
+    return buildResult(check.name, 'failed', durationMs, check.fix, error);
+  }
+}
+
+/** Mark a check as skipped with zero duration. */
+function skipCheck(check: PreflightCheck): PreflightResult {
+  return buildResult(check.name, 'skipped', 0, check.fix);
+}
+
+/** Run preconditions concurrently. Return true if all passed. */
+async function runPreconditions(preconditions: PreflightCheck[], results: PreflightResult[]): Promise<boolean> {
+  if (preconditions.length === 0) return true;
+
+  const preconditionResults = await Promise.all(preconditions.map(executeCheck));
+  results.push(...preconditionResults);
+
+  return preconditionResults.every((r) => r.status === 'passed');
+}
+
+/** Run a flat checklist: all checks concurrently. */
+async function runFlatChecks(
+  checklist: PreflightCheckList,
+  results: PreflightResult[],
+  preconditionsPassed: boolean,
+): Promise<void> {
+  if (!preconditionsPassed) {
+    results.push(...checklist.checks.map(skipCheck));
+    return;
+  }
+
+  const checkResults = await Promise.all(checklist.checks.map(executeCheck));
+  results.push(...checkResults);
+}
+
+/** Run a staged checklist: groups sequentially, checks within each group concurrently. */
+async function runStagedChecks(
+  checklist: StagedPreflightCheckList,
+  results: PreflightResult[],
+  preconditionsPassed: boolean,
+): Promise<void> {
+  if (!preconditionsPassed) {
+    for (const group of checklist.groups) {
+      results.push(...group.map(skipCheck));
+    }
+    return;
+  }
+
+  let shouldSkipRemaining = false;
+  for (const group of checklist.groups) {
+    if (shouldSkipRemaining) {
+      results.push(...group.map(skipCheck));
+      continue;
+    }
+
+    const groupResults = await Promise.all(group.map(executeCheck));
+    results.push(...groupResults);
+
+    if (groupResults.some((r) => r.status === 'failed')) {
+      shouldSkipRemaining = true;
+    }
+  }
+}
+
+/**
+ * Run all checks in a checklist and produce a report.
+ *
+ * Preconditions run first. If any fails, all subsequent checks are skipped.
+ * Flat checklists run all checks concurrently. Staged checklists run groups
+ * sequentially, bailing on later groups when an earlier group has a failure.
+ */
+export async function runPreflight(checklist: PreflightCheckList | StagedPreflightCheckList): Promise<PreflightReport> {
+  const start = performance.now();
+  const results: PreflightResult[] = [];
+
+  const preconditionsPassed = await runPreconditions(checklist.preconditions ?? [], results);
+
+  await (isFlatCheckList(checklist)
+    ? runFlatChecks(checklist, results, preconditionsPassed)
+    : runStagedChecks(checklist, results, preconditionsPassed));
+
+  const durationMs = performance.now() - start;
+  const passed = results.every((r) => r.status !== 'failed');
+
+  return { results, passed, durationMs };
+}

--- a/packages/preflight/src/types.ts
+++ b/packages/preflight/src/types.ts
@@ -1,0 +1,59 @@
+/** Placement of fix messages in the report output. */
+export type FixLocation = 'INLINE' | 'END';
+
+/** A single check to run during preflight. */
+export interface PreflightCheck {
+  name: string;
+  check: () => boolean | Promise<boolean>;
+  fix?: string;
+}
+
+/** The outcome of running a single check. */
+export interface PreflightResult {
+  name: string;
+  status: 'passed' | 'failed' | 'skipped';
+  fix?: string;
+  error?: Error;
+  durationMs: number;
+}
+
+/** Aggregate report from running a checklist. */
+export interface PreflightReport {
+  results: PreflightResult[];
+  passed: boolean;
+  durationMs: number;
+}
+
+/** A flat checklist where all checks run concurrently. */
+export interface PreflightCheckList {
+  name: string;
+  preconditions?: PreflightCheck[];
+  checks: PreflightCheck[];
+  fixLocation?: FixLocation;
+}
+
+/** A staged checklist where groups run sequentially and checks within each group run concurrently. */
+export interface StagedPreflightCheckList {
+  name: string;
+  preconditions?: PreflightCheck[];
+  groups: PreflightCheck[][];
+  fixLocation?: FixLocation;
+}
+
+/** Options controlling how the report is formatted. */
+export interface ReportOptions {
+  fixLocation?: FixLocation;
+}
+
+/** Top-level configuration for the preflight CLI. */
+export interface PreflightConfig {
+  fixLocation?: FixLocation;
+  checklists: Array<PreflightCheckList | StagedPreflightCheckList>;
+}
+
+/** Distinguish a flat checklist from a staged checklist by the presence of `checks`. */
+export function isFlatCheckList(
+  checklist: PreflightCheckList | StagedPreflightCheckList,
+): checklist is PreflightCheckList {
+  return 'checks' in checklist;
+}

--- a/packages/preflight/tsconfig.eslint.json
+++ b/packages/preflight/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+  },
+  "exclude": [],
+  "include": ["__tests__/", "src/", "eslint.config.js", "*.cjs", "*.json", "*.mjs", "*.mts", "*.ts"],
+}

--- a/packages/preflight/tsconfig.generate-typings.json
+++ b/packages/preflight/tsconfig.generate-typings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "./dist/esm",
+    "rootDir": "./src",
+    "sourceMap": false,
+    "tsBuildInfoFile": "./dist/tsconfig.generate-typings.tsbuildinfo",
+  },
+  "exclude": ["**/__tests__"],
+  "include": ["src"],
+}

--- a/packages/preflight/tsconfig.json
+++ b/packages/preflight/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2022"],
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "*.ts"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,12 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
 
+  packages/preflight:
+    dependencies:
+      jiti:
+        specifier: 2.6.1
+        version: 2.6.1
+
   packages/release-kit:
     dependencies:
       glob:


### PR DESCRIPTION
Closes #51 

## What

Adds `@williamthorsen/preflight`, a new package for running configurable pre-deployment checks with structured pass/fail reporting. The package provides a runner (flat and staged checklists with precondition gating), a reporter (INLINE/END fix-location modes with emoji indicators), jiti-based config loading, and a CLI entry point.

## Why

Tasks depending on external tooling produce cryptic, repetitive errors when prerequisites are missing. This package enables bailing early with a clear diagnosis and corrective-action messages, replacing per-test failure noise with a single structured preflight report.

## Details

### Features

- `runPreflight(checklist)` executes checks and returns a structured `PreflightReport` with per-check timing and error capture
- Flat checklists run all checks concurrently; staged checklists run groups sequentially with intra-group concurrency
- Both checklist flavors support `preconditions` that gate all subsequent checks/groups on failure
- `reportPreflight(report, options?)` formats output with configurable fix location (`INLINE` or `END`, default `END`) and emoji status indicators
- `loadPreflightConfig(path?)` loads `.config/preflight.config.ts` via jiti with manual shape validation
- `definePreflightConfig`, `definePreflightCheckList`, `defineStagedPreflightCheckList` identity helpers for type-safe config authoring
- CLI supports `preflight [--config path] [name...]` with upfront name validation and non-zero exit on failure

### Tests

- 55+ tests across 4 test files covering runner (flat, staged, preconditions, throwing checks, async, concurrency ordering, non-Error thrown values), reporter (INLINE/END modes, error-only, fix-only, skipped, summary line, default mode), config (define helpers, validation), and CLI (argument parsing, name filtering, error paths, exit codes)

## Test plan

- [ ] `npx nmr check` passes at root (typecheck, lint, format, tests)
- [ ] `npx nmr build` produces correct dist output for preflight package
- [ ] Create a sample `.config/preflight.config.ts` and run `npx preflight` to verify CLI end-to-end