### PR TITLE
#14 Add eligibility check failure and short-circuit tests

### DIFF
--- a/packages/release-kit/src/init/__tests__/initCommand.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/initCommand.unit.test.ts
@@ -147,4 +147,43 @@ describe(initCommand, () => {
 
     expect(mockScaffoldFiles).toHaveBeenCalledWith(expect.objectContaining({ repoType: 'monorepo' }));
   });
+
+  it('returns 1 when hasPackageJson fails', () => {
+    mockIsGitRepo.mockReturnValue({ ok: true });
+    mockHasPackageJson.mockReturnValue({ ok: false, message: 'No package.json found' });
+
+    const exitCode = initCommand({ dryRun: false, force: false, withConfig: false });
+
+    expect(exitCode).toBe(1);
+    expect(mockScaffoldFiles).not.toHaveBeenCalled();
+  });
+
+  it('returns 1 when usesPnpm fails', () => {
+    mockIsGitRepo.mockReturnValue({ ok: true });
+    mockHasPackageJson.mockReturnValue({ ok: true });
+    mockUsesPnpm.mockReturnValue({ ok: false, message: 'pnpm not detected' });
+
+    const exitCode = initCommand({ dryRun: false, force: false, withConfig: false });
+
+    expect(exitCode).toBe(1);
+    expect(mockScaffoldFiles).not.toHaveBeenCalled();
+  });
+
+  it('does not call hasPackageJson or usesPnpm when isGitRepo fails', () => {
+    mockIsGitRepo.mockReturnValue({ ok: false, message: 'Not a git repo' });
+
+    initCommand({ dryRun: false, force: false, withConfig: false });
+
+    expect(mockHasPackageJson).not.toHaveBeenCalled();
+    expect(mockUsesPnpm).not.toHaveBeenCalled();
+  });
+
+  it('does not call usesPnpm when hasPackageJson fails', () => {
+    mockIsGitRepo.mockReturnValue({ ok: true });
+    mockHasPackageJson.mockReturnValue({ ok: false, message: 'No package.json found' });
+
+    initCommand({ dryRun: false, force: false, withConfig: false });
+
+    expect(mockUsesPnpm).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #14 

## What

Adds 4 unit tests to `initCommand.unit.test.ts` covering the remaining `checkEligibility` orchestration gaps: individual failure exit codes for `hasPackageJson` and `usesPnpm`, and short-circuit verification ensuring downstream checks are skipped when an earlier check fails.

## Why

The existing tests covered the happy path and several error paths but did not verify that each eligibility check independently produces exit code 1 on failure, nor that the short-circuit early-return behavior prevents unnecessary downstream checks from running.

## Details

### Tests

- Verify `initCommand` returns 1 when `hasPackageJson` fails (with `isGitRepo` passing).
- Verify `initCommand` returns 1 when `usesPnpm` fails (with preceding checks passing).
- Verify `hasPackageJson` and `usesPnpm` are not called when `isGitRepo` fails.
- Verify `usesPnpm` is not called when `hasPackageJson` fails.

## Test plan

- [ ] All 14 `initCommand` unit tests pass (10 existing + 4 new).