### PR TITLE
#99 Support named suites of checklists

### DIFF
--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -301,7 +301,7 @@ describe(runCommand, () => {
       json: false,
     });
 
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unknown checklist(s): nonexistent'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown name(s): nonexistent'));
     expect(exitCode).toBe(1);
   });
 
@@ -544,7 +544,7 @@ describe(runCommand, () => {
         json: true,
       });
 
-      expect(mockFormatJsonError).toHaveBeenCalledWith(expect.stringContaining('unknown checklist(s): nonexistent'));
+      expect(mockFormatJsonError).toHaveBeenCalledWith(expect.stringContaining('Unknown name(s): nonexistent'));
       expect(stderrSpy).not.toHaveBeenCalled();
       expect(exitCode).toBe(1);
     });

--- a/packages/preflight/__tests__/compileCommand.test.ts
+++ b/packages/preflight/__tests__/compileCommand.test.ts
@@ -1,12 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 const mockCompileConfig = vi.hoisted(() => vi.fn());
+const mockValidateCompiledOutput = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockReaddirSync = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/compile/compileConfig.ts', () => ({
   compileConfig: mockCompileConfig,
+}));
+
+vi.mock('../src/compile/validateCompiledOutput.ts', () => ({
+  validateCompiledOutput: mockValidateCompiledOutput,
 }));
 
 vi.mock('../src/loadConfig.ts', () => ({
@@ -27,11 +32,13 @@ describe(compileCommand, () => {
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockValidateCompiledOutput.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     mockCompileConfig.mockReset();
+    mockValidateCompiledOutput.mockReset();
     mockLoadConfig.mockReset();
     mockExistsSync.mockReset();
     mockReaddirSync.mockReset();
@@ -144,5 +151,31 @@ describe(compileCommand, () => {
 
     expect(exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('No .ts files found'));
+  });
+
+  // Post-compile validation tests
+  it('returns 1 when post-compile validation fails for explicit input', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js' });
+    mockValidateCompiledOutput.mockRejectedValue(new Error('Suite name(s) collide with checklist name(s): deploy'));
+
+    const exitCode = await compileCommand(['input.ts']);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Suite name(s) collide'));
+  });
+
+  it('returns 1 when post-compile validation fails during batch compile', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.preflight/distribution', outDir: '.preflight/distribution' },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['a.ts']);
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js' });
+    mockValidateCompiledOutput.mockRejectedValue(new Error('suite "ci" references unknown checklist "missing"'));
+
+    const exitCode = await compileCommand([]);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('references unknown checklist'));
   });
 });

--- a/packages/preflight/__tests__/resolveCollectionExports.test.ts
+++ b/packages/preflight/__tests__/resolveCollectionExports.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveCollectionExports } from '../src/resolveCollectionExports.ts';
+
+describe(resolveCollectionExports, () => {
+  it('extracts checklists from a module with named exports', () => {
+    const checklists = [{ name: 'a', checks: [] }];
+    const result = resolveCollectionExports({ checklists });
+
+    expect(result).toStrictEqual({ checklists });
+  });
+
+  it('unwraps checklists from a default export', () => {
+    const checklists = [{ name: 'a', checks: [] }];
+    const result = resolveCollectionExports({ default: { checklists } });
+
+    expect(result).toStrictEqual({ checklists });
+  });
+
+  it('forwards fixLocation when defined', () => {
+    const checklists = [{ name: 'a', checks: [] }];
+    const result = resolveCollectionExports({ checklists, fixLocation: 'INLINE' });
+
+    expect(result).toStrictEqual({ checklists, fixLocation: 'INLINE' });
+  });
+
+  it('omits fixLocation when undefined', () => {
+    const checklists = [{ name: 'a', checks: [] }];
+    const result = resolveCollectionExports({ checklists });
+
+    expect(result).not.toHaveProperty('fixLocation');
+  });
+
+  it('forwards suites when defined', () => {
+    const checklists = [{ name: 'a', checks: [] }];
+    const suites = { ci: ['a'] };
+    const result = resolveCollectionExports({ checklists, suites });
+
+    expect(result).toStrictEqual({ checklists, suites });
+  });
+
+  it('omits suites when undefined', () => {
+    const checklists = [{ name: 'a', checks: [] }];
+    const result = resolveCollectionExports({ checklists });
+
+    expect(result).not.toHaveProperty('suites');
+  });
+
+  it('forwards both fixLocation and suites from a default export', () => {
+    const checklists = [{ name: 'a', checks: [] }];
+    const suites = { ci: ['a'] };
+    const result = resolveCollectionExports({ default: { checklists, fixLocation: 'END', suites } });
+
+    expect(result).toStrictEqual({ checklists, fixLocation: 'END', suites });
+  });
+
+  it('throws when checklists is missing', () => {
+    expect(() => resolveCollectionExports({ other: 'value' })).toThrow('must export checklists');
+  });
+});

