### PR TITLE
#71 Prevent unparseable commits from being silently dropped

### DIFF
--- a/packages/release-kit/cliff.toml.template
+++ b/packages/release-kit/cliff.toml.template
@@ -39,7 +39,9 @@ filter_unconventional = false
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
-  # Strip issue-ticket prefixes like "TOOL-123 " or "AFG-456 "
+  # Strip GitHub-style issue prefixes like "#8 " or "#123 "
+  { pattern = '^#\d+\s+', replace = "" },
+  # Strip Jira-style ticket prefixes like "TOOL-123 " or "AFG-456 "
   { pattern = '^[A-Z]+-\d+\s+', replace = "" },
 ]
 # regex for parsing and grouping commits

--- a/packages/release-kit/src/__tests__/cliffConfigAlignment.unit.test.ts
+++ b/packages/release-kit/src/__tests__/cliffConfigAlignment.unit.test.ts
@@ -6,6 +6,7 @@ import { parse } from 'smol-toml';
 import { describe, expect, it } from 'vitest';
 
 import { DEFAULT_WORK_TYPES } from '../defaults.ts';
+import { COMMIT_PREPROCESSOR_PATTERNS } from '../parseCommitMessage.ts';
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
 const templatePath = resolve(thisDir, '..', '..', 'cliff.toml.template');
@@ -16,18 +17,28 @@ interface CommitParser {
   group: string;
 }
 
+interface CommitPreprocessor {
+  pattern: string;
+  replace: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-/** Parse cliff.toml.template and extract the commit_parsers array with runtime validation. */
-function getCommitParsers(): CommitParser[] {
+/** Parse the [git] section from cliff.toml.template with runtime validation. */
+function getGitSection(): Record<string, unknown> {
   const config = parse(templateContent);
   const git = config.git;
   if (!isRecord(git)) {
     throw new Error('cliff.toml.template is missing [git] section');
   }
+  return git;
+}
 
+/** Extract the commit_parsers array from the TOML [git] section. */
+function getCommitParsers(): CommitParser[] {
+  const git = getGitSection();
   const parsers = git.commit_parsers;
   if (!Array.isArray(parsers)) {
     throw new TypeError('cliff.toml.template is missing git.commit_parsers array');
@@ -38,6 +49,22 @@ function getCommitParsers(): CommitParser[] {
       throw new Error(`Invalid commit_parser entry: ${JSON.stringify(entry)}`);
     }
     return { message: entry.message, group: entry.group };
+  });
+}
+
+/** Extract the commit_preprocessors array from the TOML [git] section. */
+function getCommitPreprocessors(): CommitPreprocessor[] {
+  const git = getGitSection();
+  const preprocessors = git.commit_preprocessors;
+  if (!Array.isArray(preprocessors)) {
+    throw new TypeError('cliff.toml.template is missing git.commit_preprocessors array');
+  }
+
+  return preprocessors.map((entry) => {
+    if (!isRecord(entry) || typeof entry.pattern !== 'string' || typeof entry.replace !== 'string') {
+      throw new Error(`Invalid commit_preprocessor entry: ${JSON.stringify(entry)}`);
+    }
+    return { pattern: entry.pattern, replace: entry.replace };
   });
 }
 
@@ -85,4 +112,26 @@ describe('cliff.toml.template alignment with DEFAULT_WORK_TYPES', () => {
       });
     }
   });
+});
+
+describe('cliff.toml.template alignment with COMMIT_PREPROCESSOR_PATTERNS', () => {
+  const tomlPreprocessors = getCommitPreprocessors();
+  const tomlPatterns = tomlPreprocessors.map((p) => p.pattern);
+  const tsPatterns = COMMIT_PREPROCESSOR_PATTERNS.map((r) => r.source);
+
+  it('has the same number of preprocessor patterns in both locations', () => {
+    expect(tsPatterns).toHaveLength(tomlPatterns.length);
+  });
+
+  for (const pattern of tsPatterns) {
+    it(`TypeScript pattern "${pattern}" exists in cliff.toml.template`, () => {
+      expect(tomlPatterns).toContain(pattern);
+    });
+  }
+
+  for (const pattern of tomlPatterns) {
+    it(`TOML pattern "${pattern}" exists in COMMIT_PREPROCESSOR_PATTERNS`, () => {
+      expect(tsPatterns).toContain(pattern);
+    });
+  }
 });

