### PR TITLE
#70 Add commit command for local release flow

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -119,15 +119,10 @@ jobs:
       - name: Commit, tag, and push
         if: steps.check.outputs.changed == 'true'
         run: |
-          TAGS="${{ steps.tags.outputs.tags }}"
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "release: ${TAGS}"
 
-          for TAG in $TAGS; do
-            git tag "$TAG"
-          done
+          release-kit commit
+          release-kit tag --no-git-checks
 
-          git push origin HEAD $TAGS
+          git push origin HEAD ${{ steps.tags.outputs.tags }}

--- a/packages/release-kit/src/__tests__/buildReleaseSummary.unit.test.ts
+++ b/packages/release-kit/src/__tests__/buildReleaseSummary.unit.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildReleaseSummary } from '../buildReleaseSummary.ts';
+import type { PrepareResult } from '../types.ts';
+
+/** Build a minimal PrepareResult for testing. */
+function makeResult(overrides?: Partial<PrepareResult>): PrepareResult {
+  return {
+    components: [],
+    tags: [],
+    dryRun: false,
+    ...overrides,
+  };
+}
+
+describe(buildReleaseSummary, () => {
+  it('produces a summary with tag heading and scope-stripped commits', () => {
+    const result = makeResult({
+      components: [
+        {
+          name: 'release-kit',
+          status: 'released',
+          tag: 'release-kit-v2.4.0',
+          commitCount: 2,
+          bumpedFiles: [],
+          changelogFiles: [],
+          commits: [
+            { message: 'release-kit|feat: Add commit command', hash: 'abc' },
+            { message: '#72 release-kit|fix: Propagate bumps (#80)', hash: 'def' },
+          ],
+        },
+      ],
+    });
+
+    expect(buildReleaseSummary(result)).toBe(
+      'release-kit-v2.4.0\n- feat: Add commit command\n- #72 fix: Propagate bumps (#80)',
+    );
+  });
+
+  it('separates multiple components with blank lines', () => {
+    const result = makeResult({
+      components: [
+        {
+          name: 'core',
+          status: 'released',
+          tag: 'core-v1.0.0',
+          commitCount: 1,
+          bumpedFiles: [],
+          changelogFiles: [],
+          commits: [{ message: 'core|feat: Init', hash: 'a1' }],
+        },
+        {
+          name: 'utils',
+          status: 'released',
+          tag: 'utils-v2.0.0',
+          commitCount: 1,
+          bumpedFiles: [],
+          changelogFiles: [],
+          commits: [{ message: 'utils|fix: Bug', hash: 'b2' }],
+        },
+      ],
+    });
+
+    expect(buildReleaseSummary(result)).toBe('core-v1.0.0\n- feat: Init\n\nutils-v2.0.0\n- fix: Bug');
+  });
+
+  it('omits propagation-only components (no commits)', () => {
+    const result = makeResult({
+      components: [
+        {
+          name: 'core',
+          status: 'released',
+          tag: 'core-v1.0.1',
+          commitCount: 0,
+          bumpedFiles: [],
+          changelogFiles: [],
+          propagatedFrom: [{ packageName: '@scope/utils', newVersion: '2.0.0' }],
+        },
+      ],
+    });
+
+    expect(buildReleaseSummary(result)).toBe('');
+  });
+
+  it('omits skipped components', () => {
+    const result = makeResult({
+      components: [
+        {
+          name: 'skipped-pkg',
+          status: 'skipped',
+          commitCount: 0,
+          bumpedFiles: [],
+          changelogFiles: [],
+          skipReason: 'No changes',
+        },
+      ],
+    });
+
+    expect(buildReleaseSummary(result)).toBe('');
+  });
+
+  it('returns empty string when there are no components', () => {
+    expect(buildReleaseSummary(makeResult())).toBe('');
+  });
+});

