### PR TITLE
#142 Add --version flag to nmr and release-kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ coverage/
 .vitest-result.json
 
 # Generated files
-packages/preflight/src/version.ts
+packages/*/src/version.ts
 
 # TypeScript
 *.tsbuildinfo

--- a/config/generateVersion.ts
+++ b/config/generateVersion.ts
@@ -2,9 +2,8 @@
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packageDir = process.cwd();
 const raw: unknown = JSON.parse(readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
 
 if (typeof raw !== 'object' || raw === null || !('version' in raw) || typeof raw.version !== 'string') {

--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -239,6 +239,7 @@ nmr [flags] <command> [args...]
 | `-w, --workspace-root`   | Force root script registry                          | —       |
 | `-q, --quiet`            | Suppress info messages; show full output on failure | —       |
 | `-?, --help`             | Show available commands                             | —       |
+| `-V, --version`          | Show version number                                 | —       |
 | `--int-test`             | Use integration test scripts                        | —       |
 
 ### Examples

--- a/packages/nmr/package.json
+++ b/packages/nmr/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "scripts": {
-    "prepare": "tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json"
+    "prepare": "tsx ../../config/generateVersion.ts && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json"
   },
   "dependencies": {
     "jiti": "2.6.1",

--- a/packages/nmr/src/cli.ts
+++ b/packages/nmr/src/cli.ts
@@ -7,6 +7,7 @@ import { resolveContext } from './context.js';
 import { generateHelp } from './help.js';
 import { buildRootRegistry, buildWorkspaceRegistry, resolveScript } from './resolver.js';
 import { runCommand } from './runner.js';
+import { VERSION } from './version.js';
 
 /**
  * Shell-escapes a single argument by wrapping in single quotes
@@ -22,6 +23,7 @@ interface ParsedArgs {
   recursive: boolean;
   workspaceRoot: boolean;
   help: boolean;
+  version: boolean;
   intTest: boolean;
   command?: string;
   passthrough: string[];
@@ -34,6 +36,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     recursive: false,
     workspaceRoot: false,
     help: false,
+    version: false,
     intTest: false,
     passthrough: [],
   };
@@ -69,6 +72,11 @@ function parseArgs(argv: string[]): ParsedArgs {
       i++;
       continue;
     }
+    if (arg === '-V' || arg === '--version') {
+      result.version = true;
+      i++;
+      continue;
+    }
     if (arg === '-q' || arg === '--quiet') {
       result.quiet = true;
       i++;
@@ -91,6 +99,12 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 async function main(): Promise<void> {
   const parsed = parseArgs(process.argv);
+
+  if (parsed.version) {
+    console.info(VERSION);
+    process.exit(0);
+  }
+
   const context = await resolveContext();
 
   if (parsed.help || !parsed.command) {

--- a/packages/preflight/package.json
+++ b/packages/preflight/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "scripts": {
-    "prepare": "tsx config/generateVersion.ts && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json"
+    "prepare": "tsx ../../config/generateVersion.ts && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json"
   },
   "dependencies": {
     "@williamthorsen/node-monorepo-core": "workspace:*",

--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -157,6 +157,13 @@ Work types from your config are merged with these defaults by key — your entri
 
 ## CLI reference
 
+### Global options
+
+| Flag              | Description         |
+| ----------------- | ------------------- |
+| `--help`, `-h`    | Show help message   |
+| `--version`, `-V` | Show version number |
+
 ### `release-kit prepare`
 
 Run release preparation with automatic workspace discovery.

--- a/packages/release-kit/package.json
+++ b/packages/release-kit/package.json
@@ -31,7 +31,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "prepare": "tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json",
+    "prepare": "tsx ../../config/generateVersion.ts && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json",
     "prepublishOnly": "nmr build",
     "test": "pnpm exec vitest --config=vitest.standalone.config.ts",
     "test:coverage": "pnpm exec vitest --config=vitest.standalone.config.ts --coverage",

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -10,6 +10,7 @@ import { generateCommand } from '../sync-labels/generateCommand.ts';
 import { syncLabelsInitCommand } from '../sync-labels/initCommand.ts';
 import { syncLabelsCommand } from '../sync-labels/syncCommand.ts';
 import { tagCommand } from '../tagCommand.ts';
+import { VERSION } from '../version.ts';
 
 function showUsage(): void {
   console.info(`
@@ -154,6 +155,11 @@ Options:
 const args = process.argv.slice(2);
 const command = args[0];
 const flags = args.slice(1);
+
+if (command === '--version' || command === '-V') {
+  console.info(VERSION);
+  process.exit(0);
+}
 
 if (command === '--help' || command === '-h' || command === undefined) {
   showUsage();


### PR DESCRIPTION
Closes #142 

## What

Add `--version` / `-V` support to the `nmr` and `release-kit` CLIs, matching the existing `preflight` behavior. Move the build-time version generation script to the shared `config/` directory so all three packages use a single `generateVersion.ts`.

## Why

Users of `nmr` and `release-kit` had no way to check which version they were running. Preflight already supported this, so the other two CLIs needed parity. Deduplicating the generation script avoids maintaining three identical copies.

## Details

### Features

- `nmr --version` / `nmr -V` prints the package version and exits
- `release-kit --version` / `release-kit -V` prints the package version and exits
- Version is handled before workspace resolution in nmr, so it works outside a monorepo

### Refactoring

- Move `packages/preflight/config/generateVersion.ts` to shared `config/generateVersion.ts`
- Switch from `import.meta.url`-based resolution to `process.cwd()` for package directory detection
- Simplify `.gitignore` to use `packages/*/src/version.ts` glob instead of a single package entry
- All three packages' `prepare` scripts now reference `../../config/generateVersion.ts`

### Docs

- Add `-V, --version` to nmr's CLI reference flag table
- Add "Global options" section to release-kit's CLI reference with `--help` and `--version`

## Test plan

- [x] `nmr --version` and `nmr -V` print `0.5.0` and exit 0
- [x] `release-kit --version` and `release-kit -V` print `4.0.0` and exit 0
- [x] `preflight --version` still works (no regression)
- [x] `nmr check` passes (603 tests, no type errors)