### PR TITLE
#73 Support conventional commit format in commit parsing

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -43,19 +43,20 @@ commit_preprocessors = [
   { pattern = '^[A-Z]+-\d+\s+', replace = "" },
 ]
 # regex for parsing and grouping commits
-# Supports both "type: description" and "workspace|type: description" formats
+# Supports "type: desc", "scope|type: desc", and "type(scope): desc" formats
 commit_parsers = [
-  { message = "^.*\\|?fix(!)?:", group = "Bug fixes" },
-  { message = "^.*\\|?feat(!)?:", group = "Features" },
-  { message = "^.*\\|?feature(!)?:", group = "Features" },
-  { message = "^.*\\|?internal(!)?:", group = "Internal" },
-  { message = "^.*\\|?refactor(!)?:", group = "Refactoring" },
-  { message = "^.*\\|?tests?(!)?:", group = "Tests" },
-  { message = "^.*\\|?tooling(!)?:", group = "Tooling" },
-  { message = "^.*\\|?ci(!)?:", group = "CI" },
-  { message = "^.*\\|?deps?(!)?:", group = "Dependencies" },
-  { message = "^.*\\|?docs?(!)?:", group = "Documentation" },
-  { message = "^.*\\|?fmt(!)?:", group = "Formatting" },
+  { message = "^(.*\\|)?fix(\\(.*\\))?(!)?:", group = "Bug fixes" },
+  { message = "^(.*\\|)?bugfix(\\(.*\\))?(!)?:", group = "Bug fixes" },
+  { message = "^(.*\\|)?feat(\\(.*\\))?(!)?:", group = "Features" },
+  { message = "^(.*\\|)?feature(\\(.*\\))?(!)?:", group = "Features" },
+  { message = "^(.*\\|)?internal(\\(.*\\))?(!)?:", group = "Internal" },
+  { message = "^(.*\\|)?refactor(\\(.*\\))?(!)?:", group = "Refactoring" },
+  { message = "^(.*\\|)?tests?(\\(.*\\))?(!)?:", group = "Tests" },
+  { message = "^(.*\\|)?tooling(\\(.*\\))?(!)?:", group = "Tooling" },
+  { message = "^(.*\\|)?ci(\\(.*\\))?(!)?:", group = "CI" },
+  { message = "^(.*\\|)?deps?(\\(.*\\))?(!)?:", group = "Dependencies" },
+  { message = "^(.*\\|)?docs?(\\(.*\\))?(!)?:", group = "Documentation" },
+  { message = "^(.*\\|)?fmt(\\(.*\\))?(!)?:", group = "Formatting" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false

--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -154,7 +154,6 @@ release-kit parses commits in these formats:
 
 ```
 type: description              # e.g., feat: add utility
-type(scope): description       # e.g., fix(parser): handle edge case
 scope|type: description        # e.g., arrays|feat: add compact function
 type(scope): description       # e.g., feat(arrays): add compact function
 type!: description             # breaking change (triggers major bump)

--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -98,14 +98,14 @@ The config file supports both `export default config` and `export const config =
 
 ### `ReleaseKitConfig` reference
 
-| Field              | Type                             | Description                                                                                                                   |
-| ------------------ | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `cliffConfigPath`  | `string`                         | Explicit path to cliff config. If omitted, resolved automatically: `.config/git-cliff.toml` → `cliff.toml` → bundled template |
-| `components`       | `ComponentOverride[]`            | Override or exclude discovered components (matched by `dir`)                                                                  |
-| `formatCommand`    | `string`                         | Shell command to run after changelog generation; modified file paths are appended as arguments                                |
-| `versionPatterns`  | `VersionPatterns`                | Rules for which commit types trigger major/minor bumps                                                                        |
-| `workspaceAliases` | `Record<string, string>`         | Maps shorthand workspace names to canonical names in commits                                                                  |
-| `workTypes`        | `Record<string, WorkTypeConfig>` | Work type definitions, merged with defaults by key                                                                            |
+| Field             | Type                             | Description                                                                                                                   |
+| ----------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `cliffConfigPath` | `string`                         | Explicit path to cliff config. If omitted, resolved automatically: `.config/git-cliff.toml` → `cliff.toml` → bundled template |
+| `components`      | `ComponentOverride[]`            | Override or exclude discovered components (matched by `dir`)                                                                  |
+| `formatCommand`   | `string`                         | Shell command to run after changelog generation; modified file paths are appended as arguments                                |
+| `versionPatterns` | `VersionPatterns`                | Rules for which commit types trigger major/minor bumps                                                                        |
+| `scopeAliases`    | `Record<string, string>`         | Maps shorthand scope names to canonical names in commits                                                                      |
+| `workTypes`       | `Record<string, WorkTypeConfig>` | Work type definitions, merged with defaults by key                                                                            |
 
 All fields are optional.
 
@@ -155,11 +155,14 @@ release-kit parses commits in these formats:
 ```
 type: description              # e.g., feat: add utility
 type(scope): description       # e.g., fix(parser): handle edge case
-workspace|type: description    # e.g., arrays|feat: add compact function
-!type: description             # breaking change (triggers major bump)
+scope|type: description        # e.g., arrays|feat: add compact function
+type(scope): description       # e.g., feat(arrays): add compact function
+type!: description             # breaking change (triggers major bump)
+scope|type!: description       # scoped breaking change
+type(scope)!: description      # conventional scoped breaking change
 ```
 
-The `workspace|type:` format scopes a commit to a specific workspace in a monorepo. Use `workspaceAliases` in your config to map shorthand names to canonical workspace names.
+The `scope|type:` format scopes a commit to a specific component in a monorepo. Use `scopeAliases` in your config to map shorthand names to canonical scope names.
 
 ## Using `component()` for manual configuration
 

--- a/packages/release-kit/cliff.toml.template
+++ b/packages/release-kit/cliff.toml.template
@@ -45,19 +45,20 @@ commit_preprocessors = [
   { pattern = '^[A-Z]+-\d+\s+', replace = "" },
 ]
 # regex for parsing and grouping commits
-# Supports both "type: description" and "workspace|type: description" formats
+# Supports "type: desc", "scope|type: desc", and "type(scope): desc" formats
 commit_parsers = [
-  { message = "^.*\\|?fix(!)?:", group = "Bug fixes" },
-  { message = "^.*\\|?feat(!)?:", group = "Features" },
-  { message = "^.*\\|?feature(!)?:", group = "Features" },
-  { message = "^.*\\|?internal(!)?:", group = "Internal" },
-  { message = "^.*\\|?refactor(!)?:", group = "Refactoring" },
-  { message = "^.*\\|?tests?(!)?:", group = "Tests" },
-  { message = "^.*\\|?tooling(!)?:", group = "Tooling" },
-  { message = "^.*\\|?ci(!)?:", group = "CI" },
-  { message = "^.*\\|?deps?(!)?:", group = "Dependencies" },
-  { message = "^.*\\|?docs?(!)?:", group = "Documentation" },
-  { message = "^.*\\|?fmt(!)?:", group = "Formatting" },
+  { message = "^(.*\\|)?fix(\\(.*\\))?(!)?:", group = "Bug fixes" },
+  { message = "^(.*\\|)?bugfix(\\(.*\\))?(!)?:", group = "Bug fixes" },
+  { message = "^(.*\\|)?feat(\\(.*\\))?(!)?:", group = "Features" },
+  { message = "^(.*\\|)?feature(\\(.*\\))?(!)?:", group = "Features" },
+  { message = "^(.*\\|)?internal(\\(.*\\))?(!)?:", group = "Internal" },
+  { message = "^(.*\\|)?refactor(\\(.*\\))?(!)?:", group = "Refactoring" },
+  { message = "^(.*\\|)?tests?(\\(.*\\))?(!)?:", group = "Tests" },
+  { message = "^(.*\\|)?tooling(\\(.*\\))?(!)?:", group = "Tooling" },
+  { message = "^(.*\\|)?ci(\\(.*\\))?(!)?:", group = "CI" },
+  { message = "^(.*\\|)?deps?(\\(.*\\))?(!)?:", group = "Dependencies" },
+  { message = "^(.*\\|)?docs?(\\(.*\\))?(!)?:", group = "Documentation" },
+  { message = "^(.*\\|)?fmt(\\(.*\\))?(!)?:", group = "Formatting" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false

--- a/packages/release-kit/src/__tests__/cliffConfigAlignment.unit.test.ts
+++ b/packages/release-kit/src/__tests__/cliffConfigAlignment.unit.test.ts
@@ -90,10 +90,72 @@ describe('cliff.toml.template alignment with DEFAULT_WORK_TYPES', () => {
   const expectedTypes = getExpectedTypes();
   const knownHeaders = getKnownHeaders();
 
-  describe('every work type and alias is matched by a commit parser', () => {
+  describe('every work type and alias is matched by a commit parser (bare format)', () => {
     for (const { typeName, header } of expectedTypes) {
-      it(`"${typeName}" is matched and grouped as "${header}"`, () => {
+      it(`"${typeName}: test" is matched and grouped as "${header}"`, () => {
         const syntheticMessage = `${typeName}: test`;
+        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
+
+        if (matchingParser === undefined) {
+          expect.fail(`No commit parser matches "${syntheticMessage}"`);
+        }
+        expect(matchingParser.group).toBe(header);
+      });
+    }
+  });
+
+  describe('every work type is matched in pipe-prefixed scope format', () => {
+    for (const { typeName, header } of expectedTypes) {
+      it(`"scope|${typeName}: test" is matched and grouped as "${header}"`, () => {
+        const syntheticMessage = `scope|${typeName}: test`;
+        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
+
+        if (matchingParser === undefined) {
+          expect.fail(`No commit parser matches "${syntheticMessage}"`);
+        }
+        expect(matchingParser.group).toBe(header);
+      });
+    }
+  });
+
+  describe('every work type is matched in conventional commit format', () => {
+    for (const { typeName, header } of expectedTypes) {
+      it(`"${typeName}(scope): test" is matched and grouped as "${header}"`, () => {
+        const syntheticMessage = `${typeName}(scope): test`;
+        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
+
+        if (matchingParser === undefined) {
+          expect.fail(`No commit parser matches "${syntheticMessage}"`);
+        }
+        expect(matchingParser.group).toBe(header);
+      });
+    }
+  });
+
+  describe('breaking variants are matched in all formats', () => {
+    for (const { typeName, header } of expectedTypes) {
+      it(`"${typeName}!: test" (bare breaking) is matched as "${header}"`, () => {
+        const syntheticMessage = `${typeName}!: test`;
+        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
+
+        if (matchingParser === undefined) {
+          expect.fail(`No commit parser matches "${syntheticMessage}"`);
+        }
+        expect(matchingParser.group).toBe(header);
+      });
+
+      it(`"${typeName}(scope)!: test" (conventional breaking) is matched as "${header}"`, () => {
+        const syntheticMessage = `${typeName}(scope)!: test`;
+        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
+
+        if (matchingParser === undefined) {
+          expect.fail(`No commit parser matches "${syntheticMessage}"`);
+        }
+        expect(matchingParser.group).toBe(header);
+      });
+
+      it(`"scope|${typeName}!: test" (pipe breaking) is matched as "${header}"`, () => {
+        const syntheticMessage = `scope|${typeName}!: test`;
         const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
 
         if (matchingParser === undefined) {

--- a/packages/release-kit/src/__tests__/cliffConfigAlignment.unit.test.ts
+++ b/packages/release-kit/src/__tests__/cliffConfigAlignment.unit.test.ts
@@ -90,16 +90,19 @@ describe('cliff.toml.template alignment with DEFAULT_WORK_TYPES', () => {
   const expectedTypes = getExpectedTypes();
   const knownHeaders = getKnownHeaders();
 
+  /** Assert that a synthetic commit message is matched by a parser and grouped under the expected header. */
+  function assertParsedAs(message: string, expectedGroup: string): void {
+    const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(message));
+    if (matchingParser === undefined) {
+      expect.fail(`No commit parser matches "${message}"`);
+    }
+    expect(matchingParser.group).toBe(expectedGroup);
+  }
+
   describe('every work type and alias is matched by a commit parser (bare format)', () => {
     for (const { typeName, header } of expectedTypes) {
       it(`"${typeName}: test" is matched and grouped as "${header}"`, () => {
-        const syntheticMessage = `${typeName}: test`;
-        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
-
-        if (matchingParser === undefined) {
-          expect.fail(`No commit parser matches "${syntheticMessage}"`);
-        }
-        expect(matchingParser.group).toBe(header);
+        assertParsedAs(`${typeName}: test`, header);
       });
     }
   });
@@ -107,13 +110,7 @@ describe('cliff.toml.template alignment with DEFAULT_WORK_TYPES', () => {
   describe('every work type is matched in pipe-prefixed scope format', () => {
     for (const { typeName, header } of expectedTypes) {
       it(`"scope|${typeName}: test" is matched and grouped as "${header}"`, () => {
-        const syntheticMessage = `scope|${typeName}: test`;
-        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
-
-        if (matchingParser === undefined) {
-          expect.fail(`No commit parser matches "${syntheticMessage}"`);
-        }
-        expect(matchingParser.group).toBe(header);
+        assertParsedAs(`scope|${typeName}: test`, header);
       });
     }
   });
@@ -121,13 +118,7 @@ describe('cliff.toml.template alignment with DEFAULT_WORK_TYPES', () => {
   describe('every work type is matched in conventional commit format', () => {
     for (const { typeName, header } of expectedTypes) {
       it(`"${typeName}(scope): test" is matched and grouped as "${header}"`, () => {
-        const syntheticMessage = `${typeName}(scope): test`;
-        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
-
-        if (matchingParser === undefined) {
-          expect.fail(`No commit parser matches "${syntheticMessage}"`);
-        }
-        expect(matchingParser.group).toBe(header);
+        assertParsedAs(`${typeName}(scope): test`, header);
       });
     }
   });
@@ -135,33 +126,15 @@ describe('cliff.toml.template alignment with DEFAULT_WORK_TYPES', () => {
   describe('breaking variants are matched in all formats', () => {
     for (const { typeName, header } of expectedTypes) {
       it(`"${typeName}!: test" (bare breaking) is matched as "${header}"`, () => {
-        const syntheticMessage = `${typeName}!: test`;
-        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
-
-        if (matchingParser === undefined) {
-          expect.fail(`No commit parser matches "${syntheticMessage}"`);
-        }
-        expect(matchingParser.group).toBe(header);
+        assertParsedAs(`${typeName}!: test`, header);
       });
 
       it(`"${typeName}(scope)!: test" (conventional breaking) is matched as "${header}"`, () => {
-        const syntheticMessage = `${typeName}(scope)!: test`;
-        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
-
-        if (matchingParser === undefined) {
-          expect.fail(`No commit parser matches "${syntheticMessage}"`);
-        }
-        expect(matchingParser.group).toBe(header);
+        assertParsedAs(`${typeName}(scope)!: test`, header);
       });
 
       it(`"scope|${typeName}!: test" (pipe breaking) is matched as "${header}"`, () => {
-        const syntheticMessage = `scope|${typeName}!: test`;
-        const matchingParser = parsers.find((parser) => new RegExp(parser.message).test(syntheticMessage));
-
-        if (matchingParser === undefined) {
-          expect.fail(`No commit parser matches "${syntheticMessage}"`);
-        }
-        expect(matchingParser.group).toBe(header);
+        assertParsedAs(`scope|${typeName}!: test`, header);
       });
     }
   });

--- a/packages/release-kit/src/__tests__/determineBumpFromCommits.unit.test.ts
+++ b/packages/release-kit/src/__tests__/determineBumpFromCommits.unit.test.ts
@@ -108,8 +108,8 @@ describe(determineBumpFromCommits, () => {
     });
   });
 
-  describe('workspace alias resolution', () => {
-    it('passes workspace aliases through to parseCommitMessage', () => {
+  describe('scope alias resolution', () => {
+    it('passes scope aliases through to parseCommitMessage', () => {
       const aliases = { rk: 'release-kit' };
       const commits = [makeCommit('rk|feat: add thing')];
       const result = determineBumpFromCommits(commits, workTypes, versionPatterns, aliases);

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -176,12 +176,12 @@ describe(mergeMonorepoConfig, () => {
     expect(result.cliffConfigPath).toBe('custom/cliff.toml');
   });
 
-  it('passes through workspaceAliases from config', () => {
+  it('passes through scopeAliases from config', () => {
     const result = mergeMonorepoConfig(discoveredPaths, {
-      workspaceAliases: { api: 'backend-api' },
+      scopeAliases: { api: 'backend-api' },
     });
 
-    expect(result.workspaceAliases).toStrictEqual({ api: 'backend-api' });
+    expect(result.scopeAliases).toStrictEqual({ api: 'backend-api' });
   });
 });
 
@@ -216,11 +216,11 @@ describe(mergeSinglePackageConfig, () => {
     const result = mergeSinglePackageConfig({
       formatCommand: 'pnpm run fmt',
       cliffConfigPath: 'custom/cliff.toml',
-      workspaceAliases: { api: 'backend-api' },
+      scopeAliases: { api: 'backend-api' },
     });
 
     expect(result.formatCommand).toBe('pnpm run fmt');
     expect(result.cliffConfigPath).toBe('custom/cliff.toml');
-    expect(result.workspaceAliases).toStrictEqual({ api: 'backend-api' });
+    expect(result.scopeAliases).toStrictEqual({ api: 'backend-api' });
   });
 });

--- a/packages/release-kit/src/__tests__/parseCommitMessage.unit.test.ts
+++ b/packages/release-kit/src/__tests__/parseCommitMessage.unit.test.ts
@@ -22,14 +22,14 @@ describe(parseCommitMessage, () => {
     });
   });
 
-  it('parses a "workspace|type: description" message', () => {
+  it('parses a "scope|type: description" message', () => {
     const result = parseCommitMessage('web|fix: resolve navbar bug', 'def456', workTypes);
     expect(result).toStrictEqual({
       message: 'web|fix: resolve navbar bug',
       hash: 'def456',
       type: 'fix',
       description: 'resolve navbar bug',
-      workspace: 'web',
+      scope: 'web',
       breaking: false,
     });
   });
@@ -45,14 +45,14 @@ describe(parseCommitMessage, () => {
     });
   });
 
-  it('resolves an alias in workspace format', () => {
+  it('resolves an alias in scope|type format', () => {
     const result = parseCommitMessage('api|bugfix: fix timeout', 'jkl012', workTypes);
     expect(result).toStrictEqual({
       message: 'api|bugfix: fix timeout',
       hash: 'jkl012',
       type: 'fix',
       description: 'fix timeout',
-      workspace: 'api',
+      scope: 'api',
       breaking: false,
     });
   });
@@ -117,14 +117,14 @@ describe(parseCommitMessage, () => {
     });
   });
 
-  it('parses a workspace prefix combined with a breaking change marker', () => {
+  it('parses a scope prefix combined with a breaking change marker', () => {
     const result = parseCommitMessage('api|feat!: redesign endpoint', 'combo1', workTypes);
     expect(result).toStrictEqual({
       message: 'api|feat!: redesign endpoint',
       hash: 'combo1',
       type: 'feat',
       description: 'redesign endpoint',
-      workspace: 'api',
+      scope: 'api',
       breaking: true,
     });
   });
@@ -152,14 +152,14 @@ describe(parseCommitMessage, () => {
       });
     });
 
-    it('strips a ticket prefix with workspace format', () => {
+    it('strips a ticket prefix with scope|type format', () => {
       const result = parseCommitMessage('#8 web|feat: add thing', 'tp3', workTypes);
       expect(result).toStrictEqual({
         message: '#8 web|feat: add thing',
         hash: 'tp3',
         type: 'feat',
         description: 'add thing',
-        workspace: 'web',
+        scope: 'web',
         breaking: false,
       });
     });
@@ -181,56 +181,132 @@ describe(parseCommitMessage, () => {
     });
   });
 
-  describe('workspace alias resolution', () => {
+  describe('conventional commit format — type(scope): description', () => {
+    it('parses a "type(scope): description" message', () => {
+      const result = parseCommitMessage('fix(parser): handle edge case', 'cc1', workTypes);
+      expect(result).toStrictEqual({
+        message: 'fix(parser): handle edge case',
+        hash: 'cc1',
+        type: 'fix',
+        description: 'handle edge case',
+        scope: 'parser',
+        breaking: false,
+      });
+    });
+
+    it('parses a breaking change with parenthesized scope', () => {
+      const result = parseCommitMessage('feat(api)!: redesign endpoint', 'cc2', workTypes);
+      expect(result).toStrictEqual({
+        message: 'feat(api)!: redesign endpoint',
+        hash: 'cc2',
+        type: 'feat',
+        description: 'redesign endpoint',
+        scope: 'api',
+        breaking: true,
+      });
+    });
+
+    it('resolves an alias with parenthesized scope', () => {
+      const result = parseCommitMessage('feature(web): add dashboard', 'cc3', workTypes);
+      expect(result).toStrictEqual({
+        message: 'feature(web): add dashboard',
+        hash: 'cc3',
+        type: 'feat',
+        description: 'add dashboard',
+        scope: 'web',
+        breaking: false,
+      });
+    });
+
+    it('strips a ticket prefix with conventional format', () => {
+      const result = parseCommitMessage('#42 fix(core): patch null check', 'cc4', workTypes);
+      expect(result).toStrictEqual({
+        message: '#42 fix(core): patch null check',
+        hash: 'cc4',
+        type: 'fix',
+        description: 'patch null check',
+        scope: 'core',
+        breaking: false,
+      });
+    });
+
+    it('resolves scope aliases in conventional format', () => {
+      const aliases: Record<string, string> = { api: 'backend-api' };
+      const result = parseCommitMessage('fix(api): fix timeout', 'cc5', workTypes, aliases);
+      expect(result).toStrictEqual({
+        message: 'fix(api): fix timeout',
+        hash: 'cc5',
+        type: 'fix',
+        description: 'fix timeout',
+        scope: 'backend-api',
+        breaking: false,
+      });
+    });
+
+    it('gives pipe scope precedence over parenthesized scope', () => {
+      // Edge case: both formats present — pipe scope wins
+      const result = parseCommitMessage('web|feat(other): add thing', 'cc6', workTypes);
+      expect(result).toStrictEqual({
+        message: 'web|feat(other): add thing',
+        hash: 'cc6',
+        type: 'feat',
+        description: 'add thing',
+        scope: 'web',
+        breaking: false,
+      });
+    });
+  });
+
+  describe('scope alias resolution', () => {
     const aliases: Record<string, string> = {
       api: 'backend-api',
       web: 'frontend-web',
     };
 
-    it('resolves a workspace alias to its canonical name', () => {
+    it('resolves a scope alias to its canonical name', () => {
       const result = parseCommitMessage('api|fix: fix timeout', 'ws1', workTypes, aliases);
       expect(result).toStrictEqual({
         message: 'api|fix: fix timeout',
         hash: 'ws1',
         type: 'fix',
         description: 'fix timeout',
-        workspace: 'backend-api',
+        scope: 'backend-api',
         breaking: false,
       });
     });
 
-    it('passes through an unknown workspace unchanged', () => {
+    it('passes through an unknown scope unchanged', () => {
       const result = parseCommitMessage('mobile|feat: add splash screen', 'ws2', workTypes, aliases);
       expect(result).toStrictEqual({
         message: 'mobile|feat: add splash screen',
         hash: 'ws2',
         type: 'feat',
         description: 'add splash screen',
-        workspace: 'mobile',
+        scope: 'mobile',
         breaking: false,
       });
     });
 
-    it('does not resolve workspace aliases when no alias map is provided', () => {
+    it('does not resolve scope aliases when no alias map is provided', () => {
       const result = parseCommitMessage('api|fix: fix timeout', 'ws3', workTypes);
       expect(result).toStrictEqual({
         message: 'api|fix: fix timeout',
         hash: 'ws3',
         type: 'fix',
         description: 'fix timeout',
-        workspace: 'api',
+        scope: 'api',
         breaking: false,
       });
     });
 
-    it('resolves workspace alias with breaking change marker', () => {
+    it('resolves scope alias with breaking change marker', () => {
       const result = parseCommitMessage('web|feat!: redesign layout', 'ws4', workTypes, aliases);
       expect(result).toStrictEqual({
         message: 'web|feat!: redesign layout',
         hash: 'ws4',
         type: 'feat',
         description: 'redesign layout',
-        workspace: 'frontend-web',
+        scope: 'frontend-web',
         breaking: true,
       });
     });

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -149,15 +149,15 @@ describe(validateConfig, () => {
       expect(config.cliffConfigPath).toBe('custom/cliff.toml');
     });
 
-    it('validates workspaceAliases as a string record', () => {
-      const { config, errors } = validateConfig({ workspaceAliases: { api: 'backend-api' } });
+    it('validates scopeAliases as a string record', () => {
+      const { config, errors } = validateConfig({ scopeAliases: { api: 'backend-api' } });
       expect(errors).toStrictEqual([]);
-      expect(config.workspaceAliases).toStrictEqual({ api: 'backend-api' });
+      expect(config.scopeAliases).toStrictEqual({ api: 'backend-api' });
     });
 
-    it('returns an error when workspaceAliases values are not strings', () => {
-      const { errors } = validateConfig({ workspaceAliases: { api: 123 } });
-      expect(errors).toContain('workspaceAliases.api: value must be a string');
+    it('returns an error when scopeAliases values are not strings', () => {
+      const { errors } = validateConfig({ scopeAliases: { api: 123 } });
+      expect(errors).toContain('scopeAliases.api: value must be a string');
     });
   });
 });

--- a/packages/release-kit/src/determineBumpFromCommits.ts
+++ b/packages/release-kit/src/determineBumpFromCommits.ts
@@ -14,13 +14,13 @@ export function determineBumpFromCommits(
   commits: Commit[],
   workTypes: Record<string, WorkTypeConfig>,
   versionPatterns: VersionPatterns,
-  workspaceAliases: Record<string, string> | undefined,
+  scopeAliases: Record<string, string> | undefined,
 ): BumpDetermination {
   const parsedCommits: ParsedCommit[] = [];
   const unparseable: Commit[] = [];
 
   for (const commit of commits) {
-    const parsed = parseCommitMessage(commit.message, commit.hash, workTypes, workspaceAliases);
+    const parsed = parseCommitMessage(commit.message, commit.hash, workTypes, scopeAliases);
     if (parsed === undefined) {
       unparseable.push(commit);
     } else {

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -49,7 +49,7 @@ export async function loadConfig(): Promise<unknown> {
  *   removes the component; unlisted packages keep defaults.
  * - `workTypes`: shallow merge — consumer entries override or add to defaults by key.
  * - `versionPatterns`: consumer value replaces defaults entirely.
- * - `formatCommand`, `cliffConfigPath`, `workspaceAliases`: consumer value wins.
+ * - `formatCommand`, `cliffConfigPath`, `scopeAliases`: consumer value wins.
  */
 export function mergeMonorepoConfig(
   discoveredPaths: string[],
@@ -94,9 +94,9 @@ export function mergeMonorepoConfig(
     result.cliffConfigPath = cliffConfigPath;
   }
 
-  const workspaceAliases = userConfig?.workspaceAliases;
-  if (workspaceAliases !== undefined) {
-    result.workspaceAliases = workspaceAliases;
+  const scopeAliases = userConfig?.scopeAliases;
+  if (scopeAliases !== undefined) {
+    result.scopeAliases = scopeAliases;
   }
 
   return result;
@@ -132,9 +132,9 @@ export function mergeSinglePackageConfig(userConfig: ReleaseKitConfig | undefine
     result.cliffConfigPath = cliffConfigPath;
   }
 
-  const workspaceAliases = userConfig?.workspaceAliases;
-  if (workspaceAliases !== undefined) {
-    result.workspaceAliases = workspaceAliases;
+  const scopeAliases = userConfig?.scopeAliases;
+  if (scopeAliases !== undefined) {
+    result.scopeAliases = scopeAliases;
   }
 
   return result;

--- a/packages/release-kit/src/parseCommitMessage.ts
+++ b/packages/release-kit/src/parseCommitMessage.ts
@@ -11,31 +11,40 @@ export const COMMIT_PREPROCESSOR_PATTERNS: readonly RegExp[] = [/^#\d+\s+/, /^[A
 /**
  * Parse a commit message into structured metadata.
  *
- * Supports both `type: description` and `workspace|type: description` formats.
+ * Supports three formats:
+ * - `type: description`
+ * - `scope|type: description` (pipe-prefixed scope)
+ * - `type(scope): description` (conventional commit parenthesized scope)
+ *
  * Resolves aliases (e.g., 'feature' -> 'feat') using the provided work type configs.
- * Resolves workspace aliases when a `workspaceAliases` map is provided.
+ * Resolves scope aliases when a `scopeAliases` map is provided.
  * Detects breaking changes via `type!:` or `BREAKING CHANGE:` in the message.
  */
 export function parseCommitMessage(
   message: string,
   hash: string,
   workTypes: Record<string, WorkTypeConfig>,
-  workspaceAliases?: Record<string, string>,
+  scopeAliases?: Record<string, string>,
 ): ParsedCommit | undefined {
   // Strip ticket prefixes (e.g., "#8 " or "TOOL-123 ") before matching
   const stripped = stripTicketPrefix(message);
 
-  // Match both `type: desc` and `workspace|type: desc` formats
-  // The `!` before `:` indicates a breaking change
-  const match = stripped.match(/^(?:([^|]+)\|)?(\w+)(!)?:\s*(.*)$/);
+  // Match pipe-prefixed scope, type, optional parenthesized scope, breaking marker, description.
+  // Group 1: pipe-prefixed scope (e.g., "web" in "web|feat: ...")
+  // Group 2: type (e.g., "feat")
+  // Group 3: parenthesized scope (e.g., "parser" in "fix(parser): ...")
+  // Group 4: breaking marker ("!")
+  // Group 5: description
+  const match = stripped.match(/^(?:([^|]+)\|)?(\w+)(?:\(([^)]+)\))?(!)?:\s*(.*)$/);
   if (!match) {
     return undefined;
   }
 
-  const workspace = match[1];
+  const pipeScope = match[1];
   const rawType = match[2];
-  const breakingMarker = match[3];
-  const description = match[4];
+  const parenthesizedScope = match[3];
+  const breakingMarker = match[4];
+  const description = match[5];
 
   if (rawType === undefined || description === undefined) {
     return undefined;
@@ -49,9 +58,12 @@ export function parseCommitMessage(
 
   const breaking = breakingMarker === '!' || message.includes('BREAKING CHANGE:');
 
-  // Resolve workspace alias to canonical name if a mapping is provided
-  const resolvedWorkspace =
-    workspace !== undefined && workspaceAliases !== undefined ? (workspaceAliases[workspace] ?? workspace) : workspace;
+  // Pipe scope takes precedence; fall back to parenthesized scope
+  const rawScope = pipeScope ?? parenthesizedScope;
+
+  // Resolve scope alias to canonical name if a mapping is provided
+  const resolvedScope =
+    rawScope !== undefined && scopeAliases !== undefined ? (scopeAliases[rawScope] ?? rawScope) : rawScope;
 
   return {
     message,
@@ -59,7 +71,7 @@ export function parseCommitMessage(
     type: resolvedType,
     description,
     breaking,
-    ...(resolvedWorkspace !== undefined && { workspace: resolvedWorkspace }),
+    ...(resolvedScope !== undefined && { scope: resolvedScope }),
   };
 }
 

--- a/packages/release-kit/src/parseCommitMessage.ts
+++ b/packages/release-kit/src/parseCommitMessage.ts
@@ -46,6 +46,7 @@ export function parseCommitMessage(
   const breakingMarker = match[4];
   const description = match[5];
 
+  // Both groups are non-optional in the regex, but TypeScript cannot infer that
   if (rawType === undefined || description === undefined) {
     return undefined;
   }

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -43,7 +43,7 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   let unparseableCommits: Commit[] | undefined;
 
   if (bumpOverride === undefined) {
-    const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.workspaceAliases);
+    const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.scopeAliases);
     parsedCommitCount = determination.parsedCommitCount;
     unparseableCommits = determination.unparseableCommits;
     releaseType = determination.releaseType;

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -163,7 +163,7 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
     let unparseableCommits: Commit[] | undefined;
 
     if (bumpOverride === undefined) {
-      const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.workspaceAliases);
+      const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.scopeAliases);
       parsedCommitCount = determination.parsedCommitCount;
       unparseableCommits = determination.unparseableCommits;
       releaseType = determination.releaseType;

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -94,11 +94,11 @@ export interface ReleaseKitConfig {
   /** Path to the cliff.toml file; defaults to 'cliff.toml' when absent. */
   cliffConfigPath?: string;
   /**
-   * Maps workspace shorthand names to their canonical names.
-   * When a commit uses `shorthand|type: description`, the shorthand is resolved
-   * to the canonical workspace name before the parsed commit is returned.
+   * Maps scope shorthand names to their canonical names.
+   * When a commit uses `shorthand|type: description` or `type(shorthand): description`,
+   * the shorthand is resolved to the canonical scope name before the parsed commit is returned.
    */
-  workspaceAliases?: Record<string, string>;
+  scopeAliases?: Record<string, string>;
 }
 
 /** Override for a single component in the config file. */
@@ -127,8 +127,8 @@ export interface ParsedCommit {
   type: string;
   /** The commit description after the type prefix. */
   description: string;
-  /** The workspace scope if the commit used `workspace|type:` format. */
-  workspace?: string;
+  /** The scope extracted from `scope|type:` or `type(scope):` format. */
+  scope?: string;
   /** Whether this is a breaking change. */
   breaking: boolean;
 }
@@ -164,11 +164,11 @@ export interface MonorepoReleaseConfig {
   /** Path to the cliff.toml file; defaults to 'cliff.toml' when absent. */
   cliffConfigPath?: string;
   /**
-   * Maps workspace shorthand names to their canonical names.
-   * When a commit uses `shorthand|type: description`, the shorthand is resolved
-   * to the canonical workspace name before the parsed commit is returned.
+   * Maps scope shorthand names to their canonical names.
+   * When a commit uses `shorthand|type: description` or `type(shorthand): description`,
+   * the shorthand is resolved to the canonical scope name before the parsed commit is returned.
    */
-  workspaceAliases?: Record<string, string>;
+  scopeAliases?: Record<string, string>;
 }
 
 /** Configuration for the release workflow. */
@@ -192,9 +192,9 @@ export interface ReleaseConfig {
   /** Path to the cliff.toml file; defaults to 'cliff.toml' when absent. */
   cliffConfigPath?: string;
   /**
-   * Maps workspace shorthand names to their canonical names.
-   * When a commit uses `shorthand|type: description`, the shorthand is resolved
-   * to the canonical workspace name before the parsed commit is returned.
+   * Maps scope shorthand names to their canonical names.
+   * When a commit uses `shorthand|type: description` or `type(shorthand): description`,
+   * the shorthand is resolved to the canonical scope name before the parsed commit is returned.
    */
-  workspaceAliases?: Record<string, string>;
+  scopeAliases?: Record<string, string>;
 }

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -23,7 +23,7 @@ export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors
     'workTypes',
     'formatCommand',
     'cliffConfigPath',
-    'workspaceAliases',
+    'scopeAliases',
   ]);
 
   for (const key of Object.keys(raw)) {
@@ -37,7 +37,7 @@ export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors
   validateWorkTypes(raw.workTypes, config, errors);
   validateStringField('formatCommand', raw.formatCommand, config, errors);
   validateStringField('cliffConfigPath', raw.cliffConfigPath, config, errors);
-  validateWorkspaceAliases(raw.workspaceAliases, config, errors);
+  validateScopeAliases(raw.scopeAliases, config, errors);
 
   return { config, errors };
 }
@@ -158,11 +158,11 @@ function validateStringField(
   config[fieldName] = value;
 }
 
-function validateWorkspaceAliases(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
+function validateScopeAliases(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
   if (value === undefined) return;
 
   if (!isRecord(value)) {
-    errors.push("'workspaceAliases' must be a record (object)");
+    errors.push("'scopeAliases' must be a record (object)");
     return;
   }
 
@@ -172,7 +172,7 @@ function validateWorkspaceAliases(value: unknown, config: ReleaseKitConfig, erro
     if (typeof v === 'string') {
       aliases[key] = v;
     } else {
-      errors.push(`workspaceAliases.${key}: value must be a string`);
+      errors.push(`scopeAliases.${key}: value must be a string`);
       valid = false;
     }
   }
@@ -180,6 +180,6 @@ function validateWorkspaceAliases(value: unknown, config: ReleaseKitConfig, erro
   // Unlike `validateComponents`, partial results are not useful for aliases
   // because the mapping is consumed as a complete lookup table.
   if (valid) {
-    config.workspaceAliases = aliases;
+    config.scopeAliases = aliases;
   }
 }


### PR DESCRIPTION
Closes #73 

## What

Adds support for the conventional commits format (`type(scope): description`) alongside the existing pipe-prefixed format (`scope|type: description`) in release-kit's commit parser. Renames `workspace` to `scope` throughout release-kit types, config, validation, and consumers.

## Why

The conventional commits format is the dominant convention in the ecosystem. Supporting both formats lets the same release-kit installation work across repos with different commit conventions. The `workspace` terminology conflated an informational commit label with the pnpm workspace concept; `scope` is the standard term used by conventional commits and git-cliff.

## Details

### Features

- Extended `parseCommitMessage` regex to capture optional parenthesized scope: `^(?:([^|]+)\|)?(\w+)(?:\(([^)]+)\))?(!)?:\s*(.*)$`
- Both formats produce identical `ParsedCommit` output; pipe scope takes precedence when both are present
- Breaking change detection works in both formats (`type!:` and `type(scope)!:`)
- Scope alias resolution applies identically regardless of format

### Refactoring

- Renamed `ParsedCommit.workspace` → `.scope` across all release-kit source
- Renamed `workspaceAliases` → `scopeAliases` in config types, validation, loading, and all consumers
- Updated `cliff.toml` and `cliff.toml.template` commit_parsers from `^.*\\|?type(!)?:` to `^(.*\\|)?type(\\(.*\\))?(!)?:` to match both formats
- Added explicit `bugfix` entry to cliff.toml (previously matched implicitly via `.*` prefix)

### Tests

- Added test cases for all six format variants from the issue table
- Extended cliff config alignment test with four describe blocks covering bare, pipe-prefixed, conventional, and breaking variants
- Extracted `assertParsedAs` helper to reduce test duplication
- 558 tests passing across 44 test files