### PR TITLE
#126 Automate compilation of preflight distribution files

### DIFF
--- a/.config/nmr.config.ts
+++ b/.config/nmr.config.ts
@@ -1,12 +1,10 @@
 import { defineConfig } from '@williamthorsen/nmr';
 
-/**
- * nmr configuration for this monorepo.
- *
- * Intentionally present to dogfood nmr's config-loading feature: the file
- * exercises the `defineConfig` API and verifies that nmr discovers and loads
- * `.config/nmr.config.ts` at startup. The built-in defaults already match
- * this repo's conventions; override `rootScripts` or `workspaceScripts` here
- * to customize.
- */
-export default defineConfig({});
+/** nmr configuration for this monorepo. */
+export default defineConfig({
+  rootScripts: {
+    build: ['build:workspaces', 'build:preflight'],
+    'build:workspaces': 'pnpm --recursive exec nmr build',
+    'build:preflight': 'preflight compile',
+  },
+});


### PR DESCRIPTION
Closes #126 

## What

Overrides `rootScripts.build` in `.config/nmr.config.ts` to decompose the root build into two named sub-steps: `build:workspaces` (recursive workspace build) and `build:preflight` (`preflight compile`). This makes preflight distribution compilation automatic during `nmr build` and `nmr ci`.

## Why

`.preflight/distribution/nmr.js` is compiled from `nmr.ts` but had no automated build step, requiring developers to manually run `preflight compile` after editing the TypeScript source. This caused drift between the source and compiled output.

## Details

### Features

- `nmr build` now runs workspace builds followed by `preflight compile`
- `nmr build:workspaces` and `nmr build:preflight` are independently invocable sub-commands

## Test plan

- [ ] `nmr build` compiles `.preflight/distribution/nmr.js` after workspace builds
- [ ] `nmr build:preflight` works independently
- [ ] `nmr build:workspaces` works independently
- [ ] Drift-detection test (`preflight-compiled-sync.app.test.ts`) passes