### PR TITLE
#107 Add `--json` flag for structured output

### DIFF
--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -6,6 +6,8 @@ const mockLoadPreflightConfig = vi.hoisted(() => vi.fn());
 const mockRunPreflight = vi.hoisted(() => vi.fn());
 const mockReportPreflight = vi.hoisted(() => vi.fn());
 const mockFormatCombinedSummary = vi.hoisted(() => vi.fn());
+const mockFormatJsonReport = vi.hoisted(() => vi.fn());
+const mockFormatJsonError = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/config.ts', () => ({
   loadPreflightConfig: mockLoadPreflightConfig,
@@ -21,6 +23,14 @@ vi.mock('../src/reportPreflight.ts', () => ({
 
 vi.mock('../src/formatCombinedSummary.ts', () => ({
   formatCombinedSummary: mockFormatCombinedSummary,
+}));
+
+vi.mock('../src/formatJsonReport.ts', () => ({
+  formatJsonReport: mockFormatJsonReport,
+}));
+
+vi.mock('../src/formatJsonError.ts', () => ({
+  formatJsonError: mockFormatJsonError,
 }));
 
 import { parseRunArgs, runCommand } from '../src/cli.ts';
@@ -81,6 +91,26 @@ describe(parseRunArgs, () => {
     expect(() => parseRunArgs(['--config='])).toThrow('--config requires a path argument');
   });
 
+  it('parses --json flag', () => {
+    const result = parseRunArgs(['--json']);
+
+    expect(result.json).toBe(true);
+    expect(result.names).toStrictEqual([]);
+  });
+
+  it('parses --json with positional names', () => {
+    const result = parseRunArgs(['--json', 'deploy']);
+
+    expect(result.json).toBe(true);
+    expect(result.names).toStrictEqual(['deploy']);
+  });
+
+  it('defaults json to false', () => {
+    const result = parseRunArgs([]);
+
+    expect(result.json).toBe(false);
+  });
+
   it('throws on unknown flags', () => {
     expect(() => parseRunArgs(['--unknown'])).toThrow("unknown flag '--unknown'");
   });
@@ -103,6 +133,8 @@ describe(runCommand, () => {
     mockRunPreflight.mockReset();
     mockReportPreflight.mockReset();
     mockFormatCombinedSummary.mockReset();
+    mockFormatJsonReport.mockReset();
+    mockFormatJsonError.mockReset();
   });
 
   it('runs all checklists when no names are given', async () => {
@@ -270,5 +302,86 @@ describe(runCommand, () => {
       expect.objectContaining({ name: 'deploy', passed: 1, failed: 1, skipped: 0, allPassed: false }),
       expect.objectContaining({ name: 'infra', passed: 0, failed: 0, skipped: 1, allPassed: false }),
     ]);
+  });
+
+  describe('JSON mode', () => {
+    beforeEach(() => {
+      mockFormatJsonReport.mockReturnValue('{"allPassed":true}');
+      mockFormatJsonError.mockReturnValue('{"error":"boom"}');
+    });
+
+    it('emits JSON output and no human-readable text', async () => {
+      const config = makeConfig();
+      mockLoadPreflightConfig.mockResolvedValue(config);
+      mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+      const exitCode = await runCommand({ names: [], json: true });
+
+      expect(mockFormatJsonReport).toHaveBeenCalledTimes(1);
+      expect(mockReportPreflight).not.toHaveBeenCalled();
+      expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
+      expect(stdoutSpy).toHaveBeenCalledWith('{"allPassed":true}\n');
+      expect(exitCode).toBe(0);
+    });
+
+    it('returns exit code 1 when any checklist fails in JSON mode', async () => {
+      const config = makeConfig();
+      mockLoadPreflightConfig.mockResolvedValue(config);
+      mockRunPreflight
+        .mockResolvedValueOnce({ results: [], passed: true, durationMs: 0 })
+        .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
+
+      const exitCode = await runCommand({ names: [], json: true });
+
+      expect(exitCode).toBe(1);
+    });
+
+    it('emits JSON error to stdout for config loading errors', async () => {
+      mockLoadPreflightConfig.mockRejectedValue(new Error('Config not found'));
+
+      const exitCode = await runCommand({ names: [], json: true });
+
+      expect(mockFormatJsonError).toHaveBeenCalledWith('Config not found');
+      expect(stdoutSpy).toHaveBeenCalledWith('{"error":"boom"}\n');
+      expect(stderrSpy).not.toHaveBeenCalled();
+      expect(exitCode).toBe(1);
+    });
+
+    it('emits JSON error to stdout for unknown checklist names', async () => {
+      const config = makeConfig();
+      mockLoadPreflightConfig.mockResolvedValue(config);
+
+      const exitCode = await runCommand({ names: ['nonexistent'], json: true });
+
+      expect(mockFormatJsonError).toHaveBeenCalledWith(expect.stringContaining('unknown checklist(s): nonexistent'));
+      expect(stderrSpy).not.toHaveBeenCalled();
+      expect(exitCode).toBe(1);
+    });
+
+    it('passes checklist name-report pairs to formatJsonReport', async () => {
+      const config = makeConfig();
+      mockLoadPreflightConfig.mockResolvedValue(config);
+      const report1 = { results: [], passed: true, durationMs: 10 };
+      const report2 = { results: [], passed: true, durationMs: 20 };
+      mockRunPreflight.mockResolvedValueOnce(report1).mockResolvedValueOnce(report2);
+
+      await runCommand({ names: [], json: true });
+
+      expect(mockFormatJsonReport).toHaveBeenCalledWith([
+        { name: 'deploy', report: report1 },
+        { name: 'infra', report: report2 },
+      ]);
+    });
+
+    it('does not write headers in JSON mode', async () => {
+      const config = makeConfig();
+      mockLoadPreflightConfig.mockResolvedValue(config);
+      mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+      await runCommand({ names: [], json: true });
+
+      const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(allOutput).not.toContain('---');
+    });
   });
 });

--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -150,7 +150,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    const exitCode = await runCommand({ names: [] });
+    const exitCode = await runCommand({ names: [], json: false });
 
     expect(mockRunPreflight).toHaveBeenCalledTimes(2);
     expect(exitCode).toBe(0);
@@ -161,7 +161,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    const exitCode = await runCommand({ names: ['deploy'] });
+    const exitCode = await runCommand({ names: ['deploy'], json: false });
 
     expect(mockRunPreflight).toHaveBeenCalledTimes(1);
     expect(mockRunPreflight).toHaveBeenCalledWith(config.checklists[0]);
@@ -172,7 +172,7 @@ describe(runCommand, () => {
     const config = makeConfig();
     mockLoadPreflightConfig.mockResolvedValue(config);
 
-    const exitCode = await runCommand({ names: ['nonexistent'] });
+    const exitCode = await runCommand({ names: ['nonexistent'], json: false });
 
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unknown checklist(s): nonexistent'));
     expect(exitCode).toBe(1);
@@ -185,7 +185,7 @@ describe(runCommand, () => {
       .mockResolvedValueOnce({ results: [], passed: true, durationMs: 0 })
       .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
 
-    const exitCode = await runCommand({ names: [] });
+    const exitCode = await runCommand({ names: [], json: false });
 
     expect(exitCode).toBe(1);
   });
@@ -195,7 +195,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: [], configPath: 'custom/path.ts' });
+    await runCommand({ names: [], configPath: 'custom/path.ts', json: false });
 
     expect(mockLoadPreflightConfig).toHaveBeenCalledWith('custom/path.ts');
   });
