### PR TITLE
#54 Add styled terminal output to prepare command

### DIFF
--- a/packages/release-kit/src/__tests__/format.unit.test.ts
+++ b/packages/release-kit/src/__tests__/format.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { bold, dim, sectionHeader } from '../format.ts';
+
+describe(bold, () => {
+  it('wraps text in ANSI bold escape codes', () => {
+    expect(bold('hello')).toBe('\u001B[1mhello\u001B[0m');
+  });
+
+  it('handles an empty string', () => {
+    expect(bold('')).toBe('\u001B[1m\u001B[0m');
+  });
+});
+
+describe(dim, () => {
+  it('wraps text in ANSI dim escape codes', () => {
+    expect(dim('hello')).toBe('\u001B[2mhello\u001B[0m');
+  });
+
+  it('handles an empty string', () => {
+    expect(dim('')).toBe('\u001B[2m\u001B[0m');
+  });
+});
+
+describe(sectionHeader, () => {
+  it('wraps the name in box-drawing rules', () => {
+    expect(sectionHeader('release-kit')).toBe('━━━ release-kit ━━━');
+  });
+
+  it('handles a short name', () => {
+    expect(sectionHeader('a')).toBe('━━━ a ━━━');
+  });
+});

--- a/packages/release-kit/src/bumpAllVersions.ts
+++ b/packages/release-kit/src/bumpAllVersions.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 
 import { bumpVersion } from './bumpVersion.ts';
