### PR TITLE
#135 Refine release-kit README to match preflight documentation standard

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -20,6 +20,36 @@ npx @williamthorsen/release-kit init
 npx @williamthorsen/release-kit prepare --dry-run
 ```
 
+Example output from `prepare --dry-run` in a monorepo:
+
+```
+🔍 DRY RUN — no files will be modified
+
+── arrays ──────────────────────────────────────
+  Found 4 commits since arrays-v1.2.0
+  Parsed 3 typed commits
+  Bumping versions (minor)...
+  📦 1.2.0 → 1.3.0 (minor)
+  [dry-run] Would bump packages/arrays/package.json
+  Generating changelogs...
+  [dry-run] Would run: npx --yes git-cliff ... --output packages/arrays/CHANGELOG.md
+  🏷️  arrays-v1.3.0
+
+── strings ─────────────────────────────────────
+  Found 2 commits since strings-v0.5.1
+  Parsed 2 typed commits
+  Bumping versions (patch)...
+  📦 0.5.1 → 0.5.2 (patch)
+  [dry-run] Would bump packages/strings/package.json
+  Generating changelogs...
+  [dry-run] Would run: npx --yes git-cliff ... --output packages/strings/CHANGELOG.md
+  🏷️  strings-v0.5.2
+
+✅ Release preparation complete.
+   🏷️  arrays-v1.3.0
+   🏷️  strings-v0.5.2
+```
+
 That's it for most repos. The CLI auto-discovers workspaces and applies sensible defaults. The bundled `cliff.toml.template` is used automatically — no need to copy it. Customize only what you need via `.config/release-kit.config.ts`.
 
 ## How it works
@@ -30,58 +60,20 @@ That's it for most repos. The CLI auto-discovers workspaces and applies sensible
 4. **Version bump + changelog**: bumps `package.json` versions and generates changelogs via `git-cliff`.
 5. **Release tags file**: writes computed tags to `tmp/.release-tags` for the release workflow to read when tagging and pushing.
 
-## CLI reference
+## Commit format
 
-### `release-kit prepare`
-
-Run release preparation with automatic workspace discovery.
+release-kit parses commits in these formats:
 
 ```
-Usage: release-kit prepare [options]
-
-Options:
-  --dry-run                   Preview changes without writing files
-  --bump=major|minor|patch    Override the bump type for all components
-  --only=name1,name2          Only process the named components (monorepo only)
-  --help, -h                  Show help
+type: description              # e.g., feat: add utility
+scope|type: description        # e.g., arrays|feat: add compact function
+type(scope): description       # e.g., feat(arrays): add compact function
+type!: description             # breaking change (triggers major bump)
+scope|type!: description       # scoped breaking change
+type(scope)!: description      # conventional scoped breaking change
 ```
 
-Component names for `--only` match the package directory name (e.g., `arrays`, `release-kit`).
-
-### `release-kit init`
-
-Initialize release-kit in the current repository. By default, scaffolds only the GitHub Actions workflow file. Use `--with-config` to also scaffold configuration files.
-
-```
-Usage: release-kit init [options]
-
-Options:
-  --with-config    Also scaffold .config/release-kit.config.ts and .config/git-cliff.toml
-  --force          Overwrite existing files instead of skipping them
-  --dry-run        Preview changes without writing files
-  --help, -h       Show help
-```
-
-Scaffolded files:
-
-- `.github/workflows/release.yaml` — workflow that delegates to a reusable release workflow
-- `.config/release-kit.config.ts` — starter config with commented-out customization examples (with `--with-config`)
-- `.config/git-cliff.toml` — copied from the bundled template (with `--with-config`)
-
-### `release-kit sync-labels`
-
-Manage GitHub label definitions via config-driven YAML files.
-
-```
-Usage: release-kit sync-labels <command> [options]
-
-Commands:
-  init        Scaffold sync-labels config and caller workflow
-  generate    Generate .github/labels.yaml from config
-  sync        Generate labels and push to GitHub (runs generate + gh label sync)
-```
-
-`init` scaffolds `.config/sync-labels.config.ts` with auto-detected workspace scope labels and a `.github/workflows/sync-labels.yaml` caller workflow. `generate` reads the config and writes `.github/labels.yaml`. `sync` runs `generate` and then applies labels to the GitHub repo.
+The `scope|type:` format scopes a commit to a specific component in a monorepo. Use `scopeAliases` in your config to map shorthand names to canonical scope names.
 
 ## Configuration
 
@@ -144,7 +136,7 @@ interface VersionPatterns {
 }
 ```
 
