### PR TITLE
#122 Validate suites field shape with Zod schemas

### DIFF
--- a/packages/preflight/__tests__/assertIsPreflightCollection.test.ts
+++ b/packages/preflight/__tests__/assertIsPreflightCollection.test.ts
@@ -1,42 +1,73 @@
 import { describe, expect, it } from 'vitest';
+import { ZodError } from 'zod';
 
 import { assertIsPreflightCollection } from '../src/assertIsPreflightCollection.ts';
 
 describe(assertIsPreflightCollection, () => {
   it('throws when input is not an object', () => {
-    expect(() => assertIsPreflightCollection('string')).toThrow('Preflight collection must be an object, got string');
+    expect(() => assertIsPreflightCollection('string')).toThrow(ZodError);
   });
 
   it('throws when input is an array', () => {
-    expect(() => assertIsPreflightCollection([])).toThrow('Preflight collection must be an object, got array');
+    expect(() => assertIsPreflightCollection([])).toThrow(ZodError);
   });
 
   it('throws when checklists is missing', () => {
-    expect(() => assertIsPreflightCollection({})).toThrow("must have a 'checklists' array");
+    expect(() => assertIsPreflightCollection({})).toThrow(ZodError);
   });
 
   it('throws when a checklist has neither checks nor groups', () => {
-    expect(() => assertIsPreflightCollection({ checklists: [{ name: 'bad' }] })).toThrow(
-      "must have either 'checks' or 'groups'",
-    );
+    expect(() => assertIsPreflightCollection({ checklists: [{ name: 'bad' }] })).toThrow(ZodError);
   });
 
   it('throws when a checklist has both checks and groups', () => {
-    expect(() => assertIsPreflightCollection({ checklists: [{ name: 'bad', checks: [], groups: [] }] })).toThrow(
-      "cannot have both 'checks' and 'groups'",
-    );
+    try {
+      assertIsPreflightCollection({ checklists: [{ name: 'bad', checks: [], groups: [] }] });
+      expect.unreachable('Expected ZodError');
+    } catch (error) {
+      if (!(error instanceof ZodError)) throw error;
+      expect(error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: "Checklist cannot have both 'checks' and 'groups'" }),
+        ]),
+      );
+    }
   });
 
   it('throws when a checklist entry is not an object', () => {
-    expect(() => assertIsPreflightCollection({ checklists: ['not-an-object'] })).toThrow(
-      'checklists[0]: must be an object',
-    );
+    try {
+      assertIsPreflightCollection({ checklists: ['not-an-object'] });
+      expect.unreachable('Expected ZodError');
+    } catch (error) {
+      if (!(error instanceof ZodError)) throw error;
+      expect(error.issues[0]?.path).toEqual(expect.arrayContaining(['checklists', 0]));
+    }
   });
 
   it('throws when a checklist name is missing', () => {
-    expect(() => assertIsPreflightCollection({ checklists: [{ checks: [] }] })).toThrow(
-      "checklists[0]: 'name' is required and must be a non-empty string",
-    );
+    try {
+      assertIsPreflightCollection({ checklists: [{ checks: [] }] });
+      expect.unreachable('Expected ZodError');
+    } catch (error) {
+      if (!(error instanceof ZodError)) throw error;
+      const nameIssue = error.issues
+        .flatMap((i) => ('errors' in i ? i.errors.flat() : [i]))
+        .find((i) => i.path.includes('name'));
+      expect(nameIssue).toBeDefined();
+    }
+  });
+
+  it('throws when a checklist name is empty', () => {
+    try {
+      assertIsPreflightCollection({ checklists: [{ name: '', checks: [] }] });
+      expect.unreachable('Expected ZodError');
+    } catch (error) {
+      if (!(error instanceof ZodError)) throw error;
+      const nameIssue = error.issues
+        .flatMap((i) => ('errors' in i ? i.errors.flat() : [i]))
+        .find((i) => i.path.includes('name'));
+      expect(nameIssue).toBeDefined();
+    }
   });
 
   it('accepts a valid collection with flat checklists', () => {
@@ -53,5 +84,67 @@ describe(assertIsPreflightCollection, () => {
         checklists: [{ name: 'test', groups: [[{ name: 'a', check: () => true }]] }],
       }),
     ).not.toThrow();
+  });
+
+  it('accepts a valid collection with suites', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'lint', checks: [] }],
+        suites: { ci: ['lint'] },
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts a collection without suites', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws when suites is not an object', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        suites: 'not-a-record',
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it('throws when a suite value is not an array', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        suites: { ci: 'not-an-array' },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it('throws when a suite contains non-string entries', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        suites: { ci: [42] },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it('accepts a valid fixLocation', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        fixLocation: 'INLINE',
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws when fixLocation is invalid', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        fixLocation: 'WRONG',
+      }),
+    ).toThrow(ZodError);
   });
 });

