### PR TITLE
#103 Support remote config URLs

### DIFF
--- a/packages/preflight/__tests__/assertIsPreflightConfig.test.ts
+++ b/packages/preflight/__tests__/assertIsPreflightConfig.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertIsPreflightConfig } from '../src/assertIsPreflightConfig.ts';
+
+describe(assertIsPreflightConfig, () => {
+  it('throws when input is not an object', () => {
+    expect(() => assertIsPreflightConfig('string')).toThrow('Preflight config must be an object, got string');
+  });
+
+  it('throws when input is an array', () => {
+    expect(() => assertIsPreflightConfig([])).toThrow('Preflight config must be an object, got array');
+  });
+
+  it('throws when checklists is missing', () => {
+    expect(() => assertIsPreflightConfig({})).toThrow("must have a 'checklists' array");
+  });
+
+  it('throws when a checklist has neither checks nor groups', () => {
+    expect(() => assertIsPreflightConfig({ checklists: [{ name: 'bad' }] })).toThrow(
+      "must have either 'checks' or 'groups'",
+    );
+  });
+
+  it('throws when a checklist has both checks and groups', () => {
+    expect(() => assertIsPreflightConfig({ checklists: [{ name: 'bad', checks: [], groups: [] }] })).toThrow(
+      "cannot have both 'checks' and 'groups'",
+    );
+  });
+
+  it('throws when a checklist entry is not an object', () => {
+    expect(() => assertIsPreflightConfig({ checklists: ['not-an-object'] })).toThrow(
+      'checklists[0]: must be an object',
+    );
+  });
+
+  it('throws when a checklist name is missing', () => {
+    expect(() => assertIsPreflightConfig({ checklists: [{ checks: [] }] })).toThrow(
+      "checklists[0]: 'name' is required and must be a non-empty string",
+    );
+  });
+
+  it('accepts a valid config with flat checklists', () => {
+    expect(() =>
+      assertIsPreflightConfig({
+        checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts a valid config with staged checklists', () => {
+    expect(() =>
+      assertIsPreflightConfig({
+        checklists: [{ name: 'test', groups: [[{ name: 'a', check: () => true }]] }],
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -8,6 +8,9 @@ const mockReportPreflight = vi.hoisted(() => vi.fn());
 const mockFormatCombinedSummary = vi.hoisted(() => vi.fn());
 const mockFormatJsonReport = vi.hoisted(() => vi.fn());
 const mockFormatJsonError = vi.hoisted(() => vi.fn());
+const mockExpandGitHubShorthand = vi.hoisted(() => vi.fn());
+const mockResolveGitHubToken = vi.hoisted(() => vi.fn());
+const mockLoadRemoteConfig = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/config.ts', () => ({
   loadPreflightConfig: mockLoadPreflightConfig,
@@ -33,6 +36,18 @@ vi.mock('../src/formatJsonError.ts', () => ({
   formatJsonError: mockFormatJsonError,
 }));
 
+vi.mock('../src/expandGitHubShorthand.ts', () => ({
+  expandGitHubShorthand: mockExpandGitHubShorthand,
+}));
+
+vi.mock('../src/resolveGitHubToken.ts', () => ({
+  resolveGitHubToken: mockResolveGitHubToken,
+}));
+
+vi.mock('../src/loadRemoteConfig.ts', () => ({
+  loadRemoteConfig: mockLoadRemoteConfig,
+}));
+
 import { parseRunArgs, runCommand } from '../src/cli.ts';
 
 function makeConfig(overrides?: Partial<PreflightConfig>): PreflightConfig {
@@ -46,36 +61,36 @@ function makeConfig(overrides?: Partial<PreflightConfig>): PreflightConfig {
 }
 
 describe(parseRunArgs, () => {
-  it('parses positional names', () => {
+  it('parses positional names with default local source', () => {
     const result = parseRunArgs(['deploy', 'infra']);
 
     expect(result.names).toStrictEqual(['deploy', 'infra']);
-    expect(result.configPath).toBeUndefined();
+    expect(result.configSource).toStrictEqual({ type: 'local' });
   });
 
   it('parses --config flag', () => {
     const result = parseRunArgs(['--config', 'custom/path.ts']);
 
-    expect(result.configPath).toBe('custom/path.ts');
+    expect(result.configSource).toStrictEqual({ type: 'local', path: 'custom/path.ts' });
     expect(result.names).toStrictEqual([]);
   });
 
   it('parses --config= syntax', () => {
     const result = parseRunArgs(['--config=custom/path.ts']);
 
-    expect(result.configPath).toBe('custom/path.ts');
+    expect(result.configSource).toStrictEqual({ type: 'local', path: 'custom/path.ts' });
   });
 
   it('parses -c flag', () => {
     const result = parseRunArgs(['-c', 'custom/path.ts']);
 
-    expect(result.configPath).toBe('custom/path.ts');
+    expect(result.configSource).toStrictEqual({ type: 'local', path: 'custom/path.ts' });
   });
 
   it('parses mixed flags and names', () => {
     const result = parseRunArgs(['-c', 'config.ts', 'deploy']);
 
-    expect(result.configPath).toBe('config.ts');
+    expect(result.configSource).toStrictEqual({ type: 'local', path: 'config.ts' });
     expect(result.names).toStrictEqual(['deploy']);
   });
 
@@ -115,12 +130,79 @@ describe(parseRunArgs, () => {
     const result = parseRunArgs(['--json', '--config', '/path/to/config', 'deploy']);
 
     expect(result.json).toBe(true);
-    expect(result.configPath).toBe('/path/to/config');
+    expect(result.configSource).toStrictEqual({ type: 'local', path: '/path/to/config' });
     expect(result.names).toStrictEqual(['deploy']);
   });
 
   it('throws on unknown flags', () => {
     expect(() => parseRunArgs(['--unknown'])).toThrow("unknown flag '--unknown'");
+  });
+
+  // --github flag
+  it('parses --github flag with space-separated value', () => {
+    const result = parseRunArgs(['--github', 'org/repo/path.js@v1']);
+
+    expect(result.configSource).toStrictEqual({ type: 'github', shorthand: 'org/repo/path.js@v1' });
+  });
+
+  it('parses --github= syntax', () => {
+    const result = parseRunArgs(['--github=org/repo/path.js']);
+
+    expect(result.configSource).toStrictEqual({ type: 'github', shorthand: 'org/repo/path.js' });
+  });
+
+  it('throws when --github has no value', () => {
+    expect(() => parseRunArgs(['--github'])).toThrow('--github requires a shorthand argument');
+  });
+
+  it('throws when --github= has an empty value', () => {
+    expect(() => parseRunArgs(['--github='])).toThrow('--github requires a shorthand argument');
+  });
+
+  // --url flag
+  it('parses --url flag with space-separated value', () => {
+    const result = parseRunArgs(['--url', 'https://example.com/config.js']);
+
+    expect(result.configSource).toStrictEqual({ type: 'url', url: 'https://example.com/config.js' });
+  });
+
+  it('parses --url= syntax', () => {
+    const result = parseRunArgs(['--url=https://example.com/config.js']);
+
+    expect(result.configSource).toStrictEqual({ type: 'url', url: 'https://example.com/config.js' });
+  });
+
+  it('throws when --url has no value', () => {
+    expect(() => parseRunArgs(['--url'])).toThrow('--url requires a URL argument');
+  });
+
+  it('throws when --url= has an empty value', () => {
+    expect(() => parseRunArgs(['--url='])).toThrow('--url requires a URL argument');
+  });
+
+  // Mutual exclusivity
+  it('throws when --config and --github are combined', () => {
+    expect(() => parseRunArgs(['--config', 'path.ts', '--github', 'org/repo/path.js'])).toThrow(
+      'Cannot combine --config, --github, and --url flags',
+    );
+  });
+
+  it('throws when --config and --url are combined', () => {
+    expect(() => parseRunArgs(['--config', 'path.ts', '--url', 'https://example.com/config.js'])).toThrow(
+      'Cannot combine --config, --github, and --url flags',
+    );
+  });
+
+  it('throws when a flag name is passed as value to another flag', () => {
+    expect(() => parseRunArgs(['--github', '--url'])).toThrow('--github requires a shorthand argument');
+    expect(() => parseRunArgs(['--url', '--github'])).toThrow('--url requires a URL argument');
+    expect(() => parseRunArgs(['--config', '--github'])).toThrow('--config requires a path argument');
+  });
+
+  it('throws when --github and --url are combined', () => {
+    expect(() => parseRunArgs(['--github', 'org/repo/path.js', '--url', 'https://example.com/config.js'])).toThrow(
+      'Cannot combine --config, --github, and --url flags',
+    );
   });
 });
 
@@ -143,6 +225,9 @@ describe(runCommand, () => {
     mockFormatCombinedSummary.mockReset();
     mockFormatJsonReport.mockReset();
     mockFormatJsonError.mockReset();
+    mockExpandGitHubShorthand.mockReset();
+    mockResolveGitHubToken.mockReset();
+    mockLoadRemoteConfig.mockReset();
   });
 
   it('runs all checklists when no names are given', async () => {
@@ -150,7 +235,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    const exitCode = await runCommand({ names: [], json: false });
+    const exitCode = await runCommand({ names: [], configSource: { type: 'local' }, json: false });
 
     expect(mockRunPreflight).toHaveBeenCalledTimes(2);
     expect(exitCode).toBe(0);
@@ -161,7 +246,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    const exitCode = await runCommand({ names: ['deploy'], json: false });
+    const exitCode = await runCommand({ names: ['deploy'], configSource: { type: 'local' }, json: false });
 
     expect(mockRunPreflight).toHaveBeenCalledTimes(1);
     expect(mockRunPreflight).toHaveBeenCalledWith(config.checklists[0]);
@@ -172,7 +257,7 @@ describe(runCommand, () => {
     const config = makeConfig();
     mockLoadPreflightConfig.mockResolvedValue(config);
 
-    const exitCode = await runCommand({ names: ['nonexistent'], json: false });
+    const exitCode = await runCommand({ names: ['nonexistent'], configSource: { type: 'local' }, json: false });
 
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unknown checklist(s): nonexistent'));
     expect(exitCode).toBe(1);
@@ -185,17 +270,17 @@ describe(runCommand, () => {
       .mockResolvedValueOnce({ results: [], passed: true, durationMs: 0 })
       .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
 
-    const exitCode = await runCommand({ names: [], json: false });
+    const exitCode = await runCommand({ names: [], configSource: { type: 'local' }, json: false });
 
     expect(exitCode).toBe(1);
   });
 
-  it('passes configPath to config loader', async () => {
+  it('passes config path to local config loader', async () => {
     const config = makeConfig();
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: [], configPath: 'custom/path.ts', json: false });
+    await runCommand({ names: [], configSource: { type: 'local', path: 'custom/path.ts' }, json: false });
 
     expect(mockLoadPreflightConfig).toHaveBeenCalledWith('custom/path.ts');
   });
@@ -205,7 +290,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: [], json: false });
+    await runCommand({ names: [], configSource: { type: 'local' }, json: false });
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(allOutput).toContain('--- deploy ---');
@@ -217,7 +302,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: ['deploy'], json: false });
+    await runCommand({ names: ['deploy'], configSource: { type: 'local' }, json: false });
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(allOutput).not.toContain('---');
@@ -231,7 +316,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: [], json: false });
+    await runCommand({ names: [], configSource: { type: 'local' }, json: false });
 
     expect(mockReportPreflight).toHaveBeenCalledWith(expect.anything(), { fixLocation: 'INLINE' });
   });
@@ -244,7 +329,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: [], json: false });
+    await runCommand({ names: [], configSource: { type: 'local' }, json: false });
 
     expect(mockReportPreflight).toHaveBeenCalledWith(expect.anything(), { fixLocation: 'END' });
   });
@@ -252,7 +337,7 @@ describe(runCommand, () => {
   it('reports config loading errors to stderr', async () => {
     mockLoadPreflightConfig.mockRejectedValue(new Error('Config not found'));
 
-    const exitCode = await runCommand({ names: [], json: false });
+    const exitCode = await runCommand({ names: [], configSource: { type: 'local' }, json: false });
 
     expect(stderrSpy).toHaveBeenCalledWith('Error: Config not found\n');
     expect(exitCode).toBe(1);
@@ -267,7 +352,7 @@ describe(runCommand, () => {
       durationMs: 10,
     });
 
-    await runCommand({ names: [], json: false });
+    await runCommand({ names: [], configSource: { type: 'local' }, json: false });
 
     expect(mockFormatCombinedSummary).toHaveBeenCalledTimes(1);
     expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
@@ -281,7 +366,7 @@ describe(runCommand, () => {
     mockLoadPreflightConfig.mockResolvedValue(config);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runCommand({ names: ['deploy'], json: false });
+    await runCommand({ names: ['deploy'], configSource: { type: 'local' }, json: false });
 
     expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
   });
@@ -304,7 +389,7 @@ describe(runCommand, () => {
         durationMs: 0,
       });
 
-    await runCommand({ names: [], json: false });
+    await runCommand({ names: [], configSource: { type: 'local' }, json: false });
 
     expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
       expect.objectContaining({ name: 'deploy', passed: 1, failed: 1, skipped: 0, allPassed: false }),
@@ -323,7 +408,7 @@ describe(runCommand, () => {
       mockLoadPreflightConfig.mockResolvedValue(config);
       mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-      const exitCode = await runCommand({ names: [], json: true });
+      const exitCode = await runCommand({ names: [], configSource: { type: 'local' }, json: true });
 
       expect(mockFormatJsonReport).toHaveBeenCalledTimes(1);
       expect(mockReportPreflight).not.toHaveBeenCalled();
@@ -339,7 +424,7 @@ describe(runCommand, () => {
         .mockResolvedValueOnce({ results: [], passed: true, durationMs: 0 })
         .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
 
-      const exitCode = await runCommand({ names: [], json: true });
+      const exitCode = await runCommand({ names: [], configSource: { type: 'local' }, json: true });
 
       expect(exitCode).toBe(1);
     });
@@ -347,7 +432,7 @@ describe(runCommand, () => {
     it('emits JSON error to stdout for config loading errors', async () => {
       mockLoadPreflightConfig.mockRejectedValue(new Error('Config not found'));
 
-      const exitCode = await runCommand({ names: [], json: true });
+      const exitCode = await runCommand({ names: [], configSource: { type: 'local' }, json: true });
 
       expect(mockFormatJsonError).toHaveBeenCalledWith('Config not found');
       expect(stdoutSpy).toHaveBeenCalledWith('{"error":"boom"}\n');
@@ -359,7 +444,7 @@ describe(runCommand, () => {
       const config = makeConfig();
       mockLoadPreflightConfig.mockResolvedValue(config);
 
-      const exitCode = await runCommand({ names: ['nonexistent'], json: true });
+      const exitCode = await runCommand({ names: ['nonexistent'], configSource: { type: 'local' }, json: true });
 
       expect(mockFormatJsonError).toHaveBeenCalledWith(expect.stringContaining('unknown checklist(s): nonexistent'));
       expect(stderrSpy).not.toHaveBeenCalled();
@@ -373,7 +458,7 @@ describe(runCommand, () => {
       const report2 = { results: [], passed: true, durationMs: 20 };
       mockRunPreflight.mockResolvedValueOnce(report1).mockResolvedValueOnce(report2);
 
-      await runCommand({ names: [], json: true });
+      await runCommand({ names: [], configSource: { type: 'local' }, json: true });
 
       expect(mockFormatJsonReport).toHaveBeenCalledWith([
         { name: 'deploy', report: report1 },
@@ -386,7 +471,7 @@ describe(runCommand, () => {
       mockLoadPreflightConfig.mockResolvedValue(config);
       mockRunPreflight.mockRejectedValue(new Error('runner crashed'));
 
-      const exitCode = await runCommand({ names: ['deploy'], json: true });
+      const exitCode = await runCommand({ names: ['deploy'], configSource: { type: 'local' }, json: true });
 
       expect(mockFormatJsonError).toHaveBeenCalledWith('runner crashed');
       expect(stderrSpy).not.toHaveBeenCalled();
@@ -398,10 +483,84 @@ describe(runCommand, () => {
       mockLoadPreflightConfig.mockResolvedValue(config);
       mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-      await runCommand({ names: [], json: true });
+      await runCommand({ names: [], configSource: { type: 'local' }, json: true });
 
       const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(allOutput).not.toContain('---');
     });
+  });
+
+  // GitHub source tests
+  it('expands shorthand and resolves token for --github source', async () => {
+    const config = makeConfig();
+    mockExpandGitHubShorthand.mockReturnValue('https://raw.githubusercontent.com/org/repo/main/config.js');
+    mockResolveGitHubToken.mockReturnValue('token-abc');
+    mockLoadRemoteConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    const exitCode = await runCommand({
+      names: [],
+      configSource: { type: 'github', shorthand: 'org/repo/config.js' },
+      json: false,
+    });
+
+    expect(mockExpandGitHubShorthand).toHaveBeenCalledWith('org/repo/config.js');
+    expect(mockResolveGitHubToken).toHaveBeenCalled();
+    expect(mockLoadRemoteConfig).toHaveBeenCalledWith({
+      url: 'https://raw.githubusercontent.com/org/repo/main/config.js',
+      token: 'token-abc',
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it('omits token when resolveGitHubToken returns undefined for --github source', async () => {
+    const config = makeConfig();
+    mockExpandGitHubShorthand.mockReturnValue('https://raw.githubusercontent.com/org/repo/main/config.js');
+    mockResolveGitHubToken.mockReturnValue(undefined);
+    mockLoadRemoteConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runCommand({
+      names: [],
+      configSource: { type: 'github', shorthand: 'org/repo/config.js' },
+      json: false,
+    });
+
+    expect(mockLoadRemoteConfig).toHaveBeenCalledWith({
+      url: 'https://raw.githubusercontent.com/org/repo/main/config.js',
+    });
+    expect(Object.keys(mockLoadRemoteConfig.mock.calls[0][0] as Record<string, unknown>)).not.toContain('token');
+  });
+
+  // URL source tests
+  it('fetches directly for --url source without token resolution', async () => {
+    const config = makeConfig();
+    mockLoadRemoteConfig.mockResolvedValue(config);
+    mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    const exitCode = await runCommand({
+      names: [],
+      configSource: { type: 'url', url: 'https://example.com/config.js' },
+      json: false,
+    });
+
+    expect(mockResolveGitHubToken).not.toHaveBeenCalled();
+    expect(mockLoadRemoteConfig).toHaveBeenCalledWith({
+      url: 'https://example.com/config.js',
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it('reports remote config loading errors to stderr', async () => {
+    mockLoadRemoteConfig.mockRejectedValue(new Error('Failed to fetch remote config'));
+
+    const exitCode = await runCommand({
+      names: [],
+      configSource: { type: 'url', url: 'https://example.com/config.js' },
+      json: false,
+    });
+
+    expect(stderrSpy).toHaveBeenCalledWith('Error: Failed to fetch remote config\n');
+    expect(exitCode).toBe(1);
   });
 });

--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -529,7 +529,7 @@ describe(runCommand, () => {
     expect(mockLoadRemoteConfig).toHaveBeenCalledWith({
       url: 'https://raw.githubusercontent.com/org/repo/main/config.js',
     });
-    expect(Object.keys(mockLoadRemoteConfig.mock.calls[0][0] as Record<string, unknown>)).not.toContain('token');
+    expect(mockLoadRemoteConfig.mock.calls[0][0]).not.toHaveProperty('token');
   });
 
   // URL source tests

--- a/packages/preflight/__tests__/config.test.ts
+++ b/packages/preflight/__tests__/config.test.ts
@@ -74,29 +74,6 @@ describe(loadPreflightConfig, () => {
     await expect(loadPreflightConfig()).rejects.toThrow('must have a default export or a named `config` export');
   });
 
-  it('throws when checklists is missing', async () => {
-    mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ default: {} });
-
-    await expect(loadPreflightConfig()).rejects.toThrow("must have a 'checklists' array");
-  });
-
-  it('throws when a checklist has neither checks nor groups', async () => {
-    mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ default: { checklists: [{ name: 'bad' }] } });
-
-    await expect(loadPreflightConfig()).rejects.toThrow("must have either 'checks' or 'groups'");
-  });
-
-  it('throws when a checklist has both checks and groups', async () => {
-    mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({
-      default: { checklists: [{ name: 'bad', checks: [], groups: [] }] },
-    });
-
-    await expect(loadPreflightConfig()).rejects.toThrow("cannot have both 'checks' and 'groups'");
-  });
-
   it('returns a valid config with flat checklists', async () => {
     const validConfig = {
       checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],

--- a/packages/preflight/__tests__/expandGitHubShorthand.test.ts
+++ b/packages/preflight/__tests__/expandGitHubShorthand.test.ts
@@ -21,6 +21,12 @@ describe(expandGitHubShorthand, () => {
     expect(() => expandGitHubShorthand('org/repo')).toThrow('expected at least "org/repo/file"');
   });
 
+  it('splits on the last @ when multiple @ symbols are present', () => {
+    expect(expandGitHubShorthand('org/repo/path.js@v1@v2')).toBe(
+      'https://raw.githubusercontent.com/org/repo/v2/path.js@v1',
+    );
+  });
+
   it('throws when ref after @ is empty', () => {
     expect(() => expandGitHubShorthand('org/repo/path.js@')).toThrow("ref after '@' must not be empty");
   });

--- a/packages/preflight/__tests__/expandGitHubShorthand.test.ts
+++ b/packages/preflight/__tests__/expandGitHubShorthand.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { expandGitHubShorthand } from '../src/expandGitHubShorthand.ts';
+
+describe(expandGitHubShorthand, () => {
+  it('expands org/repo/path@ref to a raw URL', () => {
+    expect(expandGitHubShorthand('org/repo/path.js@v1')).toBe('https://raw.githubusercontent.com/org/repo/v1/path.js');
+  });
+
+  it('expands a deep path with a ref', () => {
+    expect(expandGitHubShorthand('org/repo/deep/path.js@main')).toBe(
+      'https://raw.githubusercontent.com/org/repo/main/deep/path.js',
+    );
+  });
+
+  it('defaults ref to main when no @ is present', () => {
+    expect(expandGitHubShorthand('org/repo/path.js')).toBe('https://raw.githubusercontent.com/org/repo/main/path.js');
+  });
+
+  it('throws when fewer than 3 segments are provided', () => {
+    expect(() => expandGitHubShorthand('org/repo')).toThrow('expected at least "org/repo/file"');
+  });
+
+  it('throws when ref after @ is empty', () => {
+    expect(() => expandGitHubShorthand('org/repo/path.js@')).toThrow("ref after '@' must not be empty");
+  });
+});

--- a/packages/preflight/__tests__/loadRemoteConfig.test.ts
+++ b/packages/preflight/__tests__/loadRemoteConfig.test.ts
@@ -88,10 +88,11 @@ describe(loadRemoteConfig, () => {
   it('cleans up temp directory even on failure', async () => {
     mockFetch.mockResolvedValue(mockResponse('export default {};'));
     mockMkdtempSync.mockReturnValue('/tmp/preflight-abc');
-
-    await loadRemoteConfig({ url: 'https://example.com/config.js' }).catch(() => {
-      // Expected to throw due to invalid config
+    mockWriteFileSync.mockImplementation(() => {
+      throw new Error('disk full');
     });
+
+    await expect(loadRemoteConfig({ url: 'https://example.com/config.js' })).rejects.toThrow('disk full');
 
     expect(mockRmSync).toHaveBeenCalledWith('/tmp/preflight-abc', { recursive: true, force: true });
   });

--- a/packages/preflight/__tests__/loadRemoteConfig.test.ts
+++ b/packages/preflight/__tests__/loadRemoteConfig.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockMkdtempSync = vi.hoisted(() => vi.fn());
+const mockRmSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  mkdtempSync: mockMkdtempSync,
+  rmSync: mockRmSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+const mockFetch = vi.hoisted(() => vi.fn());
+vi.stubGlobal('fetch', mockFetch);
+
+import { loadRemoteConfig } from '../src/loadRemoteConfig.ts';
+
+/** Build a minimal mock Response with the given body and status. */
+function mockResponse(
+  body: string,
+  init?: { status?: number; statusText?: string },
+): Pick<Response, 'ok' | 'status' | 'statusText' | 'text' | 'headers'> {
+  return {
+    ok: (init?.status ?? 200) >= 200 && (init?.status ?? 200) < 300,
+    status: init?.status ?? 200,
+    statusText: init?.statusText ?? 'OK',
+    text: () => Promise.resolve(body),
+    headers: new Headers(),
+  };
+}
+
+describe(loadRemoteConfig, () => {
+  afterEach(() => {
+    mockMkdtempSync.mockReset();
+    mockRmSync.mockReset();
+    mockWriteFileSync.mockReset();
+    mockFetch.mockReset();
+  });
+
+  it('throws on non-2xx responses', async () => {
+    mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
+
+    await expect(loadRemoteConfig({ url: 'https://example.com/config.js' })).rejects.toThrow(
+      'Failed to fetch remote config from https://example.com/config.js: 404 Not Found',
+    );
+  });
+
+  it('detects HTML error pages', async () => {
+    mockFetch.mockResolvedValue(mockResponse('<!DOCTYPE html><html><body>Error</body></html>'));
+
+    await expect(loadRemoteConfig({ url: 'https://example.com/config.js' })).rejects.toThrow(
+      'Remote config URL returned an HTML page instead of JavaScript',
+    );
+  });
+
+  it('detects HTML pages with <html prefix', async () => {
+    mockFetch.mockResolvedValue(mockResponse('<html><body>Error</body></html>'));
+
+    await expect(loadRemoteConfig({ url: 'https://example.com/config.js' })).rejects.toThrow(
+      'Remote config URL returned an HTML page instead of JavaScript',
+    );
+  });
+
+  it('sends authorization header when token is provided', async () => {
+    mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
+
+    await loadRemoteConfig({ url: 'https://example.com/config.js', token: 'my-token' }).catch(() => {
+      // Expected to throw due to 404
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/config.js', {
+      headers: { Authorization: 'token my-token' },
+    });
+  });
+
+  it('does not send authorization header when no token is provided', async () => {
+    mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
+
+    await loadRemoteConfig({ url: 'https://example.com/config.js' }).catch(() => {
+      // Expected to throw due to 404
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/config.js', {
+      headers: {},
+    });
+  });
+
+  it('cleans up temp directory even on failure', async () => {
+    mockFetch.mockResolvedValue(mockResponse('export default {};'));
+    mockMkdtempSync.mockReturnValue('/tmp/preflight-abc');
+
+    await loadRemoteConfig({ url: 'https://example.com/config.js' }).catch(() => {
+      // Expected to throw due to invalid config
+    });
+
+    expect(mockRmSync).toHaveBeenCalledWith('/tmp/preflight-abc', { recursive: true, force: true });
+  });
+});

--- a/packages/preflight/__tests__/resolveGitHubToken.test.ts
+++ b/packages/preflight/__tests__/resolveGitHubToken.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+import { resolveGitHubToken } from '../src/resolveGitHubToken.ts';
+
+describe(resolveGitHubToken, () => {
+  const originalEnv = process.env.GITHUB_TOKEN;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalEnv;
+    }
+    mockExecFileSync.mockReset();
+  });
+
+  it('returns GITHUB_TOKEN env var when set', () => {
+    process.env.GITHUB_TOKEN = 'env-token-123';
+
+    expect(resolveGitHubToken()).toBe('env-token-123');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('falls back to gh auth token output', () => {
+    delete process.env.GITHUB_TOKEN;
+    mockExecFileSync.mockReturnValue('  gh-token-456\n');
+
+    expect(resolveGitHubToken()).toBe('gh-token-456');
+  });
+
+  it('returns undefined when both sources fail', () => {
+    delete process.env.GITHUB_TOKEN;
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('gh not found');
+    });
+
+    expect(resolveGitHubToken()).toBeUndefined();
+  });
+
+  it('returns undefined when gh returns empty output', () => {
+    delete process.env.GITHUB_TOKEN;
+    mockExecFileSync.mockReturnValue('  \n');
+
+    expect(resolveGitHubToken()).toBeUndefined();
+  });
+
+  it('skips empty GITHUB_TOKEN env var', () => {
+    process.env.GITHUB_TOKEN = '';
+    mockExecFileSync.mockReturnValue('gh-token-789\n');
+
+    expect(resolveGitHubToken()).toBe('gh-token-789');
+  });
+});

--- a/packages/preflight/__tests__/route.test.ts
+++ b/packages/preflight/__tests__/route.test.ts
@@ -76,23 +76,23 @@ describe(routeCommand, () => {
   });
 
   it('delegates to runCommand for run subcommand', async () => {
-    mockParseRunArgs.mockReturnValue({ names: ['deploy'], json: false, configPath: undefined });
+    mockParseRunArgs.mockReturnValue({ names: ['deploy'], configSource: { type: 'local' }, json: false });
     mockRunCommand.mockResolvedValue(0);
 
     const exitCode = await routeCommand(['run', 'deploy']);
 
     expect(mockParseRunArgs).toHaveBeenCalledWith(['deploy']);
-    expect(mockRunCommand).toHaveBeenCalledWith({ names: ['deploy'], json: false, configPath: undefined });
+    expect(mockRunCommand).toHaveBeenCalledWith({ names: ['deploy'], configSource: { type: 'local' }, json: false });
     expect(exitCode).toBe(0);
   });
 
   it('passes --json flag through to runCommand', async () => {
-    mockParseRunArgs.mockReturnValue({ names: [], json: true, configPath: undefined });
+    mockParseRunArgs.mockReturnValue({ names: [], configSource: { type: 'local' }, json: true });
     mockRunCommand.mockResolvedValue(0);
 
     const exitCode = await routeCommand(['run', '--json']);
 
-    expect(mockRunCommand).toHaveBeenCalledWith({ names: [], json: true, configPath: undefined });
+    expect(mockRunCommand).toHaveBeenCalledWith({ names: [], configSource: { type: 'local' }, json: true });
     expect(exitCode).toBe(0);
   });
 

--- a/packages/preflight/src/assertIsPreflightConfig.ts
+++ b/packages/preflight/src/assertIsPreflightConfig.ts
@@ -1,0 +1,40 @@
+import type { PreflightConfig } from './types.ts';
+
+/** Check whether a value is a plain object (non-null, non-array). */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validate that a raw value conforms to the PreflightConfig shape.
+ *
+ * Throws on invalid input. When it returns without throwing, the value is a valid PreflightConfig.
+ * Because jiti loads the actual TypeScript module, the config objects retain their original types
+ * including function-valued properties like `check`.
+ */
+export function assertIsPreflightConfig(raw: unknown): asserts raw is PreflightConfig {
+  if (!isRecord(raw)) {
+    throw new TypeError(`Preflight config must be an object, got ${Array.isArray(raw) ? 'array' : typeof raw}`);
+  }
+
+  if (!Array.isArray(raw.checklists)) {
+    throw new TypeError("Preflight config must have a 'checklists' array");
+  }
+
+  for (const [i, entry] of raw.checklists.entries()) {
+    if (!isRecord(entry)) {
+      throw new Error(`checklists[${i}]: must be an object`);
+    }
+    if (typeof entry.name !== 'string' || entry.name === '') {
+      throw new Error(`checklists[${i}]: 'name' is required and must be a non-empty string`);
+    }
+    const hasChecks = 'checks' in entry;
+    const hasGroups = 'groups' in entry;
+    if (!hasChecks && !hasGroups) {
+      throw new Error(`checklists[${i}]: must have either 'checks' or 'groups'`);
+    }
+    if (hasChecks && hasGroups) {
+      throw new Error(`checklists[${i}]: cannot have both 'checks' and 'groups'`);
+    }
+  }
+}

--- a/packages/preflight/src/bin/route.ts
+++ b/packages/preflight/src/bin/route.ts
@@ -22,10 +22,14 @@ Usage: preflight run [names...] [options]
 
 Run preflight checklists. If no names are given, all checklists are run.
 
+Config source (mutually exclusive):
+  --config, -c <path>              Path to a local config file
+  --github <org/repo/path[@ref]>   Fetch config from a GitHub repository
+  --url <url>                      Fetch config from a URL
+
 Options:
-  --config, -c <path>   Path to the config file
-  --json                Output results as JSON
-  --help, -h            Show this help message
+  --json                           Output results as JSON
+  --help, -h                       Show this help message
 `);
 }
 

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -1,10 +1,13 @@
 import process from 'node:process';
 
 import { loadPreflightConfig } from './config.ts';
+import { expandGitHubShorthand } from './expandGitHubShorthand.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonError } from './formatJsonError.ts';
 import { formatJsonReport } from './formatJsonReport.ts';
+import { loadRemoteConfig, type LoadRemoteConfigOptions } from './loadRemoteConfig.ts';
 import { reportPreflight } from './reportPreflight.ts';
+import { resolveGitHubToken } from './resolveGitHubToken.ts';
 import { runPreflight } from './runPreflight.ts';
 import type {
   ChecklistSummary,
@@ -15,42 +18,88 @@ import type {
   StagedPreflightCheckList,
 } from './types.ts';
 
+/** Discriminated union describing how to locate the preflight config. */
+export type ConfigSource =
+  | { type: 'local'; path?: string }
+  | { type: 'github'; shorthand: string }
+  | { type: 'url'; url: string };
+
 interface ParsedRunArgs {
-  configPath?: string;
+  configSource: ConfigSource;
   json: boolean;
   names: string[];
 }
 
+/** Extract a flag value from either `--flag value` or `--flag=value` form, advancing the index when needed. */
+function extractFlagValue(
+  flagName: string,
+  arg: string,
+  flags: string[],
+  index: number,
+  errorHint: string,
+): { value: string; nextIndex: number } {
+  const eqPrefix = `${flagName}=`;
+  if (arg.startsWith(eqPrefix)) {
+    const value = arg.slice(eqPrefix.length);
+    if (value === '') {
+      throw new Error(`${flagName} requires ${errorHint}`);
+    }
+    return { value, nextIndex: index };
+  }
+  const next = flags[index + 1];
+  if (next === undefined || next.startsWith('-')) {
+    throw new Error(`${flagName} requires ${errorHint}`);
+  }
+  return { value: next, nextIndex: index + 1 };
+}
+
+/** Throw if a config source flag has already been set. */
+function assertNoExistingSource(existing: ConfigSource | undefined): void {
+  if (existing !== undefined) {
+    throw new Error('Cannot combine --config, --github, and --url flags');
+  }
+}
+
 /** Parse run-subcommand flags into a structured object. */
 export function parseRunArgs(flags: string[]): ParsedRunArgs {
-  const result: ParsedRunArgs = { json: false, names: [] };
+  const names: string[] = [];
+  let configSource: ConfigSource | undefined;
+  let json = false;
 
   for (let i = 0; i < flags.length; i++) {
-    const arg = flags[i];
-    if (arg === undefined) break;
+    const arg = flags[i] ?? '';
+
     if (arg === '--json') {
-      result.json = true;
-    } else if (arg === '--config' || arg === '-c') {
-      i++;
-      const configValue = flags[i];
-      if (configValue === undefined) {
-        throw new Error('--config requires a path argument');
-      }
-      result.configPath = configValue;
-    } else if (arg.startsWith('--config=')) {
-      const configValue = arg.slice('--config='.length);
-      if (configValue === '') {
-        throw new Error('--config requires a path argument');
-      }
-      result.configPath = configValue;
+      json = true;
+    } else if (arg === '--config' || arg === '-c' || arg.startsWith('--config=')) {
+      assertNoExistingSource(configSource);
+      const { value, nextIndex } = extractFlagValue('--config', arg, flags, i, 'a path argument');
+      i = nextIndex;
+      configSource = { type: 'local', path: value };
+    } else if (arg === '--github' || arg.startsWith('--github=')) {
+      assertNoExistingSource(configSource);
+      const { value, nextIndex } = extractFlagValue(
+        '--github',
+        arg,
+        flags,
+        i,
+        'a shorthand argument (org/repo/path[@ref])',
+      );
+      i = nextIndex;
+      configSource = { type: 'github', shorthand: value };
+    } else if (arg === '--url' || arg.startsWith('--url=')) {
+      assertNoExistingSource(configSource);
+      const { value, nextIndex } = extractFlagValue('--url', arg, flags, i, 'a URL argument');
+      i = nextIndex;
+      configSource = { type: 'url', url: value };
     } else if (arg.startsWith('-')) {
       throw new Error(`unknown flag '${arg}'`);
     } else {
-      result.names.push(arg);
+      names.push(arg);
     }
   }
 
-  return result;
+  return { configSource: configSource ?? { type: 'local' }, json, names };
 }
 
 /** Resolve the effective fixLocation for a checklist, falling back to the config-level default. */
@@ -76,15 +125,34 @@ function summarizeReport(name: string, report: PreflightReport): ChecklistSummar
 
 interface RunCommandOptions {
   names: string[];
-  configPath?: string;
+  configSource: ConfigSource;
   json: boolean;
 }
 
+/** Load a preflight config from the appropriate source. */
+async function loadConfig(source: ConfigSource): Promise<PreflightConfig> {
+  switch (source.type) {
+    case 'local':
+      return loadPreflightConfig(source.path);
+    case 'github': {
+      const url = expandGitHubShorthand(source.shorthand);
+      const token = resolveGitHubToken();
+      const options: LoadRemoteConfigOptions = { url };
+      if (token !== undefined) {
+        options.token = token;
+      }
+      return loadRemoteConfig(options);
+    }
+    case 'url':
+      return loadRemoteConfig({ url: source.url });
+  }
+}
+
 /** Run preflight checklists. Returns a numeric exit code. */
-export async function runCommand({ names, configPath, json }: RunCommandOptions): Promise<number> {
+export async function runCommand({ names, configSource, json }: RunCommandOptions): Promise<number> {
   let config: PreflightConfig;
   try {
-    config = await loadPreflightConfig(configPath);
+    config = await loadConfig(configSource);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     if (json) {

--- a/packages/preflight/src/config.ts
+++ b/packages/preflight/src/config.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
+import { assertIsPreflightConfig, isRecord } from './assertIsPreflightConfig.ts';
 import type { PreflightCheckList, PreflightConfig, StagedPreflightCheckList } from './types.ts';
 
 /** The default config file path, resolved relative to `process.cwd()`. */
@@ -19,45 +20,6 @@ export function definePreflightCheckList(checklist: PreflightCheckList): Preflig
 /** Type-safe identity function for defining a staged checklist. */
 export function defineStagedPreflightCheckList(checklist: StagedPreflightCheckList): StagedPreflightCheckList {
   return checklist;
-}
-
-/** Check whether a value is a plain object (non-null, non-array). */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-/**
- * Validate that a raw value conforms to the PreflightConfig shape.
- *
- * Throws on invalid input. When it returns without throwing, the value is a valid PreflightConfig.
- * Because jiti loads the actual TypeScript module, the config objects retain their original types
- * including function-valued properties like `check`.
- */
-function assertIsPreflightConfig(raw: unknown): asserts raw is PreflightConfig {
-  if (!isRecord(raw)) {
-    throw new TypeError(`Preflight config must be an object, got ${Array.isArray(raw) ? 'array' : typeof raw}`);
-  }
-
-  if (!Array.isArray(raw.checklists)) {
-    throw new TypeError("Preflight config must have a 'checklists' array");
-  }
-
-  for (const [i, entry] of raw.checklists.entries()) {
-    if (!isRecord(entry)) {
-      throw new Error(`checklists[${i}]: must be an object`);
-    }
-    if (typeof entry.name !== 'string' || entry.name === '') {
-      throw new Error(`checklists[${i}]: 'name' is required and must be a non-empty string`);
-    }
-    const hasChecks = 'checks' in entry;
-    const hasGroups = 'groups' in entry;
-    if (!hasChecks && !hasGroups) {
-      throw new Error(`checklists[${i}]: must have either 'checks' or 'groups'`);
-    }
-    if (hasChecks && hasGroups) {
-      throw new Error(`checklists[${i}]: cannot have both 'checks' and 'groups'`);
-    }
-  }
 }
 
 /**

--- a/packages/preflight/src/expandGitHubShorthand.ts
+++ b/packages/preflight/src/expandGitHubShorthand.ts
@@ -1,0 +1,32 @@
+/**
+ * Parse a GitHub shorthand string into a raw.githubusercontent.com URL.
+ *
+ * Format: `org/repo/path[/deeper]@ref` where `@ref` is optional (defaults to `main`).
+ */
+export function expandGitHubShorthand(shorthand: string): string {
+  const atIndex = shorthand.lastIndexOf('@');
+  let pathPart: string;
+  let ref: string;
+
+  if (atIndex === -1) {
+    pathPart = shorthand;
+    ref = 'main';
+  } else {
+    pathPart = shorthand.slice(0, atIndex);
+    ref = shorthand.slice(atIndex + 1);
+    if (ref === '') {
+      throw new Error(`Invalid GitHub shorthand: ref after '@' must not be empty in "${shorthand}"`);
+    }
+  }
+
+  const segments = pathPart.split('/');
+  if (segments.length < 3) {
+    throw new Error(`Invalid GitHub shorthand: expected at least "org/repo/file", got "${shorthand}"`);
+  }
+
+  const org = segments[0];
+  const repo = segments[1];
+  const filePath = segments.slice(2).join('/');
+
+  return `https://raw.githubusercontent.com/${org}/${repo}/${ref}/${filePath}`;
+}

--- a/packages/preflight/src/loadRemoteConfig.ts
+++ b/packages/preflight/src/loadRemoteConfig.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { assertIsPreflightConfig, isRecord } from './assertIsPreflightConfig.ts';
+import type { PreflightConfig } from './types.ts';
+
+export interface LoadRemoteConfigOptions {
+  url: string;
+  token?: string;
+}
+
+/**
+ * Fetch a remote `.js` config bundle, evaluate it, and return a validated PreflightConfig.
+ *
+ * Writes the fetched content to a temp file for dynamic import, then cleans up.
+ */
+export async function loadRemoteConfig({ url, token }: LoadRemoteConfigOptions): Promise<PreflightConfig> {
+  const headers: Record<string, string> = {};
+  if (token !== undefined) {
+    headers.Authorization = `token ${token}`;
+  }
+
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch remote config from ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  const body = await response.text();
+
+  // Detect HTML error pages (e.g., GitHub 404 pages that return 200)
+  const trimmedBody = body.trimStart().toLowerCase();
+  if (trimmedBody.startsWith('<html') || trimmedBody.startsWith('<!doctype')) {
+    throw new Error(`Remote config URL returned an HTML page instead of JavaScript: ${url}`);
+  }
+
+  const tempDir = mkdtempSync(join(tmpdir(), 'preflight-'));
+  const tempFile = join(tempDir, 'config.js');
+
+  try {
+    writeFileSync(tempFile, body, 'utf8');
+
+    const fileUrl = pathToFileURL(tempFile).href + `?t=${Date.now()}`;
+    const imported: unknown = await import(fileUrl);
+
+    if (!isRecord(imported)) {
+      throw new Error(
+        `Remote config must export an object, got ${Array.isArray(imported) ? 'array' : typeof imported}`,
+      );
+    }
+
+    const resolved = imported.default ?? imported.config;
+    if (resolved === undefined) {
+      throw new Error('Remote config must have a default export or a named `config` export');
+    }
+
+    assertIsPreflightConfig(resolved);
+    return resolved;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}

--- a/packages/preflight/src/loadRemoteConfig.ts
+++ b/packages/preflight/src/loadRemoteConfig.ts
@@ -42,16 +42,12 @@ export async function loadRemoteConfig({ url, token }: LoadRemoteConfigOptions):
   try {
     writeFileSync(tempFile, body, 'utf8');
 
-    const fileUrl = pathToFileURL(tempFile).href + `?t=${Date.now()}`;
+    const fileUrl = `${pathToFileURL(tempFile).href}?t=${Date.now()}`;
     const imported: unknown = await import(fileUrl);
-
-    if (!isRecord(imported)) {
-      throw new Error(
-        `Remote config must export an object, got ${Array.isArray(imported) ? 'array' : typeof imported}`,
-      );
-    }
-
-    const resolved = imported.default ?? imported.config;
+    // Narrow the module namespace to access exports. `import()` always returns an object,
+    // but TypeScript types it as `any`; narrowing avoids unsafe-member-access lint errors.
+    const moduleRecord = isRecord(imported) ? imported : {};
+    const resolved: unknown = moduleRecord.default ?? moduleRecord.config;
     if (resolved === undefined) {
       throw new Error('Remote config must have a default export or a named `config` export');
     }

--- a/packages/preflight/src/resolveGitHubToken.ts
+++ b/packages/preflight/src/resolveGitHubToken.ts
@@ -1,0 +1,29 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Resolve a GitHub token from ambient sources for authenticating private repo fetches.
+ *
+ * Checks `GITHUB_TOKEN` env var first, then falls back to `gh auth token`.
+ * Returns `undefined` when neither source produces a token.
+ */
+export function resolveGitHubToken(): string | undefined {
+  const envToken = process.env.GITHUB_TOKEN;
+  if (envToken !== undefined && envToken !== '') {
+    return envToken;
+  }
+
+  try {
+    const output = execFileSync('gh', ['auth', 'token'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const trimmed = output.trim();
+    if (trimmed !== '') {
+      return trimmed;
+    }
+  } catch {
+    // gh CLI not installed or not logged in
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Closes #103 

## What

Adds `--github` and `--url` flags to `preflight run` so it can fetch and evaluate remote `.js` config bundles hosted on GitHub or any URL. Extracts config validation into a shared module reused by both local and remote loaders.

## Why

Remote configs turn preflight into a single-command compliance tool — new hires can run convention checks without cloning a config repo, and shared conventions can be versioned independently of consumer repos via git refs.

## Details

### Features

- `--github org/repo/path[@ref]` expands to a `raw.githubusercontent.com` URL, resolves an ambient GitHub token (`GITHUB_TOKEN` env var → `gh auth token` → absent), and fetches the config
- `--url <full-url>` fetches directly with no token resolution
- Mutual exclusivity enforced: combining `--config`, `--github`, or `--url` throws a validation error
- Remote configs are evaluated via `import()` of a temp file with cache-busting, not jiti
- HTML error pages (e.g., GitHub 404s returning 200) are detected before evaluation
- Temp directory is cleaned up in a `finally` block

### Refactoring

- Extracted `assertIsPreflightConfig` and `isRecord` from `config.ts` into a standalone `assertIsPreflightConfig.ts` module shared by both `loadPreflightConfig` and `loadRemoteConfig`
- Replaced `configPath?: string` with a discriminated `ConfigSource` union (`local | github | url`) on both `ParsedRunArgs` and `RunCommandOptions`
- Extracted `extractFlagValue` and `assertNoExistingSource` helpers from `parseRunArgs` to stay under cyclomatic complexity lint threshold
- Removed dead code: unreachable `undefined` guard in flag-parsing loop, unreachable `isRecord` throwing branch in remote loader

### Tests

- New test files: `assertIsPreflightConfig.test.ts`, `expandGitHubShorthand.test.ts`, `resolveGitHubToken.test.ts`, `loadRemoteConfig.test.ts`
- Extended `cli.test.ts` with tests for `--github`/`--url` parsing, mutual exclusivity, flag-as-value rejection, absent token path, and `runCommand` integration for all three source types
- Updated `route.test.ts` to use the new `configSource` interface
- Migrated config shape validation tests from `config.test.ts` to `assertIsPreflightConfig.test.ts`

### Follow-up

- #113 — Test gaps (missing export path, happy-path integration) and fetch timeout
- #114 — Package README