--- a/packages/preflight/__tests__/resolveRequestedNames.test.ts
+++ b/packages/preflight/__tests__/resolveRequestedNames.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveRequestedNames } from '../src/resolveRequestedNames.ts';
+import type { PreflightCollection } from '../src/types.ts';
+
+/** Build a minimal collection with named checklists and optional suites. */
+function makeCollection(overrides?: Partial<PreflightCollection>): PreflightCollection {
+  return {
+    checklists: [
+      { name: 'deploy', checks: [{ name: 'a', check: () => true }] },
+      { name: 'infra', checks: [{ name: 'b', check: () => true }] },
+      { name: 'lint', checks: [{ name: 'c', check: () => true }] },
+    ],
+    ...overrides,
+  };
+}
+
+describe(resolveRequestedNames, () => {
+  it('returns all checklist names when no names are requested', () => {
+    const result = resolveRequestedNames([], makeCollection());
+
+    expect(result).toStrictEqual(['deploy', 'infra', 'lint']);
+  });
+
+  it('returns a single checklist name when requested', () => {
+    const result = resolveRequestedNames(['deploy'], makeCollection());
+
+    expect(result).toStrictEqual(['deploy']);
+  });
+
+  it('preserves requested order for checklist names', () => {
+    const result = resolveRequestedNames(['lint', 'deploy'], makeCollection());
+
+    expect(result).toStrictEqual(['lint', 'deploy']);
+  });
+
+  it('expands a suite name to its constituent checklists in suite-defined order', () => {
+    const collection = makeCollection({ suites: { ci: ['infra', 'deploy'] } });
+    const result = resolveRequestedNames(['ci'], collection);
+
+    expect(result).toStrictEqual(['infra', 'deploy']);
+  });
+
+  it('combines suite expansion with individual checklist names', () => {
+    const collection = makeCollection({ suites: { ci: ['deploy'] } });
+    const result = resolveRequestedNames(['ci', 'lint'], collection);
+
+    expect(result).toStrictEqual(['deploy', 'lint']);
+  });
+
+  it('deduplicates by first occurrence across suites', () => {
+    const collection = makeCollection({
+      suites: { ci: ['deploy', 'infra'], cd: ['infra', 'lint'] },
+    });
+    const result = resolveRequestedNames(['ci', 'cd'], collection);
+
+    expect(result).toStrictEqual(['deploy', 'infra', 'lint']);
+  });
+
+  it('deduplicates when explicit name overlaps with suite', () => {
+    const collection = makeCollection({ suites: { ci: ['deploy', 'infra'] } });
+    const result = resolveRequestedNames(['deploy', 'ci'], collection);
+
+    expect(result).toStrictEqual(['deploy', 'infra']);
+  });
+
+  it('throws on unknown names with available checklists listed', () => {
+    expect(() => resolveRequestedNames(['missing'], makeCollection())).toThrow(
+      'Unknown name(s): missing. Checklists: deploy, infra, lint',
+    );
+  });
+
+  it('includes suite names in the error for unknown names', () => {
+    const collection = makeCollection({ suites: { ci: ['deploy'] } });
+
+    expect(() => resolveRequestedNames(['missing'], collection)).toThrow('Suites: ci');
+  });
+
+  it('throws when multiple names are unknown', () => {
+    expect(() => resolveRequestedNames(['x', 'y'], makeCollection())).toThrow('Unknown name(s): x, y');
+  });
+
+  it('does not list suites in error when collection has no suites', () => {
+    const error = getError(() => resolveRequestedNames(['missing'], makeCollection()));
+
+    expect(error.message).not.toContain('Suites');
+  });
+});
+
+/** Extract the thrown error from a function call. */
+function getError(fn: () => unknown): Error {
+  try {
+    fn();
+  } catch (error: unknown) {
+    if (error instanceof Error) return error;
+    throw new Error('Expected an Error to be thrown');
+  }
+  throw new Error('Expected function to throw');
+}