--- a/packages/preflight/__tests__/loadConfig.test.ts
+++ b/packages/preflight/__tests__/loadConfig.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ZodError } from 'zod';
 
 const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockJitiImport = vi.hoisted(() => vi.fn());
@@ -82,21 +83,21 @@ describe(loadConfig, () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ compile: 'bad' });
 
-    await expect(loadConfig('config.ts')).rejects.toThrow("'compile' must be an object");
+    await expect(loadConfig('config.ts')).rejects.toThrow(ZodError);
   });
 
   it('throws when compile.srcDir is not a string', async () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ compile: { srcDir: 42 } });
 
-    await expect(loadConfig('config.ts')).rejects.toThrow("'compile.srcDir' must be a string");
+    await expect(loadConfig('config.ts')).rejects.toThrow(ZodError);
   });
 
   it('throws when compile.outDir is not a string', async () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ compile: { outDir: false } });
 
-    await expect(loadConfig('config.ts')).rejects.toThrow("'compile.outDir' must be a string");
+    await expect(loadConfig('config.ts')).rejects.toThrow(ZodError);
   });
 
   it('applies defaults for missing compile fields', async () => {

--- a/packages/preflight/package.json
+++ b/packages/preflight/package.json
@@ -39,7 +39,8 @@
   },
   "dependencies": {
     "@williamthorsen/node-monorepo-core": "workspace:*",
-    "jiti": "2.6.1"
+    "jiti": "2.6.1",
+    "zod": "4.3.6"
   },
   "peerDependencies": {
     "esbuild": ">=0.17.0"

--- a/packages/preflight/src/assertIsPreflightCollection.ts
+++ b/packages/preflight/src/assertIsPreflightCollection.ts
@@ -1,40 +1,39 @@
+import { z } from 'zod';
+
 import type { PreflightCollection } from './types.ts';
 
-/** Check whether a value is a plain object (non-null, non-array). */
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+/** Schema for a flat checklist (has `checks`, no `groups`). */
+const FlatChecklistSchema = z.looseObject({
+  name: z.string().min(1),
+  checks: z.array(z.unknown()),
+});
+
+/** Schema for a staged checklist (has `groups`, no `checks`). */
+const StagedChecklistSchema = z.looseObject({
+  name: z.string().min(1),
+  groups: z.array(z.unknown()),
+});
+
+const ChecklistSchema = z
+  .union([FlatChecklistSchema, StagedChecklistSchema])
+  .refine((val) => !('checks' in val && 'groups' in val), {
+    message: "Checklist cannot have both 'checks' and 'groups'",
+  });
+
+/** Structural schema for a PreflightCollection. */
+const PreflightCollectionSchema = z.looseObject({
+  fixLocation: z.enum(['INLINE', 'END']).optional(),
+  checklists: z.array(ChecklistSchema),
+  suites: z.record(z.string(), z.array(z.string())).optional(),
+});
 
 /**
  * Validate that a raw value conforms to the PreflightCollection shape.
  *
- * Throws on invalid input. When it returns without throwing, the value is a valid PreflightCollection.
- * Because jiti loads the actual TypeScript module, the config objects retain their original types
- * including function-valued properties like `check`.
+ * Throws a ZodError on invalid input. When it returns without throwing, the value is a valid
+ * PreflightCollection. Function-valued properties like `check` are passed through without
+ * validation because jiti loads the actual TypeScript module and preserves original types.
  */
 export function assertIsPreflightCollection(raw: unknown): asserts raw is PreflightCollection {
-  if (!isRecord(raw)) {
-    throw new TypeError(`Preflight collection must be an object, got ${Array.isArray(raw) ? 'array' : typeof raw}`);
-  }
-
-  if (!Array.isArray(raw.checklists)) {
-    throw new TypeError("Preflight collection must have a 'checklists' array");
-  }
-
-  for (const [i, entry] of raw.checklists.entries()) {
-    if (!isRecord(entry)) {
-      throw new Error(`checklists[${i}]: must be an object`);
-    }
-    if (typeof entry.name !== 'string' || entry.name === '') {
-      throw new Error(`checklists[${i}]: 'name' is required and must be a non-empty string`);
-    }
-    const hasChecks = 'checks' in entry;
-    const hasGroups = 'groups' in entry;
-    if (!hasChecks && !hasGroups) {
-      throw new Error(`checklists[${i}]: must have either 'checks' or 'groups'`);
-    }
-    if (hasChecks && hasGroups) {
-      throw new Error(`checklists[${i}]: cannot have both 'checks' and 'groups'`);
-    }
-  }
+  PreflightCollectionSchema.parse(raw);
 }

--- a/packages/preflight/src/compile/validateCompiledOutput.ts
+++ b/packages/preflight/src/compile/validateCompiledOutput.ts
@@ -1,7 +1,8 @@
 import { rmSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
-import { assertIsPreflightCollection, isRecord } from '../assertIsPreflightCollection.ts';
+import { assertIsPreflightCollection } from '../assertIsPreflightCollection.ts';
+import { isRecord } from '../isRecord.ts';
 import { resolveCollectionExports } from '../resolveCollectionExports.ts';
 import { validateCollection } from '../validateCollection.ts';
 

--- a/packages/preflight/src/config.ts
+++ b/packages/preflight/src/config.ts
@@ -1,7 +1,8 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
-import { assertIsPreflightCollection, isRecord } from './assertIsPreflightCollection.ts';
+import { assertIsPreflightCollection } from './assertIsPreflightCollection.ts';
+import { isRecord } from './isRecord.ts';
 import { resolveCollectionExports } from './resolveCollectionExports.ts';
 import type { PreflightChecklist, PreflightCollection, PreflightConfig, PreflightStagedChecklist } from './types.ts';
 import { validateCollection } from './validateCollection.ts';

--- a/packages/preflight/src/isRecord.ts
+++ b/packages/preflight/src/isRecord.ts
@@ -1,0 +1,4 @@
+/** Check whether a value is a plain object (non-null, non-array). */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/preflight/src/loadConfig.ts
+++ b/packages/preflight/src/loadConfig.ts
@@ -1,6 +1,9 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
+import { z } from 'zod';
+
+import { isRecord } from './isRecord.ts';
 import type { PreflightConfig, ResolvedPreflightConfig } from './types.ts';
 
 /** Default config values when no config file is found. */
@@ -14,28 +17,19 @@ const DEFAULT_CONFIG: ResolvedPreflightConfig = {
 /** Ordered lookup paths for the config file, resolved relative to `process.cwd()`. */
 const LOOKUP_PATHS = ['.config/preflight/config.ts', '.config/preflight.config.ts'];
 
-/** Check whether a value is a plain object (non-null, non-array). */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+/** Structural schema for PreflightConfig. */
+const PreflightConfigSchema = z.looseObject({
+  compile: z
+    .looseObject({
+      srcDir: z.string().optional(),
+      outDir: z.string().optional(),
+    })
+    .optional(),
+});
 
 /** Validate that a raw value has the expected PreflightConfig shape. */
 function assertIsPreflightConfig(raw: unknown): asserts raw is PreflightConfig {
-  if (!isRecord(raw)) {
-    throw new TypeError(`Preflight config must be an object, got ${Array.isArray(raw) ? 'array' : typeof raw}`);
-  }
-
-  if (raw.compile !== undefined) {
-    if (!isRecord(raw.compile)) {
-      throw new TypeError("'compile' must be an object");
-    }
-    if (raw.compile.srcDir !== undefined && typeof raw.compile.srcDir !== 'string') {
-      throw new TypeError("'compile.srcDir' must be a string");
-    }
-    if (raw.compile.outDir !== undefined && typeof raw.compile.outDir !== 'string') {
-      throw new TypeError("'compile.outDir' must be a string");
-    }
-  }
+  PreflightConfigSchema.parse(raw);
 }
 
 /**
@@ -79,11 +73,13 @@ export async function loadConfig(overridePath?: string): Promise<ResolvedPreflig
 
   assertIsPreflightConfig(raw);
 
-  const compile = raw.compile;
+  // Guard is redundant at runtime (Zod already validated) but needed for type narrowing
+  // because `raw` is `Record<string, unknown> & PreflightConfig` after the assertion.
+  const compile = isRecord(raw.compile) ? raw.compile : undefined;
   return {
     compile: {
-      srcDir: isRecord(compile) && typeof compile.srcDir === 'string' ? compile.srcDir : DEFAULT_CONFIG.compile.srcDir,
-      outDir: isRecord(compile) && typeof compile.outDir === 'string' ? compile.outDir : DEFAULT_CONFIG.compile.outDir,
+      srcDir: typeof compile?.srcDir === 'string' ? compile.srcDir : DEFAULT_CONFIG.compile.srcDir,
+      outDir: typeof compile?.outDir === 'string' ? compile.outDir : DEFAULT_CONFIG.compile.outDir,
     },
   };
 }

--- a/packages/preflight/src/loadRemoteCollection.ts
+++ b/packages/preflight/src/loadRemoteCollection.ts
@@ -3,7 +3,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { assertIsPreflightCollection, isRecord } from './assertIsPreflightCollection.ts';
+import { assertIsPreflightCollection } from './assertIsPreflightCollection.ts';
+import { isRecord } from './isRecord.ts';
 import { resolveCollectionExports } from './resolveCollectionExports.ts';
 import type { PreflightCollection } from './types.ts';
 import { validateCollection } from './validateCollection.ts';

--- a/packages/preflight/src/resolveCollectionExports.ts
+++ b/packages/preflight/src/resolveCollectionExports.ts
@@ -1,7 +1,4 @@
-/** Check whether a value is a plain object (non-null, non-array). */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+import { isRecord } from './isRecord.ts';
 
 /**
  * Extract `checklists`, `fixLocation`, and `suites` from an imported module namespace.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       jiti:
         specifier: 2.6.1
         version: 2.6.1
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
 
   packages/release-kit:
     dependencies:


### PR DESCRIPTION
Closes #122 

## What

Replaces hand-rolled structural assertions in `assertIsPreflightCollection` and `assertIsPreflightConfig` with declarative Zod schemas. This adds the missing `suites` field validation (`Record<string, string[]>`) and consolidates three identical `isRecord` helper definitions into a single shared utility.

## Why

`assertIsPreflightCollection` validated `checklists` entries in detail but had no validation for `suites`. Malformed suites values passed structural validation and only failed later with unclear runtime errors in `validateCollection`. With Zod already in the monorepo, replacing the hand-rolled checks reduces maintenance surface and provides structured error output for free.

## Details

### Features

- `suites` is now validated as an optional record of string arrays; malformed values (`"not-a-record"`, `{ ci: "not-an-array" }`, `{ ci: [42] }`) produce a clear `ZodError`
- `fixLocation` is validated against the `'INLINE' | 'END'` enum
- Checklist `checks`/`groups` mutual exclusion is enforced via a Zod union with a refinement

### Refactoring

- `assertIsPreflightCollection` rewritten as `PreflightCollectionSchema.parse()`
- `assertIsPreflightConfig` in `loadConfig.ts` rewritten as `PreflightConfigSchema.parse()`
- `isRecord` extracted from three duplicate definitions into `src/isRecord.ts`; six import sites updated

### Tests

- New test cases for `suites` validation (non-record, non-array value, non-string entries) and `fixLocation` validation
- Error tests verify Zod error paths and messages for nuanced cases (mutual exclusion, missing/empty name, non-object entry)

### Dependencies

- Added `zod` 4.3.6 as a runtime dependency of `@williamthorsen/preflight`

## Test plan

- [ ] Verify malformed `suites` values produce clear errors
- [ ] Verify collections without `suites` continue to pass
- [ ] Verify existing checklist validation is preserved