-Default: `{ major: ['!'], minor: ['feat', 'feature'] }`
+Default: `{ major: ['!'], minor: ['feat'] }`
 
 ### Default work types
 
@@ -163,20 +155,100 @@ Default: `{ major: ['!'], minor: ['feat', 'feature'] }`
 
 Work types from your config are merged with these defaults by key — your entries override or extend, they don't replace the full set.
 
-## Commit format
+## CLI reference
 
-release-kit parses commits in these formats:
+### `release-kit prepare`
 
+Run release preparation with automatic workspace discovery.
+
+| Flag                         | Description                                                      |
+| ---------------------------- | ---------------------------------------------------------------- |
+| `--dry-run`                  | Preview changes without writing files                            |
+| `--bump=major\|minor\|patch` | Override the bump type for all components                        |
+| `--force`                    | Bypass the "no commits since last tag" check (requires `--bump`) |
+| `--only=name1,name2`         | Only process the named components (monorepo only)                |
+| `--help`, `-h`               | Show help                                                        |
+
+Component names for `--only` match the package directory name (e.g., `arrays`, `release-kit`).
+
+### `release-kit init`
+
+Initialize release-kit in the current repository. By default, scaffolds only the GitHub Actions workflow file. Use `--with-config` to also scaffold configuration files.
+
+| Flag            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| `--with-config` | Also scaffold `.config/release-kit.config.ts` and `.config/git-cliff.toml` |
+| `--force`       | Overwrite existing files instead of skipping them                          |
+| `--dry-run`     | Preview changes without writing files                                      |
+| `--help`, `-h`  | Show help                                                                  |
+
+Scaffolded files:
+
+- `.github/workflows/release.yaml` — workflow that delegates to a reusable release workflow
+- `.config/release-kit.config.ts` — starter config with commented-out customization examples (with `--with-config`)
+- `.config/git-cliff.toml` — copied from the bundled template (with `--with-config`)
+
+### `release-kit sync-labels`
+
+Manage GitHub label definitions via config-driven YAML files.
+
+| Subcommand | Description                                                    | Flags                  |
+| ---------- | -------------------------------------------------------------- | ---------------------- |
+| `init`     | Scaffold config, caller workflow, and generate labels          | `--dry-run`, `--force` |
+| `generate` | Regenerate `.github/labels.yaml` from config                   | —                      |
+| `sync`     | Trigger the `sync-labels` GitHub Actions workflow via `gh` CLI | —                      |
+
+`init` scaffolds `.config/sync-labels.config.ts` with auto-detected workspace scope labels and a `.github/workflows/sync-labels.yaml` caller workflow, then generates `.github/labels.yaml`. `generate` reads the config and writes `.github/labels.yaml`. `sync` triggers the workflow remotely — it requires the `gh` CLI and an existing workflow file.
+
+## GitHub Actions workflow
+
+The `init` command scaffolds a release workflow at `.github/workflows/release.yaml` that delegates to a reusable release workflow. The scaffolded workflow accepts these inputs:
+
+| Input  | Type   | Description                                                         |
+| ------ | ------ | ------------------------------------------------------------------- |
+| `only` | string | Components to release (comma-separated, leave empty for all)        |
+| `bump` | choice | Override bump type: `patch`, `minor`, `major` (empty = auto-detect) |
+
+For repos that need a self-contained workflow instead of the reusable one, the scaffolded file can be expanded. The key steps are: checkout with full history (`fetch-depth: 0`), run `release-kit prepare` with optional `--only` and `--bump` flags, check for changes, read tags from `tmp/.release-tags`, then commit, tag, and push.
+
+### Triggering a release
+
+```sh
+# All components
+gh workflow run release.yaml
+
+# Specific component(s)
+gh workflow run release.yaml -f only=arrays
+gh workflow run release.yaml -f only=arrays,strings -f bump=minor
 ```
