### PR TITLE
#72 Propagate version bumps to workspace dependents

### DIFF
--- a/packages/release-kit/src/__tests__/buildDependencyGraph.unit.test.ts
+++ b/packages/release-kit/src/__tests__/buildDependencyGraph.unit.test.ts
@@ -54,6 +54,8 @@ describe(buildDependencyGraph, () => {
 
     expect(graph.packageNameToDir.get('@scope/core')).toBe('core');
     expect(graph.packageNameToDir.get('@scope/release-kit')).toBe('release-kit');
+    expect(graph.dirToPackageName.get('core')).toBe('@scope/core');
+    expect(graph.dirToPackageName.get('release-kit')).toBe('@scope/release-kit');
     expect(graph.dependentsOf.get('@scope/core')).toStrictEqual([compB, compC]);
   });
 

--- a/packages/release-kit/src/__tests__/buildDependencyGraph.unit.test.ts
+++ b/packages/release-kit/src/__tests__/buildDependencyGraph.unit.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  readFileSync: mockReadFileSync,
+}));
+
+import { buildDependencyGraph } from '../buildDependencyGraph.ts';
+import type { ComponentConfig } from '../types.ts';
+
+function makeComponent(dir: string, packageFile?: string): ComponentConfig {
+  return {
+    dir,
+    tagPrefix: `${dir}-v`,
+    packageFiles: [packageFile ?? `packages/${dir}/package.json`],
+    changelogPaths: [`packages/${dir}`],
+    paths: [`packages/${dir}/**`],
+  };
+}
+
+describe(buildDependencyGraph, () => {
+  afterEach(() => {
+    mockReadFileSync.mockReset();
+  });
+
+  it('builds a reverse dependency map for workspace dependencies', () => {
+    const compA = makeComponent('core');
+    const compB = makeComponent('release-kit');
+    const compC = makeComponent('preflight');
+
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath.includes('core')) {
+        return JSON.stringify({ name: '@scope/core', version: '1.0.0' });
+      }
+      if (filePath.includes('release-kit')) {
+        return JSON.stringify({
+          name: '@scope/release-kit',
+          version: '2.0.0',
+          dependencies: { '@scope/core': 'workspace:*' },
+        });
+      }
+      if (filePath.includes('preflight')) {
+        return JSON.stringify({
+          name: '@scope/preflight',
+          version: '1.0.0',
+          dependencies: { '@scope/core': 'workspace:*' },
+        });
+      }
+      return '{}';
+    });
+
+    const graph = buildDependencyGraph([compA, compB, compC]);
+
+    expect(graph.packageNameToDir.get('@scope/core')).toBe('core');
+    expect(graph.packageNameToDir.get('@scope/release-kit')).toBe('release-kit');
+    expect(graph.dependentsOf.get('@scope/core')).toStrictEqual([compB, compC]);
+  });
+
+  it('includes peerDependencies with workspace: protocol', () => {
+    const compA = makeComponent('core');
+    const compB = makeComponent('plugin');
+
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath.includes('core')) {
+        return JSON.stringify({ name: '@scope/core', version: '1.0.0' });
+      }
+      if (filePath.includes('plugin')) {
+        return JSON.stringify({
+          name: '@scope/plugin',
+          version: '1.0.0',
+          peerDependencies: { '@scope/core': 'workspace:^' },
+        });
+      }
+      return '{}';
+    });
+
+    const graph = buildDependencyGraph([compA, compB]);
+
+    expect(graph.dependentsOf.get('@scope/core')).toStrictEqual([compB]);
+  });
+
+  it('ignores non-workspace dependencies', () => {
+    const compA = makeComponent('core');
+    const compB = makeComponent('app');
+
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath.includes('core')) {
+        return JSON.stringify({ name: '@scope/core', version: '1.0.0' });
+      }
+      if (filePath.includes('app')) {
+        return JSON.stringify({
+          name: '@scope/app',
+          version: '1.0.0',
+          dependencies: { '@scope/core': '^1.0.0', lodash: '^4.0.0' },
+        });
+      }
+      return '{}';
+    });
+
+    const graph = buildDependencyGraph([compA, compB]);
+
+    expect(graph.dependentsOf.get('@scope/core')).toBeUndefined();
+  });
+
+  it('ignores devDependencies', () => {
+    const compA = makeComponent('core');
+    const compB = makeComponent('app');
+
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath.includes('core')) {
+        return JSON.stringify({ name: '@scope/core', version: '1.0.0' });
+      }
+      if (filePath.includes('app')) {
+        return JSON.stringify({
+          name: '@scope/app',
+          version: '1.0.0',
+          devDependencies: { '@scope/core': 'workspace:*' },
+        });
+      }
+      return '{}';
+    });
+
+    const graph = buildDependencyGraph([compA, compB]);
+
+    expect(graph.dependentsOf.get('@scope/core')).toBeUndefined();
+  });
+
+  it('handles transitive dependencies (A -> B -> C)', () => {
+    const compA = makeComponent('core');
+    const compB = makeComponent('middle');
+    const compC = makeComponent('app');
+
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath.includes('core')) {
+        return JSON.stringify({ name: '@scope/core', version: '1.0.0' });
+      }
+      if (filePath.includes('middle')) {
+        return JSON.stringify({
+          name: '@scope/middle',
+          version: '1.0.0',
+          dependencies: { '@scope/core': 'workspace:*' },
+        });
+      }
+      if (filePath.includes('app')) {
+        return JSON.stringify({
+          name: '@scope/app',
+          version: '1.0.0',
+          dependencies: { '@scope/middle': 'workspace:*' },
+        });
+      }
+      return '{}';
+    });
+
+    const graph = buildDependencyGraph([compA, compB, compC]);
+
+    expect(graph.dependentsOf.get('@scope/core')).toStrictEqual([compB]);
+    expect(graph.dependentsOf.get('@scope/middle')).toStrictEqual([compC]);
+  });
+
+  it('returns empty maps when no components have workspace dependencies', () => {
+    const comp = makeComponent('standalone');
+
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@scope/standalone', version: '1.0.0' }));
+
+    const graph = buildDependencyGraph([comp]);
+
+    expect(graph.packageNameToDir.size).toBe(1);
+    expect(graph.dependentsOf.size).toBe(0);
+  });
+
+  it('handles components with no packageFiles gracefully', () => {
+    const comp: ComponentConfig = {
+      dir: 'empty',
+      tagPrefix: 'empty-v',
+      packageFiles: [],
+      changelogPaths: [],
+      paths: [],
+    };
+
+    const graph = buildDependencyGraph([comp]);
+
+    expect(graph.packageNameToDir.size).toBe(0);
+    expect(graph.dependentsOf.size).toBe(0);
+  });
+});

--- a/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
+++ b/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
@@ -19,8 +19,11 @@ function makeGraph(
   nameToDir: Record<string, string>,
   dependentsOf: Record<string, ComponentConfig[]>,
 ): DependencyGraph {
+  const packageNameToDir = new Map(Object.entries(nameToDir));
+  const dirToPackageName = new Map(Object.entries(nameToDir).map(([name, dir]) => [dir, name]));
   return {
-    packageNameToDir: new Map(Object.entries(nameToDir)),
+    packageNameToDir,
+    dirToPackageName,
     dependentsOf: new Map(Object.entries(dependentsOf)),
   };
 }

