### PR TITLE
#13 Add cliff.toml.template alignment test

### DIFF
--- a/packages/release-kit/package.json
+++ b/packages/release-kit/package.json
@@ -44,7 +44,8 @@
     "js-yaml": "4.1.1"
   },
   "devDependencies": {
-    "@types/js-yaml": "4.0.9"
+    "@types/js-yaml": "4.0.9",
+    "smol-toml": "1.6.1"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/release-kit/src/__tests__/cliffConfigAlignment.unit.test.ts
+++ b/packages/release-kit/src/__tests__/cliffConfigAlignment.unit.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parse } from 'smol-toml';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_WORK_TYPES } from '../defaults.ts';
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const templatePath = resolve(thisDir, '..', '..', 'cliff.toml.template');
+const templateContent = readFileSync(templatePath, 'utf8');
+
+interface CommitParser {
+  message: string;
+  group: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Parse cliff.toml.template and extract the commit_parsers array with runtime validation. */
+function getCommitParsers(): CommitParser[] {
+  const config = parse(templateContent);
+  const git = config.git;
+  if (!isRecord(git)) {
+    throw new Error('cliff.toml.template is missing [git] section');
+  }
+
+  const parsers = git.commit_parsers;
+  if (!Array.isArray(parsers)) {
+    throw new TypeError('cliff.toml.template is missing git.commit_parsers array');
+  }
+
+  return parsers.map((entry) => {
+    if (!isRecord(entry) || typeof entry.message !== 'string' || typeof entry.group !== 'string') {
+      throw new Error(`Invalid commit_parser entry: ${JSON.stringify(entry)}`);
+    }
+    return { message: entry.message, group: entry.group };
+  });
+}
+
+/** Collect all type names and aliases from DEFAULT_WORK_TYPES, each paired with its expected header. */
+function getExpectedTypes(): Array<{ typeName: string; header: string }> {
+  const entries: Array<{ typeName: string; header: string }> = [];
+  for (const [key, config] of Object.entries(DEFAULT_WORK_TYPES)) {
+    entries.push({ typeName: key, header: config.header });
+    for (const alias of config.aliases ?? []) {
+      entries.push({ typeName: alias, header: config.header });
+    }
+  }
+  return entries;
+}
+
+/** Collect all unique header values from DEFAULT_WORK_TYPES. */
+function getKnownHeaders(): Set<string> {
+  return new Set(Object.values(DEFAULT_WORK_TYPES).map((config) => config.header));
+}
+
+describe('cliff.toml.template alignment with DEFAULT_WORK_TYPES', () => {
+  const parsers = getCommitParsers();
+  const expectedTypes = getExpectedTypes();
+  const knownHeaders = getKnownHeaders();
+
+  describe('every work type and alias is matched by a commit parser', () => {
+    for (const { typeName, header } of expectedTypes) {
+      it(`"${typeName}" is matched and grouped as "${header}"`, () => {
+        const syntheticMessage = `${typeName}: test`;
+        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
+
+        if (matchingParser === undefined) {
+          expect.fail(`No commit parser matches "${syntheticMessage}"`);
+        }
+        expect(matchingParser.group).toBe(header);
+      });
+    }
+  });
+
+  describe('every commit parser group maps to a known work type header', () => {
+    const uniqueGroups = [...new Set(parsers.map((p) => p.group))];
+    for (const group of uniqueGroups) {
+      it(`group "${group}" corresponds to a DEFAULT_WORK_TYPES header`, () => {
+        expect(knownHeaders).toContain(group);
+      });
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@types/js-yaml':
         specifier: 4.0.9
         version: 4.0.9
+      smol-toml:
+        specifier: 1.6.1
+        version: 1.6.1
 
 packages:
 
@@ -2029,6 +2032,10 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
 
   sort-object-keys@2.1.0:
     resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
@@ -4440,6 +4447,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  smol-toml@1.6.1: {}
 
   sort-object-keys@2.1.0: {}
 


### PR DESCRIPTION
Closes #13 

## What

Adds a unit test that enforces bidirectional alignment between `DEFAULT_WORK_TYPES` and the bundled `cliff.toml.template` commit parsers. The test parses the TOML template using `smol-toml`, then verifies that every canonical type name and alias is matched by a parser with the correct group heading, and that every parser group maps to a known work type header.

## Why

`DEFAULT_WORK_TYPES` (bump determination) and `cliff.toml.template` (CHANGELOG generation) are configured independently. They currently happen to be aligned, but nothing enforces it. A drift between the two would cause version bumps with no CHANGELOG entries or CHANGELOG entries that don't influence bumps — both confusing outcomes.

## Details

### Tests

- New `cliffConfigAlignment.unit.test.ts` with 25 dynamically generated test cases covering all 10 canonical types, 5 aliases, and 10 unique parser groups
- Work types → parsers: constructs synthetic commit messages and matches against parser regex patterns, verifying group-to-header correspondence
- Parsers → work types: verifies every parser `group` maps to a `header` in `DEFAULT_WORK_TYPES`
- Uses runtime validation (type guards) to narrow parsed TOML structure — no type assertions

### Dependencies

- Added `smol-toml` (v1.6.1) as a dev dependency for TOML parsing in the alignment test

## Test plan

- [ ] Verify all 25 alignment tests pass
- [ ] Verify adding a fake work type without a parser causes test failure
- [ ] Verify adding a parser with an unknown group causes test failure