@@ -205,7 +205,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: [] });
+    await runCommand({ names: [], json: false });
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(allOutput).toContain('--- deploy ---');
@@ -217,7 +217,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: ['deploy'] });
+    await runCommand({ names: ['deploy'], json: false });
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(allOutput).not.toContain('---');
@@ -231,7 +231,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: [] });
+    await runCommand({ names: [], json: false });
 
     expect(mockReportPreflight).toHaveBeenCalledWith(expect.anything(), { fixLocation: 'INLINE' });
   });
@@ -244,7 +244,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: [] });
+    await runCommand({ names: [], json: false });
 
     expect(mockReportPreflight).toHaveBeenCalledWith(expect.anything(), { fixLocation: 'END' });
   });
@@ -252,7 +252,7 @@ describe(runCommand, () => {
   it('reports config loading errors to stderr', async () => {
     mockLoadPreflightConfig.mockRejectedValue(new Error('Config not found'));
 
-    const exitCode = await runCommand({ names: [] });
+    const exitCode = await runCommand({ names: [], json: false });
 
     expect(stderrSpy).toHaveBeenCalledWith('Error: Config not found\n');
     expect(exitCode).toBe(1);
@@ -267,7 +267,7 @@ describe(runCommand, () => {
       durationMs: 10,
     });
 
-    await runCommand({ names: [] });
+    await runCommand({ names: [], json: false });
 
     expect(mockFormatCombinedSummary).toHaveBeenCalledTimes(1);
     expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
@@ -281,7 +281,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: ['deploy'] });
+    await runCommand({ names: ['deploy'], json: false });
 
     expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
   });