--- a/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
+++ b/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DependencyGraph } from '../buildDependencyGraph.ts';
+import type { ReleaseEntry } from '../propagateBumps.ts';
+import { propagateBumps } from '../propagateBumps.ts';
+import type { ComponentConfig } from '../types.ts';
+
+function makeComponent(dir: string): ComponentConfig {
+  return {
+    dir,
+    tagPrefix: `${dir}-v`,
+    packageFiles: [`packages/${dir}/package.json`],
+    changelogPaths: [`packages/${dir}`],
+    paths: [`packages/${dir}/**`],
+  };
+}
+
+function makeGraph(
+  nameToDir: Record<string, string>,
+  dependentsOf: Record<string, ComponentConfig[]>,
+): DependencyGraph {
+  return {
+    packageNameToDir: new Map(Object.entries(nameToDir)),
+    dependentsOf: new Map(Object.entries(dependentsOf)),
+  };
+}
+
+describe(propagateBumps, () => {
+  it('propagates a patch bump to a single dependent', () => {
+    const dependent = makeComponent('release-kit');
+
+    const graph = makeGraph(
+      { '@scope/core': 'core', '@scope/release-kit': 'release-kit' },
+      { '@scope/core': [dependent] },
+    );
+
+    const directBumps = new Map<string, ReleaseEntry>([['core', { releaseType: 'minor' }]]);
+
+    const currentVersions = new Map([
+      ['core', '1.0.0'],
+      ['release-kit', '2.0.0'],
+    ]);
+
+    const result = propagateBumps(directBumps, graph, currentVersions);
+
+    expect(result.get('core')).toMatchObject({ releaseType: 'minor' });
+    expect(result.get('release-kit')).toMatchObject({
+      releaseType: 'patch',
+      propagatedFrom: [{ packageName: '@scope/core', newVersion: '1.1.0' }],
+    });
+  });
+
+  it('propagates transitively (A -> B -> C)', () => {
+    const compB = makeComponent('middle');
+    const compC = makeComponent('app');
+
+    const graph = makeGraph(
+      { '@scope/core': 'core', '@scope/middle': 'middle', '@scope/app': 'app' },
+      { '@scope/core': [compB], '@scope/middle': [compC] },
+    );
+
+    const directBumps = new Map<string, ReleaseEntry>([['core', { releaseType: 'patch' }]]);
+
+    const currentVersions = new Map([
+      ['core', '1.0.0'],
+      ['middle', '2.0.0'],
+      ['app', '3.0.0'],
+    ]);
+
+    const result = propagateBumps(directBumps, graph, currentVersions);
+
+    expect(result.get('core')).toMatchObject({ releaseType: 'patch' });
+    expect(result.get('middle')).toMatchObject({
+      releaseType: 'patch',
+      propagatedFrom: [{ packageName: '@scope/core', newVersion: '1.0.1' }],
+    });
+    expect(result.get('app')).toMatchObject({
+      releaseType: 'patch',
+      propagatedFrom: [{ packageName: '@scope/middle', newVersion: '2.0.1' }],
+    });
+  });
+
+  it('does not downgrade a higher direct bump', () => {
+    const dependent = makeComponent('release-kit');
+
+    const graph = makeGraph(
+      { '@scope/core': 'core', '@scope/release-kit': 'release-kit' },
+      { '@scope/core': [dependent] },
+    );
+
+    const directBumps = new Map<string, ReleaseEntry>([
+      ['core', { releaseType: 'patch' }],
+      ['release-kit', { releaseType: 'minor' }],
+    ]);
+
+    const currentVersions = new Map([
+      ['core', '1.0.0'],
+      ['release-kit', '2.0.0'],
+    ]);
+
+    const result = propagateBumps(directBumps, graph, currentVersions);
+
+    // release-kit keeps its minor bump but gains propagatedFrom metadata.
+    expect(result.get('release-kit')).toMatchObject({
+      releaseType: 'minor',
+      propagatedFrom: [{ packageName: '@scope/core', newVersion: '1.0.1' }],
+    });
+  });
+
+  it('handles circular dependencies without infinite loops', () => {
+    const compA = makeComponent('alpha');
+    const compB = makeComponent('beta');
+
+    const graph = makeGraph(
+      { '@scope/alpha': 'alpha', '@scope/beta': 'beta' },
+      { '@scope/alpha': [compB], '@scope/beta': [compA] },
+    );
+
+    const directBumps = new Map<string, ReleaseEntry>([['alpha', { releaseType: 'patch' }]]);
+
+    const currentVersions = new Map([
+      ['alpha', '1.0.0'],
+      ['beta', '2.0.0'],
+    ]);
+
+    // Should terminate without infinite loop.
+    const result = propagateBumps(directBumps, graph, currentVersions);
+
+    expect(result.get('alpha')).toMatchObject({ releaseType: 'patch' });
+    expect(result.get('beta')).toMatchObject({
+      releaseType: 'patch',
+      propagatedFrom: [{ packageName: '@scope/alpha', newVersion: '1.0.1' }],
+    });
+  });
+
+  it('adds propagatedFrom metadata to a directly bumped component with a propagated dependency', () => {
+    const dependent = makeComponent('kit');
+
+    const graph = makeGraph({ '@scope/core': 'core', '@scope/kit': 'kit' }, { '@scope/core': [dependent] });
+
+    const directBumps = new Map<string, ReleaseEntry>([
+      ['core', { releaseType: 'major' }],
+      ['kit', { releaseType: 'patch' }],
+    ]);
+
+    const currentVersions = new Map([
+      ['core', '1.0.0'],
+      ['kit', '1.0.0'],
+    ]);
+
+    const result = propagateBumps(directBumps, graph, currentVersions);
+
+    // kit is already in set with patch; propagation adds metadata but keeps bump type.
+    expect(result.get('kit')).toMatchObject({
+      releaseType: 'patch',
+      propagatedFrom: [{ packageName: '@scope/core', newVersion: '2.0.0' }],
+    });
+  });
+
+  it('handles multiple dependencies triggering propagation to the same component', () => {
+    const compC = makeComponent('app');
+
+    const graph = makeGraph(
+      { '@scope/core': 'core', '@scope/utils': 'utils', '@scope/app': 'app' },
+      { '@scope/core': [compC], '@scope/utils': [compC] },
+    );
+
+    const directBumps = new Map<string, ReleaseEntry>([
+      ['core', { releaseType: 'patch' }],
+      ['utils', { releaseType: 'minor' }],
+    ]);
+
+    const currentVersions = new Map([
+      ['core', '1.0.0'],
+      ['utils', '2.0.0'],
+      ['app', '3.0.0'],
+    ]);
+
+    const result = propagateBumps(directBumps, graph, currentVersions);
+
+    const appEntry = result.get('app');
+    expect(appEntry).toBeDefined();
+    expect(appEntry?.releaseType).toBe('patch');
+    expect(appEntry?.propagatedFrom).toHaveLength(2);
+    expect(appEntry?.propagatedFrom).toContainEqual({ packageName: '@scope/core', newVersion: '1.0.1' });
+    expect(appEntry?.propagatedFrom).toContainEqual({ packageName: '@scope/utils', newVersion: '2.1.0' });
+  });
+
+  it('returns only direct bumps when there are no dependents', () => {
+    const graph = makeGraph({ '@scope/core': 'core' }, {});
+
+    const directBumps = new Map<string, ReleaseEntry>([['core', { releaseType: 'minor' }]]);
+    const currentVersions = new Map([['core', '1.0.0']]);
+
+    const result = propagateBumps(directBumps, graph, currentVersions);
+
+    expect(result.size).toBe(1);
+    expect(result.get('core')).toMatchObject({ releaseType: 'minor' });
+  });
+});

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockExecFileSync = vi.hoisted(() => vi.fn());
 const mockExecSync = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
 const mockHasPrettierConfig = vi.hoisted(() => vi.fn());
@@ -12,6 +13,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
   readFileSync: mockReadFileSync,
   writeFileSync: mockWriteFileSync,
 }));
