### PR TITLE
#127 Add `build-local` input to publish and release workflows

### DIFF
--- a/.github/workflows/publish.reusable.yaml
+++ b/.github/workflows/publish.reusable.yaml
@@ -6,6 +6,8 @@ name: Publish
 # Triggered by tag pushes. Installs `@williamthorsen/release-kit` globally and
 # runs `release-kit publish` with OIDC-based npm authentication.
 # Pass `provenance: true` to enable npm provenance attestations (requires a public repo).
+# Pass `build-local: true` to build release-kit from source instead of installing from npm
+# (required when publishing release-kit itself to avoid bootstrap problems).
 # The calling workflow must grant `id-token: write` and `contents: read` permissions.
 #
 # Usage:
@@ -23,6 +25,11 @@ on:
         default: '24'
       provenance:
         description: 'Generate npm provenance attestations (requires a public repo)'
+        required: false
+        type: boolean
+        default: false
+      build-local:
+        description: 'Build release-kit from source instead of installing from npm'
         required: false
         type: boolean
         default: false
@@ -49,19 +56,42 @@ jobs:
       # Strip the packageManager field so that actions/setup-node does not
       # try to install it. The field is irrelevant for publishing.
       - name: Neutralize packageManager field
+        if: ${{ !inputs.build-local }}
         run: node -e "const fs=require('fs'),f='package.json',p=JSON.parse(fs.readFileSync(f));delete p.packageManager;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
+
+      # Preserve the packageManager field so pnpm/action-setup can read the version.
+      - name: Set up pnpm
+        if: ${{ inputs.build-local }}
+        uses: pnpm/action-setup@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: https://registry.npmjs.org
+          cache: ${{ inputs.build-local && 'pnpm' || '' }}
 
       - name: Disable Corepack
+        if: ${{ !inputs.build-local }}
         run: corepack disable
 
-      - name: Install release-kit
+      - name: Install release-kit from npm
+        if: ${{ !inputs.build-local }}
         run: npm install --global @williamthorsen/release-kit
+
+      # Build release-kit from source to avoid bootstrap problems when
+      # publishing a version that introduces new CLI flags.
+      - name: Install dependencies
+        if: ${{ inputs.build-local }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Build release-kit from source
+        if: ${{ inputs.build-local }}
+        run: pnpm --filter @williamthorsen/release-kit... run prepare
+
+      - name: Link release-kit onto PATH
+        if: ${{ inputs.build-local }}
+        run: npm link --workspace packages/release-kit
 
       - name: Publish
         run: release-kit publish ${{ inputs.provenance && '--provenance' || '' }} --no-git-checks

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/publish.reusable.yaml
     with:
       provenance: true
+      build-local: true

--- a/.github/workflows/release.reusable.yaml
+++ b/.github/workflows/release.reusable.yaml
@@ -12,6 +12,9 @@ name: Release
 # Project dependencies are not installed: release-kit runs git-cliff and prettier
 # via `npx`, so no local node_modules are needed.
 #
+# Pass `build-local: true` to build release-kit from source instead of installing from npm
+# (required when releasing release-kit itself to avoid bootstrap problems).
+#
 # Usage:
 #   jobs:
 #     release:
@@ -34,6 +37,11 @@ on:
         default: ''
       force:
         description: 'Force a version bump even when there are no release-worthy changes'
+        type: boolean
+        default: false
+      build-local:
+        description: 'Build release-kit from source instead of installing from npm'
+        required: false
         type: boolean
         default: false
 
@@ -63,21 +71,44 @@ jobs:
       # Strip the packageManager field so that actions/setup-node does not
       # try to install it. The field is irrelevant for release preparation.
       - name: Neutralize packageManager field
+        if: ${{ !inputs.build-local }}
         run: node -e "const fs=require('fs'),f='package.json',p=JSON.parse(fs.readFileSync(f));delete p.packageManager;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
+
+      # Preserve the packageManager field so pnpm/action-setup can read the version.
+      - name: Set up pnpm
+        if: ${{ inputs.build-local }}
+        uses: pnpm/action-setup@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
           node-version: '24'
+          cache: ${{ inputs.build-local && 'pnpm' || '' }}
 
       - name: Disable Corepack
+        if: ${{ !inputs.build-local }}
         run: corepack disable
 
       # Install globally so the binary is on PATH.
       # npm exec / npx binary resolution is unreliable with scoped packages
       # on newer npm versions (11.x), so explicit install is more robust.
-      - name: Install release-kit
+      - name: Install release-kit from npm
+        if: ${{ !inputs.build-local }}
         run: npm install --global @williamthorsen/release-kit
+
+      # Build release-kit from source to avoid bootstrap problems when
+      # releasing a version that introduces new CLI flags.
+      - name: Install dependencies
+        if: ${{ inputs.build-local }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Build release-kit from source
+        if: ${{ inputs.build-local }}
+        run: pnpm --filter @williamthorsen/release-kit... run prepare
+
+      - name: Link release-kit onto PATH
+        if: ${{ inputs.build-local }}
+        run: npm link --workspace packages/release-kit
 
       - name: Run release preparation
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
   release:
     uses: ./.github/workflows/release.reusable.yaml
     with:
+      build-local: true
       only: ${{ inputs.only }}
       bump: ${{ inputs.bump }}
       # TODO: The reusable workflow (release-pnpm.yaml@v3) does not yet accept `force`.


### PR DESCRIPTION
Closes #127 

## What

Adds a `build-local` boolean input to both reusable workflows (`publish.reusable.yaml`, `release.reusable.yaml`). When true, the workflow installs pnpm, resolves workspace dependencies, builds release-kit from source, and links it onto PATH — instead of installing from npm. The calling workflows in this repo pass `build-local: true`.

## Why

Both workflows install `@williamthorsen/release-kit` from npm before invoking its CLI. When publishing release-kit itself, the npm version may lack CLI flags that the current branch introduces — a bootstrap problem that caused the v3.0.0 publish to fail with `Error: Unknown option: --provenance`. Building from source eliminates this class of version-skew problems.

## Details

### Fixes

- Add `build-local` input (default `false`) to `publish.reusable.yaml` and `release.reusable.yaml`. When true: install pnpm via `pnpm/action-setup@v4`, run `pnpm install --frozen-lockfile`, build with `pnpm --filter @williamthorsen/release-kit... run prepare`, and link onto PATH with `npm link --workspace packages/release-kit`.
- Make existing npm-install steps (`Neutralize packageManager`, `Disable Corepack`, `Install release-kit`) conditional on `!inputs.build-local` so the default path is unchanged for external consumers.
- Pass `build-local: true` in both `publish.yaml` and `release.yaml`.

## Test plan

- [ ] Verify the `build-local: false` path is unchanged by diffing the conditional steps against the pre-change workflow.
- [ ] Trigger a test release or publish run with `build-local: true` to confirm pnpm install, build, and link succeed.