### PR TITLE
#109 Add type discriminant to Progress union

### DIFF
--- a/packages/preflight/__tests__/formatJsonReport.test.ts
+++ b/packages/preflight/__tests__/formatJsonReport.test.ts
@@ -170,7 +170,7 @@ describe(formatJsonReport, () => {
           status: 'failed',
           fix: 'run npm install',
           detail: 'missing dependency',
-          progress: { passedCount: 3, count: 5 },
+          progress: { type: 'fraction', passedCount: 3, count: 5 },
           durationMs: 10,
         },
       ],
@@ -187,7 +187,7 @@ describe(formatJsonReport, () => {
             {
               fix: 'run npm install',
               detail: 'missing dependency',
-              progress: { passedCount: 3, count: 5 },
+              progress: { type: 'fraction', passedCount: 3, count: 5 },
             },
           ],
         },
@@ -201,7 +201,7 @@ describe(formatJsonReport, () => {
         {
           name: 'a',
           status: 'passed',
-          progress: { percent: 75 },
+          progress: { type: 'percent', percent: 75 },
           durationMs: 10,
         },
       ],
@@ -212,7 +212,7 @@ describe(formatJsonReport, () => {
     const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
 
     expect(parsed).toMatchObject({
-      checklists: [{ checks: [{ progress: { percent: 75 } }] }],
+      checklists: [{ checks: [{ progress: { type: 'percent', percent: 75 } }] }],
     });
   });
 });

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -203,7 +203,14 @@ describe(reportPreflight, () => {
 
     it('renders fraction progress', () => {
       const report = makeReport({
-        results: [{ name: 'check-b', status: 'failed', durationMs: 5, progress: { passedCount: 7, count: 10 } }],
+        results: [
+          {
+            name: 'check-b',
+            status: 'failed',
+            durationMs: 5,
+            progress: { type: 'fraction', passedCount: 7, count: 10 },
+          },
+        ],
         passed: false,
       });
 
@@ -214,7 +221,7 @@ describe(reportPreflight, () => {
 
     it('renders percent progress', () => {
       const report = makeReport({
-        results: [{ name: 'check-c', status: 'failed', durationMs: 3, progress: { percent: 85 } }],
+        results: [{ name: 'check-c', status: 'failed', durationMs: 3, progress: { type: 'percent', percent: 85 } }],
         passed: false,
       });
 
@@ -231,7 +238,7 @@ describe(reportPreflight, () => {
             status: 'failed',
             durationMs: 5,
             detail: 'some detail',
-            progress: { passedCount: 7, count: 10 },
+            progress: { type: 'fraction', passedCount: 7, count: 10 },
           },
         ],
         passed: false,
@@ -244,7 +251,15 @@ describe(reportPreflight, () => {
 
     it('renders detail and progress on passing checks', () => {
       const report = makeReport({
-        results: [{ name: 'check-e', status: 'passed', durationMs: 2, detail: 'all good', progress: { percent: 100 } }],
+        results: [
+          {
+            name: 'check-e',
+            status: 'passed',
+            durationMs: 2,
+            detail: 'all good',
+            progress: { type: 'percent', percent: 100 },
+          },
+        ],
       });
 
       const output = reportPreflight(report);

--- a/packages/preflight/__tests__/runPreflight.test.ts
+++ b/packages/preflight/__tests__/runPreflight.test.ts
@@ -210,14 +210,19 @@ describe(runPreflight, () => {
     it('carries progress from a failing CheckOutcome', async () => {
       const checklist: PreflightCheckList = {
         name: 'outcome',
-        checks: [{ name: 'with-progress', check: () => ({ ok: false, progress: { passedCount: 7, count: 10 } }) }],
+        checks: [
+          {
+            name: 'with-progress',
+            check: () => ({ ok: false, progress: { type: 'fraction', passedCount: 7, count: 10 } }),
+          },
+        ],
       };
 
       const report = await runPreflight(checklist);
 
       expect(report.passed).toBe(false);
       expect(report.results[0]?.status).toBe('failed');
-      expect(report.results[0]?.progress).toStrictEqual({ passedCount: 7, count: 10 });
+      expect(report.results[0]?.progress).toStrictEqual({ type: 'fraction', passedCount: 7, count: 10 });
     });
 
     it('carries both detail and progress', async () => {
@@ -226,7 +231,7 @@ describe(runPreflight, () => {
         checks: [
           {
             name: 'full-outcome',
-            check: () => ({ ok: false, detail: 'missing deps', progress: { percent: 85 } }),
+            check: () => ({ ok: false, detail: 'missing deps', progress: { type: 'percent', percent: 85 } }),
           },
         ],
       };
@@ -234,7 +239,7 @@ describe(runPreflight, () => {
       const report = await runPreflight(checklist);
 
       expect(report.results[0]?.detail).toBe('missing deps');
-      expect(report.results[0]?.progress).toStrictEqual({ percent: 85 });
+      expect(report.results[0]?.progress).toStrictEqual({ type: 'percent', percent: 85 });
     });
 
     it('does not set detail or progress on skipped results', async () => {

--- a/packages/preflight/src/formatJsonReport.ts
+++ b/packages/preflight/src/formatJsonReport.ts
@@ -16,10 +16,17 @@ interface JsonCheckResult {
   progress?: JsonProgress;
 }
 
-interface JsonProgress {
-  percent?: number;
-  passedCount?: number;
-  count?: number;
+type JsonProgress = JsonFractionProgress | JsonPercentProgress;
+
+interface JsonFractionProgress {
+  type: 'fraction';
+  passedCount: number;
+  count: number;
+}
+
+interface JsonPercentProgress {
+  type: 'percent';
+  percent: number;
 }
 
 interface JsonChecklist {
@@ -108,7 +115,7 @@ function buildCheckResult(result: PreflightResult): JsonCheckResult {
 /** Serialize a Progress union into a plain object with only the relevant fields. */
 function serializeProgress(progress: Progress): JsonProgress {
   if (isPercentProgress(progress)) {
-    return { percent: progress.percent };
+    return { type: 'percent', percent: progress.percent };
   }
-  return { passedCount: progress.passedCount, count: progress.count };
+  return { type: 'fraction', passedCount: progress.passedCount, count: progress.count };
 }

--- a/packages/preflight/src/types.ts
+++ b/packages/preflight/src/types.ts
@@ -3,21 +3,23 @@ export type FixLocation = 'INLINE' | 'END';
 
 /** Progress expressed as a fraction with passed and total counts. */
 export interface FractionProgress {
+  type: 'fraction';
   passedCount: number;
   count: number;
 }
 
 /** Progress expressed as a percentage. */
 export interface PercentProgress {
+  type: 'percent';
   percent: number;
 }
 
-/** Union of progress representations, discriminated by the presence of `percent`. */
+/** Union of progress representations, discriminated by `type`. */
 export type Progress = FractionProgress | PercentProgress;
 
 /** Return true if a progress value uses the percentage representation. */
 export function isPercentProgress(progress: Progress): progress is PercentProgress {
-  return 'percent' in progress;
+  return progress.type === 'percent';
 }
 
 /** Structured outcome from a check, carrying diagnostic data alongside the pass/fail status. */


### PR DESCRIPTION
Closes #109 

## What

Adds an explicit `type` discriminant field (`"fraction"` | `"percent"`) to the `FractionProgress` and `PercentProgress` interfaces, converting `Progress` from a structurally discriminated union to a properly tagged discriminated union. Updates `isPercentProgress` to use the `type` field, and upgrade `JsonProgress` from a flat optional-field bag to a matching discriminated union so JSON output includes the tag.

## Why

The `Progress` union is serialized in JSON output (added in #107). Without an explicit discriminant, JSON consumers in other languages must inspect which fields are present to determine the variant — fragile and undocumented by shape alone. A `type` tag lets consumers switch on a single key.

## Details

### Refactoring

- Add `type: 'fraction'` to `FractionProgress` and `type: 'percent'` to `PercentProgress` in `types.ts`
- Update `isPercentProgress` to check `progress.type === 'percent'` instead of `'percent' in progress`
- Replace the flat `JsonProgress` interface (optional fields) with a `JsonFractionProgress | JsonPercentProgress` discriminated union in `formatJsonReport.ts`
- Include `type` in `serializeProgress` output

### Tests

- Update all progress literal fixtures in `runPreflight.test.ts`, `reportPreflight.test.ts`, and `formatJsonReport.test.ts` to include the `type` field
- Update JSON-output assertions to expect the `type` field