### PR TITLE
#12 Add unit tests for releasePrepare return values

### DIFF
--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -171,4 +171,48 @@ describe(releasePrepare, () => {
     expect(mockExecSync).not.toHaveBeenCalled();
     expect(result.formatCommand).toBeUndefined();
   });
+
+  it('uses bumpOverride directly, bypassing commit-based bump detection', () => {
+    setupFeatCommit();
+
+    const result = releasePrepare(makeConfig(), { dryRun: false, bumpOverride: 'patch' });
+
+    expect(result.tags).toStrictEqual(['v1.0.1']);
+    expect(result.components[0]).toMatchObject({
+      status: 'released',
+      releaseType: 'patch',
+      newVersion: '1.0.1',
+      tag: 'v1.0.1',
+    });
+    expect(result.components[0]?.parsedCommitCount).toBeUndefined();
+  });
+
+  it('constructs tags using the configured tagPrefix', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'my-lib-v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'feat: add feature\u001Fabc123';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    const result = releasePrepare(makeConfig({ tagPrefix: 'my-lib-v' }), { dryRun: false });
+
+    expect(result.tags).toStrictEqual(['my-lib-v1.1.0']);
+    expect(result.components[0]).toMatchObject({
+      tag: 'my-lib-v1.1.0',
+    });
+  });
+
+  it('populates tags in dry-run mode', () => {
+    setupFeatCommit();
+
+    const result = releasePrepare(makeConfig(), { dryRun: true });
+
+    expect(result.tags).toStrictEqual(['v1.1.0']);
+    expect(result.dryRun).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes #12 

## What

Adds three unit tests to `releasePrepare.unit.test.ts` covering previously untested code paths: the `bumpOverride` bypass of commit-based bump detection, custom `tagPrefix` propagation into tags, and tag computation in dry-run mode.

## Why

The existing tests covered the two primary return paths (released and skipped) but left several input variations untested. These new tests close the coverage gaps identified in issue #12, ensuring that the override path, prefix construction, and dry-run tag behavior are verified.

## Details

### Tests

- **`bumpOverride` path**: Verifies that providing `bumpOverride: 'patch'` skips `determineBumpType` (asserts `parsedCommitCount` is `undefined`) and produces a patch bump instead of the minor bump that commit analysis would yield.
- **Custom `tagPrefix`**: Verifies that `tagPrefix: 'my-lib-v'` produces `my-lib-v1.1.0` in both the component-level `tag` and top-level `tags` array.
- **Dry-run tags**: Verifies that `result.tags` is populated identically in dry-run mode (tags are computed, just not applied).

## Test plan

- [ ] Three new tests pass in `releasePrepare.unit.test.ts`
- [ ] No existing tests regressed