--- a/packages/release-kit/src/__tests__/commitCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/commitCommand.unit.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  readFileSync: mockReadFileSync,
+}));
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+import { commitCommand } from '../commitCommand.ts';
+
+/** Sentinel error thrown by the mocked process.exit. */
+class ExitError extends Error {
+  constructor(public readonly code: number | undefined) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe(commitCommand, () => {
+  beforeEach(() => {
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new ExitError(typeof code === 'number' ? code : undefined);
+    });
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockReadFileSync.mockReset();
+    mockExecFileSync.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a commit with tags and summary', () => {
+    mockReadFileSync.mockImplementation((path: string) => {
+      if (path === 'tmp/.release-tags') return 'release-kit-v2.4.0\ncore-v1.0.0\n';
+      if (path === 'tmp/.release-summary')
+        return 'release-kit-v2.4.0\n- feat: Add commit command\n\ncore-v1.0.0\n- fix: Bug';
+      throw new Error('ENOENT');
+    });
+
+    commitCommand([]);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['add', '-A']);
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', [
+      'commit',
+      '-m',
+      'release: release-kit-v2.4.0 core-v1.0.0\n\nrelease-kit-v2.4.0\n- feat: Add commit command\n\ncore-v1.0.0\n- fix: Bug',
+    ]);
+    expect(console.info).toHaveBeenCalledWith('Created release commit: release: release-kit-v2.4.0 core-v1.0.0');
+  });
+
+  it('throws when tags file is missing', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(() => commitCommand([])).toThrow('No tags file found. Run `release-kit prepare` first.');
+  });
+
+  it('throws when tags file is empty', () => {
+    mockReadFileSync.mockImplementation((path: string) => {
+      if (path === 'tmp/.release-tags') return '  \n  ';
+      throw new Error('ENOENT');
+    });
+
+    expect(() => commitCommand([])).toThrow('Tags file is empty. Run `release-kit prepare` first.');
+  });
+
+  it('falls back to empty body when summary file is missing', () => {
+    mockReadFileSync.mockImplementation((path: string) => {
+      if (path === 'tmp/.release-tags') return 'v1.0.0\n';
+      throw new Error('ENOENT');
+    });
+
+    commitCommand([]);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['commit', '-m', 'release: v1.0.0']);
+  });
+
+  it('reports without executing in dry-run mode', () => {
+    mockReadFileSync.mockImplementation((path: string) => {
+      if (path === 'tmp/.release-tags') return 'v1.0.0\n';
+      if (path === 'tmp/.release-summary') return 'v1.0.0\n- feat: New feature';
+      throw new Error('ENOENT');
+    });
+    mockExecFileSync.mockReturnValue('M package.json\n');
+
+    commitCommand(['--dry-run']);
+
+    expect(console.info).toHaveBeenCalledWith('[dry-run] Would create commit with message:\n');
+    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('release: v1.0.0'));
+    // Should not call git add or git commit.
+    expect(mockExecFileSync).not.toHaveBeenCalledWith('git', expect.arrayContaining(['add']));
+    expect(mockExecFileSync).not.toHaveBeenCalledWith('git', expect.arrayContaining(['commit']));
+  });
+
+  it('exits with error for unknown flags', () => {
+    expect(() => commitCommand(['--unknown'])).toThrow(ExitError);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Unknown option'));
+  });
+});

