### PR TITLE
#74 Add script to enforce prepublishOnly hooks

### DIFF
--- a/packages/nmr/__tests__/commands/ensure-prepublish-hooks.test.ts
+++ b/packages/nmr/__tests__/commands/ensure-prepublish-hooks.test.ts
@@ -1,0 +1,146 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ensurePrepublishHooks } from '../../src/commands/ensure-prepublish-hooks.js';
+import { readPackageJson } from '../../src/helpers/package-json.js';
+
+/**
+ * Create a minimal monorepo fixture with a pnpm-workspace.yaml
+ * and the given packages under a `packages/` directory.
+ */
+function createFixture(
+  tmpDir: string,
+  packages: Array<{ name: string; private?: boolean; prepublishOnly?: string }>,
+): void {
+  fs.writeFileSync(path.join(tmpDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n');
+  fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'root', private: true }));
+
+  const packagesDir = path.join(tmpDir, 'packages');
+  fs.mkdirSync(packagesDir);
+
+  for (const pkg of packages) {
+    const dirName = pkg.name.replace(/^@[^/]+\//, '');
+    const pkgDir = path.join(packagesDir, dirName);
+    fs.mkdirSync(pkgDir);
+
+    const pkgJson: Record<string, unknown> = { name: pkg.name, version: '1.0.0' };
+    if (pkg.private) pkgJson.private = true;
+    if (pkg.prepublishOnly) {
+      pkgJson.scripts = { prepublishOnly: pkg.prepublishOnly };
+    }
+
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify(pkgJson, null, 2) + '\n');
+  }
+}
+
+describe('ensurePrepublishHooks', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nmr-prepublish-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  describe('check mode', () => {
+    it('reports ok when all non-private packages have prepublishOnly', () => {
+      createFixture(tmpDir, [
+        { name: '@scope/lib-a', prepublishOnly: 'pnpm run build' },
+        { name: '@scope/lib-b', prepublishOnly: 'npm run compile' },
+      ]);
+
+      const result = ensurePrepublishHooks(tmpDir, { fix: false, dryRun: false });
+
+      expect(result.hasFailures).toBe(false);
+      expect(result.packages).toHaveLength(2);
+      expect(result.packages.every((p) => p.action === 'ok')).toBe(true);
+    });
+
+    it('reports missing when a non-private package lacks prepublishOnly', () => {
+      createFixture(tmpDir, [{ name: '@scope/lib-a', prepublishOnly: 'pnpm run build' }, { name: '@scope/lib-b' }]);
+
+      const result = ensurePrepublishHooks(tmpDir, { fix: false, dryRun: false });
+
+      expect(result.hasFailures).toBe(true);
+      const missing = result.packages.filter((p) => p.action === 'missing');
+      expect(missing).toHaveLength(1);
+      expect(missing[0].packageName).toBe('@scope/lib-b');
+    });
+
+    it('skips private packages', () => {
+      createFixture(tmpDir, [
+        { name: '@scope/private-pkg', private: true },
+        { name: '@scope/public-pkg', prepublishOnly: 'pnpm run build' },
+      ]);
+
+      const result = ensurePrepublishHooks(tmpDir, { fix: false, dryRun: false });
+
+      expect(result.hasFailures).toBe(false);
+      const privatePkg = result.packages.find((p) => p.packageName === '@scope/private-pkg');
+      expect(privatePkg?.isPrivate).toBe(true);
+      expect(privatePkg?.action).toBe('ok');
+    });
+  });
+
+  describe('fix mode', () => {
+    it('adds prepublishOnly to packages missing it', () => {
+      createFixture(tmpDir, [{ name: '@scope/lib-a' }, { name: '@scope/lib-b', prepublishOnly: 'pnpm run build' }]);
+
+      const result = ensurePrepublishHooks(tmpDir, { fix: true, dryRun: false });
+
+      expect(result.hasFailures).toBe(false);
+      const fixed = result.packages.find((p) => p.packageName === '@scope/lib-a');
+      expect(fixed?.action).toBe('fixed');
+
+      // Verify file was actually written
+      const written = readPackageJson(path.join(tmpDir, 'packages', 'lib-a'));
+      expect(written.scripts?.prepublishOnly).toBe('npm run build');
+    });
+
+    it('creates scripts object if missing', () => {
+      createFixture(tmpDir, [{ name: '@scope/lib-a' }]);
+
+      ensurePrepublishHooks(tmpDir, { fix: true, dryRun: false });
+
+      const written = readPackageJson(path.join(tmpDir, 'packages', 'lib-a'));
+      expect(written.scripts).toEqual({ prepublishOnly: 'npm run build' });
+    });
+
+    it('uses custom command when provided', () => {
+      createFixture(tmpDir, [{ name: '@scope/lib-a' }]);
+
+      ensurePrepublishHooks(tmpDir, { fix: true, dryRun: false, command: 'pnpm run build' });
+
+      const written = readPackageJson(path.join(tmpDir, 'packages', 'lib-a'));
+      expect(written.scripts?.prepublishOnly).toBe('pnpm run build');
+    });
+
+    it('does not modify private packages', () => {
+      createFixture(tmpDir, [{ name: '@scope/private-pkg', private: true }]);
+
+      const result = ensurePrepublishHooks(tmpDir, { fix: true, dryRun: false });
+
+      expect(result.packages[0].action).toBe('ok');
+    });
+  });
+
+  describe('dry-run mode', () => {
+    it('reports would-fix without writing files', () => {
+      createFixture(tmpDir, [{ name: '@scope/lib-a' }]);
+
+      const result = ensurePrepublishHooks(tmpDir, { fix: true, dryRun: true });
+
+      expect(result.hasFailures).toBe(false);
+      expect(result.packages[0].action).toBe('would-fix');
+
+      // Verify file was NOT written
+      const raw = readPackageJson(path.join(tmpDir, 'packages', 'lib-a'));
+      expect(raw.scripts).toBeUndefined();
+    });
+  });
+});

