### PR TITLE
#68 Pass tag pattern to git-cliff based on tagPrefix

### DIFF
--- a/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
@@ -11,8 +11,18 @@ vi.mock('../resolveCliffConfigPath.ts', () => ({
   resolveCliffConfigPath: mockResolveCliffConfigPath,
 }));
 
-import { generateChangelog, generateChangelogs } from '../generateChangelogs.ts';
+import { buildTagPattern, generateChangelog, generateChangelogs } from '../generateChangelogs.ts';
 import type { ReleaseConfig } from '../types.ts';
+
+describe(buildTagPattern, () => {
+  it('constructs a tag pattern from a single-package prefix', () => {
+    expect(buildTagPattern('v')).toBe('v[0-9].*');
+  });
+
+  it('constructs a tag pattern from a monorepo component prefix', () => {
+    expect(buildTagPattern('release-kit-v')).toBe('release-kit-v[0-9].*');
+  });
+});
 
 describe(generateChangelog, () => {
   afterEach(() => {

--- a/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
@@ -90,6 +90,48 @@ describe(generateChangelog, () => {
     );
   });
 
+  it('appends --tag-pattern flag when tagPattern is provided', () => {
+    mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
+    const config = { cliffConfigPath: 'cliff.toml' };
+
+    generateChangelog(config, 'packages/arrays', 'arrays-v1.0.0', false, {
+      tagPattern: 'arrays-v[0-9].*',
+      includePaths: ['packages/arrays'],
+    });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      [
+        '--yes',
+        'git-cliff',
+        '--config',
+        'cliff.toml',
+        '--output',
+        'packages/arrays/CHANGELOG.md',
+        '--tag',
+        'arrays-v1.0.0',
+        '--tag-pattern',
+        'arrays-v[0-9].*',
+        '--include-path',
+        'packages/arrays',
+      ],
+      { stdio: 'inherit' },
+    );
+  });
+
+  it('does not append --tag-pattern flag when tagPattern is not provided', () => {
+    mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
+    const config = { cliffConfigPath: 'cliff.toml' };
+
+    generateChangelog(config, 'packages/arrays', 'v1.0.0', false);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      ['--yes', 'git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      { stdio: 'inherit' },
+    );
+  });
+
   it('does not append --include-path flags when includePaths is an empty array', () => {
     mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
     const config = { cliffConfigPath: 'cliff.toml' };
@@ -158,5 +200,35 @@ describe(generateChangelogs, () => {
 
     expect(result).toStrictEqual(['packages/arrays/CHANGELOG.md', 'packages/strings/CHANGELOG.md']);
     expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes --tag-pattern derived from tagPrefix', () => {
+    mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
+    const config = {
+      tagPrefix: 'release-kit-v',
+      packageFiles: [],
+      changelogPaths: ['packages/release-kit'],
+      workTypes: {},
+      cliffConfigPath: 'cliff.toml',
+    } satisfies ReleaseConfig;
+
+    generateChangelogs(config, 'release-kit-v2.3.0', false);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      [
+        '--yes',
+        'git-cliff',
+        '--config',
+        'cliff.toml',
+        '--output',
+        'packages/release-kit/CHANGELOG.md',
+        '--tag',
+        'release-kit-v2.3.0',
+        '--tag-pattern',
+        'release-kit-v[0-9].*',
+      ],
+      { stdio: 'inherit' },
+    );
   });
 });

--- a/packages/release-kit/src/generateChangelogs.ts
+++ b/packages/release-kit/src/generateChangelogs.ts
@@ -3,8 +3,15 @@ import { execFileSync } from 'node:child_process';
 import { resolveCliffConfigPath } from './resolveCliffConfigPath.ts';
 import type { ReleaseConfig } from './types.ts';
 
+/** Build a git-cliff tag pattern from a tag prefix (e.g., `"release-kit-v"` → `"release-kit-v[0-9].*"`). */
+export function buildTagPattern(tagPrefix: string): string {
+  return `${tagPrefix}[0-9].*`;
+}
+
 /** Options for single-changelog generation. */
 export interface GenerateChangelogOptions {
+  /** Tag pattern to match release tags (passed as --tag-pattern to git-cliff). */
+  tagPattern?: string;
   /** Paths to include in the changelog (passed as --include-path to git-cliff). */
   includePaths?: string[];
 }
@@ -26,6 +33,11 @@ export function generateChangelog(
   const cliffConfigPath = resolveCliffConfigPath(config.cliffConfigPath, import.meta.url);
   const outputFile = `${changelogPath}/CHANGELOG.md`;
   const args = ['--config', cliffConfigPath, '--output', outputFile, '--tag', tag];
+
+  // Append --tag-pattern flag when a tag pattern is provided.
+  if (options?.tagPattern) {
+    args.push('--tag-pattern', options.tagPattern);
+  }
 
   // Append --include-path flags when path filtering is requested.
   for (const includePath of options?.includePaths ?? []) {
@@ -51,9 +63,10 @@ export function generateChangelog(
  * Returns the collected output file paths from all `generateChangelog` calls.
  */
 export function generateChangelogs(config: ReleaseConfig, tag: string, dryRun: boolean): string[] {
+  const tagPattern = buildTagPattern(config.tagPrefix);
   const results: string[] = [];
   for (const changelogPath of config.changelogPaths) {
-    results.push(...generateChangelog(config, changelogPath, tag, dryRun));
+    results.push(...generateChangelog(config, changelogPath, tag, dryRun, { tagPattern }));
   }
   return results;
 }

--- a/packages/release-kit/src/generateChangelogs.ts
+++ b/packages/release-kit/src/generateChangelogs.ts
@@ -35,7 +35,7 @@ export function generateChangelog(
   const args = ['--config', cliffConfigPath, '--output', outputFile, '--tag', tag];
 
   // Append --tag-pattern flag when a tag pattern is provided.
-  if (options?.tagPattern) {
+  if (options?.tagPattern !== undefined) {
     args.push('--tag-pattern', options.tagPattern);
   }
 

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -3,7 +3,7 @@ import { execSync } from 'node:child_process';
 import { bumpAllVersions } from './bumpAllVersions.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpFromCommits } from './determineBumpFromCommits.ts';
-import { generateChangelog } from './generateChangelogs.ts';
+import { buildTagPattern, generateChangelog } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
@@ -89,7 +89,10 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     const changelogFiles: string[] = [];
     for (const changelogPath of component.changelogPaths) {
       changelogFiles.push(
-        ...generateChangelog(config, changelogPath, newTag, dryRun, { includePaths: component.paths }),
+        ...generateChangelog(config, changelogPath, newTag, dryRun, {
+          tagPattern: buildTagPattern(component.tagPrefix),
+          includePaths: component.paths,
+        }),
       );
     }
 


### PR DESCRIPTION
Closes #68 

## What

Fixes the issue that git-cliff was processing the entire commit history on every run instead of only commits since the last release.

## Why

The `tag_pattern` in `cliff.toml` is hardcoded to `v[0-9].*`, which doesn't match monorepo tags like `release-kit-v2.3.0`. This caused git-cliff to miss release boundaries and reprocess the entire commit history on every run, producing spurious "grouping error" warnings and fragile changelog regeneration.

## Details

### Fixes

- `generateChangelog()` accepts a new `tagPattern` option and passes it as `--tag-pattern` to git-cliff
- `generateChangelogs()` derives the pattern from `config.tagPrefix` automatically
- `releasePrepareMono` passes a component-specific pattern via `buildTagPattern(component.tagPrefix)`

### Tests

- Direct unit tests for `buildTagPattern` covering single-package and monorepo prefixes
- Integration tests verifying `--tag-pattern` is passed through `generateChangelog` and `generateChangelogs`
- Negative test confirming `--tag-pattern` is omitted when not provided