@@ -304,7 +304,7 @@ describe(runCommand, () => {
         durationMs: 0,
       });
 
-    await runCommand({ names: [] });
+    await runCommand({ names: [], json: false });
 
     expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
       expect.objectContaining({ name: 'deploy', passed: 1, failed: 1, skipped: 0, allPassed: false }),

--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -111,6 +111,14 @@ describe(parseRunArgs, () => {
     expect(result.json).toBe(false);
   });
 
+  it('parses --json combined with --config and positional names', () => {
+    const result = parseRunArgs(['--json', '--config', '/path/to/config', 'deploy']);
+
+    expect(result.json).toBe(true);
+    expect(result.configPath).toBe('/path/to/config');
+    expect(result.names).toStrictEqual(['deploy']);
+  });
+
   it('throws on unknown flags', () => {
     expect(() => parseRunArgs(['--unknown'])).toThrow("unknown flag '--unknown'");
   });
@@ -371,6 +379,18 @@ describe(runCommand, () => {
         { name: 'deploy', report: report1 },
         { name: 'infra', report: report2 },
       ]);
+    });
+
+    it('emits JSON error to stdout when runPreflight throws', async () => {
+      const config = makeConfig();
+      mockLoadPreflightConfig.mockResolvedValue(config);
+      mockRunPreflight.mockRejectedValue(new Error('runner crashed'));
+
+      const exitCode = await runCommand({ names: ['deploy'], json: true });
+
+      expect(mockFormatJsonError).toHaveBeenCalledWith('runner crashed');
+      expect(stderrSpy).not.toHaveBeenCalled();
+      expect(exitCode).toBe(1);
     });
 
     it('does not write headers in JSON mode', async () => {

--- a/packages/preflight/__tests__/formatJsonError.test.ts
+++ b/packages/preflight/__tests__/formatJsonError.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatJsonError } from '../src/formatJsonError.ts';
+
+describe(formatJsonError, () => {
+  it('returns valid JSON with an error field', () => {
+    const output = formatJsonError('something went wrong');
+    const parsed: unknown = JSON.parse(output);
+
+    expect(parsed).toStrictEqual({ error: 'something went wrong' });
+  });
+
+  it('produces a single-line string', () => {
+    const output = formatJsonError('multi\nline\nmessage');
+
+    expect(output.includes('\n')).toBe(false);
+  });
+});

--- a/packages/preflight/__tests__/formatJsonReport.test.ts
+++ b/packages/preflight/__tests__/formatJsonReport.test.ts
@@ -118,10 +118,19 @@ describe(formatJsonReport, () => {
       durationMs: 10,
     });
 
-    const parsed = JSON.parse(formatJsonReport([{ name: 'deploy', report }])) as Record<string, unknown>;
+    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    if (typeof parsed !== 'object' || parsed === null) throw new Error('expected object');
+    // eslint-disable-next-line unicorn/no-array-sort -- toSorted requires Node 20+; engine target is >=18.17.0
     const topLevelKeys = Object.keys(parsed).sort();
 
-    expect(topLevelKeys).toStrictEqual(['allPassed', 'checklists', 'failedCount', 'passedCount', 'skippedCount']);
+    expect(topLevelKeys).toStrictEqual([
+      'allPassed',
+      'checklists',
+      'durationMs',
+      'failedCount',
+      'passedCount',
+      'skippedCount',
+    ]);
   });
 
   it('serializes error as a string message', () => {

--- a/packages/preflight/__tests__/formatJsonReport.test.ts
+++ b/packages/preflight/__tests__/formatJsonReport.test.ts
@@ -91,6 +91,39 @@ describe(formatJsonReport, () => {
     });
   });
 
