### PR TITLE
#69 Add CI publish workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-workflow.yaml
+++ b/.github/workflows/publish-workflow.yaml
@@ -14,6 +14,12 @@ name: Publish
 
 on:
   workflow_call:
+    inputs:
+      node-version:
+        description: 'Node.js version to use for publishing'
+        required: false
+        type: string
+        default: '24'
 
 permissions:
   id-token: write
@@ -42,7 +48,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
+          node-version: ${{ inputs.node-version }}
           registry-url: https://registry.npmjs.org
 
       - name: Disable Corepack
@@ -53,5 +59,3 @@ jobs:
 
       - name: Publish
         run: release-kit publish --provenance --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-workflow.yaml
+++ b/.github/workflows/publish-workflow.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Publish
+
+# Reusable publish workflow for projects using @williamthorsen/release-kit.
+#
+# Triggered by tag pushes. Installs `@williamthorsen/release-kit` globally and
+# runs `release-kit publish --provenance` with OIDC-based npm authentication.
+# The calling workflow must grant `id-token: write` and `contents: read` permissions.
+#
+# Usage:
+#   jobs:
+#     publish:
+#       uses: williamthorsen/node-monorepo-tools/.github/workflows/publish-workflow.yaml@publish-workflow-v1
+
+on:
+  workflow_call:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      # Allow npx to run even when package.json declares a different package
+      # manager (e.g., pnpm). Without this, Corepack blocks npm/npx.
+      COREPACK_ENABLE_STRICT: '0'
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      # Strip the packageManager field so that actions/setup-node does not
+      # try to install it. The field is irrelevant for publishing.
+      - name: Neutralize packageManager field
+        run: node -e "const fs=require('fs'),f='package.json',p=JSON.parse(fs.readFileSync(f));delete p.packageManager;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org
+
+      - name: Disable Corepack
+        run: corepack disable
+
+      - name: Install release-kit
+        run: npm install --global @williamthorsen/release-kit
+
+      - name: Publish
+        run: release-kit publish --provenance --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,4 +13,3 @@ permissions:
 jobs:
   publish:
     uses: ./.github/workflows/publish-workflow.yaml
-    secrets: inherit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,3 +13,4 @@ permissions:
 jobs:
   publish:
     uses: ./.github/workflows/publish-workflow.yaml
+    secrets: inherit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*-v[0-9]*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish-workflow.yaml

--- a/packages/release-kit/src/__tests__/publish.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publish.unit.test.ts
@@ -163,6 +163,33 @@ describe(publish, () => {
     });
   });
 