@@ -77,6 +79,7 @@ describe(releasePrepareMono, () => {
   afterEach(() => {
     mockExecFileSync.mockReset();
     mockExecSync.mockReset();
+    mockExistsSync.mockReset();
     mockReadFileSync.mockReset();
     mockWriteFileSync.mockReset();
     mockHasPrettierConfig.mockReset();
@@ -156,6 +159,7 @@ describe(releasePrepareMono, () => {
       }
       return '';
     });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/arrays', version: '1.0.0' }));
 
     const result = releasePrepareMono(config, { dryRun: false });
 
@@ -558,6 +562,7 @@ describe(releasePrepareMono, () => {
       }
       return '';
     });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/arrays', version: '1.0.0' }));
 
     const result = releasePrepareMono(config, { dryRun: false });
 
@@ -665,5 +670,237 @@ describe(releasePrepareMono, () => {
       'packages/arrays/CHANGELOG.md',
       'packages/arrays/docs/CHANGELOG.md',
     ]);
+  });
+
+  describe('dependency propagation', () => {
+    it('propagates a patch bump to a dependent when a dependency is bumped', () => {
+      const config = makeConfig({
+        components: [
+          {
+            dir: 'core',
+            tagPrefix: 'core-v',
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+          {
+            dir: 'app',
+            tagPrefix: 'app-v',
+            packageFiles: ['packages/app/package.json'],
+            changelogPaths: ['packages/app'],
+            paths: ['packages/app/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          const matchArg = args.find((a: string) => a.startsWith('--match='));
+          if (matchArg?.includes('core-v')) return 'core-v1.0.0\n';
+          if (matchArg?.includes('app-v')) return 'app-v2.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          const hasCorePath = args.includes('packages/core/**');
+          if (hasCorePath) return 'feat: add utility\u001Fabc123';
+          return '';
+        }
+        return '';
+      });
+
+      mockReadFileSync.mockImplementation((filePath: string) => {
+        if (filePath.includes('core')) {
+          return JSON.stringify({
+            name: '@test/core',
+            version: '1.0.0',
+          });
+        }
+        if (filePath.includes('app')) {
+          return JSON.stringify({
+            name: '@test/app',
+            version: '2.0.0',
+            dependencies: { '@test/core': 'workspace:*' },
+          });
+        }
+        return '{}';
+      });
+      mockExistsSync.mockReturnValue(false);
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      // core is bumped directly (minor), app is propagated (patch).
+      expect(result.tags).toContain('core-v1.1.0');
+      expect(result.tags).toContain('app-v2.0.1');
+      expect(result.components).toHaveLength(2);
+
+      const coreResult = result.components.find((c) => c.name === 'core');
+      expect(coreResult).toMatchObject({
+        status: 'released',
+        releaseType: 'minor',
+        newVersion: '1.1.0',
+      });
+
+      const appResult = result.components.find((c) => c.name === 'app');
+      expect(appResult).toMatchObject({
+        status: 'released',
+        releaseType: 'patch',
+        newVersion: '2.0.1',
+        commitCount: 0,
+        propagatedFrom: [{ packageName: '@test/core', newVersion: '1.1.0' }],
+      });
+    });
+
+    it('writes a synthetic changelog for propagated-only components', () => {
+      const config = makeConfig({
+        components: [
+          {
+            dir: 'core',
+            tagPrefix: 'core-v',
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+          {
+            dir: 'app',
+            tagPrefix: 'app-v',
+            packageFiles: ['packages/app/package.json'],
+            changelogPaths: ['packages/app'],
+            paths: ['packages/app/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          const matchArg = args.find((a: string) => a.startsWith('--match='));
+          if (matchArg?.includes('core-v')) return 'core-v1.0.0\n';
+          if (matchArg?.includes('app-v')) return 'app-v1.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          const hasCorePath = args.includes('packages/core/**');
+          if (hasCorePath) return 'fix: bug fix\u001Fabc123';
+          return '';
+        }
+        return '';
+      });
+
+      mockReadFileSync.mockImplementation((filePath: string) => {
+        if (filePath.includes('core')) {
+          return JSON.stringify({ name: '@test/core', version: '1.0.0' });
+        }
+        if (filePath.includes('app')) {
+          return JSON.stringify({
+            name: '@test/app',
+            version: '1.0.0',
+            dependencies: { '@test/core': 'workspace:*' },
+          });
+        }
+        return '{}';
+      });
+      mockExistsSync.mockReturnValue(false);
+
+      releasePrepareMono(config, { dryRun: false });
+
+      // git-cliff should be called only for core (direct), not for app (propagated).
+      expect(countCliffCalls()).toBe(1);
+      const cliffArgs = findCliffCallArgs();
+      expect(cliffArgs).toContain('packages/core/CHANGELOG.md');
+
+      // Synthetic changelog written for app.
+      const writeCallArgs = mockWriteFileSync.mock.calls;
+      const syntheticWrite = writeCallArgs.find(
+        (call: unknown[]) => typeof call[0] === 'string' && call[0] === 'packages/app/CHANGELOG.md',
+      );
+      expect(syntheticWrite).toBeDefined();
+      expect(syntheticWrite?.[1]).toContain('Dependency updates');
+      expect(syntheticWrite?.[1]).toContain('@test/core');
+    });
+
+    it('does not propagate to components excluded from config.components', () => {
+      // Only include "core" in config — "app" that depends on core is not listed.
+      const config = makeConfig({
+        components: [
+          {
+            dir: 'core',
+            tagPrefix: 'core-v',
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'core-v1.0.0\n';
+        if (cmd === 'git' && args[0] === 'log') return 'feat: new feature\u001Fabc123';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/core', version: '1.0.0' }));
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      // Only core should be released since app is not in config.components.
+      expect(result.tags).toStrictEqual(['core-v1.1.0']);
+      expect(result.components).toHaveLength(1);
+    });
+
+    it('preserves a direct higher bump when propagation would add a patch', () => {
+      const config = makeConfig({
+        components: [
+          {
+            dir: 'core',
+            tagPrefix: 'core-v',
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+          {
+            dir: 'app',
+            tagPrefix: 'app-v',
+            packageFiles: ['packages/app/package.json'],
+            changelogPaths: ['packages/app'],
+            paths: ['packages/app/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          const matchArg = args.find((a: string) => a.startsWith('--match='));
+          if (matchArg?.includes('core-v')) return 'core-v1.0.0\n';
+          if (matchArg?.includes('app-v')) return 'app-v2.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          // Both have commits.
+          const hasCorePath = args.includes('packages/core/**');
+          if (hasCorePath) return 'fix: core fix\u001Fabc123';
+          return 'feat: app feature\u001Fdef456';
+        }
+        return '';
+      });
+
+      mockReadFileSync.mockImplementation((filePath: string) => {
+        if (filePath.includes('core')) {
+          return JSON.stringify({ name: '@test/core', version: '1.0.0' });
+        }
+        if (filePath.includes('app')) {
+          return JSON.stringify({
+            name: '@test/app',
+            version: '2.0.0',
+            dependencies: { '@test/core': 'workspace:*' },
+          });
+        }
+        return '{}';
+      });
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      // app has its own minor bump from commits; propagation adds metadata but keeps minor.
+      const appResult = result.components.find((c) => c.name === 'app');
+      expect(appResult).toMatchObject({
+        status: 'released',
+        releaseType: 'minor',
+        propagatedFrom: [{ packageName: '@test/core', newVersion: '1.0.1' }],
+      });
+    });
   });
 });

--- a/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
@@ -467,5 +467,45 @@ describe(reportPrepare, () => {
         ),
       );
     });
+
+    it('shows propagation info for a propagated-only component', () => {
+      const result: PrepareResult = {
+        components: [
+          {
+            name: 'core',
+            status: 'released',
+            previousTag: 'core-v1.0.0',
+            commitCount: 1,
+            parsedCommitCount: 1,
+            releaseType: 'patch',
+            currentVersion: '1.0.0',
+            newVersion: '1.0.1',
+            tag: 'core-v1.0.1',
+            bumpedFiles: ['packages/core/package.json'],
+            changelogFiles: ['packages/core/CHANGELOG.md'],
+          },
+          {
+            name: 'app',
+            status: 'released',
+            previousTag: 'app-v2.0.0',
+            commitCount: 0,
+            releaseType: 'patch',
+            currentVersion: '2.0.0',
+            newVersion: '2.0.1',
+            tag: 'app-v2.0.1',
+            bumpedFiles: ['packages/app/package.json'],
+            changelogFiles: ['packages/app/CHANGELOG.md'],
+            propagatedFrom: [{ packageName: '@scope/core', newVersion: '1.0.1' }],
+          },
+        ],
+        tags: ['core-v1.0.1', 'app-v2.0.1'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('0 commits (bumped via dependency: @scope/core)');
+      expect(output).toContain('(patch, dependency: @scope/core)');
+    });
   });
 });

--- a/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
@@ -468,6 +468,35 @@ describe(reportPrepare, () => {
       );
     });
 
+    it('shows warnings when present in the result', () => {
+      const result: PrepareResult = {
+        components: [
+          {
+            name: 'core',
+            status: 'released',
+            previousTag: 'core-v1.0.0',
+            commitCount: 1,
+            parsedCommitCount: 1,
+            releaseType: 'patch',
+            currentVersion: '1.0.0',
+            newVersion: '1.0.1',
+            tag: 'core-v1.0.1',
+            bumpedFiles: ['packages/core/package.json'],
+            changelogFiles: ['packages/core/CHANGELOG.md'],
+          },
+        ],
+        tags: ['core-v1.0.1'],
+        dryRun: false,
+        warnings: [
+          'Circular workspace dependencies detected among: a, b. Propagation metadata may be incomplete for these components.',
+        ],
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('⚠️  Circular workspace dependencies detected among: a, b');
+    });
+
     it('shows propagation info for a propagated-only component', () => {
       const result: PrepareResult = {
         components: [

--- a/packages/release-kit/src/__tests__/writeSyntheticChangelog.unit.test.ts
+++ b/packages/release-kit/src/__tests__/writeSyntheticChangelog.unit.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+import { writeSyntheticChangelog } from '../writeSyntheticChangelog.ts';
+
+describe(writeSyntheticChangelog, () => {
+  afterEach(() => {
+    mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
+  });
+
+  it('writes a changelog entry for a single propagated dependency', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const result = writeSyntheticChangelog({
+      changelogPath: 'packages/app',
+      newVersion: '1.0.1',
+      date: '2026-03-28',
+      propagatedFrom: [{ packageName: '@scope/core', newVersion: '2.0.0' }],
+    });
+
+    expect(result).toBe('packages/app/CHANGELOG.md');
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      'packages/app/CHANGELOG.md',
+      expect.stringContaining('## 1.0.1 — 2026-03-28'),
+      'utf8',
+    );
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      'packages/app/CHANGELOG.md',
+      expect.stringContaining('### Dependency updates'),
+      'utf8',
+    );
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      'packages/app/CHANGELOG.md',
+      expect.stringContaining('- Bumped `@scope/core` to 2.0.0'),
+      'utf8',
+    );
+  });
+
+  it('lists multiple propagated dependencies as separate bullets', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    writeSyntheticChangelog({
+      changelogPath: 'packages/app',
+      newVersion: '1.0.1',
+      date: '2026-03-28',
+      propagatedFrom: [
+        { packageName: '@scope/core', newVersion: '2.0.0' },
+        { packageName: '@scope/utils', newVersion: '3.1.0' },
+      ],
+    });
+
+    const writtenContent = mockWriteFileSync.mock.calls[0]?.[1];
+    expect(writtenContent).toContain('- Bumped `@scope/core` to 2.0.0');
+    expect(writtenContent).toContain('- Bumped `@scope/utils` to 3.1.0');
+  });
+
+  it('prepends to existing changelog content', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('## 1.0.0 — 2026-03-01\n\nInitial release.\n');
+
+    writeSyntheticChangelog({
+      changelogPath: 'packages/app',
+      newVersion: '1.0.1',
+      date: '2026-03-28',
+      propagatedFrom: [{ packageName: '@scope/core', newVersion: '2.0.0' }],
+    });
+
+    const writtenContent = mockWriteFileSync.mock.calls[0]?.[1];
+    expect(writtenContent).toMatch(/^## 1\.0\.1/);
+    expect(writtenContent).toContain('## 1.0.0 — 2026-03-01');
+  });
+
+  it('creates the file when it does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    writeSyntheticChangelog({
+      changelogPath: 'packages/new-pkg',
+      newVersion: '0.0.1',
+      date: '2026-03-28',
+      propagatedFrom: [{ packageName: '@scope/core', newVersion: '1.0.0' }],
+    });
+
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the write in dry-run mode but returns the file path', () => {
+    const result = writeSyntheticChangelog({
+      changelogPath: 'packages/app',
+      newVersion: '1.0.1',
+      date: '2026-03-28',
+      propagatedFrom: [{ packageName: '@scope/core', newVersion: '2.0.0' }],
+      dryRun: true,
+    });
+
+    expect(result).toBe('packages/app/CHANGELOG.md');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/release-kit/src/buildDependencyGraph.ts
+++ b/packages/release-kit/src/buildDependencyGraph.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+
+import type { ComponentConfig } from './types.ts';
+
+/** Reverse adjacency map from package names to their workspace dependents. */
+export interface DependencyGraph {
+  /** Resolve a package name to its component `dir`. */
+  packageNameToDir: Map<string, string>;
+  /** Map a package name to the components that depend on it. */
+  dependentsOf: Map<string, ComponentConfig[]>;
+}
+
+interface PackageJsonSubset {
+  name?: string;
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+function isPackageJsonSubset(value: unknown): value is PackageJsonSubset {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Build a reverse dependency graph from the workspace components' `package.json` files.
+ *
+ * Reads each component's primary `package.json` (first entry in `packageFiles`) to discover
+ * `workspace:` references in `dependencies` and `peerDependencies`. Returns a map from each
+ * package name to the components that depend on it, enabling upward traversal from a bumped
+ * package to all its dependents.
+ */
+export function buildDependencyGraph(components: readonly ComponentConfig[]): DependencyGraph {
+  const packageNameToDir = new Map<string, string>();
+  const dependentsOf = new Map<string, ComponentConfig[]>();
+
+  // First pass: resolve package names from each component's package.json.
+  const componentPackageNames = new Map<ComponentConfig, string>();
+  for (const component of components) {
+    const primaryPackageFile = component.packageFiles[0];
+    if (primaryPackageFile === undefined) {
+      continue;
+    }
+
+    const pkg = readPackageJsonSubset(primaryPackageFile);
+    if (pkg.name === undefined) {
+      continue;
+    }
+
+    packageNameToDir.set(pkg.name, component.dir);
+    componentPackageNames.set(component, pkg.name);
+  }
+
+  // Second pass: build the reverse adjacency map.
+  for (const component of components) {
+    const primaryPackageFile = component.packageFiles[0];
+    if (primaryPackageFile === undefined) {
+      continue;
+    }
+
+    const pkg = readPackageJsonSubset(primaryPackageFile);
+    const allDeps = { ...pkg.dependencies, ...pkg.peerDependencies };
+
+    for (const [depName, depVersion] of Object.entries(allDeps)) {
+      if (typeof depVersion !== 'string' || !depVersion.startsWith('workspace:')) {
+        continue;
+      }
+
+      const existing = dependentsOf.get(depName);
+      if (existing === undefined) {
+        dependentsOf.set(depName, [component]);
+      } else {
+        existing.push(component);
+      }
+    }
+  }
+
+  return { packageNameToDir, dependentsOf };
+}
+
+/** Read and parse a package.json file, returning only the fields needed for graph building. */
+function readPackageJsonSubset(filePath: string): PackageJsonSubset {
+  let content: string;
+  try {
+    content = readFileSync(filePath, 'utf8');
+  } catch (error: unknown) {
+    throw new Error(`Failed to read ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error: unknown) {
+    throw new Error(`Failed to parse JSON in ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (!isPackageJsonSubset(parsed)) {
+    throw new Error(`Invalid package.json at ${filePath}`);
+  }
+
+  return parsed;
+}

--- a/packages/release-kit/src/buildDependencyGraph.ts
+++ b/packages/release-kit/src/buildDependencyGraph.ts
@@ -6,6 +6,8 @@ import type { ComponentConfig } from './types.ts';
 export interface DependencyGraph {
   /** Resolve a package name to its component `dir`. */
   packageNameToDir: Map<string, string>;
+  /** Resolve a component `dir` to its package name (inverse of `packageNameToDir`). */
+  dirToPackageName: Map<string, string>;
   /** Map a package name to the components that depend on it. */
   dependentsOf: Map<string, ComponentConfig[]>;
 }
@@ -30,10 +32,11 @@ function isPackageJsonSubset(value: unknown): value is PackageJsonSubset {
  */
 export function buildDependencyGraph(components: readonly ComponentConfig[]): DependencyGraph {
   const packageNameToDir = new Map<string, string>();
+  const dirToPackageName = new Map<string, string>();
   const dependentsOf = new Map<string, ComponentConfig[]>();
 
-  // First pass: resolve package names from each component's package.json.
-  const componentPackageNames = new Map<ComponentConfig, string>();
+  // First pass: read each component's package.json, cache the result, and register its name.
+  const componentPackages = new Map<ComponentConfig, PackageJsonSubset>();
   for (const component of components) {
     const primaryPackageFile = component.packageFiles[0];
     if (primaryPackageFile === undefined) {
@@ -41,22 +44,18 @@ export function buildDependencyGraph(components: readonly ComponentConfig[]): De
     }
 
     const pkg = readPackageJsonSubset(primaryPackageFile);
+    componentPackages.set(component, pkg);
+
     if (pkg.name === undefined) {
       continue;
     }
 
     packageNameToDir.set(pkg.name, component.dir);
-    componentPackageNames.set(component, pkg.name);
+    dirToPackageName.set(component.dir, pkg.name);
   }
 
-  // Second pass: build the reverse adjacency map.
-  for (const component of components) {
-    const primaryPackageFile = component.packageFiles[0];
-    if (primaryPackageFile === undefined) {
-      continue;
-    }
-
-    const pkg = readPackageJsonSubset(primaryPackageFile);
+  // Second pass: build the reverse adjacency map using cached package data.
+  for (const [component, pkg] of componentPackages) {
     const allDeps = { ...pkg.dependencies, ...pkg.peerDependencies };
 
     for (const [depName, depVersion] of Object.entries(allDeps)) {
@@ -73,7 +72,7 @@ export function buildDependencyGraph(components: readonly ComponentConfig[]): De
     }
   }
 
-  return { packageNameToDir, dependentsOf };
+  return { packageNameToDir, dirToPackageName, dependentsOf };
 }
 
 /** Read and parse a package.json file, returning only the fields needed for graph building. */

--- a/packages/release-kit/src/propagateBumps.ts
+++ b/packages/release-kit/src/propagateBumps.ts
@@ -1,12 +1,12 @@
 import type { DependencyGraph } from './buildDependencyGraph.ts';
 import { bumpVersion } from './bumpVersion.ts';
-import type { ReleaseType } from './types.ts';
+import type { PropagationSource, ReleaseType } from './types.ts';
 
 /** Entry in the full release set produced by propagation. */
 export interface ReleaseEntry {
   releaseType: ReleaseType;
   /** Present when this component was bumped (wholly or partly) due to a dependency update. */
-  propagatedFrom?: Array<{ packageName: string; newVersion: string }>;
+  propagatedFrom?: PropagationSource[];
 }
 
 /** Map from component `dir` to its current version string (read from package.json). */

--- a/packages/release-kit/src/propagateBumps.ts
+++ b/packages/release-kit/src/propagateBumps.ts
@@ -47,7 +47,7 @@ export function propagateBumps(
     visited.add(dir);
 
     // Resolve the package name for this component dir.
-    const packageName = resolvePackageName(dir, graph.packageNameToDir);
+    const packageName = graph.dirToPackageName.get(dir);
     if (packageName === undefined) {
       continue;
     }
@@ -92,14 +92,4 @@ export function propagateBumps(
   }
 
   return result;
-}
-
-/** Resolve a component `dir` to its package name by reverse-looking up `packageNameToDir`. */
-function resolvePackageName(dir: string, packageNameToDir: Map<string, string>): string | undefined {
-  for (const [name, componentDir] of packageNameToDir) {
-    if (componentDir === dir) {
-      return name;
-    }
-  }
-  return undefined;
 }

--- a/packages/release-kit/src/propagateBumps.ts
+++ b/packages/release-kit/src/propagateBumps.ts
@@ -1,0 +1,105 @@
+import type { DependencyGraph } from './buildDependencyGraph.ts';
+import { bumpVersion } from './bumpVersion.ts';
+import type { ReleaseType } from './types.ts';
+
+/** Entry in the full release set produced by propagation. */
+export interface ReleaseEntry {
+  releaseType: ReleaseType;
+  /** Present when this component was bumped (wholly or partly) due to a dependency update. */
+  propagatedFrom?: Array<{ packageName: string; newVersion: string }>;
+}
+
+/** Map from component `dir` to its current version string (read from package.json). */
+export type CurrentVersions = Map<string, string>;
+
+/**
+ * Walk upward through the dependency graph via BFS, adding `patch` bumps for dependents
+ * not already in the release set with a higher bump.
+ *
+ * Returns the full release set (direct + propagated). Direct entries that also have a
+ * propagated dependency get `propagatedFrom` metadata without changing their bump type.
+ */
+export function propagateBumps(
+  directBumps: Map<string, ReleaseEntry>,
+  graph: DependencyGraph,
+  currentVersions: CurrentVersions,
+): Map<string, ReleaseEntry> {
+  const result = new Map<string, ReleaseEntry>();
+
+  // Copy direct bumps into the result.
+  for (const [dir, entry] of directBumps) {
+    result.set(dir, { ...entry });
+  }
+
+  // BFS queue: component dirs whose dependents need to be checked.
+  const queue: string[] = [...directBumps.keys()];
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const dir = queue.shift();
+    if (dir === undefined) {
+      break;
+    }
+
+    if (visited.has(dir)) {
+      continue;
+    }
+    visited.add(dir);
+
+    // Resolve the package name for this component dir.
+    const packageName = resolvePackageName(dir, graph.packageNameToDir);
+    if (packageName === undefined) {
+      continue;
+    }
+
+    // Compute the new version for this component after its bump.
+    const currentVersion = currentVersions.get(dir);
+    const entry = result.get(dir);
+    if (currentVersion === undefined || entry === undefined) {
+      continue;
+    }
+    const newVersion = bumpVersion(currentVersion, entry.releaseType);
+
+    // Find dependents and propagate.
+    const dependents = graph.dependentsOf.get(packageName);
+    if (dependents === undefined) {
+      continue;
+    }
+
+    for (const dependent of dependents) {
+      const dependentDir = dependent.dir;
+      const existing = result.get(dependentDir);
+
+      const propagationInfo = { packageName, newVersion };
+
+      if (existing === undefined) {
+        // New propagated entry.
+        result.set(dependentDir, {
+          releaseType: 'patch',
+          propagatedFrom: [propagationInfo],
+        });
+      } else {
+        // Already in the release set. Add propagatedFrom metadata but don't downgrade the bump.
+        const existingPropagated = existing.propagatedFrom ?? [];
+        existing.propagatedFrom = [...existingPropagated, propagationInfo];
+      }
+
+      // Enqueue the dependent so its own dependents are checked (transitive propagation).
+      if (!visited.has(dependentDir)) {
+        queue.push(dependentDir);
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Resolve a component `dir` to its package name by reverse-looking up `packageNameToDir`. */
+function resolvePackageName(dir: string, packageNameToDir: Map<string, string>): string | undefined {
+  for (const [name, componentDir] of packageNameToDir) {
+    if (componentDir === dir) {
+      return name;
+    }
+  }
+  return undefined;
+}

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -42,6 +42,14 @@ interface SkippedResult {
   skipReason: string;
 }
 
+/** Aggregate result from Phase 1 (determine direct bumps). */
+interface Phase1Result {
+  directBumps: Map<string, ReleaseEntry>;
+  directResults: Map<string, DirectBumpResult>;
+  skippedResults: SkippedResult[];
+  currentVersions: CurrentVersions;
+}
+
 /**
  * Orchestrate release preparation for a monorepo with multiple components.
  *
@@ -51,11 +59,72 @@ interface SkippedResult {
  * Phase 3: Execute bumps and generate changelogs in dependency order.
  */
 export function releasePrepareMono(config: MonorepoReleaseConfig, options: ReleasePrepareOptions): PrepareResult {
-  const { dryRun, force, bumpOverride } = options;
+  const { dryRun } = options;
+
+  // === Phase 1: Determine direct bumps ===
+  const { directBumps, directResults, skippedResults, currentVersions } = determineDirectBumps(config, options);
+
+  // Build a lookup of previous tags for all components (needed for propagated ones).
+  const previousTags = new Map<string, string | undefined>();
+  for (const result of directResults.values()) {
+    previousTags.set(result.component.dir, result.tag);
+  }
+  for (const skipped of skippedResults) {
+    previousTags.set(skipped.component.dir, skipped.tag);
+  }
+
+  // === Phase 2: Build graph and propagate bumps ===
+  const graph = buildDependencyGraph(config.components);
+  const fullReleaseSet = propagateBumps(directBumps, graph, currentVersions);
+
+  // === Phase 2b: Topologically sort the release set ===
+  const { sorted: sortedDirs, cyclicDirs } = topologicalSort(fullReleaseSet, graph);
+  const warnings: string[] = [];
+  if (cyclicDirs.length > 0) {
+    warnings.push(
+      `Circular workspace dependencies detected among: ${cyclicDirs.join(', ')}. ` +
+        'Propagation metadata may be incomplete for these components.',
+    );
+  }
+
+  // === Phase 3: Execute bumps and generate changelogs ===
+  const components = collectSkippedComponents(skippedResults, fullReleaseSet);
+  const { tags, modifiedFiles } = executeReleaseSet(
+    sortedDirs,
+    fullReleaseSet,
+    config,
+    directResults,
+    previousTags,
+    dryRun,
+    components,
+  );
+
+  // Reorder components to match original config order.
+  const configOrder = new Map(config.components.map((c, i) => [c.dir, i]));
+  components.sort((a, b) => {
+    const orderA = configOrder.get(a.name ?? '') ?? 0;
+    const orderB = configOrder.get(b.name ?? '') ?? 0;
+    return orderA - orderB;
+  });
+
+  // === Phase 4: Format ===
+  const formatCommand = runFormatCommand(config, tags, modifiedFiles, dryRun);
+
+  return {
+    components,
+    tags,
+    formatCommand,
+    dryRun,
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+}
+
+/** Determine direct bumps from commits for each component. */
+function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePrepareOptions): Phase1Result {
+  const { force, bumpOverride } = options;
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
 
-  // === Phase 1: Determine direct bumps ===
   const directBumps = new Map<string, ReleaseEntry>();
   const directResults = new Map<string, DirectBumpResult>();
   const skippedResults: SkippedResult[] = [];
@@ -125,35 +194,15 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     });
   }
 
-  // Build a lookup of previous tags for all components (needed for propagated ones).
-  const previousTags = new Map<string, string | undefined>();
-  for (const result of directResults.values()) {
-    previousTags.set(result.component.dir, result.tag);
-  }
-  for (const skipped of skippedResults) {
-    previousTags.set(skipped.component.dir, skipped.tag);
-  }
+  return { directBumps, directResults, skippedResults, currentVersions };
+}
 
-  // === Phase 2: Build graph and propagate bumps ===
-  const graph = buildDependencyGraph(config.components);
-  const fullReleaseSet = propagateBumps(directBumps, graph, currentVersions);
-
-  // === Phase 2b: Topologically sort the release set ===
-  const { sorted: sortedDirs, cyclicDirs } = topologicalSort(fullReleaseSet, graph);
-  const warnings: string[] = [];
-  if (cyclicDirs.length > 0) {
-    warnings.push(
-      `Circular workspace dependencies detected among: ${cyclicDirs.join(', ')}. ` +
-        'Propagation metadata may be incomplete for these components.',
-    );
-  }
-
-  // === Phase 3: Execute bumps and generate changelogs ===
-  const tags: string[] = [];
-  const modifiedFiles: string[] = [];
+/** Collect skipped components, excluding those promoted via propagation. */
+function collectSkippedComponents(
+  skippedResults: SkippedResult[],
+  fullReleaseSet: Map<string, ReleaseEntry>,
+): ComponentPrepareResult[] {
   const components: ComponentPrepareResult[] = [];
-
-  // Collect skipped results (excluding components that were added via propagation).
   for (const skipped of skippedResults) {
     if (fullReleaseSet.has(skipped.component.dir)) {
       continue;
@@ -170,8 +219,21 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
       skipReason: skipped.skipReason,
     });
   }
+  return components;
+}
 
-  // Process released components in topological order.
+/** Execute bumps and generate changelogs for each component in dependency order. */
+function executeReleaseSet(
+  sortedDirs: string[],
+  fullReleaseSet: Map<string, ReleaseEntry>,
+  config: MonorepoReleaseConfig,
+  directResults: Map<string, DirectBumpResult>,
+  previousTags: Map<string, string | undefined>,
+  dryRun: boolean,
+  components: ComponentPrepareResult[],
+): { tags: string[]; modifiedFiles: string[] } {
+  const tags: string[] = [];
+  const modifiedFiles: string[] = [];
   const today = new Date().toISOString().slice(0, 10);
 
   for (const dir of sortedDirs) {
@@ -197,7 +259,6 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     const isPropagationOnly = directResult === undefined;
 
     if (isPropagationOnly && releaseEntry.propagatedFrom !== undefined) {
-      // Propagation-only: write synthetic changelog.
       for (const changelogPath of component.changelogPaths) {
         changelogFiles.push(
           writeSyntheticChangelog({
@@ -210,7 +271,6 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
         );
       }
     } else {
-      // Direct bump (possibly with propagatedFrom metadata): use git-cliff.
       for (const changelogPath of component.changelogPaths) {
         changelogFiles.push(
           ...generateChangelog(config, changelogPath, newTag, dryRun, {
@@ -238,42 +298,37 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     });
   }
 
-  // Reorder components to match original config order.
-  const configOrder = new Map(config.components.map((c, i) => [c.dir, i]));
-  components.sort((a, b) => {
-    const orderA = configOrder.get(a.name ?? '') ?? 0;
-    const orderB = configOrder.get(b.name ?? '') ?? 0;
-    return orderA - orderB;
-  });
+  return { tags, modifiedFiles };
+}
 
-  // === Phase 4: Format ===
+/** Run the format command on modified files, if configured. */
+function runFormatCommand(
+  config: MonorepoReleaseConfig,
+  tags: string[],
+  modifiedFiles: string[],
+  dryRun: boolean,
+): PrepareResult['formatCommand'] {
   const formatCommandStr = config.formatCommand ?? (hasPrettierConfig() ? 'npx prettier --write' : undefined);
-  let formatCommand: PrepareResult['formatCommand'];
 
-  if (tags.length > 0 && formatCommandStr !== undefined) {
-    const fullCommand = `${formatCommandStr} ${modifiedFiles.join(' ')}`;
-
-    if (dryRun) {
-      formatCommand = { command: fullCommand, executed: false, files: modifiedFiles };
-    } else {
-      try {
-        execSync(fullCommand, { stdio: 'inherit' });
-      } catch (error: unknown) {
-        throw new Error(
-          `Format command failed ('${fullCommand}'): ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-      formatCommand = { command: fullCommand, executed: true, files: modifiedFiles };
-    }
+  if (tags.length === 0 || formatCommandStr === undefined) {
+    return undefined;
   }
 
-  return {
-    components,
-    tags,
-    formatCommand,
-    dryRun,
-    ...(warnings.length > 0 ? { warnings } : {}),
-  };
+  const fullCommand = `${formatCommandStr} ${modifiedFiles.join(' ')}`;
+
+  if (dryRun) {
+    return { command: fullCommand, executed: false, files: modifiedFiles };
+  }
+
+  try {
+    execSync(fullCommand, { stdio: 'inherit' });
+  } catch (error: unknown) {
+    throw new Error(
+      `Format command failed ('${fullCommand}'): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  return { command: fullCommand, executed: true, files: modifiedFiles };
 }
 
 /** Find a component by its `dir` in the components array. */

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -234,8 +234,8 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
   // Reorder components to match original config order.
   const configOrder = new Map(config.components.map((c, i) => [c.dir, i]));
   components.sort((a, b) => {
-    const orderA = a.name === undefined ? 0 : (configOrder.get(a.name) ?? 0);
-    const orderB = b.name === undefined ? 0 : (configOrder.get(b.name) ?? 0);
+    const orderA = configOrder.get(a.name ?? '') ?? 0;
+    const orderB = configOrder.get(b.name ?? '') ?? 0;
     return orderA - orderB;
   });
 

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -139,7 +139,14 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
   const fullReleaseSet = propagateBumps(directBumps, graph, currentVersions);
 
   // === Phase 2b: Topologically sort the release set ===
-  const sortedDirs = topologicalSort(fullReleaseSet, graph);
+  const { sorted: sortedDirs, cyclicDirs } = topologicalSort(fullReleaseSet, graph);
+  const warnings: string[] = [];
+  if (cyclicDirs.length > 0) {
+    warnings.push(
+      `Circular workspace dependencies detected among: ${cyclicDirs.join(', ')}. ` +
+        'Propagation metadata may be incomplete for these components.',
+    );
+  }
 
   // === Phase 3: Execute bumps and generate changelogs ===
   const tags: string[] = [];
@@ -265,6 +272,7 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     tags,
     formatCommand,
     dryRun,
+    ...(warnings.length > 0 ? { warnings } : {}),
   };
 }
 
@@ -295,12 +303,15 @@ function readCurrentVersion(filePath: string): string | undefined {
  * Topologically sort component dirs so dependencies are processed before their dependents.
  *
  * Uses Kahn's algorithm. Components not in the release set are excluded. If the graph has
- * cycles, the remaining nodes are appended in arbitrary order.
+ * cycles, the remaining nodes are appended in arbitrary order and reported via `cyclicDirs`.
  */
-function topologicalSort(releaseSet: Map<string, ReleaseEntry>, graph: DependencyGraph): string[] {
+function topologicalSort(
+  releaseSet: Map<string, ReleaseEntry>,
+  graph: DependencyGraph,
+): { sorted: string[]; cyclicDirs: string[] } {
   const releaseDirs = new Set(releaseSet.keys());
   if (releaseDirs.size === 0) {
-    return [];
+    return { sorted: [], cyclicDirs: [] };
   }
 
   // Build a forward adjacency list (dependency -> dependent) restricted to the release set.
@@ -359,11 +370,14 @@ function topologicalSort(releaseSet: Map<string, ReleaseEntry>, graph: Dependenc
   }
 
   // Append any remaining (cyclic) nodes.
+  const sortedSet = new Set(sorted);
+  const cyclicDirs: string[] = [];
   for (const dir of releaseDirs) {
-    if (!sorted.includes(dir)) {
+    if (!sortedSet.has(dir)) {
       sorted.push(dir);
+      cyclicDirs.push(dir);
     }
   }
 
-  return sorted;
+  return { sorted, cyclicDirs };
 }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -1,56 +1,94 @@
 import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
+import type { DependencyGraph } from './buildDependencyGraph.ts';
+import { buildDependencyGraph } from './buildDependencyGraph.ts';
 import { bumpAllVersions } from './bumpAllVersions.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpFromCommits } from './determineBumpFromCommits.ts';
 import { buildTagPattern, generateChangelog } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
+import type { CurrentVersions, ReleaseEntry } from './propagateBumps.ts';
+import { propagateBumps } from './propagateBumps.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
-import type { Commit, ComponentPrepareResult, MonorepoReleaseConfig, PrepareResult, ReleaseType } from './types.ts';
+import type {
+  Commit,
+  ComponentConfig,
+  ComponentPrepareResult,
+  MonorepoReleaseConfig,
+  PrepareResult,
+  ReleaseType,
+} from './types.ts';
+import { writeSyntheticChangelog } from './writeSyntheticChangelog.ts';
+
+/** Intermediate result from Phase 1 (determine direct bumps). */
+interface DirectBumpResult {
+  component: ComponentConfig;
+  tag: string | undefined;
+  commits: Commit[];
+  releaseType: ReleaseType;
+  parsedCommitCount: number | undefined;
+  unparseableCommits: Commit[] | undefined;
+}
+
+/** Intermediate result for a skipped component. */
+interface SkippedResult {
+  component: ComponentConfig;
+  tag: string | undefined;
+  commitCount: number;
+  parsedCommitCount: number | undefined;
+  unparseableCommits: Commit[] | undefined;
+  skipReason: string;
+}
 
 /**
  * Orchestrate release preparation for a monorepo with multiple components.
  *
- * For each component:
- * 1. Gets path-filtered commits since the last component-specific tag.
- * 2. Determines the bump type from those commits (or uses the override).
- * 3. Bumps all configured package.json version fields.
- * 4. Generates changelogs via git-cliff with `--include-path` filtering.
- *
- * After all components are processed, runs the optional format command once.
- * Returns a structured `PrepareResult` with all data needed for presentation.
+ * Phase 1: Determine direct bumps from commits for each component.
+ * Phase 2: Build the dependency graph and propagate bumps to dependents.
+ * Phase 2b: Topologically sort the full release set.
+ * Phase 3: Execute bumps and generate changelogs in dependency order.
  */
 export function releasePrepareMono(config: MonorepoReleaseConfig, options: ReleasePrepareOptions): PrepareResult {
   const { dryRun, force, bumpOverride } = options;
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
-  const tags: string[] = [];
-  const modifiedFiles: string[] = [];
-  const components: ComponentPrepareResult[] = [];
+
+  // === Phase 1: Determine direct bumps ===
+  const directBumps = new Map<string, ReleaseEntry>();
+  const directResults = new Map<string, DirectBumpResult>();
+  const skippedResults: SkippedResult[] = [];
+  const currentVersions: CurrentVersions = new Map();
 
   for (const component of config.components) {
     const name = component.dir;
-
-    // 1. Get path-filtered commits since last tag
     const { tag, commits } = getCommitsSinceTarget(component.tagPrefix, component.paths);
     const since = tag === undefined ? '(no previous release found)' : `since ${tag}`;
 
+    // Read current version from the first package file.
+    const primaryPackageFile = component.packageFiles[0];
+    if (primaryPackageFile !== undefined) {
+      const currentVersion = readCurrentVersion(primaryPackageFile);
+      if (currentVersion !== undefined) {
+        currentVersions.set(component.dir, currentVersion);
+      }
+    }
+
     // Skip components with no changes unless --force is set.
     if (commits.length === 0 && !force) {
-      components.push({
-        name,
-        status: 'skipped',
-        previousTag: tag,
+      skippedResults.push({
+        component,
+        tag,
         commitCount: 0,
-        bumpedFiles: [],
-        changelogFiles: [],
+        parsedCommitCount: undefined,
+        unparseableCommits: undefined,
         skipReason: `No changes for ${name} ${since}. Skipping.`,
       });
       continue;
     }
 
-    // 2. Determine bump type
+    // Determine bump type.
     let releaseType: ReleaseType | undefined;
     let parsedCommitCount: number | undefined;
     let unparseableCommits: Commit[] | undefined;
@@ -65,54 +103,143 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     }
 
     if (releaseType === undefined) {
-      components.push({
-        name,
-        status: 'skipped',
-        previousTag: tag,
+      skippedResults.push({
+        component,
+        tag,
         commitCount: commits.length,
         parsedCommitCount,
         unparseableCommits,
-        bumpedFiles: [],
-        changelogFiles: [],
         skipReason: `No release-worthy changes for ${name} ${since}. Skipping.`,
       });
       continue;
     }
 
-    // 3. Bump all versions for this component
-    const bump = bumpAllVersions(component.packageFiles, releaseType, dryRun);
+    directBumps.set(component.dir, { releaseType });
+    directResults.set(component.dir, {
+      component,
+      tag,
+      commits,
+      releaseType,
+      parsedCommitCount,
+      unparseableCommits,
+    });
+  }
+
+  // Build a lookup of previous tags for all components (needed for propagated ones).
+  const previousTags = new Map<string, string | undefined>();
+  for (const result of directResults.values()) {
+    previousTags.set(result.component.dir, result.tag);
+  }
+  for (const skipped of skippedResults) {
+    previousTags.set(skipped.component.dir, skipped.tag);
+  }
+
+  // === Phase 2: Build graph and propagate bumps ===
+  const graph = buildDependencyGraph(config.components);
+  const fullReleaseSet = propagateBumps(directBumps, graph, currentVersions);
+
+  // === Phase 2b: Topologically sort the release set ===
+  const sortedDirs = topologicalSort(fullReleaseSet, graph);
+
+  // === Phase 3: Execute bumps and generate changelogs ===
+  const tags: string[] = [];
+  const modifiedFiles: string[] = [];
+  const components: ComponentPrepareResult[] = [];
+
+  // Collect skipped results (excluding components that were added via propagation).
+  for (const skipped of skippedResults) {
+    if (fullReleaseSet.has(skipped.component.dir)) {
+      continue;
+    }
+    components.push({
+      name: skipped.component.dir,
+      status: 'skipped',
+      previousTag: skipped.tag,
+      commitCount: skipped.commitCount,
+      parsedCommitCount: skipped.parsedCommitCount,
+      unparseableCommits: skipped.unparseableCommits,
+      bumpedFiles: [],
+      changelogFiles: [],
+      skipReason: skipped.skipReason,
+    });
+  }
+
+  // Process released components in topological order.
+  const today = new Date().toISOString().slice(0, 10);
+
+  for (const dir of sortedDirs) {
+    const releaseEntry = fullReleaseSet.get(dir);
+    if (releaseEntry === undefined) {
+      continue;
+    }
+
+    const component = findComponent(config.components, dir);
+    if (component === undefined) {
+      continue;
+    }
+
+    // Bump all versions for this component.
+    const bump = bumpAllVersions(component.packageFiles, releaseEntry.releaseType, dryRun);
     const newTag = `${component.tagPrefix}${bump.newVersion}`;
     tags.push(newTag);
     modifiedFiles.push(...component.packageFiles, ...component.changelogPaths.map((p) => `${p}/CHANGELOG.md`));
 
-    // 4. Generate changelogs for each configured path with include-path filtering
+    // Generate changelogs: git-cliff for direct bumps, synthetic for propagation-only.
     const changelogFiles: string[] = [];
-    for (const changelogPath of component.changelogPaths) {
-      changelogFiles.push(
-        ...generateChangelog(config, changelogPath, newTag, dryRun, {
-          tagPattern: buildTagPattern(component.tagPrefix),
-          includePaths: component.paths,
-        }),
-      );
+    const directResult = directResults.get(dir);
+    const isPropagationOnly = directResult === undefined;
+
+    if (isPropagationOnly && releaseEntry.propagatedFrom !== undefined) {
+      // Propagation-only: write synthetic changelog.
+      for (const changelogPath of component.changelogPaths) {
+        changelogFiles.push(
+          writeSyntheticChangelog({
+            changelogPath,
+            newVersion: bump.newVersion,
+            date: today,
+            propagatedFrom: releaseEntry.propagatedFrom,
+            dryRun,
+          }),
+        );
+      }
+    } else {
+      // Direct bump (possibly with propagatedFrom metadata): use git-cliff.
+      for (const changelogPath of component.changelogPaths) {
+        changelogFiles.push(
+          ...generateChangelog(config, changelogPath, newTag, dryRun, {
+            tagPattern: buildTagPattern(component.tagPrefix),
+            includePaths: component.paths,
+          }),
+        );
+      }
     }
 
     components.push({
-      name,
+      name: dir,
       status: 'released',
-      previousTag: tag,
-      commitCount: commits.length,
-      parsedCommitCount,
-      releaseType,
+      previousTag: directResult?.tag ?? previousTags.get(dir),
+      commitCount: directResult?.commits.length ?? 0,
+      parsedCommitCount: directResult?.parsedCommitCount,
+      releaseType: releaseEntry.releaseType,
       currentVersion: bump.currentVersion,
       newVersion: bump.newVersion,
       tag: newTag,
       bumpedFiles: bump.files,
       changelogFiles,
-      unparseableCommits,
+      unparseableCommits: directResult?.unparseableCommits,
+      propagatedFrom: releaseEntry.propagatedFrom,
     });
   }
 
-  // 5. Run format command once after all components are processed, appending modified file paths
+  // Reorder components to match original config order.
+  const configOrder = new Map(config.components.map((c, i) => [c.dir, i]));
+  components.sort((a, b) => {
+    const orderA = a.name === undefined ? 0 : (configOrder.get(a.name) ?? 0);
+    const orderB = b.name === undefined ? 0 : (configOrder.get(b.name) ?? 0);
+    return orderA - orderB;
+  });
+
+  // === Phase 4: Format ===
   const formatCommandStr = config.formatCommand ?? (hasPrettierConfig() ? 'npx prettier --write' : undefined);
   let formatCommand: PrepareResult['formatCommand'];
 
@@ -139,4 +266,104 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     formatCommand,
     dryRun,
   };
+}
+
+/** Find a component by its `dir` in the components array. */
+function findComponent(components: readonly ComponentConfig[], dir: string): ComponentConfig | undefined {
+  return components.find((c) => c.dir === dir);
+}
+
+function hasVersionField(value: unknown): value is { version: string } {
+  return typeof value === 'object' && value !== null && 'version' in value && typeof value.version === 'string';
+}
+
+/** Read the `version` field from a package.json file. */
+function readCurrentVersion(filePath: string): string | undefined {
+  try {
+    const content = readFileSync(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+    if (hasVersionField(parsed)) {
+      return parsed.version;
+    }
+  } catch {
+    // Return undefined if the file can't be read or parsed.
+  }
+  return undefined;
+}
+
+/**
+ * Topologically sort component dirs so dependencies are processed before their dependents.
+ *
+ * Uses Kahn's algorithm. Components not in the release set are excluded. If the graph has
+ * cycles, the remaining nodes are appended in arbitrary order.
+ */
+function topologicalSort(releaseSet: Map<string, ReleaseEntry>, graph: DependencyGraph): string[] {
+  const releaseDirs = new Set(releaseSet.keys());
+  if (releaseDirs.size === 0) {
+    return [];
+  }
+
+  // Build a forward adjacency list (dependency -> dependent) restricted to the release set.
+  const inDegree = new Map<string, number>();
+  const forwardEdges = new Map<string, string[]>();
+
+  for (const dir of releaseDirs) {
+    inDegree.set(dir, 0);
+    forwardEdges.set(dir, []);
+  }
+
+  // For each released component, find its dependencies that are also in the release set.
+  for (const [packageName, dependents] of graph.dependentsOf) {
+    const depDir = graph.packageNameToDir.get(packageName);
+    if (depDir === undefined || !releaseDirs.has(depDir)) {
+      continue;
+    }
+
+    for (const dependent of dependents) {
+      if (!releaseDirs.has(dependent.dir)) {
+        continue;
+      }
+
+      const edges = forwardEdges.get(depDir);
+      if (edges !== undefined) {
+        edges.push(dependent.dir);
+      }
+
+      inDegree.set(dependent.dir, (inDegree.get(dependent.dir) ?? 0) + 1);
+    }
+  }
+
+  // Kahn's algorithm.
+  const queue: string[] = [];
+  for (const [dir, degree] of inDegree) {
+    if (degree === 0) {
+      queue.push(dir);
+    }
+  }
+
+  const sorted: string[] = [];
+  while (queue.length > 0) {
+    const dir = queue.shift();
+    if (dir === undefined) {
+      break;
+    }
+    sorted.push(dir);
+
+    for (const dependent of forwardEdges.get(dir) ?? []) {
+      const newDegree = (inDegree.get(dependent) ?? 1) - 1;
+      inDegree.set(dependent, newDegree);
+      if (newDegree === 0) {
+        queue.push(dependent);
+      }
+    }
+  }
+
+  // Append any remaining (cyclic) nodes.
+  for (const dir of releaseDirs) {
+    if (!sorted.includes(dir)) {
+      sorted.push(dir);
+    }
+  }
+
+  return sorted;
 }

--- a/packages/release-kit/src/reportPrepare.ts
+++ b/packages/release-kit/src/reportPrepare.ts
@@ -141,6 +141,9 @@ function formatMultiComponent(result: PrepareResult): string {
   // Format command
   formatFormatCommand(lines, result);
 
+  // Warnings
+  formatWarnings(lines, result);
+
   // Tag summary
   if (result.tags.length > 0) {
     lines.push(`\n✅ Release preparation complete.`);
@@ -204,6 +207,19 @@ function formatPropagationSuffix(
   }
   const names = propagatedFrom.map((p) => p.packageName).join(', ');
   return `, dependency: ${names}`;
+}
+
+/** Append warning lines when the prepare result includes warnings. */
+function formatWarnings(lines: string[], result: PrepareResult): void {
+  const { warnings } = result;
+  if (warnings === undefined || warnings.length === 0) {
+    return;
+  }
+
+  lines.push('');
+  for (const warning of warnings) {
+    lines.push(`⚠️  ${warning}`);
+  }
 }
 
 /** Append format command lines. */

--- a/packages/release-kit/src/reportPrepare.ts
+++ b/packages/release-kit/src/reportPrepare.ts
@@ -98,10 +98,11 @@ function formatMultiComponent(result: PrepareResult): string {
       continue;
     }
 
-    const isPropagatedOnly = component.propagatedFrom !== undefined && component.commitCount === 0;
+    const { propagatedFrom } = component;
+    const isPropagatedOnly = propagatedFrom !== undefined && component.commitCount === 0;
 
-    if (isPropagatedOnly && component.propagatedFrom !== undefined) {
-      const depNames = component.propagatedFrom.map((p) => p.packageName).join(', ');
+    if (isPropagatedOnly) {
+      const depNames = propagatedFrom.map((p) => p.packageName).join(', ');
       lines.push(dim(`  0 commits (bumped via dependency: ${depNames})`));
     } else if (component.parsedCommitCount !== undefined) {
       lines.push(dim(`  Parsed ${component.parsedCommitCount} typed commits`));
@@ -122,7 +123,7 @@ function formatMultiComponent(result: PrepareResult): string {
       component.newVersion !== undefined &&
       component.releaseType !== undefined
     ) {
-      const suffix = isPropagatedOnly ? formatPropagationSuffix(component.propagatedFrom) : '';
+      const suffix = isPropagatedOnly ? formatPropagationSuffix(propagatedFrom) : '';
       lines.push(
         `  📦 ${component.currentVersion} → ${bold(component.newVersion)} (${component.releaseType}${suffix})`,
       );

--- a/packages/release-kit/src/reportPrepare.ts
+++ b/packages/release-kit/src/reportPrepare.ts
@@ -98,13 +98,18 @@ function formatMultiComponent(result: PrepareResult): string {
       continue;
     }
 
-    if (component.parsedCommitCount !== undefined) {
+    const isPropagatedOnly = component.propagatedFrom !== undefined && component.commitCount === 0;
+
+    if (isPropagatedOnly && component.propagatedFrom !== undefined) {
+      const depNames = component.propagatedFrom.map((p) => p.packageName).join(', ');
+      lines.push(dim(`  0 commits (bumped via dependency: ${depNames})`));
+    } else if (component.parsedCommitCount !== undefined) {
       lines.push(dim(`  Parsed ${component.parsedCommitCount} typed commits`));
     }
 
     formatUnparseableWarning(lines, component, '  ');
 
-    if (component.parsedCommitCount === undefined && component.releaseType !== undefined) {
+    if (component.parsedCommitCount === undefined && component.releaseType !== undefined && !isPropagatedOnly) {
       lines.push(`  Using bump override: ${component.releaseType}`);
     }
 
@@ -117,7 +122,10 @@ function formatMultiComponent(result: PrepareResult): string {
       component.newVersion !== undefined &&
       component.releaseType !== undefined
     ) {
-      lines.push(`  📦 ${component.currentVersion} → ${bold(component.newVersion)} (${component.releaseType})`);
+      const suffix = isPropagatedOnly ? formatPropagationSuffix(component.propagatedFrom) : '';
+      lines.push(
+        `  📦 ${component.currentVersion} → ${bold(component.newVersion)} (${component.releaseType}${suffix})`,
+      );
     }
 
     formatBumpFiles(lines, component, result.dryRun, '  ');
@@ -184,6 +192,17 @@ function formatUnparseableWarning(lines: string[], component: ComponentPrepareRe
     const truncatedMessage = commit.message.length > 72 ? `${commit.message.slice(0, 69)}...` : commit.message;
     lines.push(`${indent}    · ${shortHash} ${truncatedMessage}`);
   }
+}
+
+/** Format the propagation suffix for the version bump line (e.g., `, dependency: core`). */
+function formatPropagationSuffix(
+  propagatedFrom: Array<{ packageName: string; newVersion: string }> | undefined,
+): string {
+  if (propagatedFrom === undefined || propagatedFrom.length === 0) {
+    return '';
+  }
+  const names = propagatedFrom.map((p) => p.packageName).join(', ');
+  return `, dependency: ${names}`;
 }
 
 /** Append format command lines. */

--- a/packages/release-kit/src/reportPrepare.ts
+++ b/packages/release-kit/src/reportPrepare.ts
@@ -1,5 +1,5 @@
 import { bold, dim, sectionHeader } from './format.ts';
-import type { ComponentPrepareResult, PrepareResult } from './types.ts';
+import type { ComponentPrepareResult, PrepareResult, PropagationSource } from './types.ts';
 
 /**
  * Format a `PrepareResult` into styled terminal output.
@@ -199,9 +199,7 @@ function formatUnparseableWarning(lines: string[], component: ComponentPrepareRe
 }
 
 /** Format the propagation suffix for the version bump line (e.g., `, dependency: core`). */
-function formatPropagationSuffix(
-  propagatedFrom: Array<{ packageName: string; newVersion: string }> | undefined,
-): string {
+function formatPropagationSuffix(propagatedFrom: PropagationSource[] | undefined): string {
   if (propagatedFrom === undefined || propagatedFrom.length === 0) {
     return '';
   }

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -41,6 +41,8 @@ export interface PrepareResult {
       }
     | undefined;
   dryRun: boolean;
+  /** Warnings surfaced during preparation (e.g., circular dependency detection). */
+  warnings?: string[] | undefined;
 }
 
 /** Configuration for a single work type used in commit categorization. */

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -1,6 +1,12 @@
 /** Semver release type for version bumping. */
 export type ReleaseType = 'major' | 'minor' | 'patch';
 
+/** Identifies a dependency whose version bump triggered a propagated release. */
+export interface PropagationSource {
+  packageName: string;
+  newVersion: string;
+}
+
 /** Structured result from bumping version fields in package.json files. */
 export interface BumpResult {
   currentVersion: string;
@@ -25,7 +31,7 @@ export interface ComponentPrepareResult {
   /** Commits that could not be parsed into a recognized work type. */
   unparseableCommits?: Commit[] | undefined;
   /** Dependencies that triggered a propagated bump (present for propagated or mixed components). */
-  propagatedFrom?: Array<{ packageName: string; newVersion: string }> | undefined;
+  propagatedFrom?: PropagationSource[] | undefined;
   skipReason?: string | undefined;
 }
 

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -24,6 +24,8 @@ export interface ComponentPrepareResult {
   changelogFiles: string[];
   /** Commits that could not be parsed into a recognized work type. */
   unparseableCommits?: Commit[] | undefined;
+  /** Dependencies that triggered a propagated bump (present for propagated or mixed components). */
+  propagatedFrom?: Array<{ packageName: string; newVersion: string }> | undefined;
   skipReason?: string | undefined;
 }
 

--- a/packages/release-kit/src/writeSyntheticChangelog.ts
+++ b/packages/release-kit/src/writeSyntheticChangelog.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+/** Parameters for writing a synthetic changelog entry for propagated bumps. */
+export interface WriteSyntheticChangelogParams {
+  changelogPath: string;
+  newVersion: string;
+  date: string;
+  propagatedFrom: Array<{ packageName: string; newVersion: string }>;
+  dryRun?: boolean;
+}
+
+/**
+ * Prepend a synthetic changelog section for components bumped via dependency propagation.
+ *
+ * Creates the changelog file if it doesn't exist. Each propagated dependency is listed as
+ * a bullet under a "Dependency updates" heading. Returns the changelog file path.
+ */
+export function writeSyntheticChangelog(params: WriteSyntheticChangelogParams): string {
+  const { changelogPath, newVersion, date, propagatedFrom, dryRun } = params;
+  const filePath = `${changelogPath}/CHANGELOG.md`;
+
+  const bullets = propagatedFrom.map((dep) => `- Bumped \`${dep.packageName}\` to ${dep.newVersion}`).join('\n');
+
+  const section = `## ${newVersion} — ${date}\n\n### Dependency updates\n\n${bullets}\n`;
+
+  if (dryRun) {
+    return filePath;
+  }
+
+  let existingContent = '';
+  if (existsSync(filePath)) {
+    existingContent = readFileSync(filePath, 'utf8');
+  }
+
+  const newContent = existingContent.length > 0 ? `${section}\n${existingContent}` : `${section}\n`;
+
+  writeFileSync(filePath, newContent, 'utf8');
+
+  return filePath;
+}

--- a/packages/release-kit/src/writeSyntheticChangelog.ts
+++ b/packages/release-kit/src/writeSyntheticChangelog.ts
@@ -1,11 +1,13 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
+import type { PropagationSource } from './types.ts';
+
 /** Parameters for writing a synthetic changelog entry for propagated bumps. */
 export interface WriteSyntheticChangelogParams {
   changelogPath: string;
   newVersion: string;
   date: string;
-  propagatedFrom: Array<{ packageName: string; newVersion: string }>;
+  propagatedFrom: PropagationSource[];
   dryRun?: boolean;
 }
 


### PR DESCRIPTION
Closes #72 

## What

Restructures `releasePrepareMono` from a single-pass loop into a phased pipeline that automatically patch-bumps workspace dependents when a component is released. A reverse dependency graph is built from `workspace:` references in `dependencies` and `peerDependencies`, then BFS propagation walks upward from bumped components to their dependents. Propagated-only components receive synthetic changelog entries instead of git-cliff invocations.

## Why

When `release-kit prepare` bumped a workspace dependency (e.g., `core`), packages depending on it via `workspace:*` were not automatically bumped. Their published `package.json` declared stale dependency versions until independently released, so consumers didn't pick up fixes or features transitively.

## Details

### Features

- Dependency graph builder (`buildDependencyGraph.ts`) reads `workspace:` references from each component's `package.json` and constructs a reverse adjacency map with bidirectional name/dir lookups.
- Bump propagation engine (`propagateBumps.ts`) uses BFS to walk upward through dependents, adding `patch` bumps while respecting bump priority (`major > minor > patch`). Tracks `propagatedFrom` metadata with dependency name and resolved version.
- Synthetic changelog writer (`writeSyntheticChangelog.ts`) prepends "Dependency updates" sections for propagated-only components.
- `releasePrepareMono` restructured into four phases: determine direct bumps → build graph and propagate → topologically sort (Kahn's algorithm) → execute in dependency order.
- `reportPrepare` distinguishes propagated bumps in terminal output with "bumped via dependency" annotations.
- Circular dependency detection with user-facing warnings via `PrepareResult.warnings`.

### Fixes

- Topological sort cycle fallback replaced `Array.includes` with `Set.has` for O(1) lookups.

### Refactoring

- Extracted `PropagationSource` named type to replace repeated `{ packageName: string; newVersion: string }` inline shape across three interfaces.
- Removed dead `componentPackageNames` map that caused each `package.json` to be parsed twice.
- Added `dirToPackageName` inverse map to eliminate O(n) reverse lookups during BFS.
- Extracted `determineDirectBumps`, `collectSkippedComponents`, `executeReleaseSet`, and `runFormatCommand` from `releasePrepareMono` to resolve complexity lint violation (37 → under 20).

### Tests

- 25 new unit tests across 5 test files covering: dependency graph construction, BFS propagation (single-level, transitive, no-downgrade, circular, mixed, multiple triggers), synthetic changelog formatting (create, prepend, dry-run, multiple deps), integration scenarios in `releasePrepareMono`, and propagated-component reporting with warnings.

## Test plan

- [ ] Manual dry-run: `pnpm exec release-kit prepare --dry-run` shows propagation from `core` to `release-kit` and `preflight`
- [ ] Verify synthetic changelog format matches spec
- [ ] Verify `--only` filter correctly limits propagation scope