+  it('sets top-level allPassed to true when checks are skipped but none failed', () => {
+    const report = makeReport({
+      results: [
+        { name: 'a', status: 'skipped', durationMs: 0 },
+        { name: 'b', status: 'skipped', durationMs: 0 },
+      ],
+      passed: true,
+      durationMs: 0,
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+    expect(parsed).toMatchObject({
+      allPassed: true,
+      passedCount: 0,
+      failedCount: 0,
+      skippedCount: 2,
+    });
+  });
+
+  it('emits the expected top-level shape with no summary wrapper', () => {
+    const report = makeReport({
+      results: [{ name: 'a', status: 'passed', durationMs: 10 }],
+      passed: true,
+      durationMs: 10,
+    });
+
+    const parsed = JSON.parse(formatJsonReport([{ name: 'deploy', report }])) as Record<string, unknown>;
+    const topLevelKeys = Object.keys(parsed).sort();
+
+    expect(topLevelKeys).toStrictEqual(['allPassed', 'checklists', 'failedCount', 'passedCount', 'skippedCount']);
+  });
+
   it('serializes error as a string message', () => {
     const report = makeReport({
       results: [{ name: 'a', status: 'failed', error: new Error('connection refused'), durationMs: 5 }],

--- a/packages/preflight/__tests__/formatJsonReport.test.ts
+++ b/packages/preflight/__tests__/formatJsonReport.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatJsonReport } from '../src/formatJsonReport.ts';
+import type { PreflightReport } from '../src/types.ts';
+
+function makeReport(overrides?: Partial<PreflightReport>): PreflightReport {
+  return { results: [], passed: true, durationMs: 0, ...overrides };
+}
+
+describe(formatJsonReport, () => {
+  it('produces valid JSON', () => {
+    const output = formatJsonReport([{ name: 'deploy', report: makeReport() }]);
+
+    expect(() => {
+      JSON.parse(output);
+    }).not.toThrow();
+  });
+
+  it('returns correct summary counts for a single checklist', () => {
+    const report = makeReport({
+      results: [
+        { name: 'a', status: 'passed', durationMs: 10 },
+        { name: 'b', status: 'failed', durationMs: 5 },
+        { name: 'c', status: 'skipped', durationMs: 0 },
+      ],
+      passed: false,
+      durationMs: 15,
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+    expect(parsed).toMatchObject({
+      passedCount: 1,
+      failedCount: 1,
+      skippedCount: 1,
+      allPassed: false,
+    });
+  });
+
+  it('aggregates counts across multiple checklists', () => {
+    const report1 = makeReport({
+      results: [
+        { name: 'a', status: 'passed', durationMs: 10 },
+        { name: 'b', status: 'passed', durationMs: 5 },
+      ],
+      passed: true,
+      durationMs: 15,
+    });
+    const report2 = makeReport({
+      results: [{ name: 'c', status: 'failed', durationMs: 3 }],
+      passed: false,
+      durationMs: 3,
+    });
+
+    const parsed: unknown = JSON.parse(
+      formatJsonReport([
+        { name: 'deploy', report: report1 },
+        { name: 'infra', report: report2 },
+      ]),
+    );
+
+    expect(parsed).toMatchObject({
+      passedCount: 2,
+      failedCount: 1,
+      skippedCount: 0,
+      allPassed: false,
+      checklists: expect.arrayContaining([expect.anything(), expect.anything()]),
+    });
+  });
+
+  it('includes checklist-level allPassed and counts', () => {
+    const report = makeReport({
+      results: [{ name: 'a', status: 'passed', durationMs: 10 }],
+      passed: true,
+      durationMs: 10,
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+    expect(parsed).toMatchObject({
+      checklists: [
+        {
+          name: 'deploy',
+          allPassed: true,
+          passedCount: 1,
+          failedCount: 0,
+          skippedCount: 0,
+          durationMs: 10,
+        },
+      ],
+    });
+  });
+
+  it('serializes error as a string message', () => {
+    const report = makeReport({
+      results: [{ name: 'a', status: 'failed', error: new Error('connection refused'), durationMs: 5 }],
+      passed: false,
+      durationMs: 5,
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+    expect(parsed).toMatchObject({
+      checklists: [{ checks: [{ error: 'connection refused' }] }],
+    });
+  });
+
+  it('omits optional fields when undefined', () => {
+    const report = makeReport({
+      results: [{ name: 'a', status: 'passed', durationMs: 10 }],
+      passed: true,
+      durationMs: 10,
+    });
+
+    const output = formatJsonReport([{ name: 'deploy', report }]);
+
+    expect(output).not.toContain('"fix"');
+    expect(output).not.toContain('"error"');
+    expect(output).not.toContain('"detail"');
+    expect(output).not.toContain('"progress"');
+  });
+
+  it('includes optional fields when present', () => {
+    const report = makeReport({
+      results: [
+        {
+          name: 'a',
+          status: 'failed',
+          fix: 'run npm install',
+          detail: 'missing dependency',
+          progress: { passedCount: 3, count: 5 },
+          durationMs: 10,
+        },
+      ],
+      passed: false,
+      durationMs: 10,
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+    expect(parsed).toMatchObject({
+      checklists: [
+        {
+          checks: [
+            {
+              fix: 'run npm install',
+              detail: 'missing dependency',
+              progress: { passedCount: 3, count: 5 },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('serializes percent-based progress', () => {
+    const report = makeReport({
+      results: [
+        {
+          name: 'a',
+          status: 'passed',
+          progress: { percent: 75 },
+          durationMs: 10,
+        },
+      ],
+      passed: true,
+      durationMs: 10,
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+    expect(parsed).toMatchObject({
+      checklists: [{ checks: [{ progress: { percent: 75 } }] }],
+    });
+  });
+});

--- a/packages/preflight/__tests__/route.test.ts
+++ b/packages/preflight/__tests__/route.test.ts
@@ -76,14 +76,31 @@ describe(routeCommand, () => {
   });
 
   it('delegates to runCommand for run subcommand', async () => {
-    mockParseRunArgs.mockReturnValue({ names: ['deploy'], configPath: undefined });
+    mockParseRunArgs.mockReturnValue({ names: ['deploy'], json: false, configPath: undefined });
     mockRunCommand.mockResolvedValue(0);
 
     const exitCode = await routeCommand(['run', 'deploy']);
 
     expect(mockParseRunArgs).toHaveBeenCalledWith(['deploy']);
-    expect(mockRunCommand).toHaveBeenCalledWith({ names: ['deploy'], configPath: undefined });
+    expect(mockRunCommand).toHaveBeenCalledWith({ names: ['deploy'], json: false, configPath: undefined });
     expect(exitCode).toBe(0);
+  });
+
+  it('passes --json flag through to runCommand', async () => {
+    mockParseRunArgs.mockReturnValue({ names: [], json: true, configPath: undefined });
+    mockRunCommand.mockResolvedValue(0);
+
+    const exitCode = await routeCommand(['run', '--json']);
+
+    expect(mockRunCommand).toHaveBeenCalledWith({ names: [], json: true, configPath: undefined });
+    expect(exitCode).toBe(0);
+  });
+
+  it('includes --json in run help text', async () => {
+    await routeCommand(['run', '--help']);
+
+    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('--json');
   });
 
   it('returns 1 and writes to stderr when parseRunArgs throws', async () => {

--- a/packages/preflight/src/bin/route.ts
+++ b/packages/preflight/src/bin/route.ts
@@ -24,6 +24,7 @@ Run preflight checklists. If no names are given, all checklists are run.
 
 Options:
   --config, -c <path>   Path to the config file
+  --json                Output results as JSON
   --help, -h            Show this help message
 `);
 }

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -77,7 +77,7 @@ function summarizeReport(name: string, report: PreflightReport): ChecklistSummar
 interface RunCommandOptions {
   names: string[];
   configPath?: string;
-  json?: boolean;
+  json: boolean;
 }
 
 /** Run preflight checklists. Returns a numeric exit code. */
@@ -126,10 +126,16 @@ async function runJsonMode(checklists: Array<PreflightCheckList | StagedPrefligh
   const entries: Array<{ name: string; report: PreflightReport }> = [];
   let allPassed = true;
 
-  for (const checklist of checklists) {
-    const report = await runPreflight(checklist);
-    entries.push({ name: checklist.name, report });
-    if (!report.passed) allPassed = false;
+  try {
+    for (const checklist of checklists) {
+      const report = await runPreflight(checklist);
+      entries.push({ name: checklist.name, report });
+      if (!report.passed) allPassed = false;
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stdout.write(formatJsonError(message) + '\n');
+    return 1;
   }
 
   process.stdout.write(formatJsonReport(entries) + '\n');

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -2,6 +2,8 @@ import process from 'node:process';
 
 import { loadPreflightConfig } from './config.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
+import { formatJsonError } from './formatJsonError.ts';
+import { formatJsonReport } from './formatJsonReport.ts';
 import { reportPreflight } from './reportPreflight.ts';
 import { runPreflight } from './runPreflight.ts';
 import type {
@@ -15,17 +17,20 @@ import type {
 
 interface ParsedRunArgs {
   configPath?: string;
+  json: boolean;
   names: string[];
 }
 
 /** Parse run-subcommand flags into a structured object. */
 export function parseRunArgs(flags: string[]): ParsedRunArgs {
-  const result: ParsedRunArgs = { names: [] };
+  const result: ParsedRunArgs = { json: false, names: [] };
 
   for (let i = 0; i < flags.length; i++) {
     const arg = flags[i];
     if (arg === undefined) break;
-    if (arg === '--config' || arg === '-c') {
+    if (arg === '--json') {
+      result.json = true;
+    } else if (arg === '--config' || arg === '-c') {
       i++;
       const configValue = flags[i];
       if (configValue === undefined) {
@@ -72,16 +77,21 @@ function summarizeReport(name: string, report: PreflightReport): ChecklistSummar
 interface RunCommandOptions {
   names: string[];
   configPath?: string;
+  json?: boolean;
 }
 
 /** Run preflight checklists. Returns a numeric exit code. */
-export async function runCommand({ names, configPath }: RunCommandOptions): Promise<number> {
+export async function runCommand({ names, configPath, json }: RunCommandOptions): Promise<number> {
   let config: PreflightConfig;
   try {
     config = await loadPreflightConfig(configPath);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Error: ${message}\n`);
+    if (json) {
+      process.stdout.write(formatJsonError(message) + '\n');
+    } else {
+      process.stderr.write(`Error: ${message}\n`);
+    }
     return 1;
   }
 
@@ -92,13 +102,45 @@ export async function runCommand({ names, configPath }: RunCommandOptions): Prom
     const unknownNames = names.filter((n) => !availableNames.has(n));
     if (unknownNames.length > 0) {
       const available = [...availableNames].join(', ');
-      process.stderr.write(`Error: unknown checklist(s): ${unknownNames.join(', ')}. Available: ${available}\n`);
+      const message = `unknown checklist(s): ${unknownNames.join(', ')}. Available: ${available}`;
+      if (json) {
+        process.stdout.write(formatJsonError(message) + '\n');
+      } else {
+        process.stderr.write(`Error: ${message}\n`);
+      }
       return 1;
     }
     const requestedNames = new Set(names);
     checklists = config.checklists.filter((c) => requestedNames.has(c.name));
   }
 
+  if (json) {
+    return runJsonMode(checklists);
+  }
+
+  return runHumanMode(checklists, config);
+}
+
+/** Run checklists and emit a single JSON object to stdout. */
+async function runJsonMode(checklists: Array<PreflightCheckList | StagedPreflightCheckList>): Promise<number> {
+  const entries: Array<{ name: string; report: PreflightReport }> = [];
+  let allPassed = true;
+
+  for (const checklist of checklists) {
+    const report = await runPreflight(checklist);
+    entries.push({ name: checklist.name, report });
+    if (!report.passed) allPassed = false;
+  }
+
+  process.stdout.write(formatJsonReport(entries) + '\n');
+  return allPassed ? 0 : 1;
+}
+
+/** Run checklists with human-readable output. */
+async function runHumanMode(
+  checklists: Array<PreflightCheckList | StagedPreflightCheckList>,
+  config: PreflightConfig,
+): Promise<number> {
   const showHeader = checklists.length > 1;
   let allPassed = true;
   const summaries: ChecklistSummary[] = [];

--- a/packages/preflight/src/formatJsonError.ts
+++ b/packages/preflight/src/formatJsonError.ts
@@ -1,0 +1,4 @@
+/** Serialize an error message into a single-line JSON string. */
+export function formatJsonError(message: string): string {
+  return JSON.stringify({ error: message });
+}

--- a/packages/preflight/src/formatJsonReport.ts
+++ b/packages/preflight/src/formatJsonReport.ts
@@ -1,0 +1,110 @@
+import type { PreflightReport, PreflightResult, Progress } from './types.ts';
+import { isPercentProgress } from './types.ts';
+
+interface ChecklistEntry {
+  name: string;
+  report: PreflightReport;
+}
+
+interface JsonCheckResult {
+  name: string;
+  status: 'passed' | 'failed' | 'skipped';
+  durationMs: number;
+  fix?: string;
+  error?: string;
+  detail?: string;
+  progress?: JsonProgress;
+}
+
+interface JsonProgress {
+  percent?: number;
+  passedCount?: number;
+  count?: number;
+}
+
+interface JsonChecklist {
+  name: string;
+  allPassed: boolean;
+  durationMs: number;
+  passedCount: number;
+  failedCount: number;
+  skippedCount: number;
+  checks: JsonCheckResult[];
+}
+
+interface JsonReport {
+  allPassed: boolean;
+  passedCount: number;
+  failedCount: number;
+  skippedCount: number;
+  checklists: JsonChecklist[];
+}
+
+/** Transform an array of checklist results into a JSON-serializable report object. */
+export function formatJsonReport(entries: ChecklistEntry[]): string {
+  let totalPassed = 0;
+  let totalFailed = 0;
+  let totalSkipped = 0;
+
+  const checklists: JsonChecklist[] = entries.map(({ name, report }) => {
+    let passed = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    const checks: JsonCheckResult[] = report.results.map((result) => {
+      if (result.status === 'passed') passed++;
+      else if (result.status === 'failed') failed++;
+      else skipped++;
+
+      return buildCheckResult(result);
+    });
+
+    totalPassed += passed;
+    totalFailed += failed;
+    totalSkipped += skipped;
+
+    return {
+      name,
+      allPassed: report.passed,
+      durationMs: report.durationMs,
+      passedCount: passed,
+      failedCount: failed,
+      skippedCount: skipped,
+      checks,
+    };
+  });
+
+  const output: JsonReport = {
+    allPassed: totalFailed === 0 && totalSkipped === 0,
+    passedCount: totalPassed,
+    failedCount: totalFailed,
+    skippedCount: totalSkipped,
+    checklists,
+  };
+
+  return JSON.stringify(output);
+}
+
+/** Build a single check result, omitting undefined optional fields. */
+function buildCheckResult(result: PreflightResult): JsonCheckResult {
+  const entry: JsonCheckResult = {
+    name: result.name,
+    status: result.status,
+    durationMs: result.durationMs,
+  };
+
+  if (result.fix !== undefined) entry.fix = result.fix;
+  if (result.error !== undefined) entry.error = result.error.message;
+  if (result.detail !== undefined) entry.detail = result.detail;
+  if (result.progress !== undefined) entry.progress = serializeProgress(result.progress);
+
+  return entry;
+}
+
+/** Serialize a Progress union into a plain object with only the relevant fields. */
+function serializeProgress(progress: Progress): JsonProgress {
+  if (isPercentProgress(progress)) {
+    return { percent: progress.percent };
+  }
+  return { passedCount: progress.passedCount, count: progress.count };
+}

--- a/packages/preflight/src/formatJsonReport.ts
+++ b/packages/preflight/src/formatJsonReport.ts
@@ -37,6 +37,7 @@ interface JsonReport {
   passedCount: number;
   failedCount: number;
   skippedCount: number;
+  durationMs: number;
   checklists: JsonChecklist[];
 }
 
@@ -74,11 +75,14 @@ export function formatJsonReport(entries: ChecklistEntry[]): string {
     };
   });
 
+  const totalDurationMs = checklists.reduce((sum, c) => sum + c.durationMs, 0);
+
   const output: JsonReport = {
     allPassed: totalFailed === 0,
     passedCount: totalPassed,
     failedCount: totalFailed,
     skippedCount: totalSkipped,
+    durationMs: totalDurationMs,
     checklists,
   };
 

--- a/packages/preflight/src/formatJsonReport.ts
+++ b/packages/preflight/src/formatJsonReport.ts
@@ -75,7 +75,7 @@ export function formatJsonReport(entries: ChecklistEntry[]): string {
   });
 
   const output: JsonReport = {
-    allPassed: totalFailed === 0 && totalSkipped === 0,
+    allPassed: totalFailed === 0,
     passedCount: totalPassed,
     failedCount: totalFailed,
     skippedCount: totalSkipped,

--- a/packages/preflight/src/index.ts
+++ b/packages/preflight/src/index.ts
@@ -27,4 +27,5 @@ export { runPreflight } from './runPreflight.ts';
 
 // Reporter
 export { formatCombinedSummary } from './formatCombinedSummary.ts';
+export { formatJsonReport } from './formatJsonReport.ts';
 export { formatSummaryCounts, reportPreflight } from './reportPreflight.ts';


### PR DESCRIPTION
Closes #107 

## What

Adds a `--json` flag to `preflight run` that emits a single JSON object to stdout instead of the human-readable terminal report. The implementation introduces `formatJsonReport` (a pure data transformation), `formatJsonError` (for structured error output), and branches `runCommand` into `runJsonMode` / `runHumanMode` based on the flag.

## Why

Programmatic consumers — CI pipelines, dashboards, and other tooling — currently have to scrape terminal output (emojis, box-drawing, summary tables) to extract results. A structured JSON output mode lets consumers parse results directly and react to specific failures without fragile text parsing.

## Details

### Features

- `--json` flag recognized by `parseRunArgs` and threaded through `routeCommand` → `runCommand`
- `formatJsonReport` transforms `PreflightReport[]` into JSON with per-checklist `allPassed` (boolean), `passedCount`/`failedCount`/`skippedCount` (counts), `durationMs`, and individual check results including all optional fields (`fix`, `error`, `detail`, `progress`) when present
- `formatJsonError` produces `{"error":"message"}` for config loading failures, unknown checklist names, and runtime errors — all emitted to stdout (not stderr) in JSON mode
- `formatJsonReport` exported from `index.ts` for library consumers
- Top-level `durationMs` aggregated across all checklists

### Fixes

- `allPassed` at the top level uses `totalFailed === 0`, consistent with the runner's semantics where skipped checks are not failures
- `runPreflight` errors caught in JSON mode to maintain the structured output contract
- `Error` objects serialized as `error.message` (not `JSON.stringify(error)` which produces `{}`)

### Tests

- 10 tests for `formatJsonReport` covering schema shape, aggregation, optional field omission, error serialization, both progress variants, and the skipped-checks edge case
- 2 tests for `formatJsonError`
- 7 JSON-mode tests in `cli.test.ts` covering success output, error paths, flag threading, and header suppression
- 3 tests in `route.test.ts` for `--json` flag passthrough and help text

## Test plan

- [ ] `preflight run --json` emits valid JSON parseable by `jq`
- [ ] `preflight run --json` with a failing checklist emits JSON with `allPassed: false` and exits 1
- [ ] `preflight run --json` with an invalid config emits a JSON error object to stdout
- [ ] `preflight run` (no flag) produces identical output to before this change