--- a/packages/release-kit/src/__tests__/determineBumpFromCommits.unit.test.ts
+++ b/packages/release-kit/src/__tests__/determineBumpFromCommits.unit.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_VERSION_PATTERNS } from '../defaults.ts';
+import { determineBumpFromCommits } from '../determineBumpFromCommits.ts';
+import type { Commit, VersionPatterns, WorkTypeConfig } from '../types.ts';
+
+const workTypes: Record<string, WorkTypeConfig> = {
+  feat: { header: 'Features', aliases: ['feature'] },
+  fix: { header: 'Bug fixes', aliases: ['bugfix'] },
+  refactor: { header: 'Refactoring' },
+};
+
+const versionPatterns: VersionPatterns = DEFAULT_VERSION_PATTERNS;
+
+function makeCommit(message: string, hash = 'abc1234'): Commit {
+  return { message, hash };
+}
+
+describe(determineBumpFromCommits, () => {
+  describe('standard bump determination', () => {
+    it('returns minor for a feat commit', () => {
+      const commits = [makeCommit('feat: add thing')];
+      const result = determineBumpFromCommits(commits, workTypes, versionPatterns, undefined);
+
+      expect(result.releaseType).toBe('minor');
+      expect(result.parsedCommitCount).toBe(1);
+      expect(result.unparseableCommits).toBeUndefined();
+    });
+
+    it('returns patch for a fix commit', () => {
+      const commits = [makeCommit('fix: resolve bug')];
+      const result = determineBumpFromCommits(commits, workTypes, versionPatterns, undefined);
+
+      expect(result.releaseType).toBe('patch');
+      expect(result.parsedCommitCount).toBe(1);
+      expect(result.unparseableCommits).toBeUndefined();
+    });
+
+    it('returns the highest bump type across multiple commits', () => {
+      const commits = [makeCommit('fix: resolve bug'), makeCommit('feat: add thing')];
+      const result = determineBumpFromCommits(commits, workTypes, versionPatterns, undefined);
+
+      expect(result.releaseType).toBe('minor');
+      expect(result.parsedCommitCount).toBe(2);
+    });
+  });
+
+  describe('patch floor', () => {
+    it('applies patch floor when all commits are unparseable', () => {
+      const commits = [makeCommit('random noise', 'aaa1111'), makeCommit('also unparseable', 'bbb2222')];
+      const result = determineBumpFromCommits(commits, workTypes, versionPatterns, undefined);
+
+      expect(result.releaseType).toBe('patch');
+      expect(result.parsedCommitCount).toBe(0);
+      expect(result.unparseableCommits).toHaveLength(2);
+      expect(result.unparseableCommits).toEqual([
+        { message: 'random noise', hash: 'aaa1111' },
+        { message: 'also unparseable', hash: 'bbb2222' },
+      ]);
+    });
+
+    it('returns undefined releaseType for an empty commit list (no patch floor)', () => {
+      const result = determineBumpFromCommits([], workTypes, versionPatterns, undefined);
+
+      expect(result.releaseType).toBeUndefined();
+      expect(result.parsedCommitCount).toBe(0);
+      expect(result.unparseableCommits).toBeUndefined();
+    });
+  });
+
+  describe('mixed parseable and unparseable commits', () => {
+    it('uses the parsed bump type and tracks unparseable commits', () => {
+      const commits = [makeCommit('feat: add feature', 'aaa1111'), makeCommit('not a conventional commit', 'bbb2222')];
+      const result = determineBumpFromCommits(commits, workTypes, versionPatterns, undefined);
+
+      expect(result.releaseType).toBe('minor');
+      expect(result.parsedCommitCount).toBe(1);
+      expect(result.unparseableCommits).toEqual([{ message: 'not a conventional commit', hash: 'bbb2222' }]);
+    });
+
+    it('returns patch when only fix commits parse alongside unparseable ones', () => {
+      const commits = [makeCommit('fix: patch bug', 'aaa1111'), makeCommit('random message', 'bbb2222')];
+      const result = determineBumpFromCommits(commits, workTypes, versionPatterns, undefined);
+
+      expect(result.releaseType).toBe('patch');
+      expect(result.parsedCommitCount).toBe(1);
+      expect(result.unparseableCommits).toHaveLength(1);
+    });
+  });
+
+  describe('ticket-prefix stripping integration', () => {
+    it('parses commits with GitHub-style ticket prefixes', () => {
+      const commits = [makeCommit('#8 feat: add thing')];
+      const result = determineBumpFromCommits(commits, workTypes, versionPatterns, undefined);
+
+      expect(result.releaseType).toBe('minor');
+      expect(result.parsedCommitCount).toBe(1);
+      expect(result.unparseableCommits).toBeUndefined();
+    });
+
+    it('parses commits with Jira-style ticket prefixes', () => {
+      const commits = [makeCommit('TOOL-123 fix: resolve bug')];
+      const result = determineBumpFromCommits(commits, workTypes, versionPatterns, undefined);
+
+      expect(result.releaseType).toBe('patch');
+      expect(result.parsedCommitCount).toBe(1);
+      expect(result.unparseableCommits).toBeUndefined();
+    });
+  });
+
+  describe('workspace alias resolution', () => {
+    it('passes workspace aliases through to parseCommitMessage', () => {
+      const aliases = { rk: 'release-kit' };
+      const commits = [makeCommit('rk|feat: add thing')];
+      const result = determineBumpFromCommits(commits, workTypes, versionPatterns, aliases);
+
+      expect(result.releaseType).toBe('minor');
+      expect(result.parsedCommitCount).toBe(1);
+    });
+  });
+});

