### PR TITLE
Make --provenance opt-in for private repo compatibility

### DIFF
--- a/.github/workflows/publish-workflow.yaml
+++ b/.github/workflows/publish-workflow.yaml
@@ -4,7 +4,8 @@ name: Publish
 # Reusable publish workflow for projects using @williamthorsen/release-kit.
 #
 # Triggered by tag pushes. Installs `@williamthorsen/release-kit` globally and
-# runs `release-kit publish --provenance` with OIDC-based npm authentication.
+# runs `release-kit publish` with OIDC-based npm authentication.
+# Pass `provenance: true` to enable npm provenance attestations (requires a public repo).
 # The calling workflow must grant `id-token: write` and `contents: read` permissions.
 #
 # Usage:
@@ -20,6 +21,11 @@ on:
         required: false
         type: string
         default: '24'
+      provenance:
+        description: 'Generate npm provenance attestations (requires a public repo)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -58,4 +64,4 @@ jobs:
         run: npm install --global @williamthorsen/release-kit
 
       - name: Publish
-        run: release-kit publish --provenance --no-git-checks
+        run: release-kit publish ${{ inputs.provenance && '--provenance' || '' }} --no-git-checks

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,3 +13,5 @@ permissions:
 jobs:
   publish:
     uses: ./.github/workflows/publish-workflow.yaml
+    with:
+      provenance: true

--- a/packages/release-kit/src/init/__tests__/initCommand.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/initCommand.unit.test.ts
@@ -141,6 +141,17 @@ describe(initCommand, () => {
     expect(mockScaffoldFiles).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
   });
 
+  it('includes provenance and trusted publisher hints in next steps', () => {
+    setupPassingChecks();
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    initCommand({ dryRun: false, force: false, withConfig: false });
+
+    const allOutput = spy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(allOutput).toContain('provenance: true');
+    expect(allOutput).toContain('trusted publisher');
+  });
+
   it('prints dry-run banner when dryRun is true', () => {
     setupPassingChecks();
     const spy = vi.spyOn(console, 'info').mockImplementation(() => undefined);

--- a/packages/release-kit/src/init/__tests__/templates.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/templates.unit.test.ts
@@ -57,6 +57,16 @@ describe(publishWorkflow, () => {
     expect(workflow).toContain('contents: read');
     expect(workflow).not.toContain('secrets:');
   });
+
+  it.each(['monorepo', 'single-package'] as const)(
+    'includes provenance: false with an explanatory comment (%s)',
+    (repoType) => {
+      const workflow = publishWorkflow(repoType);
+
+      expect(workflow).toContain('provenance: false');
+      expect(workflow).toContain('# Set to true for public repos to generate npm provenance attestations');
+    },
+  );
 });
 
 describe(releaseWorkflow, () => {

--- a/packages/release-kit/src/init/initCommand.ts
+++ b/packages/release-kit/src/init/initCommand.ts
@@ -90,8 +90,10 @@ export function initCommand({ dryRun, force, withConfig }: InitOptions): number 
     : '1. (Optional) Run again with --with-config to scaffold config files.';
   console.info(`
   ${configHint}
-  2. Test by running: npx @williamthorsen/release-kit prepare --dry-run
-  3. Commit the generated files.
+  2. If this is a public repo, set provenance: true in .github/workflows/publish.yaml.
+  3. Test by running: npx @williamthorsen/release-kit prepare --dry-run
+  4. Commit the generated files.
+  5. Register each package as a trusted publisher on npmjs.com.
 `);
 
   return 0;

--- a/packages/release-kit/src/init/templates.ts
+++ b/packages/release-kit/src/init/templates.ts
@@ -68,6 +68,8 @@ permissions:
 jobs:
   publish:
     uses: williamthorsen/node-monorepo-tools/.github/workflows/publish-workflow.yaml@publish-workflow-v1
+    with:
+      provenance: false # Set to true for public repos to generate npm provenance attestations
 `;
 }
 


### PR DESCRIPTION
Closes #91 

## What

Makes the `--provenance` flag opt-in on the reusable `publish-workflow.yaml` by adding a `provenance` boolean input that defaults to `false`. Updates the scaffolded template, init command next-steps output, and this repo's own entry-point workflow.

## Why

npm's `--provenance` flag requires a public repo because the attestation is published to Sigstore's public transparency log. Most consuming repos are private with public packages — OIDC auth works fine, but provenance does not. Defaulting to `false` makes the scaffolded workflow work out of the box for the majority case.

## Details

### Features

- Add `provenance` boolean input (default `false`) to `publish-workflow.yaml`; conditionally pass `--provenance` to `release-kit publish` only when `true`.
- Update `publishWorkflow()` in `templates.ts` to emit `provenance: false` with an inline comment explaining when to enable it.
- Expand `release-kit init` next-steps output with provenance setting and trusted publisher registration hints.
- Set `provenance: true` in this repo's `publish.yaml` (public repo).

### Tests

- New template test using `it.each` to verify `provenance: false` and explanatory comment for both repo types.
- New init command test verifying provenance and trusted publisher hints appear in next-steps output.

## Test plan

- [ ] Verify scaffolded `publish.yaml` includes `provenance: false` with explanatory comment
- [ ] Verify `release-kit init` next-steps output includes provenance and trusted publisher hints
- [ ] Test a publish from a public repo with `provenance: true` to confirm attestation is generated
- [ ] Test a publish from a private repo with default `provenance: false` to confirm no provenance error