--- a/packages/preflight/__tests__/validateCollection.test.ts
+++ b/packages/preflight/__tests__/validateCollection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PreflightCollection } from '../src/types.ts';
+import { validateCollection } from '../src/validateCollection.ts';
+
+/** Build a minimal valid collection for testing. */
+function makeCollection(overrides?: Partial<PreflightCollection>): PreflightCollection {
+  return {
+    checklists: [
+      { name: 'a', checks: [{ name: 'check-a', check: () => true }] },
+      { name: 'b', checks: [{ name: 'check-b', check: () => true }] },
+    ],
+    ...overrides,
+  };
+}
+
+describe(validateCollection, () => {
+  it('passes when collection has no suites', () => {
+    expect(() => validateCollection(makeCollection())).not.toThrow();
+  });
+
+  it('passes when suites reference valid checklist names', () => {
+    const collection = makeCollection({ suites: { s: ['a', 'b'] } });
+
+    expect(() => validateCollection(collection)).not.toThrow();
+  });
+
+  it('throws when a suite name collides with a checklist name', () => {
+    const collection = makeCollection({ suites: { a: ['b'] } });
+
+    expect(() => validateCollection(collection)).toThrow('Suite name(s) collide with checklist name(s): a');
+  });
+
+  it('throws when multiple suite names collide with checklist names', () => {
+    const collection = makeCollection({ suites: { a: ['b'], b: ['a'] } });
+
+    expect(() => validateCollection(collection)).toThrow(/a, b/);
+  });
+
+  it('throws when a suite references an unknown checklist', () => {
+    const collection = makeCollection({ suites: { s: ['missing'] } });
+
+    expect(() => validateCollection(collection)).toThrow('suite "s" references unknown checklist "missing"');
+  });
+
+  it('throws when multiple suites reference unknown checklists', () => {
+    const collection = makeCollection({ suites: { s1: ['missing'], s2: ['also-missing'] } });
+
+    expect(() => validateCollection(collection)).toThrow(/missing.*also-missing/);
+  });
+
+  it('includes available checklists in the error message for unknown references', () => {
+    const collection = makeCollection({ suites: { s: ['missing'] } });
+
+    expect(() => validateCollection(collection)).toThrow('Available checklists: a, b');
+  });
+
+  it('passes when suites is an empty record', () => {
+    const collection = makeCollection({ suites: {} });
+
+    expect(() => validateCollection(collection)).not.toThrow();
+  });
+});

--- a/packages/preflight/__tests__/validateCollection.test.ts
+++ b/packages/preflight/__tests__/validateCollection.test.ts
@@ -60,4 +60,16 @@ describe(validateCollection, () => {
 
     expect(() => validateCollection(collection)).not.toThrow();
   });
+
+  it('passes when a suite has an empty checklist array', () => {
+    const collection = makeCollection({ suites: { s: [] } });
+
+    expect(() => validateCollection(collection)).not.toThrow();
+  });
+
+  it('passes when a suite contains duplicate entries', () => {
+    const collection = makeCollection({ suites: { s: ['a', 'a'] } });
+
+    expect(() => validateCollection(collection)).not.toThrow();
+  });
 });

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -7,6 +7,7 @@ import { formatJsonReport } from './formatJsonReport.ts';
 import { loadRemoteCollection, type LoadRemoteCollectionOptions } from './loadRemoteCollection.ts';
 import { reportPreflight } from './reportPreflight.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