--- a/packages/nmr/bin/ensure-prepublish-hooks.js
+++ b/packages/nmr/bin/ensure-prepublish-hooks.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import('../dist/esm/cli-ensure-prepublish-hooks.js');

--- a/packages/nmr/package.json
+++ b/packages/nmr/package.json
@@ -17,6 +17,7 @@
     "./tests": "./dist/esm/tests/consistency.js"
   },
   "bin": {
+    "ensure-prepublish-hooks": "bin/ensure-prepublish-hooks.js",
     "nmr": "bin/nmr.js",
     "nmr-report-overrides": "bin/nmr-report-overrides.js",
     "nmr-sync-pnpm-version": "bin/nmr-sync-pnpm-version.js"

--- a/packages/nmr/src/cli-ensure-prepublish-hooks.ts
+++ b/packages/nmr/src/cli-ensure-prepublish-hooks.ts
@@ -1,0 +1,76 @@
+/* eslint n/no-process-exit: off */
+/* eslint unicorn/no-process-exit: off */
+
+import { DEFAULT_HOOK, ensurePrepublishHooks } from './commands/ensure-prepublish-hooks.js';
+import { findMonorepoRoot } from './context.js';
+
+let fix = false;
+let dryRun = false;
+let command: string | undefined;
+
+const args = process.argv.slice(2);
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  switch (arg) {
+    case '--fix':
+      fix = true;
+
+      break;
+
+    case '--dry-run':
+      dryRun = true;
+
+      break;
+
+    case '--command':
+      i++;
+      command = args[i];
+      if (!command) {
+        console.error('--command requires a value');
+        process.exit(1);
+      }
+
+      break;
+
+    default:
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(1);
+  }
+}
+
+try {
+  const monorepoRoot = findMonorepoRoot();
+  const hookCommand = command ?? DEFAULT_HOOK;
+  const options = command ? { fix, dryRun, command } : { fix, dryRun };
+  const result = ensurePrepublishHooks(monorepoRoot, options);
+
+  for (const pkg of result.packages) {
+    if (pkg.isPrivate) {
+      continue;
+    }
+
+    switch (pkg.action) {
+      case 'ok':
+        console.info(`✓ ${pkg.packageName}: prepublishOnly = "${pkg.prepublishOnly}"`);
+        break;
+      case 'missing':
+        console.warn(`✗ ${pkg.packageName}: missing prepublishOnly`);
+        break;
+      case 'fixed':
+        console.info(`✓ ${pkg.packageName}: added prepublishOnly = "${hookCommand}"`);
+        break;
+      case 'would-fix':
+        console.info(`~ ${pkg.packageName}: would add prepublishOnly = "${hookCommand}"`);
+        break;
+    }
+  }
+
+  if (result.hasFailures) {
+    const missing = result.packages.filter((p) => p.action === 'missing').length;
+    console.error(`\n${missing} package(s) missing prepublishOnly. Use --fix to add it.`);
+    process.exit(1);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/packages/nmr/src/commands/ensure-prepublish-hooks.ts
+++ b/packages/nmr/src/commands/ensure-prepublish-hooks.ts
@@ -1,0 +1,109 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { getWorkspacePackageDirs } from '../context.js';
+import { readPackageJson } from '../helpers/package-json.js';
+import { isObject } from '../helpers/type-guards.js';
+
+export interface PackageHookStatus {
+  packageName: string;
+  packageDir: string;
+  isPrivate: boolean;
+  prepublishOnly: string | undefined;
+  action: 'ok' | 'missing' | 'fixed' | 'would-fix';
+}
+
+export interface EnsurePrepublishHooksResult {
+  packages: PackageHookStatus[];
+  hasFailures: boolean;
+}
+
+export const DEFAULT_HOOK = 'npm run build';
+
+/**
+ * Check (and optionally fix) whether all publishable workspace packages
+ * have a `prepublishOnly` script.
+ */
+export function ensurePrepublishHooks(
+  monorepoRoot: string,
+  options: { fix: boolean; dryRun: boolean; command?: string },
+): EnsurePrepublishHooksResult {
+  const hookCommand = options.command ?? DEFAULT_HOOK;
+  const packageDirs = getWorkspacePackageDirs(monorepoRoot);
+  const packages: PackageHookStatus[] = [];
+
+  for (const packageDir of packageDirs) {
+    const pkg = readPackageJson(packageDir);
+    const packageName = pkg.name ?? path.basename(packageDir);
+    const isPrivate = pkg.private === true;
+
+    if (isPrivate) {
+      packages.push({
+        packageName,
+        packageDir,
+        isPrivate: true,
+        prepublishOnly: pkg.scripts?.prepublishOnly,
+        action: 'ok',
+      });
+      continue;
+    }
+
+    const existing = pkg.scripts?.prepublishOnly;
+
+    if (existing) {
+      packages.push({
+        packageName,
+        packageDir,
+        isPrivate: false,
+        prepublishOnly: existing,
+        action: 'ok',
+      });
+      continue;
+    }
+
+    if (options.fix) {
+      const action = options.dryRun ? ('would-fix' as const) : ('fixed' as const);
+
+      if (!options.dryRun) {
+        addPrepublishOnly(packageDir, hookCommand);
+      }
+
+      packages.push({
+        packageName,
+        packageDir,
+        isPrivate: false,
+        prepublishOnly: undefined,
+        action,
+      });
+    } else {
+      packages.push({
+        packageName,
+        packageDir,
+        isPrivate: false,
+        prepublishOnly: undefined,
+        action: 'missing',
+      });
+    }
+  }
+
+  const hasFailures = packages.some((p) => p.action === 'missing');
+
+  return { packages, hasFailures };
+}
+
+/** Read a package.json, insert `prepublishOnly` into scripts, and write back. */
+function addPrepublishOnly(packageDir: string, command: string): void {
+  const filePath = path.join(packageDir, 'package.json');
+  const raw = readFileSync(filePath, 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+
+  if (!isObject(parsed)) {
+    throw new TypeError(`Invalid package.json in ${packageDir}: expected an object`);
+  }
+
+  const scripts = isObject(parsed.scripts) ? parsed.scripts : {};
+  scripts.prepublishOnly = command;
+  parsed.scripts = scripts;
+
+  writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf8');
+}

--- a/packages/nmr/src/helpers/package-json.ts
+++ b/packages/nmr/src/helpers/package-json.ts
@@ -5,6 +5,7 @@ import { isObject } from './type-guards.js';
 
 export interface PackageJson {
   name?: string;
+  private?: boolean;
   version?: string;
   packageManager?: string;
   scripts?: Record<string, string>;
@@ -26,6 +27,7 @@ export function readPackageJson(dir: string): PackageJson {
   // PackageJson fields are all optional, so this is structurally compatible.
   const pkg: PackageJson = {};
   if (typeof parsed.name === 'string') pkg.name = parsed.name;
+  if (parsed.private === true) pkg.private = true;
   if (typeof parsed.version === 'string') pkg.version = parsed.version;
   if (typeof parsed.packageManager === 'string') pkg.packageManager = parsed.packageManager;
   if (isObject(parsed.scripts)) {


### PR DESCRIPTION
Closes #74 

## What

Adds `ensure-prepublish-hooks` binary to `@williamthorsen/nmr` that scans all workspace packages and verifies that every publishable (non-private) package has a `prepublishOnly` script. Supports `--fix` to insert the hook, `--dry-run` to preview changes, and `--command` to override the default hook value (`npm run build`).

## Why

Publishing a package with stale distribution files is an irreversible failure — the version number is burned on the registry. The `prepublishOnly` lifecycle hook prevents this by triggering a build before publish, but nothing enforces its presence. This tool makes the unsafe default detectable and fixable.

## Details

### Features

- Check mode (default): reports each non-private package's `prepublishOnly` status, exits non-zero if any are missing. CI-friendly.
- Fix mode (`--fix`): inserts `"prepublishOnly": "npm run build"` into packages missing it. Creates `scripts` object if absent.
- Dry-run (`--fix --dry-run`): reports what would change without writing files.
- Custom command (`--command <value>`): overrides the default hook value for `--fix`.
- Adds `private` field extraction to the shared `PackageJson` interface in `helpers/package-json.ts`.

### Tests

- 8 new test cases covering check mode (ok, missing, private skip), fix mode (adds hook, creates scripts, custom command, skips private), and dry-run mode (reports without writing).

## Test plan

- [ ] Run `ensure-prepublish-hooks` from monorepo root — verify it reports missing hooks and exits non-zero
- [ ] Run with `--fix --dry-run` — verify it previews changes without modifying files
- [ ] Run with `--fix` — verify it inserts `prepublishOnly` and exits zero
- [ ] Run with `--fix --command "pnpm run build"` — verify custom command is used