--- a/packages/release-kit/src/__tests__/commitCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/commitCommand.unit.test.ts
@@ -13,6 +13,11 @@ vi.mock('node:child_process', () => ({
 
 import { commitCommand } from '../commitCommand.ts';
 
+/** Create an Error with a `code` property, matching Node's ErrnoException shape. */
+function errnoError(message: string, code: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
 /** Sentinel error thrown by the mocked process.exit. */
 class ExitError extends Error {
   constructor(public readonly code: number | undefined) {
@@ -65,7 +70,7 @@ describe(commitCommand, () => {
   it('throws when tags file is empty', () => {
     mockReadFileSync.mockImplementation((path: string) => {
       if (path === 'tmp/.release-tags') return '  \n  ';
-      throw new Error('ENOENT');
+      throw errnoError('ENOENT', 'ENOENT');
     });
 
     expect(() => commitCommand([])).toThrow('Tags file is empty. Run `release-kit prepare` first.');
@@ -74,7 +79,7 @@ describe(commitCommand, () => {
   it('falls back to empty body when summary file is missing', () => {
     mockReadFileSync.mockImplementation((path: string) => {
       if (path === 'tmp/.release-tags') return 'v1.0.0\n';
-      throw new Error('ENOENT');
+      throw errnoError('ENOENT', 'ENOENT');
     });
 
     commitCommand([]);
@@ -86,7 +91,7 @@ describe(commitCommand, () => {
     mockReadFileSync.mockImplementation((path: string) => {
       if (path === 'tmp/.release-tags') return 'v1.0.0\n';
       if (path === 'tmp/.release-summary') return 'v1.0.0\n- feat: New feature';
-      throw new Error('ENOENT');
+      throw errnoError('ENOENT', 'ENOENT');
     });
     mockExecFileSync.mockReturnValue('M package.json\n');
 
@@ -94,9 +99,49 @@ describe(commitCommand, () => {
 
     expect(console.info).toHaveBeenCalledWith('[dry-run] Would create commit with message:\n');
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining('release: v1.0.0'));
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['status', '--porcelain'], { encoding: 'utf8' });
+    expect(console.info).toHaveBeenCalledWith('\nUncommitted changes:');
     // Should not call git add or git commit.
     expect(mockExecFileSync).not.toHaveBeenCalledWith('git', expect.arrayContaining(['add']));
     expect(mockExecFileSync).not.toHaveBeenCalledWith('git', expect.arrayContaining(['commit']));
+  });
+
+  it('falls back to empty body when summary file contains only whitespace', () => {
+    mockReadFileSync.mockImplementation((path: string) => {
+      if (path === 'tmp/.release-tags') return 'v1.0.0\n';
+      if (path === 'tmp/.release-summary') return '  \n  ';
+      throw errnoError('ENOENT', 'ENOENT');
+    });
+
+    commitCommand([]);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['commit', '-m', 'release: v1.0.0']);
+  });
+
+  it('re-throws non-ENOENT errors when reading summary file', () => {
+    mockReadFileSync.mockImplementation((path: string) => {
+      if (path === 'tmp/.release-tags') return 'v1.0.0\n';
+      if (path === 'tmp/.release-summary') {
+        throw errnoError('EACCES: permission denied', 'EACCES');
+      }
+      throw new Error('ENOENT');
+    });
+
+    expect(() => commitCommand([])).toThrow('EACCES: permission denied');
+  });
+
+  it('logs a diagnostic when dry-run git status fails', () => {
+    mockReadFileSync.mockImplementation((path: string) => {
+      if (path === 'tmp/.release-tags') return 'v1.0.0\n';
+      throw errnoError('ENOENT', 'ENOENT');
+    });
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('git not found');
+    });
+
+    commitCommand(['--dry-run']);
+
+    expect(console.info).toHaveBeenCalledWith('(Could not determine uncommitted changes)');
   });
 
   it('exits with error for unknown flags', () => {

--- a/packages/release-kit/src/__tests__/createTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createTags.unit.test.ts
@@ -188,6 +188,14 @@ describe(createTags, () => {
     expect(mockUnlinkSync).toHaveBeenCalledWith('tmp/.release-tags');
   });
 
+  it('deletes the summary file after successful tag creation', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+
+    createTags({ dryRun: false, noGitChecks: true });
+
+    expect(mockUnlinkSync).toHaveBeenCalledWith('tmp/.release-summary');
+  });
+
   it('does not delete the tags file in dry-run mode', () => {
     mockReadFileSync.mockReturnValue('v1.0.0\n');
 
@@ -200,6 +208,20 @@ describe(createTags, () => {
     mockReadFileSync.mockReturnValue('v1.0.0\n');
     mockUnlinkSync.mockImplementation(() => {
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    expect(() => createTags({ dryRun: false, noGitChecks: true })).not.toThrow();
+  });
+
+  it('tolerates missing summary file on deletion', () => {
+    mockReadFileSync.mockReturnValue('v1.0.0\n');
+    let callCount = 0;
+    mockUnlinkSync.mockImplementation(() => {
+      callCount++;
+      // First call is tags file (succeeds), second is summary file (ENOENT).
+      if (callCount === 2) {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }
     });
 
     expect(() => createTags({ dryRun: false, noGitChecks: true })).not.toThrow();

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -223,6 +223,21 @@ describe(prepareCommand, () => {
     expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
   });
 
+  it('exits with a distinct error when writing release summary fails', async () => {
+    mockBuildReleaseSummary.mockReturnValue('arrays-v1.0.0\n- feat: Something');
+    mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['arrays-v1.0.0'] }));
+    mockWriteFileWithCheck.mockImplementation((_path: string) => {
+      if (_path === RELEASE_SUMMARY_FILE) {
+        return { filePath: RELEASE_SUMMARY_FILE, outcome: 'failed', error: 'permission denied' };
+      }
+      return { filePath: RELEASE_TAGS_FILE, outcome: 'created' };
+    });
+
+    await expect(prepareCommand([])).rejects.toThrow(ExitError);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('release summary'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
+  });
+
   it('prints release tags file path when tags are produced', async () => {
     mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['arrays-v1.0.0'] }));
 

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const mockBuildReleaseSummary = vi.hoisted(() => vi.fn());
 const mockDiscoverWorkspaces = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockReleasePrepareMono = vi.hoisted(() => vi.fn());
 const mockReleasePrepare = vi.hoisted(() => vi.fn());
 const mockWriteFileWithCheck = vi.hoisted(() => vi.fn());
+
+vi.mock('../buildReleaseSummary.ts', () => ({
+  buildReleaseSummary: mockBuildReleaseSummary,
+}));
 
 vi.mock('../discoverWorkspaces.ts', () => ({
   discoverWorkspaces: mockDiscoverWorkspaces,
@@ -30,7 +35,7 @@ vi.mock(import('@williamthorsen/node-monorepo-core'), () => ({
   writeFileWithCheck: mockWriteFileWithCheck,
 }));
 
-import { parseArgs, prepareCommand, RELEASE_TAGS_FILE } from '../prepareCommand.ts';
+import { parseArgs, prepareCommand, RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from '../prepareCommand.ts';
 import type { PrepareResult } from '../types.ts';
 
 /** Sentinel error thrown by the mocked process.exit. */
@@ -52,6 +57,7 @@ function makePrepareResult(overrides?: Partial<PrepareResult>): PrepareResult {
 
 describe(prepareCommand, () => {
   beforeEach(() => {
+    mockBuildReleaseSummary.mockReturnValue('');
     mockDiscoverWorkspaces.mockResolvedValue(['packages/arrays', 'packages/strings']);
     mockLoadConfig.mockResolvedValue(undefined);
     mockReleasePrepareMono.mockReturnValue(makePrepareResult());
@@ -66,6 +72,7 @@ describe(prepareCommand, () => {
   });
 
   afterEach(() => {
+    mockBuildReleaseSummary.mockReset();
     mockDiscoverWorkspaces.mockReset();
     mockLoadConfig.mockReset();
     mockReleasePrepareMono.mockReset();
@@ -240,6 +247,48 @@ describe(prepareCommand, () => {
     expect(console.info).not.toHaveBeenCalledWith(expect.stringContaining('Release tags file:'));
   });
 
+  it('writes the release summary file when summary is non-empty', async () => {
+    mockBuildReleaseSummary.mockReturnValue('release-kit-v2.4.0\n- feat: Add commit command');
+    mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['release-kit-v2.4.0'] }));
+
+    await prepareCommand([]);
+
+    expect(mockWriteFileWithCheck).toHaveBeenCalledWith(
+      RELEASE_SUMMARY_FILE,
+      'release-kit-v2.4.0\n- feat: Add commit command',
+      { dryRun: false, overwrite: true },
+    );
+  });
+
+  it('does not write the release summary file when summary is empty', async () => {
+    mockBuildReleaseSummary.mockReturnValue('');
+    mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['core-v1.0.0'] }));
+
+    await prepareCommand([]);
+
+    expect(mockWriteFileWithCheck).not.toHaveBeenCalledWith(
+      RELEASE_SUMMARY_FILE,
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
+  it('prints follow-up message after successful non-dry-run with tags', async () => {
+    mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['v1.0.0'] }));
+
+    await prepareCommand([]);
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Run 'release-kit commit'"));
+  });
+
+  it('does not print follow-up message during dry run', async () => {
+    mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['v1.0.0'], dryRun: true }));
+
+    await prepareCommand(['--dry-run']);
+
+    expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining("Run 'release-kit commit'"));
+  });
+
   it('applies component exclusion from config', async () => {
     mockLoadConfig.mockResolvedValue({
       components: [{ dir: 'strings', shouldExclude: true }],
@@ -311,5 +360,11 @@ describe(parseArgs, () => {
 describe('RELEASE_TAGS_FILE', () => {
   it('points to tmp/ relative to the project root', () => {
     expect(RELEASE_TAGS_FILE).toBe('tmp/.release-tags');
+  });
+});
+
+describe('RELEASE_SUMMARY_FILE', () => {
+  it('points to tmp/ relative to the project root', () => {
+    expect(RELEASE_SUMMARY_FILE).toBe('tmp/.release-summary');
   });
 });

--- a/packages/release-kit/src/__tests__/stripScope.unit.test.ts
+++ b/packages/release-kit/src/__tests__/stripScope.unit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripScope } from '../stripScope.ts';
+
+describe(stripScope, () => {
+  it.each([
+    ['release-kit|fix: Foo', 'fix: Foo'],
+    ['#72 release-kit|fix: Foo (#80)', '#72 fix: Foo (#80)'],
+    ['fix(release-kit): Foo', 'fix: Foo'],
+    ['#72 fix(release-kit): Foo', '#72 fix: Foo'],
+    ['feat: No scope here', 'feat: No scope here'],
+    ['unparseable message', 'unparseable message'],
+    ['release-kit|feat!: Breaking change', 'feat!: Breaking change'],
+    ['feat(parser)!: Breaking scoped', 'feat!: Breaking scoped'],
+    ['TOOL-123 web|fix: Jira prefix', 'TOOL-123 fix: Jira prefix'],
+  ])('stripScope(%j) -> %j', (input, expected) => {
+    expect(stripScope(input)).toBe(expected);
+  });
+});

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -2,6 +2,7 @@
 /* eslint n/hashbang: off, n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
+import { commitCommand } from '../commitCommand.ts';
 import { initCommand } from '../init/initCommand.ts';
 import { prepareCommand } from '../prepareCommand.ts';
 import { publishCommand } from '../publishCommand.ts';
@@ -16,6 +17,7 @@ Usage: release-kit <command> [options]
 
 Commands:
   prepare       Run release preparation (auto-discovers workspaces)
+  commit        Stage changes and create the release commit
   tag           Create annotated git tags from the tags file
   publish       Publish packages with release tags on HEAD
   init          Initialize release-kit in the current repository
@@ -108,6 +110,19 @@ Options:
 `);
 }
 
+function showCommitHelp(): void {
+  console.info(`
+Usage: release-kit commit [options]
+
+Stage all changes and create the release commit using tags and summary
+produced by \`prepare\`.
+
+Options:
+  --dry-run     Preview the commit message without creating it
+  --help, -h    Show this help message
+`);
+}
+
 function showTagHelp(): void {
   console.info(`
 Usage: release-kit tag [options]
@@ -151,6 +166,21 @@ if (command === 'prepare') {
   }
 
   await prepareCommand(flags);
+  process.exit(0);
+}
+
+if (command === 'commit') {
+  if (flags.some((f) => f === '--help' || f === '-h')) {
+    showCommitHelp();
+    process.exit(0);
+  }
+
+  try {
+    commitCommand(flags);
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
   process.exit(0);
 }
 

--- a/packages/release-kit/src/buildReleaseSummary.ts
+++ b/packages/release-kit/src/buildReleaseSummary.ts
@@ -1,0 +1,34 @@
+import { stripScope } from './stripScope.ts';
+import type { PrepareResult } from './types.ts';
+
+/**
+ * Build a release commit body from a prepare result.
+ *
+ * Each released component with commits gets a section headed by its tag,
+ * followed by scope-stripped commit messages as bullet points. Sections
+ * are separated by blank lines. Returns an empty string when no released
+ * components have commits.
+ */
+export function buildReleaseSummary(result: PrepareResult): string {
+  const sections: string[] = [];
+
+  for (const component of result.components) {
+    if (component.status !== 'released' || component.tag === undefined) {
+      continue;
+    }
+
+    const commits = component.commits;
+    if (commits === undefined || commits.length === 0) {
+      continue;
+    }
+
+    const lines = [component.tag];
+    for (const commit of commits) {
+      lines.push(`- ${stripScope(commit.message)}`);
+    }
+
+    sections.push(lines.join('\n'));
+  }
+
+  return sections.join('\n\n');
+}

--- a/packages/release-kit/src/commitCommand.ts
+++ b/packages/release-kit/src/commitCommand.ts
@@ -1,0 +1,81 @@
+/* eslint n/no-process-exit: off */
+/* eslint unicorn/no-process-exit: off */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+import { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from './prepareCommand.ts';
+
+/** Options for the commit command. */
+export interface CommitCommandOptions {
+  dryRun: boolean;
+}
+
+/**
+ * Orchestrate the CLI `commit` command.
+ *
+ * Reads the tags and summary files produced by `prepare`, stages all
+ * changes, and creates a release commit with a formatted message.
+ */
+export function commitCommand(argv: string[]): void {
+  const knownFlags = new Set(['--dry-run']);
+  const unknownFlags = argv.filter((f) => !knownFlags.has(f));
+  if (unknownFlags.length > 0) {
+    console.error(`Error: Unknown option: ${unknownFlags[0]}`);
+    process.exit(1);
+  }
+
+  const dryRun = argv.includes('--dry-run');
+
+  // Read tags file.
+  let tagsContent: string;
+  try {
+    tagsContent = readFileSync(RELEASE_TAGS_FILE, 'utf8');
+  } catch {
+    throw new Error('No tags file found. Run `release-kit prepare` first.');
+  }
+
+  const tags = tagsContent
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (tags.length === 0) {
+    throw new Error('Tags file is empty. Run `release-kit prepare` first.');
+  }
+
+  // Read summary file (optional — may not exist for propagation-only releases).
+  let summary = '';
+  try {
+    summary = readFileSync(RELEASE_SUMMARY_FILE, 'utf8').trim();
+  } catch {
+    // Missing summary is acceptable.
+  }
+
+  // Build commit message.
+  const title = `release: ${tags.join(' ')}`;
+  const message = summary.length > 0 ? `${title}\n\n${summary}` : title;
+
+  if (dryRun) {
+    console.info('[dry-run] Would create commit with message:\n');
+    console.info(message);
+
+    try {
+      const status = execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' });
+      if (status.trim().length > 0) {
+        console.info('\nStaged files:');
+        console.info(status.trimEnd());
+      }
+    } catch {
+      // Ignore git status errors in dry-run.
+    }
+
+    return;
+  }
+
+  // Stage all changes and create the commit.
+  execFileSync('git', ['add', '-A']);
+  execFileSync('git', ['commit', '-m', message]);
+
+  console.info(`Created release commit: ${title}`);
+}

--- a/packages/release-kit/src/commitCommand.ts
+++ b/packages/release-kit/src/commitCommand.ts
@@ -6,11 +6,6 @@ import { readFileSync } from 'node:fs';
 
 import { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from './prepareCommand.ts';
 
-/** Options for the commit command. */
-export interface CommitCommandOptions {
-  dryRun: boolean;
-}
-
 /**
  * Orchestrate the CLI `commit` command.
  *
@@ -48,8 +43,12 @@ export function commitCommand(argv: string[]): void {
   let summary = '';
   try {
     summary = readFileSync(RELEASE_SUMMARY_FILE, 'utf8').trim();
-  } catch {
-    // Missing summary is acceptable.
+  } catch (error: unknown) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      // Missing summary is acceptable.
+    } else {
+      throw error;
+    }
   }
 
   // Build commit message.
@@ -63,11 +62,11 @@ export function commitCommand(argv: string[]): void {
     try {
       const status = execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' });
       if (status.trim().length > 0) {
-        console.info('\nStaged files:');
+        console.info('\nUncommitted changes:');
         console.info(status.trimEnd());
       }
     } catch {
-      // Ignore git status errors in dry-run.
+      console.info('(Could not determine uncommitted changes)');
     }
 
     return;

--- a/packages/release-kit/src/createTags.ts
+++ b/packages/release-kit/src/createTags.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync, unlinkSync } from 'node:fs';
 
-import { RELEASE_TAGS_FILE } from './prepareCommand.ts';
+import { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from './prepareCommand.ts';
 
 export interface CreateTagsOptions {
   dryRun: boolean;
@@ -66,6 +66,7 @@ export function createTags(options: CreateTagsOptions): string[] {
   }
 
   deleteTagsFile();
+  deleteSummaryFile();
 
   return tags;
 }
@@ -74,6 +75,18 @@ export function createTags(options: CreateTagsOptions): string[] {
 function deleteTagsFile(): void {
   try {
     unlinkSync(RELEASE_TAGS_FILE);
+  } catch (error: unknown) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+}
+
+/** Remove the summary file after successful tag creation. Tolerate missing file. */
+function deleteSummaryFile(): void {
+  try {
+    unlinkSync(RELEASE_SUMMARY_FILE);
   } catch (error: unknown) {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
       return;

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -1,5 +1,4 @@
 // Types
-export type { CommitCommandOptions } from './commitCommand.ts';
 export type { CreateTagsOptions } from './createTags.ts';
 export type { PackageManager } from './detectPackageManager.ts';
 export type { GenerateChangelogOptions } from './generateChangelogs.ts';

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -1,4 +1,5 @@
 // Types
+export type { CommitCommandOptions } from './commitCommand.ts';
 export type { CreateTagsOptions } from './createTags.ts';
 export type { PackageManager } from './detectPackageManager.ts';
 export type { GenerateChangelogOptions } from './generateChangelogs.ts';
@@ -26,8 +27,10 @@ export type {
 export { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 
 // Functions
+export { buildReleaseSummary } from './buildReleaseSummary.ts';
 export { bumpAllVersions } from './bumpAllVersions.ts';
 export { bumpVersion } from './bumpVersion.ts';
+export { commitCommand } from './commitCommand.ts';
 export { component } from './component.ts';
 export { createTags } from './createTags.ts';
 export { detectPackageManager } from './detectPackageManager.ts';
@@ -36,9 +39,10 @@ export { discoverWorkspaces } from './discoverWorkspaces.ts';
 export { generateChangelog, generateChangelogs } from './generateChangelogs.ts';
 export { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 export { COMMIT_PREPROCESSOR_PATTERNS, parseCommitMessage } from './parseCommitMessage.ts';
-export { RELEASE_TAGS_FILE, writeReleaseTags } from './prepareCommand.ts';
+export { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE, writeReleaseTags } from './prepareCommand.ts';
 export { publish } from './publish.ts';
 export { releasePrepare } from './releasePrepare.ts';
 export { releasePrepareMono } from './releasePrepareMono.ts';
 export { reportPrepare } from './reportPrepare.ts';
 export { resolveReleaseTags } from './resolveReleaseTags.ts';
+export { stripScope } from './stripScope.ts';

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -4,6 +4,7 @@
 import type { WriteResult } from '@williamthorsen/node-monorepo-core';
 import { writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
 
+import { buildReleaseSummary } from './buildReleaseSummary.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
 import { dim } from './format.ts';
 import { loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig } from './loadConfig.ts';
@@ -18,6 +19,12 @@ import { validateConfig } from './validateConfig.ts';
  * Relative to the project root so it works identically in CI and local runs.
  */
 export const RELEASE_TAGS_FILE = 'tmp/.release-tags';
+
+/**
+ * File written by the release preparation step, containing the commit body summary.
+ * Relative to the project root so it works identically in CI and local runs.
+ */
+export const RELEASE_SUMMARY_FILE = 'tmp/.release-summary';
 
 const VALID_BUMP_TYPES: readonly string[] = ['major', 'minor', 'patch'];
 
@@ -211,5 +218,26 @@ function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
       console.info(dim(`  Wrote ${RELEASE_TAGS_FILE}: ${result.tags.join(' ')}`));
       console.info(dim(`\n   Release tags file: ${RELEASE_TAGS_FILE}`));
     }
+  }
+
+  // Write the release summary file for the commit command.
+  const summary = buildReleaseSummary(result);
+  if (summary.length > 0) {
+    const summaryResult = writeFileWithCheck(RELEASE_SUMMARY_FILE, summary, { dryRun, overwrite: true });
+
+    if (summaryResult.outcome === 'failed') {
+      console.error(`Error writing release summary: ${summaryResult.error ?? 'unknown error'}`);
+      process.exit(1);
+    }
+
+    if (dryRun) {
+      console.info(dim(`  [dry-run] Would write ${RELEASE_SUMMARY_FILE}`));
+    } else {
+      console.info(dim(`  Wrote ${RELEASE_SUMMARY_FILE}`));
+    }
+  }
+
+  if (writeResult && !dryRun) {
+    console.error(`\nRun 'release-kit commit' to create the release commit.`);
   }
 }

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -112,6 +112,7 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
         tag: newTag,
         bumpedFiles: bump.files,
         changelogFiles,
+        commits,
         unparseableCommits,
       },
     ],

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -293,6 +293,7 @@ function executeReleaseSet(
       tag: newTag,
       bumpedFiles: bump.files,
       changelogFiles,
+      commits: directResult?.commits,
       unparseableCommits: directResult?.unparseableCommits,
       propagatedFrom: releaseEntry.propagatedFrom,
     });

--- a/packages/release-kit/src/stripScope.ts
+++ b/packages/release-kit/src/stripScope.ts
@@ -1,0 +1,36 @@
+import { COMMIT_PREPROCESSOR_PATTERNS } from './parseCommitMessage.ts';
+
+/**
+ * Strip scope indicators from a raw commit message.
+ *
+ * Handles `scope|type: desc`, `type(scope): desc`, and messages with
+ * ticket prefixes (e.g., `#72 release-kit|fix: ...`). Returns the
+ * message unchanged when no scope is detected.
+ */
+export function stripScope(message: string): string {
+  // Detect and remove ticket prefix so we can parse the remainder.
+  let ticketPrefix = '';
+  let remainder = message;
+
+  for (const pattern of COMMIT_PREPROCESSOR_PATTERNS) {
+    const match = remainder.match(pattern);
+    if (match) {
+      ticketPrefix += match[0];
+      remainder = remainder.slice(match[0].length);
+    }
+  }
+
+  // Try pipe-prefixed scope: `scope|type: desc` or `scope|type!: desc`
+  const pipeMatch = remainder.match(/^[^|]+\|(.*)$/);
+  if (pipeMatch) {
+    return `${ticketPrefix}${pipeMatch[1]}`;
+  }
+
+  // Try parenthesized scope: `type(scope): desc` or `type(scope)!: desc`
+  const parenMatch = remainder.match(/^(\w+)\([^)]+\)(.*)$/);
+  if (parenMatch) {
+    return `${ticketPrefix}${parenMatch[1]}${parenMatch[2]}`;
+  }
+
+  return message;
+}

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -28,6 +28,8 @@ export interface ComponentPrepareResult {
   tag?: string | undefined;
   bumpedFiles: string[];
   changelogFiles: string[];
+  /** Raw commits associated with this component (present for direct releases, absent for propagation-only). */
+  commits?: Commit[] | undefined;
   /** Commits that could not be parsed into a recognized work type. */
   unparseableCommits?: Commit[] | undefined;
   /** Dependencies that triggered a propagated bump (present for propagated or mixed components). */


### PR DESCRIPTION
Closes #70 

## What

Adds a `release-kit commit` command that centralizes the release commit step between `prepare` and `tag`. The command reads tag names and a per-component commit summary from temporary files written by `prepare`, stages all changes, and creates a formatted commit. Two new utilities — `stripScope` and `buildReleaseSummary` — support building the commit body by stripping redundant scope indicators and formatting commits under their component headings. The CI workflow is simplified to use `release-kit commit` and `release-kit tag` instead of inline shell logic.

## Why

The release commit step had no CLI equivalent. Locally, users had to manually stage and commit with the right message format. In CI, the same logic was inlined in the workflow YAML. This duplication meant the commit message format was defined in two places with no shared implementation, and any format change required coordinated edits.

## Details

### Features

- `release-kit commit` command: reads `tmp/.release-tags` and `tmp/.release-summary`, stages changes with `git add -A`, creates commit with title `release: {tags}` and per-component body
- `--dry-run` flag: previews the commit message and lists uncommitted changes without executing
- `prepareCommand` now writes `tmp/.release-summary` alongside `tmp/.release-tags` and prints a follow-up message suggesting `release-kit commit`
- `stripScope` utility: strips both `scope|type:` (pipe) and `type(scope):` (conventional) scope indicators from commit messages, preserving ticket prefixes
- `buildReleaseSummary` utility: produces the formatted commit body from `PrepareResult` data

### Fixes

- Error handling in `commitCommand`: catch blocks discriminate by `error.code` (ENOENT-only tolerance) instead of swallowing all errors
- Dry-run output label changed from misleading "Staged files:" to accurate "Uncommitted changes:"
- Removed unused `CommitCommandOptions` interface that was exported but never consumed

### Refactoring

- CI workflow (`release-workflow.yaml`): replaced inline commit shell script and tag loop with `release-kit commit` + `release-kit tag --no-git-checks`
- `createTags` extended to clean up `tmp/.release-summary` alongside `tmp/.release-tags` after tag creation
- `ComponentPrepareResult` type extended with optional `commits` field, populated in both `releasePrepare` and `releasePrepareMono`

### Tests

- New test suites for `commitCommand`, `stripScope`, and `buildReleaseSummary`
- Extended `prepareCommand` tests for summary file writing and failure handling
- Extended `createTags` tests for summary file cleanup
- All tests use `errnoError` helper instead of type assertions for `NodeJS.ErrnoException` construction