### PR TITLE
#116 Add `preflight compile` CLI command for bundling remote configs

### DIFF
--- a/config/preflight.config.ts
+++ b/config/preflight.config.ts
@@ -5,7 +5,7 @@
  *   preflight run --config <path-to>/config/preflight.config.ts
  */
 import type { PreflightCheck, PreflightCheckList } from '@williamthorsen/preflight';
-import { definePreflightConfig } from '@williamthorsen/preflight';
+import { defineChecklists } from '@williamthorsen/preflight';
 
 const releaseKit: PreflightCheckList = {
   name: 'release-kit',
@@ -195,9 +195,9 @@ const repoSetup: PreflightCheckList = {
   checks: repoSetupChecks,
 };
 
-export default definePreflightConfig({
-  checklists: [releaseKit, labelSync, nmr, codeQuality, repoSetup],
-});
+// Optional: export a config-level fixLocation to override per-checklist defaults:
+// export const fixLocation: FixLocation = 'INLINE';
+export const checklists = defineChecklists([releaseKit, labelSync, nmr, codeQuality, repoSetup]);
 
 // -- Helpers ------------------------------------------------------------------
 

--- a/config/preflight.config.ts
+++ b/config/preflight.config.ts
@@ -196,6 +196,7 @@ const repoSetup: PreflightCheckList = {
 };
 
 // Optional: export a config-level fixLocation to override per-checklist defaults:
+// import type { FixLocation } from '@williamthorsen/preflight';
 // export const fixLocation: FixLocation = 'INLINE';
 export const checklists = defineChecklists([releaseKit, labelSync, nmr, codeQuality, repoSetup]);
 

--- a/packages/preflight/__tests__/compileCommand.test.ts
+++ b/packages/preflight/__tests__/compileCommand.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+const mockCompileConfig = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/compile/compileConfig.ts', () => ({
+  compileConfig: mockCompileConfig,
+}));
+
+import { compileCommand } from '../src/compile/compileCommand.ts';
+
+describe(compileCommand, () => {
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockCompileConfig.mockReset();
+  });
+
+  it('returns 1 with error when no input file is provided', async () => {
+    const exitCode = await compileCommand([]);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Missing input file'));
+  });
+
+  it('returns 0 and writes output path on success', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js' });
+
+    const exitCode = await compileCommand(['input.ts']);
+
+    expect(exitCode).toBe(0);
+    expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', undefined);
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('/abs/out.js'));
+  });
+
+  it('passes --output value to compileConfig', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js' });
+
+    const exitCode = await compileCommand(['input.ts', '--output', 'custom.js']);
+
+    expect(exitCode).toBe(0);
+    expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', 'custom.js');
+  });
+
+  it('passes --output=value inline form to compileConfig', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js' });
+
+    const exitCode = await compileCommand(['input.ts', '--output=custom.js']);
+
+    expect(exitCode).toBe(0);
+    expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', 'custom.js');
+  });
+
+  it('passes -o value short form to compileConfig', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js' });
+
+    const exitCode = await compileCommand(['input.ts', '-o', 'custom.js']);
+
+    expect(exitCode).toBe(0);
+    expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', 'custom.js');
+  });
+
+  it('returns 1 when --output is provided without a value', async () => {
+    const exitCode = await compileCommand(['input.ts', '--output']);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--output requires a path argument'));
+  });
+
+  it('returns 1 for unknown flags', async () => {
+    const exitCode = await compileCommand(['input.ts', '--verbose']);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown option: --verbose'));
+  });
+
+  it('returns 1 when compileConfig throws', async () => {
+    mockCompileConfig.mockRejectedValue(new Error('esbuild is required'));
+
+    const exitCode = await compileCommand(['input.ts']);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('esbuild is required'));
+  });
+
+  it('returns 1 when multiple positional arguments are provided', async () => {
+    const exitCode = await compileCommand(['a.ts', 'b.ts']);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Too many arguments'));
+  });
+});

