### PR TITLE
#104 Add combined summary after all checklists run

### DIFF
--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -5,6 +5,7 @@ import type { PreflightConfig } from '../src/types.ts';
 const mockLoadPreflightConfig = vi.hoisted(() => vi.fn());
 const mockRunPreflight = vi.hoisted(() => vi.fn());
 const mockReportPreflight = vi.hoisted(() => vi.fn());
+const mockFormatCombinedSummary = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/config.ts', () => ({
   loadPreflightConfig: mockLoadPreflightConfig,
@@ -16,6 +17,10 @@ vi.mock('../src/runPreflight.ts', () => ({
 
 vi.mock('../src/reportPreflight.ts', () => ({
   reportPreflight: mockReportPreflight,
+}));
+
+vi.mock('../src/formatCombinedSummary.ts', () => ({
+  formatCombinedSummary: mockFormatCombinedSummary,
 }));
 
 import { parseRunArgs, runCommand } from '../src/cli.ts';
@@ -89,6 +94,7 @@ describe(runCommand, () => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockReportPreflight.mockReturnValue('report output');
+    mockFormatCombinedSummary.mockReturnValue('combined summary');
   });
 
   afterEach(() => {
@@ -96,6 +102,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockReset();
     mockRunPreflight.mockReset();
     mockReportPreflight.mockReset();
+    mockFormatCombinedSummary.mockReset();
   });
 
   it('runs all checklists when no names are given', async () => {
@@ -209,5 +216,59 @@ describe(runCommand, () => {
 
     expect(stderrSpy).toHaveBeenCalledWith('Error: Config not found\n');
     expect(exitCode).toBe(1);
+  });
+
+  it('prints combined summary when multiple checklists run', async () => {
+    const config = makeConfig();
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({
+      results: [{ name: 'a', status: 'passed', durationMs: 10 }],
+      passed: true,
+      durationMs: 10,
+    });
+
+    await runCommand({ names: [] });
+
+    expect(mockFormatCombinedSummary).toHaveBeenCalledTimes(1);
+    expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
+      expect.objectContaining({ name: 'deploy', passed: 1, failed: 0, skipped: 0, allPassed: true }),
+      expect.objectContaining({ name: 'infra', passed: 1, failed: 0, skipped: 0, allPassed: true }),
+    ]);
+  });
+
+  it('does not print combined summary for a single checklist', async () => {
+    const config = makeConfig();
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runCommand({ names: ['deploy'] });
+
+    expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
+  });
+
+  it('includes failure counts in combined summary', async () => {
+    const config = makeConfig();
+    mockLoadPreflightConfig.mockResolvedValue(config);
+    mockRunPreflight
+      .mockResolvedValueOnce({
+        results: [
+          { name: 'a', status: 'passed', durationMs: 10 },
+          { name: 'b', status: 'failed', durationMs: 5 },
+        ],
+        passed: false,
+        durationMs: 15,
+      })
+      .mockResolvedValueOnce({
+        results: [{ name: 'c', status: 'skipped', durationMs: 0 }],
+        passed: false,
+        durationMs: 0,
+      });
+
+    await runCommand({ names: [] });
+
+    expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
+      expect.objectContaining({ name: 'deploy', passed: 1, failed: 1, skipped: 0, allPassed: false }),
+      expect.objectContaining({ name: 'infra', passed: 0, failed: 0, skipped: 1, allPassed: false }),
+    ]);
   });
 });

--- a/packages/preflight/__tests__/formatCombinedSummary.test.ts
+++ b/packages/preflight/__tests__/formatCombinedSummary.test.ts
@@ -23,16 +23,16 @@ describe(formatCombinedSummary, () => {
     expect(output.split('\n').at(-2)).toMatch(/^─+$/);
   });
 