+import { bold, dim } from './format.ts';
 import type { ReleaseType } from './types.ts';
 
 interface PackageJson {
@@ -33,11 +34,11 @@ export function bumpAllVersions(packageFiles: readonly string[], releaseType: Re
   const firstPkg = readPackageJson(firstFile);
   const currentVersion = firstPkg.version;
   const newVersion = bumpVersion(currentVersion, releaseType);
-  console.info(`Bumping version: ${currentVersion} -> ${newVersion} (${releaseType})`);
+  console.info(`📦 ${currentVersion} → ${bold(newVersion)} (${releaseType})`);
 
   for (const filePath of packageFiles) {
     if (dryRun) {
-      console.info(`  [dry-run] Would bump ${filePath}`);
+      console.info(dim(`  [dry-run] Would bump ${filePath}`));
       continue;
     }
 
@@ -50,7 +51,7 @@ export function bumpAllVersions(packageFiles: readonly string[], releaseType: Re
       throw new Error(`Failed to write ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
     }
 
-    console.info(`  Bumped ${filePath}`);
+    console.info(dim(`  Bumped ${filePath}`));
   }
 
   return newVersion;

--- a/packages/release-kit/src/format.ts
+++ b/packages/release-kit/src/format.ts
@@ -1,0 +1,16 @@
+// ANSI escape helpers for styled terminal output.
+
+/** Wrap text in ANSI bold. */
+export function bold(text: string): string {
+  return `\u001B[1m${text}\u001B[0m`;
+}
+
+/** Wrap text in ANSI dim. */
+export function dim(text: string): string {
+  return `\u001B[2m${text}\u001B[0m`;
+}
+
+/** Render a section header for separating components in CLI output. */
+export function sectionHeader(name: string): string {
+  return `━━━ ${name} ━━━`;
+}

--- a/packages/release-kit/src/generateChangelogs.ts
+++ b/packages/release-kit/src/generateChangelogs.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 
+import { dim } from './format.ts';
 import { resolveCliffConfigPath } from './resolveCliffConfigPath.ts';
 import type { ReleaseConfig } from './types.ts';
 
@@ -41,11 +42,11 @@ export function generateChangelog(
   }
 
   if (dryRun) {
-    console.info(`  [dry-run] Would run: npx --yes git-cliff ${args.join(' ')}`);
+    console.info(dim(`  [dry-run] Would run: npx --yes git-cliff ${args.join(' ')}`));
     return;
   }
 
-  console.info(`  Generating changelog: ${outputFile}`);
+  console.info(dim(`  Generating changelog: ${outputFile}`));
   try {
     execFileSync('npx', ['--yes', 'git-cliff', ...args], { stdio: 'inherit' });
   } catch (error: unknown) {

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -2,6 +2,7 @@
 /* eslint unicorn/no-process-exit: off */
 
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
+import { dim } from './format.ts';
 import { loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig } from './loadConfig.ts';
 import { releasePrepare } from './releasePrepare.ts';
 import { releasePrepareMono } from './releasePrepareMono.ts';
@@ -25,6 +26,10 @@ export async function prepareCommand(argv: string[]): Promise<void> {
     force,
     ...(bumpOverride === undefined ? {} : { bumpOverride }),
   };
+
+  if (dryRun) {
+    console.info('\n🔍 DRY RUN — no files will be modified\n');
+  }
 
   // 1. Load config file
   let rawConfig: unknown;
@@ -105,6 +110,6 @@ export async function prepareCommand(argv: string[]): Promise<void> {
   }
 
   if (tags.length > 0) {
-    console.info(`\nRelease tags file: ${RELEASE_TAGS_FILE}`);
+    console.info(dim(`\n   Release tags file: ${RELEASE_TAGS_FILE}`));
   }
 }

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process';
 import { bumpAllVersions } from './bumpAllVersions.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpType } from './determineBumpType.ts';
+import { bold, dim } from './format.ts';
 import { generateChangelogs } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
@@ -37,9 +38,8 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
 
   // 1. Get commits since last tag
-  console.info('Finding commits since last release...');
   const { tag, commits } = getCommitsSinceTarget(config.tagPrefix);
-  console.info(`  Found ${commits.length} commits since ${tag ?? 'the beginning'}`);
+  console.info(dim(`Found ${commits.length} commits since ${tag ?? 'the beginning'}`));
 
   // 2. Determine bump type
   let releaseType: ReleaseType | undefined;
@@ -49,7 +49,7 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
       .map((c) => parseCommitMessage(c.message, c.hash, workTypes, config.workspaceAliases))
       .filter((c): c is ParsedCommit => c !== undefined);
 
-    console.info(`  Parsed ${parsedCommits.length} typed commits`);
+    console.info(dim(`  Parsed ${parsedCommits.length} typed commits`));
     releaseType = determineBumpType(parsedCommits, workTypes, versionPatterns);
   } else {
     releaseType = bumpOverride;
@@ -57,17 +57,17 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   }
 
   if (releaseType === undefined) {
-    console.info('No release-worthy changes found. Skipping.');
+    console.info('⏭️  No release-worthy changes found. Skipping.');
     return [];
   }
 
   // 3. Bump all versions
-  console.info(`Bumping versions (${releaseType})...`);
+  console.info(dim(`Bumping versions (${releaseType})...`));
   const newVersion = bumpAllVersions(config.packageFiles, releaseType, dryRun);
   const newTag = `${config.tagPrefix}${newVersion}`;
 
   // 4. Generate changelogs
-  console.info('Generating changelogs...');
+  console.info(dim('Generating changelogs...'));
   generateChangelogs(config, newTag, dryRun);
 
   // 5. Run format command, appending modified file paths
@@ -76,9 +76,9 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
     const modifiedFiles = [...config.packageFiles, ...config.changelogPaths.map((p) => `${p}/CHANGELOG.md`)];
     const fullCommand = `${formatCommand} ${modifiedFiles.join(' ')}`;
     if (dryRun) {
-      console.info(`  [dry-run] Would run format command: ${fullCommand}`);
+      console.info(dim(`  [dry-run] Would run format command: ${fullCommand}`));
     } else {
-      console.info(`  Running format command: ${fullCommand}`);
+      console.info(dim(`  Running format command: ${fullCommand}`));
       try {
         execSync(fullCommand, { stdio: 'inherit' });
       } catch (error: unknown) {
@@ -89,6 +89,7 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
     }
   }
 
-  console.info(`Release preparation complete: ${newTag}`);
+  console.info(`✅ Release preparation complete.`);
+  console.info(`   🏷️  ${bold(newTag)}`);
   return [newTag];
 }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process';
 import { bumpAllVersions } from './bumpAllVersions.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpType } from './determineBumpType.ts';
+import { bold, dim, sectionHeader } from './format.ts';
 import { generateChangelog } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
@@ -37,20 +38,19 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
 
   for (const component of config.components) {
     const name = component.dir;
-    console.info(`\nProcessing component: ${name}`);
+    console.info(`\n${sectionHeader(name)}`);
 
     // 1. Get path-filtered commits since last tag
-    console.info('  Finding commits since last release...');
     const { tag, commits } = getCommitsSinceTarget(component.tagPrefix, component.paths);
     const since = tag === undefined ? '(no previous release found)' : `since ${tag}`;
-    console.info(`  Found ${commits.length} commits ${since}`);
+    console.info(dim(`  Found ${commits.length} commits ${since}`));
 
     // Skip components with no changes unless --force is set. "No changes" means
     // no commits touched paths matching the component's glob patterns. Root-level
     // or cross-cutting commits not captured by the component's path globs are not
     // counted and may cause a skip even when those changes semantically apply.
     if (commits.length === 0 && !force) {
-      console.info(`  No changes for ${name} ${since}. Skipping.`);
+      console.info(`  ⏭️  No changes for ${name} ${since}. Skipping.`);
       continue;
     }
 
@@ -62,7 +62,7 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
         .map((c) => parseCommitMessage(c.message, c.hash, workTypes, config.workspaceAliases))
         .filter((c): c is ParsedCommit => c !== undefined);
 
-      console.info(`  Parsed ${parsedCommits.length} typed commits`);
+      console.info(dim(`  Parsed ${parsedCommits.length} typed commits`));
       releaseType = determineBumpType(parsedCommits, workTypes, versionPatterns);
     } else {
       releaseType = bumpOverride;
@@ -70,23 +70,23 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     }
 
     if (releaseType === undefined) {
-      console.info(`  No release-worthy changes for ${name} ${since}. Skipping.`);
+      console.info(`  ⏭️  No release-worthy changes for ${name} ${since}. Skipping.`);
       continue;
     }
 
     // 3. Bump all versions for this component
-    console.info(`  Bumping versions (${releaseType})...`);
+    console.info(dim(`  Bumping versions (${releaseType})...`));
     const newVersion = bumpAllVersions(component.packageFiles, releaseType, dryRun);
     const newTag = `${component.tagPrefix}${newVersion}`;
     tags.push(newTag);
     modifiedFiles.push(...component.packageFiles, ...component.changelogPaths.map((p) => `${p}/CHANGELOG.md`));
 
     // 4. Generate changelogs for each configured path with include-path filtering
-    console.info('  Generating changelogs...');
+    console.info(dim('  Generating changelogs...'));
     for (const changelogPath of component.changelogPaths) {
       generateChangelog(config, changelogPath, newTag, dryRun, { includePaths: component.paths });
     }
-    console.info(`  Component release prepared: ${newTag}`);
+    console.info(`  🏷️  ${bold(newTag)}`);
   }
 
   // 5. Run format command once after all components are processed, appending modified file paths
@@ -94,9 +94,9 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
   if (tags.length > 0 && formatCommand !== undefined) {
     const fullCommand = `${formatCommand} ${modifiedFiles.join(' ')}`;
     if (dryRun) {
-      console.info(`\n  [dry-run] Would run format command: ${fullCommand}`);
+      console.info(dim(`\n  [dry-run] Would run format command: ${fullCommand}`));
     } else {
-      console.info(`\n  Running format command: ${fullCommand}`);
+      console.info(dim(`\n  Running format command: ${fullCommand}`));
       try {
         execSync(fullCommand, { stdio: 'inherit' });
       } catch (error: unknown) {
@@ -107,8 +107,13 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     }
   }
 
-  const summary =
-    tags.length > 0 ? 'Monorepo release preparation complete.' : 'No components had release-worthy changes.';
-  console.info(`\n${summary}`);
+  if (tags.length > 0) {
+    console.info(`\n✅ Release preparation complete.`);
+    for (const tag of tags) {
+      console.info(`   🏷️  ${bold(tag)}`);
+    }
+  } else {
+    console.info(`\n⏭️  No components had release-worthy changes.`);
+  }
   return tags;
 }

--- a/packages/release-kit/src/runReleasePrepare.ts
+++ b/packages/release-kit/src/runReleasePrepare.ts
@@ -4,6 +4,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
+import { dim } from './format.ts';
 import { releasePrepare } from './releasePrepare.ts';
 import { releasePrepareMono } from './releasePrepareMono.ts';
 import type { MonorepoReleaseConfig, ReleaseConfig, ReleaseType } from './types.ts';
@@ -164,11 +165,11 @@ export function writeReleaseTags(tags: string[], dryRun: boolean): void {
   }
 
   if (dryRun) {
-    console.info(`  [dry-run] Would write ${RELEASE_TAGS_FILE}: ${tags.join(' ')}`);
+    console.info(dim(`  [dry-run] Would write ${RELEASE_TAGS_FILE}: ${tags.join(' ')}`));
     return;
   }
 
   mkdirSync(dirname(RELEASE_TAGS_FILE), { recursive: true });
   writeFileSync(RELEASE_TAGS_FILE, tags.join('\n'), 'utf8');
-  console.info(`  Wrote ${RELEASE_TAGS_FILE}: ${tags.join(' ')}`);
+  console.info(dim(`  Wrote ${RELEASE_TAGS_FILE}: ${tags.join(' ')}`));
 }


### PR DESCRIPTION
Closes #54 

## What

Adds ANSI formatting and emoji markers to the `release-kit prepare` command output. Progress chatter is dimmed, key results (version bumps, release tags, completion status) are highlighted with bold text and emoji, and monorepo components are separated by box-drawing section headers.

## Why

The plain-text output of `release-kit prepare` was difficult to scan visually — every line had the same weight, making it hard to find the important information (which versions bumped, which components were skipped, what tags were produced). This is human-facing CLI output that benefits from a clear visual hierarchy.

## Details

### Features

- Add `format.ts` utility with `bold`, `dim`, and `sectionHeader` ANSI helpers
- Emoji markers for key status lines: 📦 version bumps, 🏷️ release tags, ⏭️ skipped components, ✅ completion
- Box-drawing section headers (`━━━ component ━━━`) separating monorepo components
- Dry-run banner (`🔍 DRY RUN`) printed once at top instead of per-line prefixes
- Final summary block listing all produced tags in monorepo mode
- Unicode arrow (`→`) replacing ASCII (`->`) in version bump display
- Remove redundant "Finding commits..." progress messages

### Tests

- Add `format.unit.test.ts` covering `bold`, `dim`, and `sectionHeader`

## Test plan

- [ ] Run `release-kit prepare --dry-run` and verify styled output with emoji markers, dim progress lines, and bold tags
- [ ] Run `release-kit prepare --dry-run` in monorepo mode and verify section headers separate components
- [ ] Verify skipped components show ⏭️ marker
- [ ] Verify final summary lists all produced tags with 🏷️