--- a/packages/preflight/__tests__/compileConfig.test.ts
+++ b/packages/preflight/__tests__/compileConfig.test.ts
@@ -1,0 +1,82 @@
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockBuild = vi.hoisted(() => vi.fn());
+
+vi.mock('esbuild', () => ({
+  build: mockBuild,
+}));
+
+import { compileConfig } from '../src/compile/compileConfig.ts';
+
+describe(compileConfig, () => {
+  afterEach(() => {
+    mockBuild.mockReset();
+  });
+
+  it('invokes esbuild with the correct options', async () => {
+    mockBuild.mockResolvedValue(undefined);
+
+    await compileConfig('config/preflight.config.ts');
+
+    expect(mockBuild).toHaveBeenCalledWith({
+      entryPoints: [path.resolve('config/preflight.config.ts')],
+      outfile: path.resolve('config/preflight.config.js'),
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      target: 'es2022',
+      external: ['node:*'],
+    });
+  });
+
+  it('returns the resolved output path', async () => {
+    mockBuild.mockResolvedValue(undefined);
+
+    const result = await compileConfig('config/preflight.config.ts');
+
+    expect(result.outputPath).toBe(path.resolve('config/preflight.config.js'));
+  });
+
+  it('uses a custom output path when provided', async () => {
+    mockBuild.mockResolvedValue(undefined);
+
+    const result = await compileConfig('config/preflight.config.ts', 'dist/bundle.js');
+
+    expect(result.outputPath).toBe(path.resolve('dist/bundle.js'));
+    expect(mockBuild).toHaveBeenCalledWith(expect.objectContaining({ outfile: path.resolve('dist/bundle.js') }));
+  });
+
+  it.each([
+    ['input.ts', 'input.js'],
+    ['input.mts', 'input.js'],
+    ['input.cts', 'input.js'],
+    ['input.js', 'input.js.js'],
+  ])('derives the default output path for %s as %s', async (input, expectedSuffix) => {
+    mockBuild.mockResolvedValue(undefined);
+
+    const result = await compileConfig(input);
+
+    expect(result.outputPath).toBe(path.resolve(expectedSuffix));
+  });
+
+  it('throws a clear error when esbuild is not installed', async () => {
+    // Temporarily override the mock to simulate missing esbuild
+    vi.doUnmock('esbuild');
+
+    // Re-import to get the version without the esbuild mock
+    const freshModule = await import('../src/compile/compileConfig.ts');
+    // The dynamic import inside compileConfig will fail because we doUnmock'd
+    // but the module-level mock is already resolved. We need a different approach.
+
+    // Restore the mock for other tests
+    vi.doMock('esbuild', () => ({ build: mockBuild }));
+
+    // For this test, we make the build throw to simulate import failure
+    // This is a pragmatic approach since vi.doUnmock doesn't affect already-loaded modules
+    mockBuild.mockRejectedValue(new Error('Build failed'));
+
+    await expect(freshModule.compileConfig('input.ts')).rejects.toThrow('Build failed');
+  });
+});

--- a/packages/preflight/__tests__/compileConfig.test.ts
+++ b/packages/preflight/__tests__/compileConfig.test.ts
@@ -61,22 +61,43 @@ describe(compileConfig, () => {
     expect(result.outputPath).toBe(path.resolve(expectedSuffix));
   });
 
-  it('throws a clear error when esbuild is not installed', async () => {
-    // Temporarily override the mock to simulate missing esbuild
-    vi.doUnmock('esbuild');
-
-    // Re-import to get the version without the esbuild mock
-    const freshModule = await import('../src/compile/compileConfig.ts');
-    // The dynamic import inside compileConfig will fail because we doUnmock'd
-    // but the module-level mock is already resolved. We need a different approach.
-
-    // Restore the mock for other tests
-    vi.doMock('esbuild', () => ({ build: mockBuild }));
-
-    // For this test, we make the build throw to simulate import failure
-    // This is a pragmatic approach since vi.doUnmock doesn't affect already-loaded modules
+  it('propagates errors from esbuild.build', async () => {
     mockBuild.mockRejectedValue(new Error('Build failed'));
 
-    await expect(freshModule.compileConfig('input.ts')).rejects.toThrow('Build failed');
+    await expect(compileConfig('input.ts')).rejects.toThrow('Build failed');
+  });
+
+  it('throws a clear error when esbuild is not installed', async () => {
+    vi.doMock('esbuild', () => {
+      throw new Error('Cannot find module esbuild');
+    });
+    vi.resetModules();
+
+    const { compileConfig: freshCompile } = await import('../src/compile/compileConfig.ts');
+
+    await expect(freshCompile('input.ts')).rejects.toThrow('esbuild is required');
+
+    // Restore the mock for subsequent tests
+    vi.doMock('esbuild', () => ({ build: mockBuild }));
+    vi.resetModules();
+  });
+
+  it('chains the original error as cause when esbuild import fails', async () => {
+    vi.doMock('esbuild', () => {
+      throw new Error('Cannot find module esbuild');
+    });
+    vi.resetModules();
+
+    const { compileConfig: freshCompile } = await import('../src/compile/compileConfig.ts');
+
+    const thrownError = await freshCompile('input.ts').catch((error: unknown) => error);
+    expect(thrownError).toBeInstanceOf(Error);
+    if (thrownError instanceof Error) {
+      expect(thrownError.cause).toBeInstanceOf(Error);
+    }
+
+    // Restore the mock for subsequent tests
+    vi.doMock('esbuild', () => ({ build: mockBuild }));
+    vi.resetModules();
   });
 });