--- a/packages/release-kit/src/__tests__/parseCommitMessage.unit.test.ts
+++ b/packages/release-kit/src/__tests__/parseCommitMessage.unit.test.ts
@@ -129,6 +129,58 @@ describe(parseCommitMessage, () => {
     });
   });
 
+  describe('ticket-prefix stripping', () => {
+    it('strips a GitHub-style ticket prefix before parsing', () => {
+      const result = parseCommitMessage('#8 feat: add thing', 'tp1', workTypes);
+      expect(result).toStrictEqual({
+        message: '#8 feat: add thing',
+        hash: 'tp1',
+        type: 'feat',
+        description: 'add thing',
+        breaking: false,
+      });
+    });
+
+    it('strips a Jira-style ticket prefix before parsing', () => {
+      const result = parseCommitMessage('TOOL-123 fix: resolve bug', 'tp2', workTypes);
+      expect(result).toStrictEqual({
+        message: 'TOOL-123 fix: resolve bug',
+        hash: 'tp2',
+        type: 'fix',
+        description: 'resolve bug',
+        breaking: false,
+      });
+    });
+
+    it('strips a ticket prefix with workspace format', () => {
+      const result = parseCommitMessage('#8 web|feat: add thing', 'tp3', workTypes);
+      expect(result).toStrictEqual({
+        message: '#8 web|feat: add thing',
+        hash: 'tp3',
+        type: 'feat',
+        description: 'add thing',
+        workspace: 'web',
+        breaking: false,
+      });
+    });
+
+    it('preserves the original message including prefix in the result', () => {
+      const result = parseCommitMessage('#42 docs: update guide', 'tp4', workTypes);
+      expect(result?.message).toBe('#42 docs: update guide');
+    });
+
+    it('does not strip patterns that are not at the start of the message', () => {
+      const result = parseCommitMessage('feat: close #8 issue', 'tp5', workTypes);
+      expect(result).toStrictEqual({
+        message: 'feat: close #8 issue',
+        hash: 'tp5',
+        type: 'feat',
+        description: 'close #8 issue',
+        breaking: false,
+      });
+    });
+  });
+
   describe('workspace alias resolution', () => {
     const aliases: Record<string, string> = {
       api: 'backend-api',

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -90,7 +90,7 @@ describe(releasePrepare, () => {
     expect(component?.changelogFiles).toStrictEqual(['./CHANGELOG.md']);
   });
 
-  it('returns a skipped component when no release-worthy changes exist', () => {
+  it('applies patch floor when commits exist but none are release-worthy', () => {
     mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === 'git' && args[0] === 'describe') {
         return 'v1.0.0\n';
@@ -100,18 +100,41 @@ describe(releasePrepare, () => {
       }
       return '';
     });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
 
-    const result = releasePrepare(makeConfig({ formatCommand: 'npx prettier --write' }), { dryRun: false });
+    const result = releasePrepare(makeConfig(), { dryRun: false });
 
-    expect(result.tags).toStrictEqual([]);
+    expect(result.tags).toStrictEqual(['v1.0.1']);
     expect(result.components).toHaveLength(1);
     expect(result.components[0]).toMatchObject({
-      status: 'skipped',
+      status: 'released',
       commitCount: 1,
       parsedCommitCount: 0,
-      skipReason: 'No release-worthy changes found. Skipping.',
+      releaseType: 'patch',
     });
-    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(result.components[0]?.unparseableCommits).toStrictEqual([{ message: 'chore: update deps', hash: 'abc123' }]);
+  });
+
+  it('uses parsed bump type when mix of parseable and unparseable commits exist', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'feat: add feature\u001Fabc123\nchore: update deps\u001Fdef456';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    const result = releasePrepare(makeConfig(), { dryRun: false });
+
+    expect(result.components[0]).toMatchObject({
+      status: 'released',
+      releaseType: 'minor',
+      parsedCommitCount: 1,
+    });
+    expect(result.components[0]?.unparseableCommits).toStrictEqual([{ message: 'chore: update deps', hash: 'def456' }]);
   });
 
   it('runs format command with package files and changelog paths appended', () => {

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -352,7 +352,7 @@ describe(releasePrepareMono, () => {
     expect(cliffArgs).toContain('arrays-v1.1.0');
   });
 
-  it('skips a component when commits exist but none are release-worthy', () => {
+  it('applies patch floor when commits exist but none are release-worthy', () => {
     const config = makeConfig({
       components: [
         {
@@ -375,17 +375,52 @@ describe(releasePrepareMono, () => {
       }
       return '';
     });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
 
     const result = releasePrepareMono(config, { dryRun: false });
 
-    expect(result.tags).toStrictEqual([]);
+    expect(result.tags).toStrictEqual(['arrays-v1.0.1']);
     expect(result.components[0]).toMatchObject({
-      status: 'skipped',
+      status: 'released',
       commitCount: 1,
       parsedCommitCount: 0,
+      releaseType: 'patch',
     });
-    expect(mockWriteFileSync).not.toHaveBeenCalled();
-    expect(countCliffCalls()).toBe(0);
+    expect(result.components[0]?.unparseableCommits).toStrictEqual([{ message: 'chore: update deps', hash: 'abc123' }]);
+  });
+
+  it('uses parsed bump type when mix of parseable and unparseable commits exist', () => {
+    const config = makeConfig({
+      components: [
+        {
+          dir: 'arrays',
+          tagPrefix: 'arrays-v',
+          packageFiles: ['packages/arrays/package.json'],
+          changelogPaths: ['packages/arrays'],
+          paths: ['packages/arrays/**'],
+        },
+      ],
+    });
+
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'arrays-v1.0.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'feat: add utility\u001Fabc123\nchore: update deps\u001Fdef456';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    const result = releasePrepareMono(config, { dryRun: false });
+
+    expect(result.components[0]).toMatchObject({
+      status: 'released',
+      releaseType: 'minor',
+      parsedCommitCount: 1,
+    });
+    expect(result.components[0]?.unparseableCommits).toStrictEqual([{ message: 'chore: update deps', hash: 'def456' }]);
   });
 
   it('bypasses the no-commits check when force is true', () => {

--- a/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
@@ -145,6 +145,91 @@ describe(reportPrepare, () => {
 
       expect(output).toContain('Using bump override: major');
     });
+
+    it('shows unparseable commit warning when all commits are unparseable (patch floor)', () => {
+      const result: PrepareResult = {
+        components: [
+          {
+            status: 'released',
+            previousTag: 'v1.0.0',
+            commitCount: 2,
+            parsedCommitCount: 0,
+            releaseType: 'patch',
+            currentVersion: '1.0.0',
+            newVersion: '1.0.1',
+            tag: 'v1.0.1',
+            bumpedFiles: ['package.json'],
+            changelogFiles: ['./CHANGELOG.md'],
+            unparseableCommits: [
+              { message: 'chore: update deps', hash: 'abc1234' },
+              { message: 'misc: tidy up', hash: 'def5678' },
+            ],
+          },
+        ],
+        tags: ['v1.0.1'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('⚠️  2 commits could not be parsed (defaulting to patch bump)');
+      expect(output).toContain('· abc1234 chore: update deps');
+      expect(output).toContain('· def5678 misc: tidy up');
+    });
+
+    it('shows unparseable commit warning without patch-floor note when some commits parsed', () => {
+      const result: PrepareResult = {
+        components: [
+          {
+            status: 'released',
+            previousTag: 'v1.0.0',
+            commitCount: 3,
+            parsedCommitCount: 2,
+            releaseType: 'minor',
+            currentVersion: '1.0.0',
+            newVersion: '1.1.0',
+            tag: 'v1.1.0',
+            bumpedFiles: ['package.json'],
+            changelogFiles: ['./CHANGELOG.md'],
+            unparseableCommits: [{ message: 'chore: update deps', hash: 'abc1234' }],
+          },
+        ],
+        tags: ['v1.1.0'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('⚠️  1 commit could not be parsed');
+      expect(output).not.toContain('defaulting to patch bump');
+      expect(output).toContain('· abc1234 chore: update deps');
+    });
+
+    it('does not show unparseable warning when there are no unparseable commits', () => {
+      const result: PrepareResult = {
+        components: [
+          {
+            status: 'released',
+            previousTag: 'v1.0.0',
+            commitCount: 1,
+            parsedCommitCount: 1,
+            releaseType: 'minor',
+            currentVersion: '1.0.0',
+            newVersion: '1.1.0',
+            tag: 'v1.1.0',
+            bumpedFiles: ['package.json'],
+            changelogFiles: ['./CHANGELOG.md'],
+          },
+        ],
+        tags: ['v1.1.0'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).not.toContain('⚠️');
+      expect(output).not.toContain('could not be parsed');
+    });
   });
 
   describe('empty components', () => {
@@ -318,6 +403,34 @@ describe(reportPrepare, () => {
       const output = reportPrepare(result);
 
       expect(output).toContain('⏭️  No components had release-worthy changes.');
+    });
+
+    it('shows unparseable commit warning in monorepo mode', () => {
+      const result: PrepareResult = {
+        components: [
+          {
+            name: 'arrays',
+            status: 'released',
+            previousTag: 'arrays-v1.0.0',
+            commitCount: 2,
+            parsedCommitCount: 0,
+            releaseType: 'patch',
+            currentVersion: '1.0.0',
+            newVersion: '1.0.1',
+            tag: 'arrays-v1.0.1',
+            bumpedFiles: ['packages/arrays/package.json'],
+            changelogFiles: ['packages/arrays/CHANGELOG.md'],
+            unparseableCommits: [{ message: 'chore: update deps', hash: 'abc1234' }],
+          },
+        ],
+        tags: ['arrays-v1.0.1'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('⚠️  1 commit could not be parsed (defaulting to patch bump)');
+      expect(output).toContain('· abc1234 chore: update deps');
     });
 
     it('formats format command in monorepo mode', () => {

--- a/packages/release-kit/src/determineBumpFromCommits.ts
+++ b/packages/release-kit/src/determineBumpFromCommits.ts
@@ -1,0 +1,43 @@
+import { determineBumpType } from './determineBumpType.ts';
+import { parseCommitMessage } from './parseCommitMessage.ts';
+import type { Commit, ParsedCommit, ReleaseType, VersionPatterns, WorkTypeConfig } from './types.ts';
+
+/** Aggregate result of parsing commits and determining the bump type. */
+export interface BumpDetermination {
+  releaseType: ReleaseType | undefined;
+  parsedCommitCount: number;
+  unparseableCommits: Commit[] | undefined;
+}
+
+/** Parse commits, determine bump type, and apply patch floor when commits exist but none parsed. */
+export function determineBumpFromCommits(
+  commits: Commit[],
+  workTypes: Record<string, WorkTypeConfig>,
+  versionPatterns: VersionPatterns,
+  workspaceAliases: Record<string, string> | undefined,
+): BumpDetermination {
+  const parsedCommits: ParsedCommit[] = [];
+  const unparseable: Commit[] = [];
+
+  for (const commit of commits) {
+    const parsed = parseCommitMessage(commit.message, commit.hash, workTypes, workspaceAliases);
+    if (parsed === undefined) {
+      unparseable.push(commit);
+    } else {
+      parsedCommits.push(parsed);
+    }
+  }
+
+  let releaseType = determineBumpType(parsedCommits, workTypes, versionPatterns);
+
+  // Apply patch floor: commits exist but none determined a bump type
+  if (releaseType === undefined && commits.length > 0) {
+    releaseType = 'patch';
+  }
+
+  return {
+    releaseType,
+    parsedCommitCount: parsedCommits.length,
+    unparseableCommits: unparseable.length > 0 ? unparseable : undefined,
+  };
+}

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -35,7 +35,7 @@ export { determineBumpType } from './determineBumpType.ts';
 export { discoverWorkspaces } from './discoverWorkspaces.ts';
 export { generateChangelog, generateChangelogs } from './generateChangelogs.ts';
 export { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
-export { parseCommitMessage } from './parseCommitMessage.ts';
+export { COMMIT_PREPROCESSOR_PATTERNS, parseCommitMessage } from './parseCommitMessage.ts';
 export { RELEASE_TAGS_FILE, writeReleaseTags } from './prepareCommand.ts';
 export { publish } from './publish.ts';
 export { releasePrepare } from './releasePrepare.ts';

--- a/packages/release-kit/src/parseCommitMessage.ts
+++ b/packages/release-kit/src/parseCommitMessage.ts
@@ -1,18 +1,20 @@
 import type { ParsedCommit, WorkTypeConfig } from './types.ts';
 
 /**
- * Parses a commit message into structured metadata.
+ * Regex patterns stripped from the start of commit messages before parsing.
+ *
+ * Kept in sync with `commit_preprocessors` in cliff.toml.template so that
+ * both git-cliff and this parser see the same normalized messages.
+ */
+export const COMMIT_PREPROCESSOR_PATTERNS: readonly RegExp[] = [/^#\d+\s+/, /^[A-Z]+-\d+\s+/];
+
+/**
+ * Parse a commit message into structured metadata.
  *
  * Supports both `type: description` and `workspace|type: description` formats.
  * Resolves aliases (e.g., 'feature' -> 'feat') using the provided work type configs.
  * Resolves workspace aliases when a `workspaceAliases` map is provided.
  * Detects breaking changes via `type!:` or `BREAKING CHANGE:` in the message.
- *
- * @param message - The commit message (first line).
- * @param hash - The commit hash.
- * @param workTypes - Record of work type configurations keyed by canonical type name.
- * @param workspaceAliases - Optional map of workspace shorthand names to canonical names.
- * @returns A parsed commit, or undefined if the message does not match a known format.
  */
 export function parseCommitMessage(
   message: string,
@@ -20,9 +22,12 @@ export function parseCommitMessage(
   workTypes: Record<string, WorkTypeConfig>,
   workspaceAliases?: Record<string, string>,
 ): ParsedCommit | undefined {
+  // Strip ticket prefixes (e.g., "#8 " or "TOOL-123 ") before matching
+  const stripped = stripTicketPrefix(message);
+
   // Match both `type: desc` and `workspace|type: desc` formats
   // The `!` before `:` indicates a breaking change
-  const match = message.match(/^(?:([^|]+)\|)?(\w+)(!)?:\s*(.*)$/);
+  const match = stripped.match(/^(?:([^|]+)\|)?(\w+)(!)?:\s*(.*)$/);
   if (!match) {
     return undefined;
   }
@@ -78,4 +83,13 @@ function resolveType(rawType: string, workTypes: Record<string, WorkTypeConfig>)
   }
 
   return undefined;
+}
+
+/** Remove ticket-prefix patterns (e.g., "#8 " or "TOOL-123 ") from the start of a message. */
+function stripTicketPrefix(message: string): string {
+  let result = message;
+  for (const pattern of COMMIT_PREPROCESSOR_PATTERNS) {
+    result = result.replace(pattern, '');
+  }
+  return result;
 }

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -7,7 +7,7 @@ import { generateChangelogs } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
 import { parseCommitMessage } from './parseCommitMessage.ts';
-import type { ParsedCommit, PrepareResult, ReleaseConfig, ReleaseType } from './types.ts';
+import type { Commit, ParsedCommit, PrepareResult, ReleaseConfig, ReleaseType } from './types.ts';
 
 /** Options for the release preparation workflow. */
 export interface ReleasePrepareOptions {
@@ -41,14 +41,32 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   // 2. Determine bump type
   let releaseType: ReleaseType | undefined;
   let parsedCommitCount: number | undefined;
+  let unparseableCommits: Commit[] | undefined;
 
   if (bumpOverride === undefined) {
-    const parsedCommits = commits
-      .map((c) => parseCommitMessage(c.message, c.hash, workTypes, config.workspaceAliases))
-      .filter((c): c is ParsedCommit => c !== undefined);
+    const parsedCommits: ParsedCommit[] = [];
+    const unparseable: Commit[] = [];
+
+    for (const commit of commits) {
+      const parsed = parseCommitMessage(commit.message, commit.hash, workTypes, config.workspaceAliases);
+      if (parsed === undefined) {
+        unparseable.push(commit);
+      } else {
+        parsedCommits.push(parsed);
+      }
+    }
 
     parsedCommitCount = parsedCommits.length;
+    if (unparseable.length > 0) {
+      unparseableCommits = unparseable;
+    }
+
     releaseType = determineBumpType(parsedCommits, workTypes, versionPatterns);
+
+    // Apply patch floor: commits exist but none determined a bump type
+    if (releaseType === undefined && commits.length > 0) {
+      releaseType = 'patch';
+    }
   } else {
     releaseType = bumpOverride;
   }
@@ -61,6 +79,7 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
           previousTag: tag,
           commitCount: commits.length,
           parsedCommitCount,
+          unparseableCommits,
           bumpedFiles: [],
           changelogFiles: [],
           skipReason: 'No release-worthy changes found. Skipping.',
@@ -113,6 +132,7 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
         tag: newTag,
         bumpedFiles: bump.files,
         changelogFiles,
+        unparseableCommits,
       },
     ],
     tags: [newTag],

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -2,12 +2,11 @@ import { execSync } from 'node:child_process';
 
 import { bumpAllVersions } from './bumpAllVersions.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
-import { determineBumpType } from './determineBumpType.ts';
+import { determineBumpFromCommits } from './determineBumpFromCommits.ts';
 import { generateChangelogs } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
-import { parseCommitMessage } from './parseCommitMessage.ts';
-import type { Commit, ParsedCommit, PrepareResult, ReleaseConfig, ReleaseType } from './types.ts';
+import type { Commit, PrepareResult, ReleaseConfig, ReleaseType } from './types.ts';
 
 /** Options for the release preparation workflow. */
 export interface ReleasePrepareOptions {
@@ -44,29 +43,10 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   let unparseableCommits: Commit[] | undefined;
 
   if (bumpOverride === undefined) {
-    const parsedCommits: ParsedCommit[] = [];
-    const unparseable: Commit[] = [];
-
-    for (const commit of commits) {
-      const parsed = parseCommitMessage(commit.message, commit.hash, workTypes, config.workspaceAliases);
-      if (parsed === undefined) {
-        unparseable.push(commit);
-      } else {
-        parsedCommits.push(parsed);
-      }
-    }
-
-    parsedCommitCount = parsedCommits.length;
-    if (unparseable.length > 0) {
-      unparseableCommits = unparseable;
-    }
-
-    releaseType = determineBumpType(parsedCommits, workTypes, versionPatterns);
-
-    // Apply patch floor: commits exist but none determined a bump type
-    if (releaseType === undefined && commits.length > 0) {
-      releaseType = 'patch';
-    }
+    const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.workspaceAliases);
+    parsedCommitCount = determination.parsedCommitCount;
+    unparseableCommits = determination.unparseableCommits;
+    releaseType = determination.releaseType;
   } else {
     releaseType = bumpOverride;
   }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -2,28 +2,12 @@ import { execSync } from 'node:child_process';
 
 import { bumpAllVersions } from './bumpAllVersions.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
-import { determineBumpType } from './determineBumpType.ts';
+import { determineBumpFromCommits } from './determineBumpFromCommits.ts';
 import { generateChangelog } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
-import { parseCommitMessage } from './parseCommitMessage.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
-import type {
-  Commit,
-  ComponentPrepareResult,
-  MonorepoReleaseConfig,
-  ParsedCommit,
-  PrepareResult,
-  ReleaseType,
-  VersionPatterns,
-  WorkTypeConfig,
-} from './types.ts';
-
-interface BumpDetermination {
-  releaseType: ReleaseType | undefined;
-  parsedCommitCount: number;
-  unparseableCommits: Commit[] | undefined;
-}
+import type { Commit, ComponentPrepareResult, MonorepoReleaseConfig, PrepareResult, ReleaseType } from './types.ts';
 
 /**
  * Orchestrate release preparation for a monorepo with multiple components.
@@ -151,38 +135,5 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     tags,
     formatCommand,
     dryRun,
-  };
-}
-
-/** Parse commits, determine bump type, and apply patch floor when commits exist but none parsed. */
-function determineBumpFromCommits(
-  commits: Commit[],
-  workTypes: Record<string, WorkTypeConfig>,
-  versionPatterns: VersionPatterns,
-  workspaceAliases: Record<string, string> | undefined,
-): BumpDetermination {
-  const parsedCommits: ParsedCommit[] = [];
-  const unparseable: Commit[] = [];
-
-  for (const commit of commits) {
-    const parsed = parseCommitMessage(commit.message, commit.hash, workTypes, workspaceAliases);
-    if (parsed === undefined) {
-      unparseable.push(commit);
-    } else {
-      parsedCommits.push(parsed);
-    }
-  }
-
-  let releaseType = determineBumpType(parsedCommits, workTypes, versionPatterns);
-
-  // Apply patch floor: commits exist but none determined a bump type
-  if (releaseType === undefined && commits.length > 0) {
-    releaseType = 'patch';
-  }
-
-  return {
-    releaseType,
-    parsedCommitCount: parsedCommits.length,
-    unparseableCommits: unparseable.length > 0 ? unparseable : undefined,
   };
 }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -9,12 +9,21 @@ import { hasPrettierConfig } from './hasPrettierConfig.ts';
 import { parseCommitMessage } from './parseCommitMessage.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
 import type {
+  Commit,
   ComponentPrepareResult,
   MonorepoReleaseConfig,
   ParsedCommit,
   PrepareResult,
   ReleaseType,
+  VersionPatterns,
+  WorkTypeConfig,
 } from './types.ts';
+
+interface BumpDetermination {
+  releaseType: ReleaseType | undefined;
+  parsedCommitCount: number;
+  unparseableCommits: Commit[] | undefined;
+}
 
 /**
  * Orchestrate release preparation for a monorepo with multiple components.
@@ -60,14 +69,13 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     // 2. Determine bump type
     let releaseType: ReleaseType | undefined;
     let parsedCommitCount: number | undefined;
+    let unparseableCommits: Commit[] | undefined;
 
     if (bumpOverride === undefined) {
-      const parsedCommits = commits
-        .map((c) => parseCommitMessage(c.message, c.hash, workTypes, config.workspaceAliases))
-        .filter((c): c is ParsedCommit => c !== undefined);
-
-      parsedCommitCount = parsedCommits.length;
-      releaseType = determineBumpType(parsedCommits, workTypes, versionPatterns);
+      const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.workspaceAliases);
+      parsedCommitCount = determination.parsedCommitCount;
+      unparseableCommits = determination.unparseableCommits;
+      releaseType = determination.releaseType;
     } else {
       releaseType = bumpOverride;
     }
@@ -79,6 +87,7 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
         previousTag: tag,
         commitCount: commits.length,
         parsedCommitCount,
+        unparseableCommits,
         bumpedFiles: [],
         changelogFiles: [],
         skipReason: `No release-worthy changes for ${name} ${since}. Skipping.`,
@@ -112,6 +121,7 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
       tag: newTag,
       bumpedFiles: bump.files,
       changelogFiles,
+      unparseableCommits,
     });
   }
 
@@ -141,5 +151,38 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     tags,
     formatCommand,
     dryRun,
+  };
+}
+
+/** Parse commits, determine bump type, and apply patch floor when commits exist but none parsed. */
+function determineBumpFromCommits(
+  commits: Commit[],
+  workTypes: Record<string, WorkTypeConfig>,
+  versionPatterns: VersionPatterns,
+  workspaceAliases: Record<string, string> | undefined,
+): BumpDetermination {
+  const parsedCommits: ParsedCommit[] = [];
+  const unparseable: Commit[] = [];
+
+  for (const commit of commits) {
+    const parsed = parseCommitMessage(commit.message, commit.hash, workTypes, workspaceAliases);
+    if (parsed === undefined) {
+      unparseable.push(commit);
+    } else {
+      parsedCommits.push(parsed);
+    }
+  }
+
+  let releaseType = determineBumpType(parsedCommits, workTypes, versionPatterns);
+
+  // Apply patch floor: commits exist but none determined a bump type
+  if (releaseType === undefined && commits.length > 0) {
+    releaseType = 'patch';
+  }
+
+  return {
+    releaseType,
+    parsedCommitCount: parsedCommits.length,
+    unparseableCommits: unparseable.length > 0 ? unparseable : undefined,
   };
 }

--- a/packages/release-kit/src/reportPrepare.ts
+++ b/packages/release-kit/src/reportPrepare.ts
@@ -35,6 +35,8 @@ function formatSingleComponent(result: PrepareResult): string {
     lines.push(dim(`  Parsed ${component.parsedCommitCount} typed commits`));
   }
 
+  formatUnparseableWarning(lines, component);
+
   if (component.status === 'skipped') {
     lines.push(`⏭️  ${component.skipReason ?? 'Skipped'}`);
     return lines.join('\n');
@@ -100,6 +102,8 @@ function formatMultiComponent(result: PrepareResult): string {
       lines.push(dim(`  Parsed ${component.parsedCommitCount} typed commits`));
     }
 
+    formatUnparseableWarning(lines, component, '  ');
+
     if (component.parsedCommitCount === undefined && component.releaseType !== undefined) {
       lines.push(`  Using bump override: ${component.releaseType}`);
     }
@@ -160,6 +164,25 @@ function formatChangelogFiles(lines: string[], component: ComponentPrepareResult
     } else {
       lines.push(dim(`${indent}  Generating changelog: ${file}`));
     }
+  }
+}
+
+/** Append unparseable commit warning lines when applicable. */
+function formatUnparseableWarning(lines: string[], component: ComponentPrepareResult, indent = ''): void {
+  const unparseable = component.unparseableCommits;
+  if (unparseable === undefined || unparseable.length === 0) {
+    return;
+  }
+
+  const count = unparseable.length;
+  const isPatchFloor = component.parsedCommitCount === 0;
+  const suffix = isPatchFloor ? ' (defaulting to patch bump)' : '';
+  lines.push(`${indent}  ⚠️  ${count} commit${count === 1 ? '' : 's'} could not be parsed${suffix}`);
+
+  for (const commit of unparseable) {
+    const shortHash = commit.hash.slice(0, 7);
+    const truncatedMessage = commit.message.length > 72 ? `${commit.message.slice(0, 69)}...` : commit.message;
+    lines.push(`${indent}    · ${shortHash} ${truncatedMessage}`);
   }
 }
 

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -22,6 +22,8 @@ export interface ComponentPrepareResult {
   tag?: string | undefined;
   bumpedFiles: string[];
   changelogFiles: string[];
+  /** Commits that could not be parsed into a recognized work type. */
+  unparseableCommits?: Commit[] | undefined;
   skipReason?: string | undefined;
 }
 


### PR DESCRIPTION
Closes #71 

## What

Prevents `releasePrepareMono` and `releasePrepare` from silently skipping components whose commits have unparseable messages. Adds ticket-prefix stripping to `parseCommitMessage` (mirroring cliff.toml's `commit_preprocessors`), a patch-floor safety net when commits exist but none parse, and unparseable-commit reporting in `reportPrepare`.

## Why

Commit `209f5e5` (`#8 feat: Add shared writeFileWithCheck utility`) touched `packages/core/src/` but was rejected by `parseCommitMessage` because the `#8` ticket prefix doesn't match the conventional-commit regex. `core` was silently skipped, and `release-kit@2.3.0` was published depending on unreleased `core` exports — a broken install for consumers.

## Details

### Fixes

- Strip GitHub-style (`#\d+`) and Jira-style (`[A-Z]+-\d+`) ticket prefixes before the conventional-commit regex runs, matching cliff.toml's `commit_preprocessors` behavior
- Apply a `patch` floor when `commits.length > 0` but `determineBumpType` returns `undefined` — components with commits are never silently skipped
- Add `unparseableCommits?: Commit[]` to `ComponentPrepareResult` and surface warnings in `reportPrepare`, distinguishing "all unparseable → patch floor" from "some unparseable → parsed bump used"
- Add `^#\d+\s+` preprocessor pattern to cliff.toml.template

### Refactoring

- Extract `determineBumpFromCommits` as a shared pure-function helper used by both `releasePrepare` and `releasePrepareMono`, centralizing commit parsing, bump determination, patch floor, and unparseable tracking

### Tests

- Dedicated `determineBumpFromCommits.unit.test.ts` (10 tests) — standard bumps, patch floor, mixed commits, ticket-prefix integration, workspace aliases
- Ticket-prefix stripping tests in `parseCommitMessage.unit.test.ts` (5 cases)
- Bidirectional cliff.toml alignment test for `commit_preprocessors`
- Updated existing "skips when no release-worthy" tests to expect `status: 'released'` with `releaseType: 'patch'`
- Report output tests for unparseable warnings (4 cases)