### PR TITLE
#88 Extract reusable deleteFileIfExists helper

### DIFF
--- a/packages/release-kit/src/__tests__/deleteFileIfExists.unit.test.ts
+++ b/packages/release-kit/src/__tests__/deleteFileIfExists.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockUnlinkSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  unlinkSync: mockUnlinkSync,
+}));
+
+import { deleteFileIfExists } from '../deleteFileIfExists.ts';
+
+describe(deleteFileIfExists, () => {
+  it('deletes the file at the given path', () => {
+    deleteFileIfExists('/tmp/some-file');
+
+    expect(mockUnlinkSync).toHaveBeenCalledWith('/tmp/some-file');
+  });
+
+  it('silently returns when the file does not exist', () => {
+    mockUnlinkSync.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    expect(() => deleteFileIfExists('/tmp/missing')).not.toThrow();
+  });
+
+  it('re-throws non-ENOENT errors', () => {
+    mockUnlinkSync.mockImplementation(() => {
+      throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+    });
+
+    expect(() => deleteFileIfExists('/tmp/protected')).toThrow('EACCES');
+  });
+});

--- a/packages/release-kit/src/createTags.ts
+++ b/packages/release-kit/src/createTags.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync, unlinkSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 
+import { deleteFileIfExists } from './deleteFileIfExists.ts';
 import { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from './prepareCommand.ts';
 
 export interface CreateTagsOptions {
@@ -65,34 +66,10 @@ export function createTags(options: CreateTagsOptions): string[] {
     console.info(`🏷️ ${tag}`);
   }
 
-  deleteTagsFile();
-  deleteSummaryFile();
+  deleteFileIfExists(RELEASE_TAGS_FILE);
+  deleteFileIfExists(RELEASE_SUMMARY_FILE);
 
   return tags;
-}
-
-/** Remove the tags file after successful tag creation. Tolerate missing file. */
-function deleteTagsFile(): void {
-  try {
-    unlinkSync(RELEASE_TAGS_FILE);
-  } catch (error: unknown) {
-    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-      return;
-    }
-    throw error;
-  }
-}
-
-/** Remove the summary file after successful tag creation. Tolerate missing file. */
-function deleteSummaryFile(): void {
-  try {
-    unlinkSync(RELEASE_SUMMARY_FILE);
-  } catch (error: unknown) {
-    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-      return;
-    }
-    throw error;
-  }
 }
 
 /** Throw if the git working tree has uncommitted changes. */

--- a/packages/release-kit/src/deleteFileIfExists.ts
+++ b/packages/release-kit/src/deleteFileIfExists.ts
@@ -1,0 +1,13 @@
+import { unlinkSync } from 'node:fs';
+
+/** Delete a file, silently ignoring the case where it does not exist. */
+export function deleteFileIfExists(filePath: string): void {
+  try {
+    unlinkSync(filePath);
+  } catch (error: unknown) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+}

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -32,6 +32,7 @@ export { bumpVersion } from './bumpVersion.ts';
 export { commitCommand } from './commitCommand.ts';
 export { component } from './component.ts';
 export { createTags } from './createTags.ts';
+export { deleteFileIfExists } from './deleteFileIfExists.ts';
 export { detectPackageManager } from './detectPackageManager.ts';
 export { determineBumpType } from './determineBumpType.ts';
 export { discoverWorkspaces } from './discoverWorkspaces.ts';


### PR DESCRIPTION
Closes #88 

## What

Extracts a reusable `deleteFileIfExists(path)` helper from the duplicate `deleteTagsFile` and `deleteSummaryFile` functions in `createTags.ts`. The new helper lives in its own module (`deleteFileIfExists.ts`) and is exported from the `release-kit` package barrel.

## Why

Both functions were structurally identical, differing only in the file path passed to `unlinkSync`. The duplication was introduced in #70 when `deleteSummaryFile` was added alongside `deleteTagsFile`. A single parameterized helper eliminates the repetition and provides a reusable primitive for future file-cleanup code.

## Details

### Refactoring

- Created `deleteFileIfExists.ts` with the ENOENT-tolerant delete pattern extracted from `createTags.ts`.
- Replaced both `deleteTagsFile` and `deleteSummaryFile` in `createTags.ts` with calls to `deleteFileIfExists`.
- Removed the now-unused `unlinkSync` import from `createTags.ts`.
- Exported `deleteFileIfExists` from the `release-kit` barrel (`index.ts`).

### Tests

- Added `deleteFileIfExists.unit.test.ts` covering successful deletion, ENOENT tolerance, and re-throw of non-ENOENT errors.
- All existing `createTags` tests pass without modification.