### PR TITLE
#86 Resolve package.json scripts at root level and skip in recursive mode

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -19,9 +19,10 @@ on:
 
 jobs:
   code-quality:
-    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm.yaml@v1
+    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v4
     secrets:
       GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
     with:
+      check-command: nmr ci
       node-version: '24.14.0'
       pnpm-version: '10.33.0'

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "scripts": {
     "bootstrap": "cd packages/nmr && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json",
-    "ci": "nmr ci",
     "postinstall": "node scripts/postinstall.js",
     "prepare": "lefthook install"
   },

--- a/packages/nmr/__tests__/cli.test.ts
+++ b/packages/nmr/__tests__/cli.test.ts
@@ -7,10 +7,14 @@ const MONOREPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
 const NMR_PACKAGE_DIR = path.resolve(MONOREPO_ROOT, 'packages', 'nmr');
 const CLI_PATH = path.join(NMR_PACKAGE_DIR, 'dist', 'esm', 'cli.js');
 
-function runNmr(args: string, options: { cwd?: string } = {}): { stdout: string; stderr: string; exitCode: number } {
+function runNmr(
+  args: string,
+  options: { cwd?: string; env?: Record<string, string> } = {},
+): { stdout: string; stderr: string; exitCode: number } {
   try {
     const stdout = execSync(`node ${CLI_PATH} ${args}`, {
       cwd: options.cwd ?? MONOREPO_ROOT,
+      env: { ...process.env, ...options.env },
       encoding: 'utf8',
       timeout: 10_000,
     });
@@ -56,6 +60,32 @@ describe('nmr CLI', () => {
   it('exits with error for unknown command', () => {
     const { exitCode } = runNmr('nonexistent-command');
     expect(exitCode).toBe(1);
+  });
+
+  it('resolves root package.json scripts at monorepo root', () => {
+    const { exitCode } = runNmr('postinstall');
+    expect(exitCode).toBe(0);
+  });
+
+  it('does not log override message for package.json scripts not in registry', () => {
+    const { stdout, exitCode } = runNmr('postinstall');
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain('Using override script');
+  });
+
+  describe('NMR_RUN_IF_PRESENT', () => {
+    it('exits 0 for unknown command when set', () => {
+      const { exitCode, stderr } = runNmr('nonexistent-command', {
+        env: { NMR_RUN_IF_PRESENT: '1' },
+      });
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe('');
+    });
+
+    it('still exits 1 for unknown command when not set', () => {
+      const { exitCode } = runNmr('nonexistent-command');
+      expect(exitCode).toBe(1);
+    });
   });
 
   describe('--quiet flag', () => {

--- a/packages/nmr/src/cli.ts
+++ b/packages/nmr/src/cli.ts
@@ -111,6 +111,7 @@ async function main(): Promise<void> {
 
   // -R: delegate to pnpm --recursive
   if (parsed.recursive) {
+    process.env.NMR_RUN_IF_PRESENT = '1';
     const delegateCmd = `pnpm --recursive exec nmr ${command}${passthrough}`;
     const code = runCommand(delegateCmd, context.monorepoRoot, runOptions);
     process.exit(code);
@@ -120,9 +121,13 @@ async function main(): Promise<void> {
   const useRoot = parsed.workspaceRoot || context.isRoot;
   const registry = useRoot ? buildRootRegistry(context.config) : buildWorkspaceRegistry(context.config, parsed.intTest);
 
-  const resolved = resolveScript(command, registry, context.packageDir);
+  const packageDir = context.packageDir ?? context.monorepoRoot;
+  const resolved = resolveScript(command, registry, packageDir);
 
   if (!resolved) {
+    if (process.env.NMR_RUN_IF_PRESENT === '1') {
+      process.exit(0);
+    }
     console.error(`Unknown command: ${command}`);
     process.exit(1);
   }
@@ -134,7 +139,7 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  if (resolved.source === 'package' && !parsed.quiet) {
+  if (resolved.source === 'package' && !parsed.quiet && registry[command] !== undefined) {
     console.info(`Using override script: ${resolved.command}`);
   }
 


### PR DESCRIPTION
Closes #86 

## What

Pass `monorepoRoot` as `packageDir` when resolving at root level so root `package.json` scripts participate in the same override tier that workspace packages already use. Add `NMR_RUN_IF_PRESENT` env var support so `nmr -R` gracefully skips packages that don't define a given script. Fix the "Using override script" log message to only appear when a script genuinely overrides a registry command.

## Why

Previously, `nmr` could not resolve `package.json` scripts at the monorepo root — only workspace packages had their `package.json` consulted. This forced users to remember whether a script was an nmr command or a `package.json` script. Additionally, `nmr -R` with non-registry scripts would error on packages that didn't define the script, preventing its use as a unified entry point for heterogeneous workspaces.

## Details

### Features

- Root-level `package.json` scripts now resolve through the existing override tier by passing `monorepoRoot` as the package directory when `isRoot` is true.
- `nmr -R` sets `NMR_RUN_IF_PRESENT=1` in the child environment; child processes that can't resolve a command exit 0 instead of exit 1.
- "Using override script" is only logged when the `package.json` script actually overrides a registry command.

### Tests

- Root `package.json` script resolution at monorepo root (`postinstall`).
- Override message suppression for non-registry `package.json` scripts.
- `NMR_RUN_IF_PRESENT` skip behavior (exit 0 when set, exit 1 when not set).
- `runNmr` test helper extended with `env` option for environment variable injection.

### CI

- Updated `code-quality.yaml` to reference `code-quality-pnpm-workflow.yaml@v4` with explicit `check-command: nmr ci`.
- Removed self-referencing `ci: "nmr ci"` from root `package.json` to prevent infinite loops with the new root-level resolution.

## Test plan

- [ ] `nmr postinstall` at monorepo root resolves from root `package.json`
- [ ] `nmr ci` at monorepo root resolves from registry (no loop)
- [ ] `nmr unknown` at monorepo root exits 1
- [ ] `NMR_RUN_IF_PRESENT=1 nmr unknown` exits 0
- [ ] CI workflow runs successfully with the new workflow reference