-type: description              # e.g., feat: add utility
-scope|type: description        # e.g., arrays|feat: add compact function
-type(scope): description       # e.g., feat(arrays): add compact function
-type!: description             # breaking change (triggers major bump)
-scope|type!: description       # scoped breaking change
-type(scope)!: description      # conventional scoped breaking change
-```
 
-The `scope|type:` format scopes a commit to a specific component in a monorepo. Use `scopeAliases` in your config to map shorthand names to canonical scope names.
+Or use the GitHub UI: Actions > Release > Run workflow.
+
+## cliff.toml setup
+
+The package includes a bundled `cliff.toml.template` that is used automatically when no custom config is found. The resolution order:
+
+| Priority | Path                          | Notes                                           |
+| -------- | ----------------------------- | ----------------------------------------------- |
+| 1        | `cliffConfigPath` in config   | Explicit path, returned without existence check |
+| 2        | `.config/git-cliff.toml`      | Project-level override                          |
+| 3        | `cliff.toml`                  | Repo root fallback                              |
+| 4        | Bundled `cliff.toml.template` | Automatic fallback                              |
+
+The bundled template provides a generic git-cliff configuration that:
+
+- Strips issue-ticket prefixes matching `^[A-Z]+-\d+\s+` (e.g., `TOOL-123 `, `AFG-456 `)
+- Handles both `type: description` and `workspace|type: description` commit formats
+- Groups commits by work type into changelog sections
+
+To customize, scaffold a local copy with `release-kit init --with-config` and edit `.config/git-cliff.toml`.
+
+## External dependencies
+
+This package shells out to two external tools:
+
+- **`git`** — must be available on `PATH`. Used to find tags and retrieve commit history.
+- **`git-cliff`** — automatically downloaded and cached via `npx` on first invocation. No need to install it as a dev dependency.
 
 ## Using `component()` for manual configuration
 
@@ -197,152 +269,6 @@ component('packages/arrays');
 ```
 
 The `dir` field is derived from `path.basename()`, so `packages/arrays` and `libs/arrays` both produce `dir: 'arrays'`. The `tagPrefix` is always `${dir}-v` — it cannot be customized.