+import { resolveRequestedNames } from './resolveRequestedNames.ts';
 import { runPreflight } from './runPreflight.ts';
 import type {
   ChecklistSummary,
@@ -235,24 +236,25 @@ async function runSingleCollection(
   collection: PreflightCollection,
   { names, json }: { names: string[]; json: boolean },
 ): Promise<number> {
-  // Determine which checklists to run
-  let checklists = collection.checklists;
-  if (names.length > 0) {
-    const availableNames = new Set(collection.checklists.map((c) => c.name));
-    const unknownNames = names.filter((n) => !availableNames.has(n));
-    if (unknownNames.length > 0) {
-      const available = [...availableNames].join(', ');
-      const message = `unknown checklist(s): ${unknownNames.join(', ')}. Available: ${available}`;
-      if (json) {
-        process.stdout.write(formatJsonError(message) + '\n');
-      } else {
-        process.stderr.write(`Error: ${message}\n`);
-      }
-      return 1;
+  // Resolve requested names (expanding suite names) and filter checklists
+  let resolvedNames: string[];
+  try {
+    resolvedNames = resolveRequestedNames(names, collection);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (json) {
+      process.stdout.write(formatJsonError(message) + '\n');
+    } else {
+      process.stderr.write(`Error: ${message}\n`);
     }
-    const requestedNames = new Set(names);
-    checklists = collection.checklists.filter((c) => requestedNames.has(c.name));
+    return 1;
   }
+
+  const checklistByName = new Map(collection.checklists.map((c) => [c.name, c]));
+  const checklists = resolvedNames.flatMap((name) => {
+    const checklist = checklistByName.get(name);
+    return checklist !== undefined ? [checklist] : [];
+  });
 
   if (json) {
     return runJsonMode(checklists);

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -250,6 +250,8 @@ async function runSingleCollection(
     return 1;
   }
 
+  // All names in `resolvedNames` are guaranteed valid by `resolveRequestedNames`; the
+  // flatMap guard serves only as a type-narrowing filter for the `Map.get` return type.
   const checklistByName = new Map(collection.checklists.map((c) => [c.name, c]));
   const checklists = resolvedNames.flatMap((name) => {
     const checklist = checklistByName.get(name);

--- a/packages/preflight/src/compile/compileCommand.ts
+++ b/packages/preflight/src/compile/compileCommand.ts
@@ -4,6 +4,7 @@ import process from 'node:process';
 
 import { loadConfig } from '../loadConfig.ts';
 import { compileConfig } from './compileConfig.ts';
+import { validateCompiledOutput } from './validateCompiledOutput.ts';
 
 /** Extract a flag value from either `--flag value` or `--flag=value` form. */
 function extractFlagValue(
@@ -71,6 +72,7 @@ export async function compileCommand(args: string[]): Promise<number> {
   if (inputPath !== undefined) {
     try {
       const result = await compileConfig(inputPath, outputPath);
+      await validateCompiledOutput(result.outputPath);
       process.stdout.write(`Compiled: ${result.outputPath}\n`);
       return 0;
     } catch (error: unknown) {
@@ -117,6 +119,7 @@ async function compileBatch(): Promise<number> {
     const outFile = path.join(outDir, fileName.replace(/\.ts$/, '.js'));
     try {
       const result = await compileConfig(srcFile, outFile);
+      await validateCompiledOutput(result.outputPath);
       process.stdout.write(`Compiled: ${result.outputPath}\n`);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/preflight/src/compile/validateCompiledOutput.ts
+++ b/packages/preflight/src/compile/validateCompiledOutput.ts
@@ -22,10 +22,10 @@ export async function validateCompiledOutput(outputPath: string): Promise<void> 
   }
 
   const moduleRecord = isRecord(imported) ? imported : {};
-  const resolved = resolveCollectionExports(moduleRecord);
-  assertIsPreflightCollection(resolved);
 
   try {
+    const resolved = resolveCollectionExports(moduleRecord);
+    assertIsPreflightCollection(resolved);
     validateCollection(resolved);
   } catch (error: unknown) {
     rmSync(outputPath, { force: true });

--- a/packages/preflight/src/compile/validateCompiledOutput.ts
+++ b/packages/preflight/src/compile/validateCompiledOutput.ts
@@ -1,0 +1,34 @@
+import { rmSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+import { assertIsPreflightCollection, isRecord } from '../assertIsPreflightCollection.ts';
+import { resolveCollectionExports } from '../resolveCollectionExports.ts';
+import { validateCollection } from '../validateCollection.ts';
+
+/**
+ * Import a compiled collection bundle and run semantic validation.
+ *
+ * Deletes the output file when validation fails so the user isn't left with an invalid bundle.
+ */
+export async function validateCompiledOutput(outputPath: string): Promise<void> {
+  const fileUrl = `${pathToFileURL(outputPath).href}?t=${Date.now()}`;
+  let imported: unknown;
+  try {
+    imported = await import(fileUrl);
+  } catch (error: unknown) {
+    rmSync(outputPath, { force: true });
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load compiled output for validation: ${detail}`);
+  }
+
+  const moduleRecord = isRecord(imported) ? imported : {};
+  const resolved = resolveCollectionExports(moduleRecord);
+  assertIsPreflightCollection(resolved);
+
+  try {
+    validateCollection(resolved);
+  } catch (error: unknown) {
+    rmSync(outputPath, { force: true });
+    throw error;
+  }
+}

--- a/packages/preflight/src/config.ts
+++ b/packages/preflight/src/config.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { assertIsPreflightCollection, isRecord } from './assertIsPreflightCollection.ts';
 import { resolveCollectionExports } from './resolveCollectionExports.ts';
 import type { PreflightChecklist, PreflightCollection, PreflightConfig, PreflightStagedChecklist } from './types.ts';
+import { validateCollection } from './validateCollection.ts';
 
 /**
  * The legacy default collection file path, resolved relative to `process.cwd()`.
@@ -69,5 +70,6 @@ export async function loadPreflightCollection(collectionPath?: string): Promise<
 
   const resolved = resolveCollectionExports(imported);
   assertIsPreflightCollection(resolved);
+  validateCollection(resolved);
   return resolved;
 }

--- a/packages/preflight/src/loadRemoteCollection.ts
+++ b/packages/preflight/src/loadRemoteCollection.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url';
 import { assertIsPreflightCollection, isRecord } from './assertIsPreflightCollection.ts';
 import { resolveCollectionExports } from './resolveCollectionExports.ts';
 import type { PreflightCollection } from './types.ts';
+import { validateCollection } from './validateCollection.ts';
 
 export interface LoadRemoteCollectionOptions {
   url: string;
@@ -50,6 +51,7 @@ export async function loadRemoteCollection({ url, token }: LoadRemoteCollectionO
     const moduleRecord = isRecord(imported) ? imported : {};
     const resolved = resolveCollectionExports(moduleRecord);
     assertIsPreflightCollection(resolved);
+    validateCollection(resolved);
     return resolved;
   } finally {
     rmSync(tempDir, { recursive: true, force: true });

--- a/packages/preflight/src/resolveCollectionExports.ts
+++ b/packages/preflight/src/resolveCollectionExports.ts
@@ -24,6 +24,9 @@ export function resolveCollectionExports(moduleRecord: Record<string, unknown>):
   if (source.fixLocation !== undefined) {
     resolved.fixLocation = source.fixLocation;
   }
+  if (source.suites !== undefined) {
+    resolved.suites = source.suites;
+  }
 
   return resolved;
 }

--- a/packages/preflight/src/resolveCollectionExports.ts
+++ b/packages/preflight/src/resolveCollectionExports.ts
@@ -20,13 +20,9 @@ export function resolveCollectionExports(moduleRecord: Record<string, unknown>):
     );
   }
 
-  const resolved: Record<string, unknown> = { checklists: source.checklists };
-  if (source.fixLocation !== undefined) {
-    resolved.fixLocation = source.fixLocation;
-  }
-  if (source.suites !== undefined) {
-    resolved.suites = source.suites;
-  }
-
-  return resolved;
+  return {
+    checklists: source.checklists,
+    ...(source.fixLocation !== undefined && { fixLocation: source.fixLocation }),
+    ...(source.suites !== undefined && { suites: source.suites }),
+  };
 }

--- a/packages/preflight/src/resolveCollectionExports.ts
+++ b/packages/preflight/src/resolveCollectionExports.ts
@@ -4,7 +4,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Extract `checklists` and `fixLocation` from an imported module namespace.
+ * Extract `checklists`, `fixLocation`, and `suites` from an imported module namespace.
  *
  * Supports both `export default definePreflightCollection({...})` and the named-export
  * convention (`export const checklists = ...`). Returns a plain record suitable for passing

--- a/packages/preflight/src/resolveRequestedNames.ts
+++ b/packages/preflight/src/resolveRequestedNames.ts
@@ -1,0 +1,51 @@
+import type { PreflightCollection } from './types.ts';
+
+/**
+ * Resolve positional arguments against checklist names and suite names.
+ *
+ * Processes args left-to-right: suite names expand to their constituent checklists in
+ * suite-defined order; checklist names pass through directly. Duplicates are removed by
+ * first occurrence. Returns the ordered list of checklist names to run.
+ *
+ * When no names are given, returns all checklist names in collection order.
+ */
+export function resolveRequestedNames(requestedNames: string[], collection: PreflightCollection): string[] {
+  if (requestedNames.length === 0) {
+    return collection.checklists.map((c) => c.name);
+  }
+
+  const checklistNames = new Set(collection.checklists.map((c) => c.name));
+  const suites = collection.suites ?? {};
+
+  const unknownNames: string[] = [];
+  const resolved: string[] = [];
+  const seen = new Set<string>();
+
+  for (const name of requestedNames) {
+    const suiteEntries = suites[name];
+    if (suiteEntries !== undefined) {
+      for (const entry of suiteEntries) {
+        if (!seen.has(entry)) {
+          seen.add(entry);
+          resolved.push(entry);
+        }
+      }
+    } else if (checklistNames.has(name)) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        resolved.push(name);
+      }
+    } else {
+      unknownNames.push(name);
+    }
+  }
+
+  if (unknownNames.length > 0) {
+    const checklistList = [...checklistNames].join(', ');
+    const suiteNames = Object.keys(suites);
+    const suiteList = suiteNames.length > 0 ? `. Suites: ${suiteNames.join(', ')}` : '';
+    throw new Error(`Unknown name(s): ${unknownNames.join(', ')}. Checklists: ${checklistList}${suiteList}`);
+  }
+
+  return resolved;
+}

--- a/packages/preflight/src/validateCollection.ts
+++ b/packages/preflight/src/validateCollection.ts
@@ -1,0 +1,36 @@
+import type { PreflightCollection } from './types.ts';
+
+/**
+ * Check semantic invariants on a structurally valid collection.
+ *
+ * Enforces two rules: (1) no suite name may collide with a checklist name,
+ * and (2) every entry in a suite must reference an existing checklist name.
+ * Throws on violation with a descriptive message.
+ */
+export function validateCollection(collection: PreflightCollection): void {
+  const { suites } = collection;
+  if (suites === undefined) return;
+
+  const checklistNames = new Set(collection.checklists.map((c) => c.name));
+
+  const collisions = Object.keys(suites).filter((name) => checklistNames.has(name));
+  if (collisions.length > 0) {
+    throw new Error(
+      `Suite name(s) collide with checklist name(s): ${collisions.join(', ')}. Suite names and checklist names must be unique across both pools.`,
+    );
+  }
+
+  const missingBySource: string[] = [];
+  for (const [suiteName, entries] of Object.entries(suites)) {
+    for (const entry of entries) {
+      if (!checklistNames.has(entry)) {
+        missingBySource.push(`suite "${suiteName}" references unknown checklist "${entry}"`);
+      }
+    }
+  }
+  if (missingBySource.length > 0) {
+    throw new Error(
+      `Invalid suite references: ${missingBySource.join('; ')}. Available checklists: ${[...checklistNames].join(', ')}`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #99

## What

Wires up the existing `suites` stub on `PreflightCollection` end-to-end: pass through export resolution, add a shared validator for name-collision and referential-integrity checks, integrate validation into the compile path, and expand suite names in CLI checklist selection.

## Why

`PreflightCollection` had a `suites` field (`Record<string, string[]>`) that was dead code. Users could only filter by individual checklist names, with no way to define a named group of checklists invocable as a unit. As configs grow (e.g., drift checks + deployment checks in the same file), named suites let users organize and invoke related checklists as a group.

## Details

### Features

- `resolveCollectionExports` now forwards the `suites` field alongside `checklists` and `fixLocation`, using conditional spread to preserve backward compatibility
- New `validateCollection` function enforces two semantic invariants: no suite name may collide with a checklist name, and every suite entry must reference an existing checklist. Called at the end of `assertIsPreflightCollection` so all load paths get validation automatically
- New `validateCompiledOutput` function dynamically imports compiled bundles and runs the full validation pipeline. Invalid bundles are deleted before errors are reported. Integrated into `compileCommand`
- New `resolveRequestedNames` function resolves positional CLI arguments against both checklist and suite names. Suite names expand inline in suite-defined order with first-occurrence deduplication. Unknown names produce a clear error listing available checklists and suites separately

### Fixes

- `validateCompiledOutput` now cleans up the output file on all validation failures, not just `validateCollection` errors. Structural failures from `resolveCollectionExports` and `assertIsPreflightCollection` previously left invalid files on disk

### Refactoring

- `resolveCollectionExports` return simplified to a single object expression with conditional spreads instead of sequential property assignments
- CLI's `runSingleCollection` delegates name resolution to `resolveRequestedNames` instead of inline filtering

### Tests

- New test suites for `resolveRequestedNames` (10 tests), `validateCollection` (10 tests), `resolveCollectionExports` (5 tests)
- Extended `compileCommand.test.ts` with suite validation failure cases
- Edge-case tests for empty suite arrays and intra-suite duplicate entries

## Test plan

- [ ] `nmr test` passes from the preflight package directory
- [ ] Manual: create a collection with suites, run `preflight run <suite-name>`, verify correct checklists execute
- [ ] Manual: `preflight compile` with an invalid suite definition produces a clear error