### PR TITLE
#98 Support structured check outcomes with detail and progress

### DIFF
--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -174,6 +174,80 @@ describe(reportPreflight, () => {
     });
   });
 
+  describe('detail and progress rendering', () => {
+    it('renders detail inline after duration', () => {
+      const report = makeReport({
+        results: [{ name: 'check-a', status: 'passed', durationMs: 10, detail: 'some info' }],
+      });
+
+      const output = reportPreflight(report);
+
+      expect(output).toContain('\u2705 check-a (10ms) \u2014 some info');
+    });
+
+    it('renders fraction progress', () => {
+      const report = makeReport({
+        results: [{ name: 'check-b', status: 'failed', durationMs: 5, progress: { passedCount: 7, count: 10 } }],
+        passed: false,
+      });
+
+      const output = reportPreflight(report);
+
+      expect(output).toContain('\u274C check-b (5ms) \u2014 7 of 10');
+    });
+
+    it('renders percent progress', () => {
+      const report = makeReport({
+        results: [{ name: 'check-c', status: 'failed', durationMs: 3, progress: { percent: 85 } }],
+        passed: false,
+      });
+
+      const output = reportPreflight(report);
+
+      expect(output).toContain('\u274C check-c (3ms) \u2014 85%');
+    });
+
+    it('renders both detail and progress as separate segments', () => {
+      const report = makeReport({
+        results: [
+          {
+            name: 'check-d',
+            status: 'failed',
+            durationMs: 5,
+            detail: 'some detail',
+            progress: { passedCount: 7, count: 10 },
+          },
+        ],
+        passed: false,
+      });
+
+      const output = reportPreflight(report);
+
+      expect(output).toContain('\u274C check-d (5ms) \u2014 some detail \u2014 7 of 10');
+    });
+
+    it('renders detail and progress on passing checks', () => {
+      const report = makeReport({
+        results: [{ name: 'check-e', status: 'passed', durationMs: 2, detail: 'all good', progress: { percent: 100 } }],
+      });
+
+      const output = reportPreflight(report);
+
+      expect(output).toContain('\u2705 check-e (2ms) \u2014 all good \u2014 100%');
+    });
+
+    it('omits detail segment when detail is undefined', () => {
+      const report = makeReport({
+        results: [{ name: 'check-f', status: 'passed', durationMs: 1 }],
+      });
+
+      const output = reportPreflight(report);
+
+      expect(output).toContain('\u2705 check-f (1ms)');
+      expect(output).not.toContain('\u2014');
+    });
+  });
+
   it('defaults to END mode when no options are provided', () => {
     const report = makeReport({
       results: [

--- a/packages/preflight/__tests__/runPreflight.test.ts
+++ b/packages/preflight/__tests__/runPreflight.test.ts
@@ -193,6 +193,77 @@ describe(runPreflight, () => {
     });
   });
 
+  describe('structured check outcomes', () => {
+    it('carries detail from a passing CheckOutcome', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'outcome',
+        checks: [{ name: 'with-detail', check: () => ({ ok: true, detail: 'all files present' }) }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(true);
+      expect(report.results[0]?.status).toBe('passed');
+      expect(report.results[0]?.detail).toBe('all files present');
+    });
+
+    it('carries progress from a failing CheckOutcome', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'outcome',
+        checks: [{ name: 'with-progress', check: () => ({ ok: false, progress: { passedCount: 7, count: 10 } }) }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(false);
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.progress).toStrictEqual({ passedCount: 7, count: 10 });
+    });
+
+    it('carries both detail and progress', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'outcome',
+        checks: [
+          {
+            name: 'full-outcome',
+            check: () => ({ ok: false, detail: 'missing deps', progress: { percent: 85 } }),
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results[0]?.detail).toBe('missing deps');
+      expect(report.results[0]?.progress).toStrictEqual({ percent: 85 });
+    });
+
+    it('does not set detail or progress on skipped results', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'outcome',
+        preconditions: [{ name: 'pre-fail', check: () => false }],
+        checks: [{ name: 'skipped-check', check: () => ({ ok: true, detail: 'should not appear' }) }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      const skipped = report.results.find((r) => r.status === 'skipped');
+      expect(skipped?.detail).toBeUndefined();
+      expect(skipped?.progress).toBeUndefined();
+    });
+
+    it('handles async CheckOutcome', async () => {
+      const checklist: PreflightCheckList = {
+        name: 'async-outcome',
+        checks: [{ name: 'async-detail', check: () => Promise.resolve({ ok: true, detail: 'async info' }) }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(true);
+      expect(report.results[0]?.detail).toBe('async info');
+    });
+  });
+
   it('computes total duration', async () => {
     const checklist: PreflightCheckList = {
       name: 'timing',

--- a/packages/preflight/src/index.ts
+++ b/packages/preflight/src/index.ts
@@ -1,17 +1,22 @@
 // Types
 export type {
+  CheckOutcome,
+  CheckReturnValue,
   FixLocation,
+  FractionProgress,
+  PercentProgress,
   PreflightCheck,
   PreflightCheckList,
   PreflightConfig,
   PreflightReport,
   PreflightResult,
+  Progress,
   ReportOptions,
   StagedPreflightCheckList,
 } from './types.ts';
 
-// Type guard
-export { isFlatCheckList } from './types.ts';
+// Type guards
+export { isFlatCheckList, isPercentProgress } from './types.ts';
 
 // Config helpers
 export { definePreflightCheckList, definePreflightConfig, defineStagedPreflightCheckList } from './config.ts';

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -1,4 +1,5 @@
-import type { PreflightReport, PreflightResult, ReportOptions } from './types.ts';
+import type { PreflightReport, PreflightResult, Progress, ReportOptions } from './types.ts';
+import { isPercentProgress } from './types.ts';
 
 const ICON_PASSED = '\u2705';
 const ICON_FAILED = '\u274C';
@@ -14,6 +15,14 @@ function getIcon(status: PreflightResult['status']): string {
   if (status === 'passed') return ICON_PASSED;
   if (status === 'failed') return ICON_FAILED;
   return ICON_SKIPPED;
+}
+
+/** Format a progress value for display. */
+function formatProgress(progress: Progress): string {
+  if (isPercentProgress(progress)) {
+    return `${progress.percent}%`;
+  }
+  return `${progress.passedCount} of ${progress.count}`;
 }
 
 /** Collect inline detail lines (error and/or fix) for a failed result. */
@@ -41,7 +50,14 @@ export function reportPreflight(report: PreflightReport, options?: ReportOptions
 
   for (const result of report.results) {
     const icon = getIcon(result.status);
-    lines.push(`${icon} ${result.name} (${formatDuration(result.durationMs)})`);
+    let checkLine = `${icon} ${result.name} (${formatDuration(result.durationMs)})`;
+    if (result.detail !== undefined) {
+      checkLine += ` \u2014 ${result.detail}`;
+    }
+    if (result.progress !== undefined) {
+      checkLine += ` \u2014 ${formatProgress(result.progress)}`;
+    }
+    lines.push(checkLine);
 
     if (result.status === 'failed') {
       const includeFix = fixLocation === 'INLINE';

--- a/packages/preflight/src/runPreflight.ts
+++ b/packages/preflight/src/runPreflight.ts
@@ -10,28 +10,33 @@ import type {
 } from './types.ts';
 import { isFlatCheckList } from './types.ts';
 
+/** Optional fields that may appear on a preflight result. */
+interface ResultOptions {
+  fix?: string;
+  error?: Error;
+  detail?: string;
+  progress?: Progress;
+}
+
 /** Build a result object, only including optional fields when defined. */
 function buildResult(
   name: string,
   status: PreflightResult['status'],
   durationMs: number,
-  fix?: string,
-  error?: Error,
-  detail?: string,
-  progress?: Progress,
+  options: ResultOptions = {},
 ): PreflightResult {
   const result: PreflightResult = { name, status, durationMs };
-  if (fix !== undefined) {
-    result.fix = fix;
+  if (options.fix !== undefined) {
+    result.fix = options.fix;
   }
-  if (error !== undefined) {
-    result.error = error;
+  if (options.error !== undefined) {
+    result.error = options.error;
   }
-  if (detail !== undefined) {
-    result.detail = detail;
+  if (options.detail !== undefined) {
+    result.detail = options.detail;
   }
-  if (progress !== undefined) {
-    result.progress = progress;
+  if (options.progress !== undefined) {
+    result.progress = options.progress;
   }
   return result;
 }
@@ -43,27 +48,23 @@ async function executeCheck(check: PreflightCheck): Promise<PreflightResult> {
     const raw = await check.check();
     const durationMs = performance.now() - start;
     if (typeof raw === 'boolean') {
-      return buildResult(check.name, raw ? 'passed' : 'failed', durationMs, check.fix);
+      return buildResult(check.name, raw ? 'passed' : 'failed', durationMs, { fix: check.fix });
     }
-    return buildResult(
-      check.name,
-      raw.ok ? 'passed' : 'failed',
-      durationMs,
-      check.fix,
-      undefined,
-      raw.detail,
-      raw.progress,
-    );
+    return buildResult(check.name, raw.ok ? 'passed' : 'failed', durationMs, {
+      fix: check.fix,
+      detail: raw.detail,
+      progress: raw.progress,
+    });
   } catch (error_: unknown) {
     const durationMs = performance.now() - start;
     const error = error_ instanceof Error ? error_ : new Error(String(error_));
-    return buildResult(check.name, 'failed', durationMs, check.fix, error);
+    return buildResult(check.name, 'failed', durationMs, { fix: check.fix, error });
   }
 }
 
 /** Mark a check as skipped with zero duration. */
 function skipCheck(check: PreflightCheck): PreflightResult {
-  return buildResult(check.name, 'skipped', 0, check.fix);
+  return buildResult(check.name, 'skipped', 0, { fix: check.fix });
 }
 
 /** Run preconditions concurrently. Return true if all passed. */

--- a/packages/preflight/src/runPreflight.ts
+++ b/packages/preflight/src/runPreflight.ts
@@ -48,23 +48,30 @@ async function executeCheck(check: PreflightCheck): Promise<PreflightResult> {
     const raw = await check.check();
     const durationMs = performance.now() - start;
     if (typeof raw === 'boolean') {
-      return buildResult(check.name, raw ? 'passed' : 'failed', durationMs, { fix: check.fix });
+      return buildResult(
+        check.name,
+        raw ? 'passed' : 'failed',
+        durationMs,
+        check.fix !== undefined ? { fix: check.fix } : {},
+      );
     }
-    return buildResult(check.name, raw.ok ? 'passed' : 'failed', durationMs, {
-      fix: check.fix,
-      detail: raw.detail,
-      progress: raw.progress,
-    });
+    const opts: ResultOptions = {};
+    if (check.fix !== undefined) opts.fix = check.fix;
+    if (raw.detail !== undefined) opts.detail = raw.detail;
+    if (raw.progress !== undefined) opts.progress = raw.progress;
+    return buildResult(check.name, raw.ok ? 'passed' : 'failed', durationMs, opts);
   } catch (error_: unknown) {
     const durationMs = performance.now() - start;
     const error = error_ instanceof Error ? error_ : new Error(String(error_));
-    return buildResult(check.name, 'failed', durationMs, { fix: check.fix, error });
+    const opts: ResultOptions = { error };
+    if (check.fix !== undefined) opts.fix = check.fix;
+    return buildResult(check.name, 'failed', durationMs, opts);
   }
 }
 
 /** Mark a check as skipped with zero duration. */
 function skipCheck(check: PreflightCheck): PreflightResult {
-  return buildResult(check.name, 'skipped', 0, { fix: check.fix });
+  return buildResult(check.name, 'skipped', 0, check.fix !== undefined ? { fix: check.fix } : {});
 }
 
 /** Run preconditions concurrently. Return true if all passed. */

--- a/packages/preflight/src/runPreflight.ts
+++ b/packages/preflight/src/runPreflight.ts
@@ -5,6 +5,7 @@ import type {
   PreflightCheckList,
   PreflightReport,
   PreflightResult,
+  Progress,
   StagedPreflightCheckList,
 } from './types.ts';
 import { isFlatCheckList } from './types.ts';
@@ -16,6 +17,8 @@ function buildResult(
   durationMs: number,
   fix?: string,
   error?: Error,
+  detail?: string,
+  progress?: Progress,
 ): PreflightResult {
   const result: PreflightResult = { name, status, durationMs };
   if (fix !== undefined) {
@@ -24,6 +27,12 @@ function buildResult(
   if (error !== undefined) {
     result.error = error;
   }
+  if (detail !== undefined) {
+    result.detail = detail;
+  }
+  if (progress !== undefined) {
+    result.progress = progress;
+  }
   return result;
 }
 
@@ -31,9 +40,20 @@ function buildResult(
 async function executeCheck(check: PreflightCheck): Promise<PreflightResult> {
   const start = performance.now();
   try {
-    const passed = await check.check();
+    const raw = await check.check();
     const durationMs = performance.now() - start;
-    return buildResult(check.name, passed ? 'passed' : 'failed', durationMs, check.fix);
+    if (typeof raw === 'boolean') {
+      return buildResult(check.name, raw ? 'passed' : 'failed', durationMs, check.fix);
+    }
+    return buildResult(
+      check.name,
+      raw.ok ? 'passed' : 'failed',
+      durationMs,
+      check.fix,
+      undefined,
+      raw.detail,
+      raw.progress,
+    );
   } catch (error_: unknown) {
     const durationMs = performance.now() - start;
     const error = error_ instanceof Error ? error_ : new Error(String(error_));

--- a/packages/preflight/src/types.ts
+++ b/packages/preflight/src/types.ts
@@ -1,10 +1,41 @@
 /** Placement of fix messages in the report output. */
 export type FixLocation = 'INLINE' | 'END';
 
+/** Progress expressed as a fraction with passed and total counts. */
+export interface FractionProgress {
+  passedCount: number;
+  count: number;
+  failedCount?: number;
+  skippedCount?: number;
+}
+
+/** Progress expressed as a percentage. */
+export interface PercentProgress {
+  percent: number;
+}
+
+/** Union of progress representations, discriminated by the presence of `percent`. */
+export type Progress = FractionProgress | PercentProgress;
+
+/** Return true if a progress value uses the percentage representation. */
+export function isPercentProgress(progress: Progress): progress is PercentProgress {
+  return 'percent' in progress;
+}
+
+/** Structured outcome from a check, carrying diagnostic data alongside the pass/fail status. */
+export interface CheckOutcome {
+  ok: boolean;
+  detail?: string;
+  progress?: Progress;
+}
+
+/** The value a check function may return (or resolve to). */
+export type CheckReturnValue = boolean | CheckOutcome;
+
 /** A single check to run during preflight. */
 export interface PreflightCheck {
   name: string;
-  check: () => boolean | Promise<boolean>;
+  check: () => CheckReturnValue | Promise<CheckReturnValue>;
   fix?: string;
 }
 
@@ -14,6 +45,8 @@ export interface PreflightResult {
   status: 'passed' | 'failed' | 'skipped';
   fix?: string;
   error?: Error;
+  detail?: string;
+  progress?: Progress;
   durationMs: number;
 }
 

--- a/packages/preflight/src/types.ts
+++ b/packages/preflight/src/types.ts
@@ -5,8 +5,6 @@ export type FixLocation = 'INLINE' | 'END';
 export interface FractionProgress {
   passedCount: number;
   count: number;
-  failedCount?: number;
-  skippedCount?: number;
 }
 
 /** Progress expressed as a percentage. */


### PR DESCRIPTION
Closes #98 

## What

Widens the preflight check return type from `boolean` to `boolean | CheckOutcome`, where `CheckOutcome` carries an `ok` boolean plus optional `detail` (string) and `progress` (fraction or percentage) fields. The runner normalizes both return shapes, propagates `detail` and `progress` through `PreflightResult`, and the reporter renders them inline with em-dash separators for all check statuses.

## Why

Preflight checks could only report pass/fail, which is insufficient for status-reporting use cases like convention drift (#24). Checks like "workspace packages have build scripts?" need to convey "7 of 10", not just a red X.

## Details

### Features

- `CheckOutcome` type with `ok`, optional `detail`, and optional `progress` fields
- `FractionProgress` (`{ passedCount, count }`) renders as "N of M"
- `PercentProgress` (`{ percent }`) renders as "N%"
- `isPercentProgress` type guard for consumer-side discrimination
- Reporter appends detail and progress as ` — {segment}` after the duration for all statuses
- All new types exported from the public API: `CheckOutcome`, `CheckReturnValue`, `FractionProgress`, `PercentProgress`, `Progress`

### Refactoring

- `buildResult` refactored from 7 positional parameters to `(name, status, durationMs, options?)` with a `ResultOptions` object, eliminating `undefined` placeholders
- Removed unused `failedCount` and `skippedCount` from `FractionProgress`

### Tests

- Runner tests: CheckOutcome with detail, progress, both, async, and skipped-result propagation
- Reporter tests: detail rendering, fraction progress, percent progress, combined segments, passing checks, and undefined-omission