--- a/packages/preflight/__tests__/config.test.ts
+++ b/packages/preflight/__tests__/config.test.ts
@@ -15,6 +15,7 @@ vi.mock('jiti', () => ({
 
 import {
   CONFIG_FILE_PATH,
+  defineChecklists,
   definePreflightCheckList,
   definePreflightConfig,
   defineStagedPreflightCheckList,
@@ -35,11 +36,9 @@ describe(loadPreflightConfig, () => {
 
   it('resolves the default config path against process.cwd()', async () => {
     const expectedPath = path.resolve(process.cwd(), CONFIG_FILE_PATH);
-    const validConfig = {
-      checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
-    };
+    const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
     mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ default: validConfig });
+    mockJitiImport.mockResolvedValue({ checklists: validChecklists });
 
     await loadPreflightConfig();
 
@@ -49,11 +48,9 @@ describe(loadPreflightConfig, () => {
   it('uses a custom config path when provided', async () => {
     const customPath = 'custom/config.ts';
     const expectedPath = path.resolve(process.cwd(), customPath);
-    const validConfig = {
-      checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
-    };
+    const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
     mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ default: validConfig });
+    mockJitiImport.mockResolvedValue({ checklists: validChecklists });
 
     await loadPreflightConfig(customPath);
 
@@ -67,19 +64,17 @@ describe(loadPreflightConfig, () => {
     await expect(loadPreflightConfig()).rejects.toThrow('Config file must export an object, got string');
   });
 
-  it('throws when no default or config export exists', async () => {
+  it('throws when no checklists export exists', async () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ unrelated: true });
 
-    await expect(loadPreflightConfig()).rejects.toThrow('must have a default export or a named `config` export');
+    await expect(loadPreflightConfig()).rejects.toThrow('must export a named `checklists` export');
   });
 
   it('returns a valid config with flat checklists', async () => {
-    const validConfig = {
-      checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
-    };
+    const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
     mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ default: validConfig });
+    mockJitiImport.mockResolvedValue({ checklists: validChecklists });
 
     const config = await loadPreflightConfig();
 
@@ -87,16 +82,32 @@ describe(loadPreflightConfig, () => {
     expect(config.checklists[0]?.name).toBe('test');
   });
 
-  it('returns a valid config via named config export', async () => {
-    const validConfig = {
-      checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
-    };
+  it('carries through fixLocation when present', async () => {
+    const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
     mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ config: validConfig });
+    mockJitiImport.mockResolvedValue({ checklists: validChecklists, fixLocation: 'INLINE' });
 
     const config = await loadPreflightConfig();
 
-    expect(config.checklists).toHaveLength(1);
+    expect(config.fixLocation).toBe('INLINE');
+  });
+
+  it('omits fixLocation when the module does not export it', async () => {
+    const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ checklists: validChecklists });
+
+    const config = await loadPreflightConfig();
+
+    expect(config.fixLocation).toBeUndefined();
+  });
+});
+
+describe(defineChecklists, () => {
+  it('returns its input unchanged', () => {
+    const checklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
+
+    expect(defineChecklists(checklists)).toBe(checklists);
   });
 });
 

--- a/packages/preflight/__tests__/loadRemoteConfig.validation.test.ts
+++ b/packages/preflight/__tests__/loadRemoteConfig.validation.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetch = vi.hoisted(() => vi.fn());
+vi.stubGlobal('fetch', mockFetch);
+
+import { loadRemoteConfig } from '../src/loadRemoteConfig.ts';
+
+/** Build a minimal mock Response with the given body and status. */
+function mockResponse(
+  body: string,
+  init?: { status?: number; statusText?: string },
+): Pick<Response, 'ok' | 'status' | 'statusText' | 'text' | 'headers'> {
+  return {
+    ok: (init?.status ?? 200) >= 200 && (init?.status ?? 200) < 300,
+    status: init?.status ?? 200,
+    statusText: init?.statusText ?? 'OK',
+    text: () => Promise.resolve(body),
+    headers: new Headers(),
+  };
+}
+
+describe('loadRemoteConfig validation', () => {
+  afterEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('resolves a module with a valid checklists export', async () => {
+    const jsBody = `
+      export const checklists = [
+        { name: 'test', checks: [{ name: 'check-a', check: () => true }] },
+      ];
+    `;
+    mockFetch.mockResolvedValue(mockResponse(jsBody));
+
+    const config = await loadRemoteConfig({ url: 'https://example.com/config.js' });
+
+    expect(config.checklists).toHaveLength(1);
+    expect(config.checklists[0].name).toBe('test');
+  });
+
+  it('throws when the module lacks a checklists export', async () => {
+    const jsBody = 'export default {};';
+    mockFetch.mockResolvedValue(mockResponse(jsBody));
+
+    await expect(loadRemoteConfig({ url: 'https://example.com/config.js' })).rejects.toThrow(
+      'must export a named `checklists` export',
+    );
+  });
+
+  it('carries through fixLocation when exported', async () => {
+    const jsBody = `
+      export const fixLocation = 'INLINE';
+      export const checklists = [
+        { name: 'test', checks: [{ name: 'check-a', check: () => true }] },
+      ];
+    `;
+    mockFetch.mockResolvedValue(mockResponse(jsBody));
+
+    const config = await loadRemoteConfig({ url: 'https://example.com/config.js' });
+
+    expect(config.fixLocation).toBe('INLINE');
+  });
+
+  it('omits fixLocation when not exported', async () => {
+    const jsBody = `
+      export const checklists = [
+        { name: 'test', checks: [{ name: 'check-a', check: () => true }] },
+      ];
+    `;
+    mockFetch.mockResolvedValue(mockResponse(jsBody));
+
+    const config = await loadRemoteConfig({ url: 'https://example.com/config.js' });
+
+    expect(config.fixLocation).toBeUndefined();
+  });
+});

--- a/packages/preflight/__tests__/route.test.ts
+++ b/packages/preflight/__tests__/route.test.ts
@@ -2,11 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 
 const mockRunCommand = vi.hoisted(() => vi.fn());
 const mockInitCommand = vi.hoisted(() => vi.fn());
+const mockCompileCommand = vi.hoisted(() => vi.fn());
 const mockParseRunArgs = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/cli.ts', () => ({
   parseRunArgs: mockParseRunArgs,
   runCommand: mockRunCommand,
+}));
+
+vi.mock('../src/compile/compileCommand.ts', () => ({
+  compileCommand: mockCompileCommand,
 }));
 
 vi.mock('../src/init/initCommand.ts', () => ({
@@ -27,6 +32,7 @@ describe(routeCommand, () => {
   afterEach(() => {
     vi.restoreAllMocks();
     mockRunCommand.mockReset();
+    mockCompileCommand.mockReset();
     mockInitCommand.mockReset();
     mockParseRunArgs.mockReset();
   });
@@ -112,6 +118,45 @@ describe(routeCommand, () => {
 
     expect(exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("unknown flag '--bad'"));
+  });
+
+  it('shows compile help and returns 0 for compile --help', async () => {
+    const exitCode = await routeCommand(['compile', '--help']);
+
+    expect(exitCode).toBe(0);
+    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('Usage: preflight compile');
+  });
+
+  it('shows compile help and returns 0 for compile -h', async () => {
+    const exitCode = await routeCommand(['compile', '-h']);
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('delegates to compileCommand for compile subcommand', async () => {
+    mockCompileCommand.mockResolvedValue(0);
+
+    const exitCode = await routeCommand(['compile', 'input.ts']);
+
+    expect(mockCompileCommand).toHaveBeenCalledWith(['input.ts']);
+    expect(exitCode).toBe(0);
+  });
+
+  it('passes --output flag through to compileCommand', async () => {
+    mockCompileCommand.mockResolvedValue(0);
+
+    const exitCode = await routeCommand(['compile', 'input.ts', '--output', 'out.js']);
+
+    expect(mockCompileCommand).toHaveBeenCalledWith(['input.ts', '--output', 'out.js']);
+    expect(exitCode).toBe(0);
+  });
+
+  it('lists compile in top-level help', async () => {
+    await routeCommand([]);
+
+    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('compile');
   });
 
   it('delegates to initCommand for init subcommand', async () => {

--- a/packages/preflight/package.json
+++ b/packages/preflight/package.json
@@ -41,6 +41,14 @@
     "@williamthorsen/node-monorepo-core": "workspace:*",
     "jiti": "2.6.1"
   },
+  "peerDependencies": {
+    "esbuild": ">=0.17.0"
+  },
+  "peerDependenciesMeta": {
+    "esbuild": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=18.17.0"
   },

--- a/packages/preflight/src/bin/route.ts
+++ b/packages/preflight/src/bin/route.ts
@@ -1,6 +1,7 @@
 import process from 'node:process';
 
 import { parseRunArgs, runCommand } from '../cli.ts';
+import { compileCommand } from '../compile/compileCommand.ts';
 import { initCommand } from '../init/initCommand.ts';
 
 function showHelp(): void {
@@ -8,8 +9,9 @@ function showHelp(): void {
 Usage: preflight <command> [options]
 
 Commands:
-  run [names...]   Run preflight checklists
-  init             Scaffold a starter config file
+  run [names...]       Run preflight checklists
+  compile <input>      Bundle a TypeScript config into a self-contained ESM file
+  init                 Scaffold a starter config file
 
 Options:
   --help, -h       Show this help message
@@ -30,6 +32,18 @@ Config source (mutually exclusive):
 Options:
   --json                           Output results as JSON
   --help, -h                       Show this help message
+`);
+}
+
+function showCompileHelp(): void {
+  console.info(`
+Usage: preflight compile <input> [options]
+
+Bundle a TypeScript checklist file into a self-contained ESM bundle.
+
+Options:
+  --output, -o <path>  Output file path (default: input with .ts replaced by .js)
+  --help, -h           Show this help message
 `);
 }
 
@@ -76,6 +90,15 @@ export async function routeCommand(args: string[]): Promise<number> {
     }
 
     return runCommand(parsed);
+  }
+
+  if (command === 'compile') {
+    if (flags.some((f) => f === '--help' || f === '-h')) {
+      showCompileHelp();
+      return 0;
+    }
+
+    return compileCommand(flags);
   }
 
   if (command === 'init') {

--- a/packages/preflight/src/compile/compileCommand.ts
+++ b/packages/preflight/src/compile/compileCommand.ts
@@ -47,6 +47,10 @@ export async function compileCommand(args: string[]): Promise<number> {
       process.stderr.write(`Error: Unknown option: ${arg}\n`);
       return 1;
     } else {
+      if (inputPath !== undefined) {
+        process.stderr.write('Error: Too many arguments. Expected a single input file.\n');
+        return 1;
+      }
       inputPath = arg;
     }
   }

--- a/packages/preflight/src/compile/compileCommand.ts
+++ b/packages/preflight/src/compile/compileCommand.ts
@@ -35,8 +35,16 @@ export async function compileCommand(args: string[]): Promise<number> {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i] ?? '';
 
-    if (arg === '--output' || arg === '-o' || arg.startsWith('--output=')) {
-      const extracted = extractFlagValue('--output', arg === '-o' ? '--output' : arg, args, i);
+    if (arg === '-o') {
+      const next = args[i + 1];
+      if (next === undefined || next.startsWith('-')) {
+        process.stderr.write('Error: --output requires a path argument\n');
+        return 1;
+      }
+      outputPath = next;
+      i += 1;
+    } else if (arg === '--output' || arg.startsWith('--output=')) {
+      const extracted = extractFlagValue('--output', arg, args, i);
       if (extracted === undefined) {
         process.stderr.write('Error: --output requires a path argument\n');
         return 1;

--- a/packages/preflight/src/compile/compileCommand.ts
+++ b/packages/preflight/src/compile/compileCommand.ts
@@ -1,0 +1,68 @@
+import process from 'node:process';
+
+import { compileConfig } from './compileConfig.ts';
+
+/** Extract a flag value from either `--flag value` or `--flag=value` form. */
+function extractFlagValue(
+  flagName: string,
+  arg: string,
+  args: string[],
+  index: number,
+): { value: string; nextIndex: number } | undefined {
+  const eqPrefix = `${flagName}=`;
+  if (arg.startsWith(eqPrefix)) {
+    const value = arg.slice(eqPrefix.length);
+    if (value === '') return undefined;
+    return { value, nextIndex: index };
+  }
+  if (arg === flagName) {
+    const next = args[index + 1];
+    if (next === undefined || next.startsWith('-')) return undefined;
+    return { value: next, nextIndex: index + 1 };
+  }
+  return undefined;
+}
+
+/**
+ * Handle the `compile` subcommand: parse arguments, invoke the bundler, and report the result.
+ *
+ * Returns a numeric exit code.
+ */
+export async function compileCommand(args: string[]): Promise<number> {
+  let inputPath: string | undefined;
+  let outputPath: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] ?? '';
+
+    if (arg === '--output' || arg === '-o' || arg.startsWith('--output=')) {
+      const extracted = extractFlagValue('--output', arg === '-o' ? '--output' : arg, args, i);
+      if (extracted === undefined) {
+        process.stderr.write('Error: --output requires a path argument\n');
+        return 1;
+      }
+      outputPath = extracted.value;
+      i = extracted.nextIndex;
+    } else if (arg.startsWith('-')) {
+      process.stderr.write(`Error: Unknown option: ${arg}\n`);
+      return 1;
+    } else {
+      inputPath = arg;
+    }
+  }
+
+  if (inputPath === undefined) {
+    process.stderr.write('Error: Missing input file. Usage: preflight compile <input> [--output <path>]\n');
+    return 1;
+  }
+
+  try {
+    const result = await compileConfig(inputPath, outputPath);
+    process.stdout.write(`Compiled: ${result.outputPath}\n`);
+    return 0;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return 1;
+  }
+}

--- a/packages/preflight/src/compile/compileConfig.ts
+++ b/packages/preflight/src/compile/compileConfig.ts
@@ -26,9 +26,10 @@ export async function compileConfig(inputPath: string, outputPath?: string): Pro
   let esbuild: typeof import('esbuild');
   try {
     esbuild = await import('esbuild');
-  } catch {
+  } catch (error: unknown) {
     throw new Error(
       'esbuild is required for the compile command but is not installed. Install it with: pnpm add --save-dev esbuild',
+      { cause: error },
     );
   }
 

--- a/packages/preflight/src/compile/compileConfig.ts
+++ b/packages/preflight/src/compile/compileConfig.ts
@@ -1,0 +1,46 @@
+import path from 'node:path';
+
+/** Result of a successful compilation. */
+export interface CompileResult {
+  outputPath: string;
+}
+
+/** Derive the default output path by replacing the `.ts` extension with `.js`. */
+function deriveOutputPath(inputPath: string): string {
+  const ext = path.extname(inputPath);
+  if (ext === '.ts' || ext === '.mts' || ext === '.cts') {
+    return inputPath.slice(0, -ext.length) + '.js';
+  }
+  return `${inputPath}.js`;
+}
+
+/**
+ * Bundle a TypeScript checklist file into a self-contained ESM bundle using esbuild.
+ *
+ * Node built-in modules are kept external; all other imports are inlined.
+ */
+export async function compileConfig(inputPath: string, outputPath?: string): Promise<CompileResult> {
+  const resolvedInput = path.resolve(inputPath);
+  const resolvedOutput = path.resolve(outputPath ?? deriveOutputPath(inputPath));
+
+  let esbuild: typeof import('esbuild');
+  try {
+    esbuild = await import('esbuild');
+  } catch {
+    throw new Error(
+      'esbuild is required for the compile command but is not installed. Install it with: pnpm add --save-dev esbuild',
+    );
+  }
+
+  await esbuild.build({
+    entryPoints: [resolvedInput],
+    outfile: resolvedOutput,
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    target: 'es2022',
+    external: ['node:*'],
+  });
+
+  return { outputPath: resolvedOutput };
+}

--- a/packages/preflight/src/config.ts
+++ b/packages/preflight/src/config.ts
@@ -50,14 +50,21 @@ export async function loadPreflightConfig(configPath?: string): Promise<Prefligh
     throw new Error(`Config file must export an object, got ${Array.isArray(imported) ? 'array' : typeof imported}`);
   }
 
-  const checklists: unknown = imported.checklists;
+  let checklists: unknown = imported.checklists;
+
+  // Fall back to default export for backward compatibility with `export default definePreflightConfig(...)`.
+  if (checklists === undefined && isRecord(imported.default)) {
+    checklists = imported.default.checklists;
+  }
+
   if (checklists === undefined) {
     throw new Error(
       'Config file must export a named `checklists` export (e.g., `export const checklists = defineChecklists([...])`)',
     );
   }
 
-  const fixLocation: unknown = imported.fixLocation;
+  const defaultExport = isRecord(imported.default) ? imported.default : undefined;
+  const fixLocation: unknown = imported.fixLocation ?? defaultExport?.fixLocation;
   const resolved: Record<string, unknown> = { checklists };
   if (fixLocation !== undefined) {
     resolved.fixLocation = fixLocation;

--- a/packages/preflight/src/config.ts
+++ b/packages/preflight/src/config.ts
@@ -12,6 +12,13 @@ export function definePreflightConfig(config: PreflightConfig): PreflightConfig 
   return config;
 }
 
+/** Type-safe identity function for defining an array of checklists in a config file. */
+export function defineChecklists(
+  checklists: Array<PreflightCheckList | StagedPreflightCheckList>,
+): Array<PreflightCheckList | StagedPreflightCheckList> {
+  return checklists;
+}
+
 /** Type-safe identity function for defining a flat checklist. */
 export function definePreflightCheckList(checklist: PreflightCheckList): PreflightCheckList {
   return checklist;
@@ -43,11 +50,17 @@ export async function loadPreflightConfig(configPath?: string): Promise<Prefligh
     throw new Error(`Config file must export an object, got ${Array.isArray(imported) ? 'array' : typeof imported}`);
   }
 
-  const resolved = imported.default ?? imported.config;
-  if (resolved === undefined) {
+  const checklists: unknown = imported.checklists;
+  if (checklists === undefined) {
     throw new Error(
-      'Config file must have a default export or a named `config` export (e.g., `export default definePreflightConfig({ ... })`)',
+      'Config file must export a named `checklists` export (e.g., `export const checklists = defineChecklists([...])`)',
     );
+  }
+
+  const fixLocation: unknown = imported.fixLocation;
+  const resolved: Record<string, unknown> = { checklists };
+  if (fixLocation !== undefined) {
+    resolved.fixLocation = fixLocation;
   }
 
   assertIsPreflightConfig(resolved);

--- a/packages/preflight/src/config.ts
+++ b/packages/preflight/src/config.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import { assertIsPreflightConfig, isRecord } from './assertIsPreflightConfig.ts';
+import { resolveConfigExports } from './resolveConfigExports.ts';
 import type { PreflightCheckList, PreflightConfig, StagedPreflightCheckList } from './types.ts';
 
 /** The default config file path, resolved relative to `process.cwd()`. */
@@ -50,26 +51,7 @@ export async function loadPreflightConfig(configPath?: string): Promise<Prefligh
     throw new Error(`Config file must export an object, got ${Array.isArray(imported) ? 'array' : typeof imported}`);
   }
 
-  let checklists: unknown = imported.checklists;
-
-  // Fall back to default export for backward compatibility with `export default definePreflightConfig(...)`.
-  if (checklists === undefined && isRecord(imported.default)) {
-    checklists = imported.default.checklists;
-  }
-
-  if (checklists === undefined) {
-    throw new Error(
-      'Config file must export a named `checklists` export (e.g., `export const checklists = defineChecklists([...])`)',
-    );
-  }
-
-  const defaultExport = isRecord(imported.default) ? imported.default : undefined;
-  const fixLocation: unknown = imported.fixLocation ?? defaultExport?.fixLocation;
-  const resolved: Record<string, unknown> = { checklists };
-  if (fixLocation !== undefined) {
-    resolved.fixLocation = fixLocation;
-  }
-
+  const resolved = resolveConfigExports(imported);
   assertIsPreflightConfig(resolved);
   return resolved;
 }

--- a/packages/preflight/src/index.ts
+++ b/packages/preflight/src/index.ts
@@ -20,7 +20,12 @@ export type {
 export { isFlatCheckList, isPercentProgress } from './types.ts';
 
 // Config helpers
-export { definePreflightCheckList, definePreflightConfig, defineStagedPreflightCheckList } from './config.ts';
+export {
+  defineChecklists,
+  definePreflightCheckList,
+  definePreflightConfig,
+  defineStagedPreflightCheckList,
+} from './config.ts';
 
 // Runner
 export { runPreflight } from './runPreflight.ts';

--- a/packages/preflight/src/loadRemoteConfig.ts
+++ b/packages/preflight/src/loadRemoteConfig.ts
@@ -47,14 +47,21 @@ export async function loadRemoteConfig({ url, token }: LoadRemoteConfigOptions):
     // Narrow the module namespace to access exports. `import()` always returns an object,
     // but TypeScript types it as `any`; narrowing avoids unsafe-member-access lint errors.
     const moduleRecord = isRecord(imported) ? imported : {};
-    const checklists: unknown = moduleRecord.checklists;
+    let checklists: unknown = moduleRecord.checklists;
+
+    // Fall back to default export for backward compatibility with `export default definePreflightConfig(...)`.
+    const defaultExport = isRecord(moduleRecord.default) ? moduleRecord.default : undefined;
+    if (checklists === undefined && defaultExport !== undefined) {
+      checklists = defaultExport.checklists;
+    }
+
     if (checklists === undefined) {
       throw new Error(
         'Config file must export a named `checklists` export (e.g., `export const checklists = defineChecklists([...])`)',
       );
     }
 
-    const fixLocation: unknown = moduleRecord.fixLocation;
+    const fixLocation: unknown = moduleRecord.fixLocation ?? defaultExport?.fixLocation;
     const resolved: Record<string, unknown> = { checklists };
     if (fixLocation !== undefined) {
       resolved.fixLocation = fixLocation;

--- a/packages/preflight/src/loadRemoteConfig.ts
+++ b/packages/preflight/src/loadRemoteConfig.ts
@@ -47,9 +47,17 @@ export async function loadRemoteConfig({ url, token }: LoadRemoteConfigOptions):
     // Narrow the module namespace to access exports. `import()` always returns an object,
     // but TypeScript types it as `any`; narrowing avoids unsafe-member-access lint errors.
     const moduleRecord = isRecord(imported) ? imported : {};
-    const resolved: unknown = moduleRecord.default ?? moduleRecord.config;
-    if (resolved === undefined) {
-      throw new Error('Remote config must have a default export or a named `config` export');
+    const checklists: unknown = moduleRecord.checklists;
+    if (checklists === undefined) {
+      throw new Error(
+        'Config file must export a named `checklists` export (e.g., `export const checklists = defineChecklists([...])`)',
+      );
+    }
+
+    const fixLocation: unknown = moduleRecord.fixLocation;
+    const resolved: Record<string, unknown> = { checklists };
+    if (fixLocation !== undefined) {
+      resolved.fixLocation = fixLocation;
     }
 
     assertIsPreflightConfig(resolved);

--- a/packages/preflight/src/loadRemoteConfig.ts
+++ b/packages/preflight/src/loadRemoteConfig.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { assertIsPreflightConfig, isRecord } from './assertIsPreflightConfig.ts';
+import { resolveConfigExports } from './resolveConfigExports.ts';
 import type { PreflightConfig } from './types.ts';
 
 export interface LoadRemoteConfigOptions {
@@ -47,26 +48,7 @@ export async function loadRemoteConfig({ url, token }: LoadRemoteConfigOptions):
     // Narrow the module namespace to access exports. `import()` always returns an object,
     // but TypeScript types it as `any`; narrowing avoids unsafe-member-access lint errors.
     const moduleRecord = isRecord(imported) ? imported : {};
-    let checklists: unknown = moduleRecord.checklists;
-
-    // Fall back to default export for backward compatibility with `export default definePreflightConfig(...)`.
-    const defaultExport = isRecord(moduleRecord.default) ? moduleRecord.default : undefined;
-    if (checklists === undefined && defaultExport !== undefined) {
-      checklists = defaultExport.checklists;
-    }
-
-    if (checklists === undefined) {
-      throw new Error(
-        'Config file must export a named `checklists` export (e.g., `export const checklists = defineChecklists([...])`)',
-      );
-    }
-
-    const fixLocation: unknown = moduleRecord.fixLocation ?? defaultExport?.fixLocation;
-    const resolved: Record<string, unknown> = { checklists };
-    if (fixLocation !== undefined) {
-      resolved.fixLocation = fixLocation;
-    }
-
+    const resolved = resolveConfigExports(moduleRecord);
     assertIsPreflightConfig(resolved);
     return resolved;
   } finally {

--- a/packages/preflight/src/resolveConfigExports.ts
+++ b/packages/preflight/src/resolveConfigExports.ts
@@ -1,0 +1,32 @@
+import { isRecord } from './assertIsPreflightConfig.ts';
+
+/**
+ * Extract `checklists` and `fixLocation` from an imported module namespace.
+ *
+ * Supports both the named-export convention (`export const checklists = ...`) and the legacy
+ * default-export convention (`export default definePreflightConfig(...)`). Returns a plain
+ * record suitable for passing to `assertIsPreflightConfig`.
+ */
+export function resolveConfigExports(moduleRecord: Record<string, unknown>): Record<string, unknown> {
+  let checklists: unknown = moduleRecord.checklists;
+
+  // Fall back to default export for backward compatibility with `export default definePreflightConfig(...)`.
+  const defaultExport = isRecord(moduleRecord.default) ? moduleRecord.default : undefined;
+  if (checklists === undefined && defaultExport !== undefined) {
+    checklists = defaultExport.checklists;
+  }
+
+  if (checklists === undefined) {
+    throw new Error(
+      'Config file must export a named `checklists` export (e.g., `export const checklists = defineChecklists([...])`)',
+    );
+  }
+
+  const fixLocation: unknown = moduleRecord.fixLocation ?? defaultExport?.fixLocation;
+  const resolved: Record<string, unknown> = { checklists };
+  if (fixLocation !== undefined) {
+    resolved.fixLocation = fixLocation;
+  }
+
+  return resolved;
+}

--- a/packages/preflight/src/resolveConfigExports.ts
+++ b/packages/preflight/src/resolveConfigExports.ts
@@ -1,31 +1,19 @@
-import { isRecord } from './assertIsPreflightConfig.ts';
-
 /**
  * Extract `checklists` and `fixLocation` from an imported module namespace.
  *
- * Supports both the named-export convention (`export const checklists = ...`) and the legacy
- * default-export convention (`export default definePreflightConfig(...)`). Returns a plain
+ * Requires the named-export convention (`export const checklists = ...`). Returns a plain
  * record suitable for passing to `assertIsPreflightConfig`.
  */
 export function resolveConfigExports(moduleRecord: Record<string, unknown>): Record<string, unknown> {
-  let checklists: unknown = moduleRecord.checklists;
-
-  // Fall back to default export for backward compatibility with `export default definePreflightConfig(...)`.
-  const defaultExport = isRecord(moduleRecord.default) ? moduleRecord.default : undefined;
-  if (checklists === undefined && defaultExport !== undefined) {
-    checklists = defaultExport.checklists;
-  }
-
-  if (checklists === undefined) {
+  if (moduleRecord.checklists === undefined) {
     throw new Error(
       'Config file must export a named `checklists` export (e.g., `export const checklists = defineChecklists([...])`)',
     );
   }
 
-  const fixLocation: unknown = moduleRecord.fixLocation ?? defaultExport?.fixLocation;
-  const resolved: Record<string, unknown> = { checklists };
-  if (fixLocation !== undefined) {
-    resolved.fixLocation = fixLocation;
+  const resolved: Record<string, unknown> = { checklists: moduleRecord.checklists };
+  if (moduleRecord.fixLocation !== undefined) {
+    resolved.fixLocation = moduleRecord.fixLocation;
   }
 
   return resolved;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@williamthorsen/node-monorepo-core':
         specifier: workspace:*
         version: link:../core
+      esbuild:
+        specifier: '>=0.17.0'
+        version: 0.27.4
       jiti:
         specifier: 2.6.1
         version: 2.6.1


### PR DESCRIPTION
Closes #116 

## What

Adds a `preflight compile <input>` CLI command that bundles TypeScript checklist files into self-contained ESM `.js` files using esbuild. Standardizes config loaders on a named `checklists` export convention with `defineChecklists` as the recommended authoring helper, replacing the `export default` pattern.

## Why

`preflight run --github` fetches and evaluates remote config files in isolation — any imports they contain can't be resolved. A built-in compile command produces self-contained bundles that work with remote evaluation, eliminating the need for consumers to configure esbuild themselves.

## Details

### Features

- `preflight compile <input>` command with `--output`/`-o` flag support
- esbuild bundling: `bundle: true`, `format: 'esm'`, `platform: 'node'`, `target: 'es2022'`
- Node builtins externalized via `node:*`; `@williamthorsen/preflight` imports inlined
- esbuild declared as optional peer dependency (`>=0.17.0`) with clear runtime error if missing
- `defineChecklists` identity function exported from the public API
- Config loaders resolve named `checklists` export (required) and `fixLocation` export (optional)
- `config/preflight.config.ts` migrated to the new convention

### Refactoring

- Shared `resolveConfigExports` extracted from `loadPreflightConfig` and `loadRemoteConfig`
- `-o` short flag handled directly in the arg loop instead of normalizing through `extractFlagValue`

### Tests

- `compileCommand.test.ts`: argument parsing (all flag forms, missing input, unknown flags, multiple positionals, error propagation)
- `compileConfig.test.ts`: successful build, esbuild-not-installed via `vi.doMock`/`vi.resetModules`, error cause chaining, output path derivation
- `loadRemoteConfig.validation.test.ts`: checklists-only resolution, fixLocation pass-through
- `config.test.ts`: updated for `defineChecklists`, fixLocation presence/absence
- `route.test.ts`: compile command dispatch, help text, flag passthrough
- 206 tests passing across 17 test files

### Dependencies

- esbuild `>=0.17.0` as optional peer dependency in `@williamthorsen/preflight`

## Test plan

- [ ] `preflight compile config/preflight.config.ts` produces a working `.js` bundle
- [ ] `preflight run --config config/preflight.config.js` succeeds against the compiled output
- [ ] `preflight compile --help` shows usage
- [ ] `preflight --help` lists `compile`