### PR TITLE
#11 Separate tag-write errors from release preparation errors

### DIFF
--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -4,8 +4,7 @@ const mockDiscoverWorkspaces = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockReleasePrepareMono = vi.hoisted(() => vi.fn());
 const mockReleasePrepare = vi.hoisted(() => vi.fn());
-const mockMkdirSync = vi.hoisted(() => vi.fn());
-const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileWithCheck = vi.hoisted(() => vi.fn());
 
 vi.mock('../discoverWorkspaces.ts', () => ({
   discoverWorkspaces: mockDiscoverWorkspaces,
@@ -27,9 +26,8 @@ vi.mock('../releasePrepare.ts', () => ({
   releasePrepare: mockReleasePrepare,
 }));
 
-vi.mock('node:fs', () => ({
-  mkdirSync: mockMkdirSync,
-  writeFileSync: mockWriteFileSync,
+vi.mock(import('@williamthorsen/node-monorepo-core'), () => ({
+  writeFileWithCheck: mockWriteFileWithCheck,
 }));
 
 import { parseArgs, prepareCommand, RELEASE_TAGS_FILE } from '../prepareCommand.ts';
@@ -58,6 +56,7 @@ describe(prepareCommand, () => {
     mockLoadConfig.mockResolvedValue(undefined);
     mockReleasePrepareMono.mockReturnValue(makePrepareResult());
     mockReleasePrepare.mockReturnValue(makePrepareResult());
+    mockWriteFileWithCheck.mockReturnValue({ filePath: RELEASE_TAGS_FILE, outcome: 'created' });
     vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
@@ -71,8 +70,7 @@ describe(prepareCommand, () => {
     mockLoadConfig.mockReset();
     mockReleasePrepareMono.mockReset();
     mockReleasePrepare.mockReset();
-    mockMkdirSync.mockReset();
-    mockWriteFileSync.mockReset();
+    mockWriteFileWithCheck.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -168,28 +166,54 @@ describe(prepareCommand, () => {
   });
 
   it('writes release tags after successful preparation', async () => {
+    mockWriteFileWithCheck.mockReturnValue({ filePath: RELEASE_TAGS_FILE, outcome: 'created' });
     mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['arrays-v1.0.0'] }));
 
     await prepareCommand([]);
 
-    expect(mockMkdirSync).toHaveBeenCalledWith('tmp', { recursive: true });
-    expect(mockWriteFileSync).toHaveBeenCalledWith(RELEASE_TAGS_FILE, 'arrays-v1.0.0', 'utf8');
+    expect(mockWriteFileWithCheck).toHaveBeenCalledWith(RELEASE_TAGS_FILE, 'arrays-v1.0.0', {
+      dryRun: false,
+      overwrite: true,
+    });
   });
 
-  it('does not write release tags file during a dry run', async () => {
+  it('passes dryRun to writeFileWithCheck during a dry run', async () => {
+    mockWriteFileWithCheck.mockReturnValue({ filePath: RELEASE_TAGS_FILE, outcome: 'created' });
     mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['arrays-v1.0.0'], dryRun: true }));
 
     await prepareCommand(['--dry-run']);
 
-    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(mockWriteFileWithCheck).toHaveBeenCalledWith(RELEASE_TAGS_FILE, 'arrays-v1.0.0', {
+      dryRun: true,
+      overwrite: true,
+    });
   });
 
   it('joins multiple tags with newlines in the release tags file', async () => {
+    mockWriteFileWithCheck.mockReturnValue({ filePath: RELEASE_TAGS_FILE, outcome: 'created' });
     mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['arrays-v1.0.0', 'strings-v2.0.1'] }));
 
     await prepareCommand([]);
 
-    expect(mockWriteFileSync).toHaveBeenCalledWith(RELEASE_TAGS_FILE, 'arrays-v1.0.0\nstrings-v2.0.1', 'utf8');
+    expect(mockWriteFileWithCheck).toHaveBeenCalledWith(
+      RELEASE_TAGS_FILE,
+      'arrays-v1.0.0\nstrings-v2.0.1',
+      expect.any(Object),
+    );
+  });
+
+  it('exits with a distinct error when writing release tags fails', async () => {
+    mockWriteFileWithCheck.mockReturnValue({
+      filePath: RELEASE_TAGS_FILE,
+      outcome: 'failed',
+      error: 'permission denied',
+    });
+    mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['arrays-v1.0.0'] }));
+
+    await expect(prepareCommand([])).rejects.toThrow(ExitError);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('release tags'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
+    expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
   });
 
   it('prints release tags file path when tags are produced', async () => {
@@ -198,6 +222,14 @@ describe(prepareCommand, () => {
     await prepareCommand([]);
 
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining('Release tags file:'));
+  });
+
+  it('does not print release tags file path during a dry run', async () => {
+    mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['arrays-v1.0.0'], dryRun: true }));
+
+    await prepareCommand(['--dry-run']);
+
+    expect(console.info).not.toHaveBeenCalledWith(expect.stringContaining('Release tags file:'));
   });
 
   it('does not print release tags file path when no tags are produced', async () => {

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -1,8 +1,8 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
+import type { WriteResult } from '@williamthorsen/node-monorepo-core';
+import { writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
 
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
 import { dim } from './format.ts';
@@ -91,19 +91,12 @@ export function parseArgs(argv: string[]): {
  * Write computed tags to the `.release-tags` file so the CI workflow can read them
  * instead of deriving tag names independently.
  */
-export function writeReleaseTags(tags: string[], dryRun: boolean): void {
+export function writeReleaseTags(tags: string[], dryRun: boolean): WriteResult | undefined {
   if (tags.length === 0) {
-    return;
+    return undefined;
   }
 
-  if (dryRun) {
-    console.info(dim(`  [dry-run] Would write ${RELEASE_TAGS_FILE}: ${tags.join(' ')}`));
-    return;
-  }
-
-  mkdirSync(dirname(RELEASE_TAGS_FILE), { recursive: true });
-  writeFileSync(RELEASE_TAGS_FILE, tags.join('\n'), 'utf8');
-  console.info(dim(`  Wrote ${RELEASE_TAGS_FILE}: ${tags.join(' ')}`));
+  return writeFileWithCheck(RELEASE_TAGS_FILE, tags.join('\n'), { dryRun, overwrite: true });
 }
 
 /**
@@ -194,16 +187,29 @@ export async function prepareCommand(argv: string[]): Promise<void> {
 
 /** Execute the prepare workflow, format the result, write to stdout, and handle errors. */
 function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
+  let result: PrepareResult;
   try {
-    const result = execute();
-    process.stdout.write(reportPrepare(result) + '\n');
-    writeReleaseTags(result.tags, dryRun);
-
-    if (result.tags.length > 0) {
-      console.info(dim(`\n   Release tags file: ${RELEASE_TAGS_FILE}`));
-    }
+    result = execute();
   } catch (error: unknown) {
     console.error('Error preparing release:', error instanceof Error ? error.message : String(error));
     process.exit(1);
+  }
+
+  process.stdout.write(reportPrepare(result) + '\n');
+
+  const writeResult = writeReleaseTags(result.tags, dryRun);
+
+  if (writeResult?.outcome === 'failed') {
+    console.error(`Error writing release tags: ${writeResult.error ?? 'unknown error'}`);
+    process.exit(1);
+  }
+
+  if (writeResult) {
+    if (dryRun) {
+      console.info(dim(`  [dry-run] Would write ${RELEASE_TAGS_FILE}: ${result.tags.join(' ')}`));
+    } else {
+      console.info(dim(`  Wrote ${RELEASE_TAGS_FILE}: ${result.tags.join(' ')}`));
+      console.info(dim(`\n   Release tags file: ${RELEASE_TAGS_FILE}`));
+    }
   }
 }


### PR DESCRIPTION
Closes #11 

## What

When tag-file writing fails, the error message now reads "Error writing release tags:" instead of the misleading "Error preparing release:", which only appeared because both operations shared a single try/catch.

Refactors `writeReleaseTags` to use the shared `writeFileWithCheck` utility from `@node-monorepo-tools/core` instead of raw `mkdirSync`/`writeFileSync`. The function now returns a structured `WriteResult` instead of throwing, and contains no `console` calls — all presentation moves to `runAndReport`.

## Why

When `writeReleaseTags` threw (e.g., permission denied on disk write), the error was caught by `runAndReport`'s catch block which emitted "Error preparing release:" — misleading because the release preparation had already succeeded. Additionally, `writeReleaseTags` mixed business logic with presentation by calling `console.info` directly.

## Details

### Features

- Tag-write failures now produce "Error writing release tags: {error}" instead of the misleading "Error preparing release:" message
- The "Release tags file:" info line is suppressed during dry-run mode, since the file isn't actually written

### Refactoring

- `writeReleaseTags` delegates to `writeFileWithCheck` and returns `WriteResult | undefined` — no `console` calls, no direct filesystem imports
- `runAndReport` owns all presentation: dry-run messages, success messages, error messages, and the "Release tags file:" info line
- Removed `node:fs` and `node:path` imports from `prepareCommand.ts`

### Tests

- Replaced `node:fs` mock (`mockMkdirSync`, `mockWriteFileSync`) with `@williamthorsen/node-monorepo-core` mock (`mockWriteFileWithCheck`)
- Added test verifying distinct error message when `writeFileWithCheck` returns `{ outcome: 'failed' }`
- Added test verifying "Release tags file:" is not printed during dry-run
- Updated existing tag-writing tests to assert on `writeFileWithCheck` calls