### PR TITLE
#60 Reduce code duplication in config and consistency modules

### DIFF
--- a/packages/nmr/src/config.ts
+++ b/packages/nmr/src/config.ts
@@ -36,9 +36,24 @@ function isScriptRecord(value: unknown): value is Record<string, string | string
   return true;
 }
 
-/**
- * Validates that a loaded value conforms to the expected NmrConfig shape.
- */
+/** Validate and extract a single script-record field from the raw config object. */
+function validateScriptField(
+  value: Record<string, unknown>,
+  fieldName: string,
+  configPath: string,
+): Record<string, string | string[]> | undefined {
+  if (!(fieldName in value) || value[fieldName] === undefined) {
+    return undefined;
+  }
+  if (!isScriptRecord(value[fieldName])) {
+    throw new Error(
+      `Invalid nmr config at ${configPath}: \`${fieldName}\` must be a Record<string, string | string[]>`,
+    );
+  }
+  return value[fieldName];
+}
+
+/** Validate that a loaded value conforms to the expected `NmrConfig` shape. */
 function validateConfig(value: unknown, configPath: string): NmrConfig {
   if (!isObject(value)) {
     throw new Error(`Invalid nmr config at ${configPath}: expected an object, got ${typeof value}`);
@@ -46,23 +61,11 @@ function validateConfig(value: unknown, configPath: string): NmrConfig {
 
   const config: NmrConfig = {};
 
-  if ('workspaceScripts' in value && value.workspaceScripts !== undefined) {
-    if (!isScriptRecord(value.workspaceScripts)) {
-      throw new Error(
-        `Invalid nmr config at ${configPath}: \`workspaceScripts\` must be a Record<string, string | string[]>`,
-      );
-    }
-    config.workspaceScripts = value.workspaceScripts;
-  }
+  const workspaceScripts = validateScriptField(value, 'workspaceScripts', configPath);
+  if (workspaceScripts) config.workspaceScripts = workspaceScripts;
 
-  if ('rootScripts' in value && value.rootScripts !== undefined) {
-    if (!isScriptRecord(value.rootScripts)) {
-      throw new Error(
-        `Invalid nmr config at ${configPath}: \`rootScripts\` must be a Record<string, string | string[]>`,
-      );
-    }
-    config.rootScripts = value.rootScripts;
-  }
+  const rootScripts = validateScriptField(value, 'rootScripts', configPath);
+  if (rootScripts) config.rootScripts = rootScripts;
 
   return config;
 }

--- a/packages/nmr/src/tests/consistency.ts
+++ b/packages/nmr/src/tests/consistency.ts
@@ -1,12 +1,11 @@
-import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
 
 import { findMonorepoRoot } from '../context.js';
 import { getRuntimeVersionFromAsdf } from './helpers/get-runtime-version-from-asdf.js';
+import { getStringFromYamlFile } from './helpers/get-string-from-yaml-file.js';
 import { getValueAtPathOrThrow } from './helpers/get-value-at-path.js';
 
 const GITHUB_ACTION_FILE_PATH = '.github/workflows/code-quality.yaml';
@@ -35,14 +34,7 @@ function checkNodeVersionConsistency(monorepoRoot: string): void {
 
 async function getPnpmVersionFromAction(monorepoRoot: string): Promise<string> {
   const actionPath = path.join(monorepoRoot, GITHUB_ACTION_FILE_PATH);
-  const actionYaml = await fs.promises.readFile(actionPath, { encoding: 'utf8' });
-  const action = yaml.load(actionYaml);
-  assert.ok(action, 'Action YAML not found');
-
-  const version = getValueAtPathOrThrow(action, 'jobs.code-quality.with.pnpm-version');
-  assert.ok(typeof version === 'string' && version.length > 0, 'pnpm version not found in action');
-
-  return version;
+  return getStringFromYamlFile(actionPath, 'jobs.code-quality.with.pnpm-version', 'pnpm version');
 }
 
 function getPnpmVersionFromPackageJson(monorepoRoot: string): string {
@@ -69,14 +61,7 @@ function getPnpmVersionFromPackageJson(monorepoRoot: string): string {
 
 async function getNodeVersionFromAction(monorepoRoot: string): Promise<string> {
   const actionPath = path.join(monorepoRoot, GITHUB_ACTION_FILE_PATH);
-  const actionYaml = await fs.promises.readFile(actionPath, { encoding: 'utf8' });
-  const action = yaml.load(actionYaml);
-  assert.ok(action, 'Action YAML not found');
-
-  const version = getValueAtPathOrThrow(action, 'jobs.code-quality.with.node-version');
-  assert.ok(typeof version === 'string' && version.length > 0, 'Node.js version not found in action');
-
-  return version;
+  return getStringFromYamlFile(actionPath, 'jobs.code-quality.with.node-version', 'Node.js version');
 }
 
 /**

--- a/packages/nmr/src/tests/helpers/get-string-from-yaml-file.ts
+++ b/packages/nmr/src/tests/helpers/get-string-from-yaml-file.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+
+import yaml from 'js-yaml';
+
+import { getValueAtPathOrThrow } from './get-value-at-path.js';
+
+/** Read a YAML file and extract a non-empty string value at the given dot-separated key path. */
+export async function getStringFromYamlFile(filePath: string, keyPath: string, label: string): Promise<string> {
+  const raw = await fs.promises.readFile(filePath, { encoding: 'utf8' });
+  const parsed = yaml.load(raw);
+  assert.ok(parsed, `YAML content not found in ${filePath}`);
+
+  const value = getValueAtPathOrThrow(parsed, keyPath);
+  assert.ok(typeof value === 'string' && value.length > 0, `${label} not found at ${keyPath}`);
+
+  return value;
+}


### PR DESCRIPTION
Closes #60 

## What

Extracts two small helpers to consolidate structurally duplicated code in the nmr package. A new `getStringFromYamlFile` helper in `tests/helpers/` replaces the repeated YAML-read-parse-extract pattern in `consistency.ts`, and a private `validateScriptField` helper in `config.ts` replaces the duplicated script-record validation blocks.

## Why

The duplication was carried over from `packages/core` during the nmr extraction (#59) and flagged by the code-simplification reviewer. Consolidating makes it trivial to add new version checks or config fields without copying the same boilerplate.

## Details

### Refactoring

- Extract `getStringFromYamlFile(filePath, keyPath, label)` into `packages/nmr/src/tests/helpers/get-string-from-yaml-file.ts`. `getPnpmVersionFromAction` and `getNodeVersionFromAction` in `consistency.ts` now delegate to this helper.
- Extract `validateScriptField(value, fieldName, configPath)` as a private function in `config.ts`. The `workspaceScripts` and `rootScripts` validation in `validateConfig` now each call this helper instead of duplicating the check-presence/guard/throw pattern.
- Remove unused `assert` and `js-yaml` imports from `consistency.ts`.