### PR TITLE
#114 Add README for the preflight package

### DIFF
--- a/packages/preflight/README.md
+++ b/packages/preflight/README.md
@@ -1,0 +1,427 @@
+# @williamthorsen/preflight
+
+Run pre-deployment verification checks against your environment and configuration. Define checklists in TypeScript, run them locally or from a remote source, and get clear pass/fail reporting with remediation hints.
+
+## Installation
+
+```bash
+pnpm add -D @williamthorsen/preflight
+```
+
+## Quick start
+
+Scaffold a starter config and collection:
+
+```bash
+preflight init
+```
+
+This creates two files:
+
+**`.config/preflight/config.ts`** — repo-level settings:
+
+```ts
+import { definePreflightConfig } from '@williamthorsen/preflight';
+
+export default definePreflightConfig({
+  compile: {
+    srcDir: '.preflight/distribution',
+    outDir: '.preflight/distribution',
+  },
+});
+```
+
+**`.config/preflight/collections/default.ts`** — a collection with one example checklist:
+
+```ts
+import { definePreflightCollection } from '@williamthorsen/preflight';
+
+export default definePreflightCollection({
+  checklists: [
+    {
+      name: 'deploy',
+      checks: [
+        {
+          name: 'environment variables set',
+          check: () => Boolean(process.env['NODE_ENV']),
+          fix: 'Set NODE_ENV before deploying',
+        },
+      ],
+    },
+  ],
+});
+```
+
+Run the checks:
+
+```bash
+preflight run
+```
+
+Output:
+
+```
+🟢 environment variables set (3ms)
+
+🟢 1 passed (4ms)
+```
+
+If a check fails, you see the fix hint:
+
+```
+🔴 environment variables set (2ms)
+
+🔴 1 failed (3ms)
+
+Fixes:
+  Set NODE_ENV before deploying
+```
+
+### Check-result legend
+
+| Icon | Meaning                         |
+| ---- | ------------------------------- |
+| 🟢   | Passed                          |
+| 🔴   | Failed                          |
+| ⛔   | Skipped (a precondition failed) |
+
+## Configuration
+
+### Config file locations
+
+Preflight looks for a config file in this order:
+
+| Priority | Path                          | Notes           |
+| -------- | ----------------------------- | --------------- |
+| 1        | `.config/preflight/config.ts` | Preferred       |
+| 2        | `.config/preflight.config.ts` | Legacy fallback |
+
+If neither exists, defaults are used. The config controls compilation settings only:
+
+```ts
+interface PreflightConfig {
+  compile?: {
+    srcDir?: string; // default: '.preflight/distribution'
+    outDir?: string; // default: '.preflight/distribution'
+  };
+}
+```
+
+### Config authoring API
+
+All helpers are type-safe identity functions that provide editor autocomplete without runtime overhead. Import them from `@williamthorsen/preflight`.
+
+#### `definePreflightConfig`
+
+Define repo-level settings:
+
+```ts
+import { definePreflightConfig } from '@williamthorsen/preflight';
+
+export default definePreflightConfig({
+  compile: {
+    srcDir: '.preflight/distribution',
+    outDir: '.preflight/distribution',
+  },
+});
+```
+
+#### `definePreflightCollection`
+
+Define a collection of checklists with optional suites and fix placement:
+
+```ts
+import { definePreflightCollection } from '@williamthorsen/preflight';
+
+export default definePreflightCollection({
+  fixLocation: 'INLINE',
+  checklists: [
+    /* ... */
+  ],
+  suites: {
+    critical: ['auth', 'database'],
+  },
+});
+```
+
+#### `definePreflightChecklist`
+
+Define a flat checklist. All checks run concurrently:
+
+```ts
+import { definePreflightChecklist } from '@williamthorsen/preflight';
+
+const checklist = definePreflightChecklist({
+  name: 'deploy',
+  preconditions: [{ name: 'CI is green', check: () => process.env['CI_STATUS'] === 'green' }],
+  checks: [
+    {
+      name: 'environment variables set',
+      check: () => Boolean(process.env['NODE_ENV']),
+      fix: 'Set NODE_ENV before deploying',
+    },
+    {
+      name: 'database reachable',
+      check: async () => {
+        const ok = await pingDatabase();
+        return { ok, detail: ok ? 'connected' : 'timeout' };
+      },
+      fix: 'Check DATABASE_URL and network access',
+    },
+  ],
+});
+```
+
+#### `definePreflightStagedChecklist`
+
+Define a staged checklist. Groups run sequentially; checks within each group run concurrently. Use this when later checks depend on earlier ones passing:
+
+```ts
+import { definePreflightStagedChecklist } from '@williamthorsen/preflight';
+
+const checklist = definePreflightStagedChecklist({
+  name: 'release',
+  groups: [
+    // Group 1: prerequisites
+    [
+      { name: 'on main branch', check: () => getCurrentBranch() === 'main' },
+      { name: 'clean working tree', check: () => isCleanWorkingTree() },
+    ],
+    // Group 2: runs only if group 1 passes
+    [
+      { name: 'tests pass', check: async () => runTests() },
+      { name: 'build succeeds', check: async () => runBuild() },
+    ],
+  ],
+});
+```
+
+#### `defineChecklists`
+
+Type-safe wrapper for an array of checklists (flat or staged). Useful when defining checklists separately from the collection:
+
+```ts
+import { defineChecklists } from '@williamthorsen/preflight';
+
+const checklists = defineChecklists([deployChecklist, releaseChecklist]);
+```
+
+### Check return values
+
+A check function can return a `boolean` or a `CheckOutcome` object:
+
+| Return type    | Fields      | Description                                                                  |
+| -------------- | ----------- | ---------------------------------------------------------------------------- |
+| `boolean`      | —           | `true` = passed, `false` = failed                                            |
+| `CheckOutcome` | `ok`        | `true` = passed, `false` = failed                                            |
+|                | `detail?`   | Additional status info shown in the report                                   |
+|                | `progress?` | `{ type: 'fraction', passedCount, count }` or `{ type: 'percent', percent }` |
+
+### Preconditions
+
+Both flat and staged checklists accept a `preconditions` array. Preconditions run before the main checks. If any precondition fails, all remaining checks in the checklist are skipped (reported as ⛔).
+
+### Fix location
+
+Control where fix messages appear in the human-readable output:
+
+| Value             | Behavior                                                   |
+| ----------------- | ---------------------------------------------------------- |
+| `'END'` (default) | Fix messages collected in a "Fixes:" section at the bottom |
+| `'INLINE'`        | Fix messages appear directly below each failed check       |
+
+Set `fixLocation` on a collection (applies to all checklists) or on an individual checklist (overrides the collection setting).
+
+### Suites
+
+Group checklists by name for convenient invocation:
+
+```ts
+export default definePreflightCollection({
+  checklists: [authChecklist, dbChecklist, cacheChecklist],
+  suites: {
+    critical: ['auth', 'database'],
+    full: ['auth', 'database', 'cache'],
+  },
+});
+```
+
+```bash
+preflight run critical        # Runs auth + database checklists
+preflight run full            # Runs all three
+preflight run auth database   # Same as "critical", by checklist name
+```
+
+## Sharing checks across repos
+
+Preflight supports distributing checks as pre-compiled JavaScript bundles that any repo can fetch and run without installing your config as a dependency.
+
+```
+author .ts collection
+        │
+        ▼
+  preflight compile
+        │
+        ▼
+  self-contained .js bundle
+        │
+        ▼
+  push to repository
+        │
+        ▼
+  preflight run --github org/repo
+```
+
+### 1. Author a collection
+
+Write your collection in TypeScript under `.preflight/distribution/`:
+
+```ts
+// .preflight/distribution/default.ts
+import { definePreflightCollection } from '@williamthorsen/preflight';
+
+export default definePreflightCollection({
+  checklists: [
+    /* shared checks */
+  ],
+});
+```
+
+### 2. Compile
+
+Bundle the TypeScript into a self-contained ESM file with all dependencies inlined (except Node built-ins):
+
+```bash
+preflight compile .preflight/distribution/default.ts
+# Produces .preflight/distribution/default.js
+```
+
+Or compile all sources from the config's `srcDir` at once:
+
+```bash
+preflight compile
+```
+
+### 3. Commit and push
+
+Commit the compiled `.js` files. Consumers fetch them via raw URL.
+
+### 4. Consume remotely
+
+From any repo:
+
+```bash
+# Fetch from GitHub (uses GITHUB_TOKEN or gh auth token automatically)
+preflight run --github myorg/shared-checks
+
+# Fetch a specific ref
+preflight run --github myorg/shared-checks@v2.0
+
+# Fetch a named collection
+preflight run --github myorg/shared-checks --collection production
+
+# Fetch from any URL
+preflight run --url https://example.com/preflight/default.js
+```
+
+The `--github` flag constructs the URL: `https://raw.githubusercontent.com/{org}/{repo}/{ref}/.preflight/distribution/{collection}.js`
+
+## CLI reference
+
+### `preflight run`
+
+Run preflight checklists. If no names are given, all checklists in the collection are run.
+
+```
+preflight run [names...] [options]
+```
+
+| Flag                        | Description                               | Default   |
+| --------------------------- | ----------------------------------------- | --------- |
+| `--file <path>`             | Path to a local collection file           | —         |
+| `--github <org/repo[@ref]>` | Fetch collection from a GitHub repository | —         |
+| `--url <url>`               | Fetch collection from a URL               | —         |
+| `--collection <name>`       | Collection name (used with `--github`)    | `default` |
+| `--json`                    | Output results as JSON                    | —         |
+
+`--file`, `--github`, and `--url` are mutually exclusive. When none is given, preflight loads `.config/preflight/collections/default.ts` (or the named collection via `--collection`).
+
+`[names...]` can be checklist names, suite names, or a mix.
+
+### `preflight compile`
+
+Bundle TypeScript collection(s) into self-contained ESM file(s).
+
+```
+preflight compile [input] [options]
+```
+
+| Flag                  | Description           | Default                        |
+| --------------------- | --------------------- | ------------------------------ |
+| `[input]`             | Input TypeScript file | All sources in config `srcDir` |
+| `--output, -o <path>` | Output file path      | Input path with `.ts` → `.js`  |
+
+### `preflight init`
+
+Scaffold a starter config and collection.
+
+```
+preflight init [options]
+```
+
+| Flag        | Description                           |
+| ----------- | ------------------------------------- |
+| `--dry-run` | Preview changes without writing files |
+| `--force`   | Overwrite existing files              |
+
+Creates `.config/preflight/config.ts` and `.config/preflight/collections/default.ts`.
+
+## JSON output
+
+Use `--json` to get machine-readable output:
+
+```bash
+preflight run --json
+```
+
+```json
+{
+  "allPassed": false,
+  "passedCount": 2,
+  "failedCount": 1,
+  "skippedCount": 0,
+  "durationMs": 45,
+  "checklists": [
+    {
+      "name": "deploy",
+      "allPassed": false,
+      "durationMs": 45,
+      "passedCount": 2,
+      "failedCount": 1,
+      "skippedCount": 0,
+      "checks": [
+        {
+          "name": "environment variables set",
+          "status": "passed",
+          "durationMs": 3
+        },
+        {
+          "name": "database reachable",
+          "status": "passed",
+          "durationMs": 38,
+          "detail": "connected"
+        },
+        {
+          "name": "feature flags loaded",
+          "status": "failed",
+          "durationMs": 4,
+          "fix": "Check FEATURE_FLAGS_URL",
+          "error": "Connection refused"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Optional fields (`fix`, `error`, `detail`, `progress`) are omitted when not present.


### PR DESCRIPTION
Closes #114 

## What

Adds a comprehensive README for the `@williamthorsen/preflight` package, covering installation, quick start, configuration authoring API, remote distribution workflow, CLI reference, and JSON output format.

## Why

The package is published to npm but had no README, meaning no documentation was visible on the package page. This was a pre-existing gap noticed during #103 review.

## Details

### Documentation

- Quick start walkthrough from `preflight init` through first passing run with sample output
- Config authoring API: all five `define*` helpers with realistic examples
- Flat vs staged checklists, preconditions, suites, and fix location options
- Sharing checks across repos: author → compile → distribute → consume workflow with flow diagram
- CLI reference tables for `run`, `compile`, and `init` commands with all flags
- JSON output schema with representative example
- Check-result legend (🟢 🔴 ⛔)