-
-## GitHub Actions workflow
-
-The `init` command scaffolds a workflow that delegates to a reusable release workflow. For repos that need a self-contained workflow:
-
-### Monorepo
-
-```yaml
-name: Release
-
-on:
-  workflow_dispatch:
-    inputs:
-      only:
-        description: 'Components to release (comma-separated, leave empty for all)'
-        required: false
-        type: string
-      bump:
-        description: 'Override bump type (leave empty to auto-detect)'
-        required: false
-        type: choice
-        options:
-          - ''
-          - patch
-          - minor
-          - major
-
-permissions:
-  contents: write
-
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Run release preparation
-        run: |
-          ARGS=""
-          if [ -n "${{ inputs.only }}" ]; then
-            ARGS="$ARGS --only=${{ inputs.only }}"
-          fi
-          if [ -n "${{ inputs.bump }}" ]; then
-            ARGS="$ARGS --bump=${{ inputs.bump }}"
-          fi
-          npx @williamthorsen/release-kit prepare $ARGS
-
-      - name: Check for changes
-        id: check
-        run: |
-          if git diff --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No release-worthy changes found."
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Read release tags
-        if: steps.check.outputs.changed == 'true'
-        id: tags
-        run: |
-          TAGS=$(cat tmp/.release-tags | tr '\n' ' ')
-          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
-          echo "Releasing: $TAGS"
-
-      - name: Commit, tag, and push
-        if: steps.check.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "release: ${{ steps.tags.outputs.tags }}"
-          for TAG in ${{ steps.tags.outputs.tags }}; do
-            git tag "$TAG"
-          done
-          git push origin main ${{ steps.tags.outputs.tags }}
-```
-
-### Single-package repo
-
-The same workflow without the `only` input. Replace the prepare step with:
-
-```yaml
-- name: Run release preparation
-  run: |
-    ARGS=""
-    if [ -n "${{ inputs.bump }}" ]; then
-      ARGS="--bump=${{ inputs.bump }}"
-    fi
-    npx @williamthorsen/release-kit prepare $ARGS
-```
-
-And the tag step with:
-
-```yaml
-- name: Read release tag
-  if: steps.check.outputs.changed == 'true'
-  id: tags
-  run: |
-    TAG=$(cat tmp/.release-tags)
-    echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-```
-
-## Triggering a release
-
-```sh
-# All components
-gh workflow run release.yaml
-
-# Specific component(s)
-gh workflow run release.yaml -f only=arrays
-gh workflow run release.yaml -f only=arrays,strings -f bump=minor
-```
-
-Or use the GitHub UI: Actions > Release > Run workflow.
-
-## cliff.toml setup
-
-The package includes a bundled `cliff.toml.template` that is used automatically when no custom config is found. The resolution order is:
-
-1. Explicit `cliffConfigPath` in `.config/release-kit.config.ts`
-2. `.config/git-cliff.toml`
-3. `cliff.toml` (repo root)
-4. Bundled `cliff.toml.template` (automatic fallback)
-
-The bundled template provides a generic git-cliff configuration that:
-
-- Strips issue-ticket prefixes matching `^[A-Z]+-\d+\s+` (e.g., `TOOL-123 `, `AFG-456 `)
-- Handles both `type: description` and `workspace|type: description` commit formats
-- Groups commits by work type into changelog sections
-
-To customize, scaffold a local copy with `release-kit init --with-config` and edit `.config/git-cliff.toml`.
-
-## External dependencies
-
-This package shells out to two external tools:
-
-- **`git`** — must be available on `PATH`. Used to find tags and retrieve commit history.
-- **`git-cliff`** — automatically downloaded and cached via `npx` on first invocation. No need to install it as a dev dependency.
 
 ## Legacy script-based approach
 


### PR DESCRIPTION
Closes #135 

## What

Restructures the release-kit README to match the documentation standard established by the preflight README (#114). Reorders sections to follow the cross-package convention, converts CLI flag listings from code blocks to tables, adds representative `prepare --dry-run` output to the quick start, and condenses ~90 lines of inline workflow YAML into a summary with an inputs table and trigger examples. Fixes several accuracy gaps found by verifying documentation against source.

## Why

The three package READMEs (nmr, preflight, release-kit) should feel like they belong to the same family. The preflight README set the standard; the nmr README was aligned in #134. This completes the set by bringing release-kit into consistency — improving scannability for developers who work across packages.

## Details

### Fixes

- Corrected `versionPatterns` default from `['feat', 'feature']` to `['feat']` to match `defaults.ts`
- Documented the missing `prepare --force` flag (exists in source, was not in README)
- Corrected `sync-labels sync` description: it triggers the GitHub Actions workflow via `gh workflow run`, not "generate + gh label sync"

## Test plan

- [ ] Read the final README end-to-end and confirm it follows the same patterns as the preflight README
- [ ] Verify all documented flags match `packages/release-kit/src/bin/release-kit.ts`