-  it('shows ✅ prefix for a passing checklist', () => {
+  it('shows 🟢 prefix for a passing checklist', () => {
     const output = formatCombinedSummary([makeSummary({ name: 'deploy' })]);
 
-    expect(output).toContain('✅ deploy');
+    expect(output).toContain('🟢 deploy');
   });
 
-  it('shows ❌ prefix for a failing checklist', () => {
+  it('shows 🔴 prefix for a failing checklist', () => {
     const output = formatCombinedSummary([makeSummary({ name: 'deploy', failed: 1, allPassed: false })]);
 
-    expect(output).toContain('❌ deploy');
+    expect(output).toContain('🔴 deploy');
   });
 
   it('includes duration and non-zero counts in each row', () => {
@@ -40,7 +40,7 @@ describe(formatCombinedSummary, () => {
       makeSummary({ name: 'infra', passed: 2, failed: 1, skipped: 0, allPassed: false, durationMs: 45 }),
     ]);
 
-    expect(output).toContain('❌ infra  45ms  2 passed, 1 failed');
+    expect(output).toContain('🔴 infra  45ms  2 passed, 1 failed');
     expect(output).not.toContain('skipped');
   });
 
@@ -49,7 +49,7 @@ describe(formatCombinedSummary, () => {
       makeSummary({ name: 'deploy', passed: 5, failed: 0, skipped: 0, durationMs: 200 }),
     ]);
 
-    expect(output).toContain('✅ deploy  200ms  5 passed');
+    expect(output).toContain('🟢 deploy  200ms  5 passed');
     expect(output).not.toContain('failed');
   });
 
@@ -59,7 +59,7 @@ describe(formatCombinedSummary, () => {
       makeSummary({ name: 'other', passed: 5, failed: 2, skipped: 1, allPassed: false, durationMs: 200 }),
     ]);
 
-    expect(output).toContain('Total: ✅ 15 passed, ❌ 2 failed, 🚫 1 skipped (300ms)');
+    expect(output).toContain('Total: 🟢 15 passed, 🔴 2 failed, ⛔ 1 skipped (300ms)');
   });
 
   it('omits zero counts from the Total line', () => {
@@ -68,9 +68,21 @@ describe(formatCombinedSummary, () => {
       makeSummary({ name: 'other', passed: 7, failed: 0, skipped: 0, durationMs: 150 }),
     ]);
 
-    expect(output).toContain('Total: ✅ 10 passed (200ms)');
+    expect(output).toContain('Total: 🟢 10 passed (200ms)');
     expect(output).not.toContain('failed');
     expect(output).not.toContain('skipped');
+  });
+
+  it('right-aligns durations and left-aligns names across rows', () => {
+    const output = formatCombinedSummary([
+      makeSummary({ name: 'ab', durationMs: 5 }),
+      makeSummary({ name: 'cdef', durationMs: 1200 }),
+    ]);
+
+    const rows = output.split('\n').filter((l) => l.includes('passed'));
+    // "ab" padded to length of "cdef", "5ms" padded to length of "1200ms"
+    expect(rows[0]).toContain('🟢 ab       5ms');
+    expect(rows[1]).toContain('🟢 cdef  1200ms');
   });
 
   it('includes skipped in row when non-zero', () => {

--- a/packages/preflight/__tests__/formatCombinedSummary.test.ts
+++ b/packages/preflight/__tests__/formatCombinedSummary.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCombinedSummary } from '../src/formatCombinedSummary.ts';
+import type { ChecklistSummary } from '../src/types.ts';
+
+function makeSummary(overrides?: Partial<ChecklistSummary>): ChecklistSummary {
+  return {
+    name: 'test-checklist',
+    passed: 3,
+    failed: 0,
+    skipped: 0,
+    allPassed: true,
+    durationMs: 100,
+    ...overrides,
+  };
+}
+
+describe(formatCombinedSummary, () => {
+  it('renders the summary header and footer lines', () => {
+    const output = formatCombinedSummary([makeSummary()]);
+
+    expect(output).toContain('── Summary');
+    expect(output.split('\n').at(-2)).toMatch(/^─+$/);
+  });
+
+  it('shows ✅ prefix for a passing checklist', () => {
+    const output = formatCombinedSummary([makeSummary({ name: 'deploy' })]);
+
+    expect(output).toContain('✅ deploy');
+  });
+
+  it('shows ❌ prefix for a failing checklist', () => {
+    const output = formatCombinedSummary([makeSummary({ name: 'deploy', failed: 1, allPassed: false })]);
+
+    expect(output).toContain('❌ deploy');
+  });
+
+  it('includes duration and non-zero counts in each row', () => {
+    const output = formatCombinedSummary([
+      makeSummary({ name: 'infra', passed: 2, failed: 1, skipped: 0, allPassed: false, durationMs: 45 }),
+    ]);
+
+    expect(output).toContain('❌ infra  45ms  2 passed, 1 failed');
+    expect(output).not.toContain('skipped');
+  });
+
+  it('omits zero counts from row', () => {
+    const output = formatCombinedSummary([
+      makeSummary({ name: 'deploy', passed: 5, failed: 0, skipped: 0, durationMs: 200 }),
+    ]);
+
+    expect(output).toContain('✅ deploy  200ms  5 passed');
+    expect(output).not.toContain('failed');
+  });
+
+  it('renders the Total line with icon-prefixed counts and total duration', () => {
+    const output = formatCombinedSummary([
+      makeSummary({ passed: 10, failed: 0, skipped: 0, durationMs: 100 }),
+      makeSummary({ name: 'other', passed: 5, failed: 2, skipped: 1, allPassed: false, durationMs: 200 }),
+    ]);
+
+    expect(output).toContain('Total: ✅ 15 passed, ❌ 2 failed, 🚫 1 skipped (300ms)');
+  });
+
+  it('omits zero counts from the Total line', () => {
+    const output = formatCombinedSummary([
+      makeSummary({ passed: 3, failed: 0, skipped: 0, durationMs: 50 }),
+      makeSummary({ name: 'other', passed: 7, failed: 0, skipped: 0, durationMs: 150 }),
+    ]);
+
+    expect(output).toContain('Total: ✅ 10 passed (200ms)');
+    expect(output).not.toContain('failed');
+    expect(output).not.toContain('skipped');
+  });
+
+  it('includes skipped in row when non-zero', () => {
+    const output = formatCombinedSummary([
+      makeSummary({ name: 'checks', passed: 1, failed: 1, skipped: 2, allPassed: false, durationMs: 80 }),
+    ]);
+
+    expect(output).toContain('1 passed, 1 failed, 2 skipped');
+  });
+});

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -20,7 +20,7 @@ describe(reportPreflight, () => {
 
     const output = reportPreflight(report);
 
-    expect(output).toContain('\u2705 check-a (10ms)');
+    expect(output).toContain('\u{1F7E2} check-a (10ms)');
   });
 
   it('shows failed checks with cross icon', () => {
@@ -31,7 +31,7 @@ describe(reportPreflight, () => {
 
     const output = reportPreflight(report);
 
-    expect(output).toContain('\u274C check-b (5ms)');
+    expect(output).toContain('\u{1F534} check-b (5ms)');
   });
 
   it('shows skipped checks with circle icon', () => {
@@ -41,7 +41,7 @@ describe(reportPreflight, () => {
 
     const output = reportPreflight(report);
 
-    expect(output).toContain('\u26AA check-c (0ms)');
+    expect(output).toContain('\u26D4 check-c (0ms)');
   });
 
   it('renders the summary line', () => {
@@ -57,7 +57,7 @@ describe(reportPreflight, () => {
 
     const output = reportPreflight(report);
 
-    expect(output).toContain('✅ 1 passed, ❌ 1 failed, 🚫 1 skipped (142ms)');
+    expect(output).toContain('🟢 1 passed, 🔴 1 failed, ⛔ 1 skipped (142ms)');
   });
 
   it('omits zero counts from the summary line', () => {
@@ -71,7 +71,7 @@ describe(reportPreflight, () => {
 
     const output = reportPreflight(report);
 
-    expect(output).toContain('✅ 2 passed (25ms)');
+    expect(output).toContain('🟢 2 passed (25ms)');
     expect(output).not.toContain('failed');
     expect(output).not.toContain('skipped');
   });
@@ -198,7 +198,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      expect(output).toContain('\u2705 check-a (10ms) \u2014 some info');
+      expect(output).toContain('\u{1F7E2} check-a (10ms) \u2014 some info');
     });
 
     it('renders fraction progress', () => {
@@ -209,7 +209,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      expect(output).toContain('\u274C check-b (5ms) \u2014 7 of 10');
+      expect(output).toContain('\u{1F534} check-b (5ms) \u2014 7 of 10');
     });
 
     it('renders percent progress', () => {
@@ -220,7 +220,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      expect(output).toContain('\u274C check-c (3ms) \u2014 85%');
+      expect(output).toContain('\u{1F534} check-c (3ms) \u2014 85%');
     });
 
     it('renders both detail and progress as separate segments', () => {
@@ -239,7 +239,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      expect(output).toContain('\u274C check-d (5ms) \u2014 some detail \u2014 7 of 10');
+      expect(output).toContain('\u{1F534} check-d (5ms) \u2014 some detail \u2014 7 of 10');
     });
 
     it('renders detail and progress on passing checks', () => {
@@ -249,7 +249,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      expect(output).toContain('\u2705 check-e (2ms) \u2014 all good \u2014 100%');
+      expect(output).toContain('\u{1F7E2} check-e (2ms) \u2014 all good \u2014 100%');
     });
 
     it('omits detail segment when detail is undefined', () => {
@@ -259,7 +259,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      expect(output).toContain('\u2705 check-f (1ms)');
+      expect(output).toContain('\u{1F7E2} check-f (1ms)');
       expect(output).not.toContain('\u2014');
     });
   });
@@ -288,15 +288,15 @@ describe(reportPreflight, () => {
 
 describe(formatSummaryCounts, () => {
   it('includes all non-zero counts with icons', () => {
-    expect(formatSummaryCounts(3, 1, 2)).toBe('✅ 3 passed, ❌ 1 failed, 🚫 2 skipped');
+    expect(formatSummaryCounts(3, 1, 2)).toBe('🟢 3 passed, 🔴 1 failed, ⛔ 2 skipped');
   });
 
   it('omits zero counts', () => {
-    expect(formatSummaryCounts(5, 0, 0)).toBe('✅ 5 passed');
+    expect(formatSummaryCounts(5, 0, 0)).toBe('🟢 5 passed');
   });
 
   it('omits passed when zero', () => {
-    expect(formatSummaryCounts(0, 2, 1)).toBe('❌ 2 failed, 🚫 1 skipped');
+    expect(formatSummaryCounts(0, 2, 1)).toBe('🔴 2 failed, ⛔ 1 skipped');
   });
 
   it('returns empty string when all counts are zero', () => {

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { reportPreflight } from '../src/reportPreflight.ts';
+import { formatSummaryCounts, reportPreflight } from '../src/reportPreflight.ts';
 import type { PreflightReport } from '../src/types.ts';
 
 function makeReport(overrides?: Partial<PreflightReport>): PreflightReport {
@@ -57,7 +57,23 @@ describe(reportPreflight, () => {
 
     const output = reportPreflight(report);
 
-    expect(output).toContain('1 passed, 1 failed, 1 skipped (142ms)');
+    expect(output).toContain('✅ 1 passed, ❌ 1 failed, 🚫 1 skipped (142ms)');
+  });
+
+  it('omits zero counts from the summary line', () => {
+    const report = makeReport({
+      results: [
+        { name: 'a', status: 'passed', durationMs: 10 },
+        { name: 'b', status: 'passed', durationMs: 15 },
+      ],
+      durationMs: 25,
+    });
+
+    const output = reportPreflight(report);
+
+    expect(output).toContain('✅ 2 passed (25ms)');
+    expect(output).not.toContain('failed');
+    expect(output).not.toContain('skipped');
   });
 
   describe('INLINE mode', () => {
@@ -267,5 +283,23 @@ describe(reportPreflight, () => {
     expect(output).toContain('Fixes:');
     expect(output).toContain('  Fix it');
     expect(output).not.toContain('Fix: Fix it');
+  });
+});
+
+describe(formatSummaryCounts, () => {
+  it('includes all non-zero counts with icons', () => {
+    expect(formatSummaryCounts(3, 1, 2)).toBe('✅ 3 passed, ❌ 1 failed, 🚫 2 skipped');
+  });
+
+  it('omits zero counts', () => {
+    expect(formatSummaryCounts(5, 0, 0)).toBe('✅ 5 passed');
+  });
+
+  it('omits passed when zero', () => {
+    expect(formatSummaryCounts(0, 2, 1)).toBe('❌ 2 failed, 🚫 1 skipped');
+  });
+
+  it('returns empty string when all counts are zero', () => {
+    expect(formatSummaryCounts(0, 0, 0)).toBe('');
   });
 });

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -1,9 +1,17 @@
 import process from 'node:process';
 
 import { loadPreflightConfig } from './config.ts';
+import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { reportPreflight } from './reportPreflight.ts';
 import { runPreflight } from './runPreflight.ts';
-import type { FixLocation, PreflightCheckList, PreflightConfig, StagedPreflightCheckList } from './types.ts';
+import type {
+  ChecklistSummary,
+  FixLocation,
+  PreflightCheckList,
+  PreflightConfig,
+  PreflightReport,
+  StagedPreflightCheckList,
+} from './types.ts';
 
 interface ParsedRunArgs {
   configPath?: string;
@@ -48,6 +56,19 @@ function resolveFixLocation(
   return checklist.fixLocation ?? configDefault ?? 'END';
 }
 
+/** Build a checklist summary from a report and its checklist name. */
+function summarizeReport(name: string, report: PreflightReport): ChecklistSummary {
+  let passed = 0;
+  let failed = 0;
+  let skipped = 0;
+  for (const r of report.results) {
+    if (r.status === 'passed') passed++;
+    else if (r.status === 'failed') failed++;
+    else skipped++;
+  }
+  return { name, passed, failed, skipped, allPassed: report.passed, durationMs: report.durationMs };
+}
+
 interface RunCommandOptions {
   names: string[];
   configPath?: string;
@@ -80,6 +101,7 @@ export async function runCommand({ names, configPath }: RunCommandOptions): Prom
 
   const showHeader = checklists.length > 1;
   let allPassed = true;
+  const summaries: ChecklistSummary[] = [];
 
   for (const checklist of checklists) {
     if (showHeader) {
@@ -94,6 +116,14 @@ export async function runCommand({ names, configPath }: RunCommandOptions): Prom
     if (!report.passed) {
       allPassed = false;
     }
+
+    if (showHeader) {
+      summaries.push(summarizeReport(checklist.name, report));
+    }
+  }
+
+  if (summaries.length > 1) {
+    process.stdout.write('\n' + formatCombinedSummary(summaries) + '\n');
   }
 
   return allPassed ? 0 : 1;

--- a/packages/preflight/src/formatCombinedSummary.ts
+++ b/packages/preflight/src/formatCombinedSummary.ts
@@ -1,8 +1,8 @@
 import { formatSummaryCounts } from './reportPreflight.ts';
 import type { ChecklistSummary } from './types.ts';
 
-const ICON_PASSED = '\u2705';
-const ICON_FAILED = '\u274C';
+const ICON_PASSED = '\u{1F7E2}';
+const ICON_FAILED = '\u{1F534}';
 
 /** Format a duration in milliseconds for display. */
 function formatDuration(ms: number): string {
@@ -24,11 +24,15 @@ export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
     '\u2500\u2500 Summary \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500';
   const lines: string[] = [HEADER];
 
+  const maxNameLen = Math.max(...summaries.map((s) => s.name.length));
+  const maxDurationLen = Math.max(...summaries.map((s) => formatDuration(s.durationMs).length));
+
   for (const summary of summaries) {
     const icon = summary.allPassed ? ICON_PASSED : ICON_FAILED;
-    const duration = formatDuration(summary.durationMs);
+    const name = summary.name.padEnd(maxNameLen);
+    const duration = formatDuration(summary.durationMs).padStart(maxDurationLen);
     const counts = formatRowCounts(summary);
-    lines.push(`${icon} ${summary.name}  ${duration}  ${counts}`);
+    lines.push(`${icon} ${name}  ${duration}  ${counts}`);
   }
 
   lines.push(

--- a/packages/preflight/src/formatCombinedSummary.ts
+++ b/packages/preflight/src/formatCombinedSummary.ts
@@ -1,0 +1,48 @@
+import { formatSummaryCounts } from './reportPreflight.ts';
+import type { ChecklistSummary } from './types.ts';
+
+const ICON_PASSED = '\u2705';
+const ICON_FAILED = '\u274C';
+
+/** Format a duration in milliseconds for display. */
+function formatDuration(ms: number): string {
+  return `${Math.round(ms)}ms`;
+}
+
+/** Format a single row's non-zero counts without icons. */
+function formatRowCounts(summary: ChecklistSummary): string {
+  const parts: string[] = [];
+  if (summary.passed > 0) parts.push(`${summary.passed} passed`);
+  if (summary.failed > 0) parts.push(`${summary.failed} failed`);
+  if (summary.skipped > 0) parts.push(`${summary.skipped} skipped`);
+  return parts.join(', ');
+}
+
+/** Format the combined summary table shown after multiple checklists run. */
+export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
+  const HEADER =
+    '\u2500\u2500 Summary \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500';
+  const lines: string[] = [HEADER];
+
+  for (const summary of summaries) {
+    const icon = summary.allPassed ? ICON_PASSED : ICON_FAILED;
+    const duration = formatDuration(summary.durationMs);
+    const counts = formatRowCounts(summary);
+    lines.push(`${icon} ${summary.name}  ${duration}  ${counts}`);
+  }
+
+  lines.push(
+    '\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500',
+  );
+
+  const totalPassed = summaries.reduce((sum, s) => sum + s.passed, 0);
+  const totalFailed = summaries.reduce((sum, s) => sum + s.failed, 0);
+  const totalSkipped = summaries.reduce((sum, s) => sum + s.skipped, 0);
+  const totalDuration = summaries.reduce((sum, s) => sum + s.durationMs, 0);
+
+  lines.push(
+    `Total: ${formatSummaryCounts(totalPassed, totalFailed, totalSkipped)} (${formatDuration(totalDuration)})`,
+  );
+
+  return lines.join('\n');
+}

--- a/packages/preflight/src/index.ts
+++ b/packages/preflight/src/index.ts
@@ -1,5 +1,6 @@
 // Types
 export type {
+  ChecklistSummary,
   CheckOutcome,
   CheckReturnValue,
   FixLocation,
@@ -25,4 +26,5 @@ export { definePreflightCheckList, definePreflightConfig, defineStagedPreflightC
 export { runPreflight } from './runPreflight.ts';
 
 // Reporter
-export { reportPreflight } from './reportPreflight.ts';
+export { formatCombinedSummary } from './formatCombinedSummary.ts';
+export { formatSummaryCounts, reportPreflight } from './reportPreflight.ts';

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -4,6 +4,7 @@ import { isPercentProgress } from './types.ts';
 const ICON_PASSED = '\u2705';
 const ICON_FAILED = '\u274C';
 const ICON_SKIPPED = '\u26AA';
+const ICON_SKIPPED_SUMMARY = '\u{1F6AB}';
 
 /** Format a duration in milliseconds for display. */
 function formatDuration(ms: number): string {
@@ -23,6 +24,15 @@ function formatProgress(progress: Progress): string {
     return `${progress.percent}%`;
   }
   return `${progress.passedCount} of ${progress.count}`;
+}
+
+/** Build an icon-prefixed summary string, omitting counts that are zero. */
+export function formatSummaryCounts(passed: number, failed: number, skipped: number): string {
+  const parts: string[] = [];
+  if (passed > 0) parts.push(`${ICON_PASSED} ${passed} passed`);
+  if (failed > 0) parts.push(`${ICON_FAILED} ${failed} failed`);
+  if (skipped > 0) parts.push(`${ICON_SKIPPED_SUMMARY} ${skipped} skipped`);
+  return parts.join(', ');
 }
 
 /** Collect inline detail lines (error and/or fix) for a failed result. */
@@ -78,7 +88,7 @@ export function reportPreflight(report: PreflightReport, options?: ReportOptions
     else if (r.status === 'failed') failed++;
     else skipped++;
   }
-  lines.push('', `${passed} passed, ${failed} failed, ${skipped} skipped (${formatDuration(report.durationMs)})`);
+  lines.push('', `${formatSummaryCounts(passed, failed, skipped)} (${formatDuration(report.durationMs)})`);
 
   // Collected fixes section for END mode
   if (fixLocation === 'END' && collectedFixes.length > 0) {

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -1,10 +1,9 @@
 import type { PreflightReport, PreflightResult, Progress, ReportOptions } from './types.ts';
 import { isPercentProgress } from './types.ts';
 
-const ICON_PASSED = '\u2705';
-const ICON_FAILED = '\u274C';
-const ICON_SKIPPED = '\u26AA';
-const ICON_SKIPPED_SUMMARY = '\u{1F6AB}';
+const ICON_PASSED = '\u{1F7E2}';
+const ICON_FAILED = '\u{1F534}';
+const ICON_SKIPPED = '\u26D4';
 
 /** Format a duration in milliseconds for display. */
 function formatDuration(ms: number): string {
@@ -31,7 +30,7 @@ export function formatSummaryCounts(passed: number, failed: number, skipped: num
   const parts: string[] = [];
   if (passed > 0) parts.push(`${ICON_PASSED} ${passed} passed`);
   if (failed > 0) parts.push(`${ICON_FAILED} ${failed} failed`);
-  if (skipped > 0) parts.push(`${ICON_SKIPPED_SUMMARY} ${skipped} skipped`);
+  if (skipped > 0) parts.push(`${ICON_SKIPPED} ${skipped} skipped`);
   return parts.join(', ');
 }
 

--- a/packages/preflight/src/types.ts
+++ b/packages/preflight/src/types.ts
@@ -71,6 +71,16 @@ export interface StagedPreflightCheckList {
   fixLocation?: FixLocation;
 }
 
+/** Per-checklist aggregate for the combined summary table. */
+export interface ChecklistSummary {
+  name: string;
+  passed: number;
+  failed: number;
+  skipped: number;
+  allPassed: boolean;
+  durationMs: number;
+}
+
 /** Options controlling how the report is formatted. */
 export interface ReportOptions {
   fixLocation?: FixLocation;


### PR DESCRIPTION
Closes #104 

## What

Adds a combined summary table that prints after all checklists complete when two or more checklists run. Each row shows a pass/fail icon, checklist name, aligned duration, and non-zero counts. A Total line aggregates across all checklists with icon-prefixed counts and total duration. The single-checklist summary line is also updated to use icon-prefixed counts with zero omission. All status icons are changed to a traffic-light scheme (🟢/🔴/⛔) to align with the planned "greenlight" package name.

## Why

When multiple checklists run, the final checklist's summary is the last thing visible on screen. Failures from earlier checklists scroll off, making it look like everything passed. The combined summary ensures the user always sees the full picture regardless of terminal height or number of checklists.

## Details

### Features

- Combined summary table with box-drawing borders, shown only for multi-checklist runs.
- Per-row format: pass/fail icon, checklist name (left-aligned), duration (right-aligned), non-zero counts.
- Total line with icon-prefixed counts, zero omission, and total duration in parens.
- Single-checklist summary line updated from plain-text (`2 passed, 1 failed, 0 skipped`) to icon-prefixed format (`🟢 2 passed, 🔴 1 failed`) with zero omission.
- New `ChecklistSummary` type, `formatCombinedSummary` function, and `formatSummaryCounts` helper exported from the public API.

### Refactoring

- Replaced ✅/❌/⚪ icons with traffic-light 🟢/🔴/⛔ across all check result lines and summary lines.
- Unified the per-check and summary skipped icons into a single `ICON_SKIPPED` constant.

### Tests

- Updated existing `reportPreflight` tests for new icon and summary format.
- Added `formatSummaryCounts` unit tests (icon prefixing, zero omission, empty case).
- Added `formatCombinedSummary` test suite (header/footer rendering, pass/fail icons, duration and count formatting, column alignment, Total line, zero omission).
- Added CLI tests for combined summary presence/absence and summary data correctness.

## Test plan

- Manual run of `preflight run` with multiple checklists to visually confirm combined summary
- Manual run of `preflight run <single>` to confirm combined summary is absent