+  it('forwards --dry-run and --provenance together for pnpm', () => {
+    publish(singleTag, 'pnpm', { dryRun: true, noGitChecks: false, provenance: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--dry-run', '--provenance'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('forwards all three flags in deterministic order for pnpm', () => {
+    publish(singleTag, 'pnpm', { dryRun: true, noGitChecks: true, provenance: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--dry-run', '--no-git-checks', '--provenance'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('forwards --dry-run but suppresses --provenance for classic yarn', () => {
+    publish(singleTag, 'yarn', { dryRun: true, noGitChecks: false, provenance: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['publish', '--dry-run'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
   it('prints confirmation listing before publishing', () => {
     publish(multiTags, 'pnpm', { dryRun: false, noGitChecks: false, provenance: false });
 

--- a/packages/release-kit/src/__tests__/publish.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publish.unit.test.ts
@@ -27,14 +27,14 @@ describe(publish, () => {
   ];
 
   it('does nothing when resolvedTags is empty', () => {
-    publish([], 'npm', { dryRun: false, noGitChecks: false });
+    publish([], 'npm', { dryRun: false, noGitChecks: false, provenance: false });
 
     expect(mockExecFileSync).not.toHaveBeenCalled();
     expect(console.info).not.toHaveBeenCalled();
   });
 
   it('runs npm publish from the correct directory', () => {
-    publish(singleTag, 'npm', { dryRun: false, noGitChecks: false });
+    publish(singleTag, 'npm', { dryRun: false, noGitChecks: false, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish'], {
       cwd: '.',
@@ -43,7 +43,7 @@ describe(publish, () => {
   });
 
   it('runs pnpm publish from the correct directory for each package', () => {
-    publish(multiTags, 'pnpm', { dryRun: false, noGitChecks: false });
+    publish(multiTags, 'pnpm', { dryRun: false, noGitChecks: false, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish'], {
       cwd: 'packages/core',
@@ -56,7 +56,7 @@ describe(publish, () => {
   });
 
   it('forwards --dry-run flag', () => {
-    publish(singleTag, 'npm', { dryRun: true, noGitChecks: false });
+    publish(singleTag, 'npm', { dryRun: true, noGitChecks: false, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish', '--dry-run'], {
       cwd: '.',
@@ -65,7 +65,7 @@ describe(publish, () => {
   });
 
   it('forwards --no-git-checks only for pnpm', () => {
-    publish(singleTag, 'pnpm', { dryRun: false, noGitChecks: true });
+    publish(singleTag, 'pnpm', { dryRun: false, noGitChecks: true, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--no-git-checks'], {
       cwd: '.',
@@ -74,7 +74,7 @@ describe(publish, () => {
   });
 
   it('does not forward --no-git-checks for npm', () => {
-    publish(singleTag, 'npm', { dryRun: false, noGitChecks: true });
+    publish(singleTag, 'npm', { dryRun: false, noGitChecks: true, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish'], {
       cwd: '.',
@@ -83,7 +83,7 @@ describe(publish, () => {
   });
 
   it('does not forward --no-git-checks for yarn', () => {
-    publish(singleTag, 'yarn', { dryRun: false, noGitChecks: true });
+    publish(singleTag, 'yarn', { dryRun: false, noGitChecks: true, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['publish'], {
       cwd: '.',
@@ -92,7 +92,7 @@ describe(publish, () => {
   });
 
   it('runs yarn npm publish for yarn-berry', () => {
-    publish(singleTag, 'yarn-berry', { dryRun: false, noGitChecks: false });
+    publish(singleTag, 'yarn-berry', { dryRun: false, noGitChecks: false, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish'], {
       cwd: '.',
@@ -101,7 +101,7 @@ describe(publish, () => {
   });
 
   it('forwards --dry-run for yarn-berry', () => {
-    publish(singleTag, 'yarn-berry', { dryRun: true, noGitChecks: false });
+    publish(singleTag, 'yarn-berry', { dryRun: true, noGitChecks: false, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish', '--dry-run'], {
       cwd: '.',
@@ -110,7 +110,7 @@ describe(publish, () => {
   });
 
   it('does not forward --no-git-checks for yarn-berry', () => {
-    publish(singleTag, 'yarn-berry', { dryRun: false, noGitChecks: true });
+    publish(singleTag, 'yarn-berry', { dryRun: false, noGitChecks: true, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish'], {
       cwd: '.',
@@ -119,7 +119,7 @@ describe(publish, () => {
   });
 
   it('forwards both --dry-run and --no-git-checks for pnpm', () => {
-    publish(singleTag, 'pnpm', { dryRun: true, noGitChecks: true });
+    publish(singleTag, 'pnpm', { dryRun: true, noGitChecks: true, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--dry-run', '--no-git-checks'], {
       cwd: '.',
@@ -127,8 +127,44 @@ describe(publish, () => {
     });
   });
 
+  it('forwards --provenance for npm', () => {
+    publish(singleTag, 'npm', { dryRun: false, noGitChecks: false, provenance: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish', '--provenance'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('forwards --provenance for pnpm', () => {
+    publish(singleTag, 'pnpm', { dryRun: false, noGitChecks: false, provenance: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--provenance'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('forwards --provenance for yarn-berry', () => {
+    publish(singleTag, 'yarn-berry', { dryRun: false, noGitChecks: false, provenance: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish', '--provenance'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
+  it('does not forward --provenance for classic yarn', () => {
+    publish(singleTag, 'yarn', { dryRun: false, noGitChecks: false, provenance: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['publish'], {
+      cwd: '.',
+      stdio: 'inherit',
+    });
+  });
+
   it('prints confirmation listing before publishing', () => {
-    publish(multiTags, 'pnpm', { dryRun: false, noGitChecks: false });
+    publish(multiTags, 'pnpm', { dryRun: false, noGitChecks: false, provenance: false });
 
     expect(console.info).toHaveBeenCalledWith('Publishing:');
     expect(console.info).toHaveBeenCalledWith('  core-v1.3.0 (packages/core)');
@@ -136,7 +172,7 @@ describe(publish, () => {
   });
 
   it('prints dry-run confirmation listing', () => {
-    publish(multiTags, 'pnpm', { dryRun: true, noGitChecks: false });
+    publish(multiTags, 'pnpm', { dryRun: true, noGitChecks: false, provenance: false });
 
     expect(console.info).toHaveBeenCalledWith('[dry-run] Would publish:');
   });
@@ -148,7 +184,9 @@ describe(publish, () => {
       }
     });
 
-    expect(() => publish(multiTags, 'pnpm', { dryRun: false, noGitChecks: false })).toThrow('publish failed');
+    expect(() => publish(multiTags, 'pnpm', { dryRun: false, noGitChecks: false, provenance: false })).toThrow(
+      'publish failed',
+    );
 
     expect(console.warn).toHaveBeenCalledWith('Packages published before failure:');
     expect(console.warn).toHaveBeenCalledWith('  core-v1.3.0');

--- a/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
@@ -56,19 +56,38 @@ describe(publishCommand, () => {
     expect(mockPublish).toHaveBeenCalledWith([{ tag: 'v1.0.0', dir: '.', workspacePath: '.' }], 'npm', {
       dryRun: false,
       noGitChecks: false,
+      provenance: false,
     });
   });
 
   it('passes dryRun when --dry-run is provided', async () => {
     await publishCommand(['--dry-run']);
 
-    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'npm', { dryRun: true, noGitChecks: false });
+    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'npm', {
+      dryRun: true,
+      noGitChecks: false,
+      provenance: false,
+    });
   });
 
   it('passes noGitChecks when --no-git-checks is provided', async () => {
     await publishCommand(['--no-git-checks']);
 
-    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'npm', { dryRun: false, noGitChecks: true });
+    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'npm', {
+      dryRun: false,
+      noGitChecks: true,
+      provenance: false,
+    });
+  });
+
+  it('passes provenance when --provenance is provided', async () => {
+    await publishCommand(['--provenance']);
+
+    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'npm', {
+      dryRun: false,
+      noGitChecks: false,
+      provenance: true,
+    });
   });
 
   it('exits with code 1 on unknown flags', async () => {
@@ -135,7 +154,7 @@ describe(publishCommand, () => {
     expect(mockPublish).toHaveBeenCalledWith(
       [{ tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' }],
       'npm',
-      { dryRun: false, noGitChecks: false },
+      { dryRun: false, noGitChecks: false, provenance: false },
     );
   });
 

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -146,6 +146,7 @@ Options:
   --dry-run              Preview without publishing
   --no-git-checks        Skip git checks (pnpm only)
   --only=name1,name2     Only publish the named packages (comma-separated, monorepo only)
+  --provenance           Generate provenance statement (requires OIDC, not supported by classic yarn)
   --help, -h             Show this help message
 `);
 }

--- a/packages/release-kit/src/init/__tests__/initCommand.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/initCommand.unit.test.ts
@@ -41,7 +41,10 @@ function setupPassingChecks(): void {
   mockHasPackageJson.mockReturnValue({ ok: true });
   mockUsesPnpm.mockReturnValue({ ok: true });
   mockDetectRepoType.mockReturnValue('single-package');
-  mockScaffoldFiles.mockReturnValue([{ filePath: '.github/workflows/release.yaml', outcome: 'created' }]);
+  mockScaffoldFiles.mockReturnValue([
+    { filePath: '.github/workflows/release.yaml', outcome: 'created' },
+    { filePath: '.github/workflows/publish.yaml', outcome: 'created' },
+  ]);
 }
 
 describe(initCommand, () => {

--- a/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
@@ -76,7 +76,9 @@ describe('scaffold', () => {
     });
 
     it('returns skipped results when overwrite is false and files exist', () => {
-      mockWriteFileWithCheck.mockReturnValue({ filePath: '.github/workflows/release.yaml', outcome: 'skipped' });
+      mockWriteFileWithCheck
+        .mockReturnValueOnce({ filePath: '.github/workflows/release.yaml', outcome: 'skipped' })
+        .mockReturnValueOnce({ filePath: '.github/workflows/publish.yaml', outcome: 'skipped' });
 
       const results = scaffoldFiles({
         repoType: 'single-package',
@@ -85,15 +87,23 @@ describe('scaffold', () => {
         withConfig: false,
       });
 
+      expect(results).toHaveLength(2);
       expect(results[0]).toEqual({ filePath: '.github/workflows/release.yaml', outcome: 'skipped' });
+      expect(results[1]).toEqual({ filePath: '.github/workflows/publish.yaml', outcome: 'skipped' });
     });
 
     it('passes overwrite option to writeFileWithCheck', () => {
-      mockWriteFileWithCheck.mockReturnValue({ filePath: '.github/workflows/release.yaml', outcome: 'overwritten' });
+      mockWriteFileWithCheck
+        .mockReturnValueOnce({ filePath: '.github/workflows/release.yaml', outcome: 'overwritten' })
+        .mockReturnValueOnce({ filePath: '.github/workflows/publish.yaml', outcome: 'overwritten' });
 
       scaffoldFiles({ repoType: 'single-package', dryRun: false, overwrite: true, withConfig: false });
 
       expect(mockWriteFileWithCheck).toHaveBeenCalledWith('.github/workflows/release.yaml', expect.any(String), {
+        dryRun: false,
+        overwrite: true,
+      });
+      expect(mockWriteFileWithCheck).toHaveBeenCalledWith('.github/workflows/publish.yaml', expect.any(String), {
         dryRun: false,
         overwrite: true,
       });

--- a/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
@@ -29,8 +29,10 @@ describe('scaffold', () => {
   });
 
   describe(scaffoldFiles, () => {
-    it('creates only the workflow file by default', () => {
-      mockWriteFileWithCheck.mockReturnValue({ filePath: '.github/workflows/release.yaml', outcome: 'created' });
+    it('creates release and publish workflow files by default', () => {
+      mockWriteFileWithCheck
+        .mockReturnValueOnce({ filePath: '.github/workflows/release.yaml', outcome: 'created' })
+        .mockReturnValueOnce({ filePath: '.github/workflows/publish.yaml', outcome: 'created' });
 
       const results = scaffoldFiles({
         repoType: 'single-package',
@@ -39,18 +41,24 @@ describe('scaffold', () => {
         withConfig: false,
       });
 
-      expect(results).toHaveLength(1);
+      expect(results).toHaveLength(2);
       expect(results[0]).toEqual({ filePath: '.github/workflows/release.yaml', outcome: 'created' });
-      expect(mockWriteFileWithCheck).toHaveBeenCalledTimes(1);
+      expect(results[1]).toEqual({ filePath: '.github/workflows/publish.yaml', outcome: 'created' });
+      expect(mockWriteFileWithCheck).toHaveBeenCalledTimes(2);
       expect(mockWriteFileWithCheck).toHaveBeenCalledWith('.github/workflows/release.yaml', expect.any(String), {
+        dryRun: false,
+        overwrite: false,
+      });
+      expect(mockWriteFileWithCheck).toHaveBeenCalledWith('.github/workflows/publish.yaml', expect.any(String), {
         dryRun: false,
         overwrite: false,
       });
     });
 
-    it('creates workflow, config, and cliff template when withConfig is true', () => {
+    it('creates workflow, publish, config, and cliff template when withConfig is true', () => {
       mockWriteFileWithCheck
         .mockReturnValueOnce({ filePath: '.github/workflows/release.yaml', outcome: 'created' })
+        .mockReturnValueOnce({ filePath: '.github/workflows/publish.yaml', outcome: 'created' })
         .mockReturnValueOnce({ filePath: '.config/release-kit.config.ts', outcome: 'created' })
         .mockReturnValueOnce({ filePath: '.config/git-cliff.toml', outcome: 'created' });
       mockExistsSync.mockReturnValue(true); // template path exists
@@ -63,8 +71,8 @@ describe('scaffold', () => {
         withConfig: true,
       });
 
-      expect(results).toHaveLength(3);
-      expect(mockWriteFileWithCheck).toHaveBeenCalledTimes(3);
+      expect(results).toHaveLength(4);
+      expect(mockWriteFileWithCheck).toHaveBeenCalledTimes(4);
     });
 
     it('returns skipped results when overwrite is false and files exist', () => {
@@ -101,7 +109,7 @@ describe('scaffold', () => {
         withConfig: false,
       });
 
-      expect(results).toHaveLength(1);
+      expect(results).toHaveLength(2);
       expect(mockWriteFileWithCheck).toHaveBeenCalledWith('.github/workflows/release.yaml', expect.any(String), {
         dryRun: true,
         overwrite: false,

--- a/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
@@ -110,7 +110,9 @@ describe('scaffold', () => {
     });
 
     it('returns dry-run outcomes without writing', () => {
-      mockWriteFileWithCheck.mockReturnValue({ filePath: '.github/workflows/release.yaml', outcome: 'created' });
+      mockWriteFileWithCheck
+        .mockReturnValueOnce({ filePath: '.github/workflows/release.yaml', outcome: 'created' })
+        .mockReturnValueOnce({ filePath: '.github/workflows/publish.yaml', outcome: 'created' });
 
       const results = scaffoldFiles({
         repoType: 'single-package',
@@ -121,6 +123,10 @@ describe('scaffold', () => {
 
       expect(results).toHaveLength(2);
       expect(mockWriteFileWithCheck).toHaveBeenCalledWith('.github/workflows/release.yaml', expect.any(String), {
+        dryRun: true,
+        overwrite: false,
+      });
+      expect(mockWriteFileWithCheck).toHaveBeenCalledWith('.github/workflows/publish.yaml', expect.any(String), {
         dryRun: true,
         overwrite: false,
       });

--- a/packages/release-kit/src/init/__tests__/templates.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/templates.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { releaseConfigScript, releaseWorkflow } from '../templates.ts';
+import { publishWorkflow, releaseConfigScript, releaseWorkflow } from '../templates.ts';
 
 describe(releaseConfigScript, () => {
   it('generates a ReleaseKitConfig for monorepo type', () => {
@@ -32,6 +32,27 @@ describe(releaseConfigScript, () => {
     expect(single).toContain('header:');
     expect(mono).not.toContain('heading:');
     expect(single).not.toContain('heading:');
+  });
+});
+
+describe(publishWorkflow, () => {
+  it('generates a monorepo workflow with wildcard tag pattern', () => {
+    const workflow = publishWorkflow('monorepo');
+
+    expect(workflow).toContain("'*-v[0-9]*'");
+    expect(workflow).toContain('publish-workflow.yaml@publish-workflow-v1');
+    expect(workflow).toContain('id-token: write');
+    expect(workflow).toContain('contents: read');
+  });
+
+  it('generates a single-package workflow with v-prefixed tag pattern', () => {
+    const workflow = publishWorkflow('single-package');
+
+    expect(workflow).toContain("'v[0-9]*'");
+    expect(workflow).not.toContain("'*-v[0-9]*'");
+    expect(workflow).toContain('publish-workflow.yaml@publish-workflow-v1');
+    expect(workflow).toContain('id-token: write');
+    expect(workflow).toContain('contents: read');
   });
 });
 

--- a/packages/release-kit/src/init/__tests__/templates.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/templates.unit.test.ts
@@ -44,7 +44,7 @@ describe(publishWorkflow, () => {
     expect(workflow).toContain('publish-workflow.yaml@publish-workflow-v1');
     expect(workflow).toContain('id-token: write');
     expect(workflow).toContain('contents: read');
-    expect(workflow).toContain('secrets: inherit');
+    expect(workflow).not.toContain('secrets:');
   });
 
   it('generates a single-package workflow with v-prefixed tag pattern', () => {
@@ -55,7 +55,7 @@ describe(publishWorkflow, () => {
     expect(workflow).toContain('publish-workflow.yaml@publish-workflow-v1');
     expect(workflow).toContain('id-token: write');
     expect(workflow).toContain('contents: read');
-    expect(workflow).toContain('secrets: inherit');
+    expect(workflow).not.toContain('secrets:');
   });
 });
 

--- a/packages/release-kit/src/init/__tests__/templates.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/templates.unit.test.ts
@@ -40,9 +40,11 @@ describe(publishWorkflow, () => {
     const workflow = publishWorkflow('monorepo');
 
     expect(workflow).toContain("'*-v[0-9]*'");
+    expect(workflow).not.toContain("- 'v[0-9]*'");
     expect(workflow).toContain('publish-workflow.yaml@publish-workflow-v1');
     expect(workflow).toContain('id-token: write');
     expect(workflow).toContain('contents: read');
+    expect(workflow).toContain('secrets: inherit');
   });
 
   it('generates a single-package workflow with v-prefixed tag pattern', () => {
@@ -53,6 +55,7 @@ describe(publishWorkflow, () => {
     expect(workflow).toContain('publish-workflow.yaml@publish-workflow-v1');
     expect(workflow).toContain('id-token: write');
     expect(workflow).toContain('contents: read');
+    expect(workflow).toContain('secrets: inherit');
   });
 });
 

--- a/packages/release-kit/src/init/scaffold.ts
+++ b/packages/release-kit/src/init/scaffold.ts
@@ -6,7 +6,7 @@ import { writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
 
 import { findPackageRoot } from '../findPackageRoot.ts';
 import type { RepoType } from './detectRepoType.ts';
-import { releaseConfigScript, releaseWorkflow } from './templates.ts';
+import { publishWorkflow, releaseConfigScript, releaseWorkflow } from './templates.ts';
 
 interface ScaffoldOptions {
   repoType: RepoType;
@@ -40,6 +40,7 @@ export function copyCliffTemplate(dryRun: boolean, overwrite: boolean): WriteRes
 export function scaffoldFiles({ repoType, dryRun, overwrite, withConfig }: ScaffoldOptions): WriteResult[] {
   const results: WriteResult[] = [
     writeFileWithCheck('.github/workflows/release.yaml', releaseWorkflow(repoType), { dryRun, overwrite }),
+    writeFileWithCheck('.github/workflows/publish.yaml', publishWorkflow(repoType), { dryRun, overwrite }),
   ];
 
   if (withConfig) {

--- a/packages/release-kit/src/init/templates.ts
+++ b/packages/release-kit/src/init/templates.ts
@@ -44,7 +44,12 @@ export default config;
 `;
 }
 
-/** Generate the publish.yaml GitHub Actions entry-point workflow. */
+/**
+ * Generate the publish.yaml GitHub Actions entry-point workflow.
+ *
+ * The `permissions` block is present for explicitness; the reusable workflow declares its own
+ * permissions, so GitHub uses those rather than the caller's block.
+ */
 export function publishWorkflow(repoType: RepoType): string {
   const tagPattern = repoType === 'monorepo' ? "'*-v[0-9]*'" : "'v[0-9]*'";
 
@@ -63,6 +68,7 @@ permissions:
 jobs:
   publish:
     uses: williamthorsen/node-monorepo-tools/.github/workflows/publish-workflow.yaml@publish-workflow-v1
+    secrets: inherit
 `;
 }
 

--- a/packages/release-kit/src/init/templates.ts
+++ b/packages/release-kit/src/init/templates.ts
@@ -68,7 +68,6 @@ permissions:
 jobs:
   publish:
     uses: williamthorsen/node-monorepo-tools/.github/workflows/publish-workflow.yaml@publish-workflow-v1
-    secrets: inherit
 `;
 }
 

--- a/packages/release-kit/src/init/templates.ts
+++ b/packages/release-kit/src/init/templates.ts
@@ -44,6 +44,28 @@ export default config;
 `;
 }
 
+/** Generate the publish.yaml GitHub Actions entry-point workflow. */
+export function publishWorkflow(repoType: RepoType): string {
+  const tagPattern = repoType === 'monorepo' ? "'*-v[0-9]*'" : "'v[0-9]*'";
+
+  return `# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Publish
+
+on:
+  push:
+    tags:
+      - ${tagPattern}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    uses: williamthorsen/node-monorepo-tools/.github/workflows/publish-workflow.yaml@publish-workflow-v1
+`;
+}
+
 /** Generate the release.yaml GitHub Actions workflow. */
 export function releaseWorkflow(repoType: RepoType): string {
   if (repoType === 'monorepo') {

--- a/packages/release-kit/src/publish.ts
+++ b/packages/release-kit/src/publish.ts
@@ -6,6 +6,7 @@ import type { ResolvedTag } from './resolveReleaseTags.ts';
 export interface PublishOptions {
   dryRun: boolean;
   noGitChecks: boolean;
+  provenance: boolean;
 }
 
 /**
@@ -15,7 +16,7 @@ export interface PublishOptions {
  * reporting which packages were successfully published before the error.
  */
 export function publish(resolvedTags: ResolvedTag[], packageManager: PackageManager, options: PublishOptions): void {
-  const { dryRun, noGitChecks } = options;
+  const { dryRun, noGitChecks, provenance } = options;
 
   if (resolvedTags.length === 0) {
     return;
@@ -30,7 +31,7 @@ export function publish(resolvedTags: ResolvedTag[], packageManager: PackageMana
 
   for (const { tag, workspacePath } of resolvedTags) {
     const executable = resolveExecutable(packageManager);
-    const args = buildPublishArgs(packageManager, { dryRun, noGitChecks });
+    const args = buildPublishArgs(packageManager, { dryRun, noGitChecks, provenance });
 
     try {
       console.info(`\n${dryRun ? '[dry-run] ' : ''}Running: ${executable} ${args.join(' ')} (cwd: ${workspacePath})`);
@@ -66,6 +67,11 @@ function buildPublishArgs(packageManager: PackageManager, options: PublishOption
 
   if (options.noGitChecks && packageManager === 'pnpm') {
     args.push('--no-git-checks');
+  }
+
+  // Classic yarn does not support --provenance
+  if (options.provenance && packageManager !== 'yarn') {
+    args.push('--provenance');
   }
 
   return args;

--- a/packages/release-kit/src/publish.ts
+++ b/packages/release-kit/src/publish.ts
@@ -28,11 +28,10 @@ export function publish(resolvedTags: ResolvedTag[], packageManager: PackageMana
   }
 
   const published: string[] = [];
+  const executable = resolveExecutable(packageManager);
+  const args = buildPublishArgs(packageManager, { dryRun, noGitChecks, provenance });
 
   for (const { tag, workspacePath } of resolvedTags) {
-    const executable = resolveExecutable(packageManager);
-    const args = buildPublishArgs(packageManager, { dryRun, noGitChecks, provenance });
-
     try {
       console.info(`\n${dryRun ? '[dry-run] ' : ''}Running: ${executable} ${args.join(' ')} (cwd: ${workspacePath})`);
       execFileSync(executable, args, { cwd: workspacePath, stdio: 'inherit' });

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -13,7 +13,7 @@ import { resolveReleaseTags } from './resolveReleaseTags.ts';
  * detect the package manager, validate `--only`, and delegate to `publish`.
  */
 export async function publishCommand(argv: string[]): Promise<void> {
-  const knownFlags = new Set(['--dry-run', '--no-git-checks']);
+  const knownFlags = new Set(['--dry-run', '--no-git-checks', '--provenance']);
   const unknownFlags = argv.filter((f) => !f.startsWith('--only=') && !knownFlags.has(f));
   if (unknownFlags.length > 0) {
     console.error(`Error: Unknown option: ${unknownFlags[0]}`);
@@ -22,6 +22,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
 
   const dryRun = argv.includes('--dry-run');
   const noGitChecks = argv.includes('--no-git-checks');
+  const provenance = argv.includes('--provenance');
 
   const onlyArg = argv.find((f) => f.startsWith('--only='));
   const only = onlyArg?.slice('--only='.length).split(',');
@@ -67,7 +68,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
   const packageManager = detectPackageManager();
 
   try {
-    publish(resolvedTags, packageManager, { dryRun, noGitChecks });
+    publish(resolvedTags, packageManager, { dryRun, noGitChecks, provenance });
   } catch (error: unknown) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);


### PR DESCRIPTION
Closes #69

## What

Adds automated npm publication via a tag-push-triggered GitHub Actions workflow using OIDC trusted publishing. Extends `release-kit publish` with a `--provenance` flag and `release-kit init` with publish workflow scaffolding.

## Why

Publication was the last manual step in the release pipeline. With version bumps, changelogs, and tagging already automated in CI, the publish step completes the end-to-end automation. OIDC trusted publishing replaces classic npm tokens (deprecated Dec 2025), eliminating secret management and token rotation.

## Details

### Features

- `release-kit publish --provenance` forwards the `--provenance` flag to npm, pnpm, and yarn-berry publish commands (classic yarn excluded — unsupported)
- Reusable `publish-workflow.yaml` with pure OIDC auth (`id-token: write`, no secrets), configurable `node-version` input (default `'24'`)
- Entry-point `publish.yaml` triggered by tag pushes matching `*-v[0-9]*` (monorepo) or `v[0-9]*` (single-package)
- `release-kit init` scaffolds `publish.yaml` alongside `release.yaml` with the correct tag pattern per repo type

### Refactoring

- Hoisted `resolveExecutable` and `buildPublishArgs` above the publish loop — both depend only on `packageManager` and `options`, which are constant across iterations

### Tests

- Provenance forwarding per package manager (npm, pnpm, yarn-berry include; classic yarn excludes)
- Combination test for `--provenance` + `--dry-run` + `--no-git-checks`
- Template tests for monorepo and single-package variants with negative assertions for wrong tag patterns
- Scaffold tests updated to assert both workflow files across all paths (create, overwrite, skip, dry-run)