### PR TITLE
#140 Add module-not-found error guard to loadConfig

### DIFF
--- a/packages/preflight/__tests__/loadConfig.test.ts
+++ b/packages/preflight/__tests__/loadConfig.test.ts
@@ -110,6 +110,36 @@ describe(loadConfig, () => {
     expect(config.compile.outDir).toBe('.preflight/distribution');
   });
 
+  it.each(['MODULE_NOT_FOUND', 'ERR_MODULE_NOT_FOUND'])(
+    'catches %s errors with an actionable message',
+    async (code) => {
+      mockExistsSync.mockReturnValue(true);
+      const moduleError = Object.assign(new Error("Cannot find package 'some-lib'"), { code });
+      mockJitiImport.mockRejectedValue(moduleError);
+
+      await expect(loadConfig('config.ts')).rejects.toThrow(
+        /Cannot resolve 'some-lib'.*must be installed in the project/,
+      );
+    },
+  );
+
+  it('falls back to "unknown module" when the error message does not match the expected pattern', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const moduleError = Object.assign(new Error('Module load failed'), { code: 'MODULE_NOT_FOUND' });
+    mockJitiImport.mockRejectedValue(moduleError);
+
+    await expect(loadConfig('config.ts')).rejects.toThrow(
+      /Cannot resolve 'unknown module'.*must be installed in the project/,
+    );
+  });
+
+  it('re-throws non-module-resolution errors from jiti', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockRejectedValue(new SyntaxError('Unexpected token'));
+
+    await expect(loadConfig('config.ts')).rejects.toThrow(SyntaxError);
+  });
+
   it('supports named exports (no default)', async () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ compile: { srcDir: 'named/src', outDir: 'named/out' } });

--- a/packages/preflight/src/config.ts
+++ b/packages/preflight/src/config.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import { assertIsPreflightCollection } from './assertIsPreflightCollection.ts';
-import { isRecord } from './isRecord.ts';
+import { jitiImport } from './jitiImport.ts';
 import { resolveCollectionExports } from './resolveCollectionExports.ts';
 import type { PreflightChecklist, PreflightCollection, PreflightConfig, PreflightStagedChecklist } from './types.ts';
 import { validateCollection } from './validateCollection.ts';
@@ -59,34 +59,12 @@ export async function loadPreflightCollection(collectionPath?: string): Promise<
     throw new Error(`Preflight collection not found: ${collectionPath ?? resolvedPath}`);
   }
 
-  const { createJiti } = await import('jiti');
-  const jiti = createJiti(resolvedPath);
-
-  let imported: unknown;
-  try {
-    imported = await jiti.import(resolvedPath);
-  } catch (error: unknown) {
-    if (
-      error instanceof Error &&
-      'code' in error &&
-      (error.code === 'MODULE_NOT_FOUND' || error.code === 'ERR_MODULE_NOT_FOUND')
-    ) {
-      const moduleMatch = error.message.match(/Cannot find (?:module|package) '([^']+)'/);
-      const moduleName = moduleMatch?.[1] ?? 'unknown module';
-      throw new Error(
-        `Cannot resolve '${moduleName}'. ` +
-          `Uncompiled collections require the package to be installed as a project dependency. ` +
-          `Alternatively, run 'preflight compile' to produce a self-contained bundle that does not need a local install.`,
-      );
-    }
-    throw error;
-  }
-
-  if (!isRecord(imported)) {
-    throw new Error(
-      `Collection file must export an object, got ${Array.isArray(imported) ? 'array' : typeof imported}`,
-    );
-  }
+  const imported = await jitiImport(
+    resolvedPath,
+    'Uncompiled collections require the package to be installed as a project dependency. ' +
+      "Alternatively, run 'preflight compile' to produce a self-contained bundle that does not need a local install.",
+    'Collection file',
+  );
 
   const resolved = resolveCollectionExports(imported);
   assertIsPreflightCollection(resolved);

--- a/packages/preflight/src/jitiImport.ts
+++ b/packages/preflight/src/jitiImport.ts
@@ -1,0 +1,39 @@
+import { isRecord } from './isRecord.ts';
+
+/**
+ * Import a TypeScript file via jiti with module-resolution error handling.
+ *
+ * Catches `MODULE_NOT_FOUND` and `ERR_MODULE_NOT_FOUND` errors and rethrows with an
+ * actionable message using the caller-provided `moduleErrorDetail`. Validates the imported
+ * value is a plain object, using `exportNoun` in the error message if not.
+ */
+export async function jitiImport(
+  resolvedPath: string,
+  moduleErrorDetail: string,
+  exportNoun: string,
+): Promise<Record<string, unknown>> {
+  const { createJiti } = await import('jiti');
+  const jiti = createJiti(resolvedPath);
+
+  let imported: unknown;
+  try {
+    imported = await jiti.import(resolvedPath);
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      (error.code === 'MODULE_NOT_FOUND' || error.code === 'ERR_MODULE_NOT_FOUND')
+    ) {
+      const moduleMatch = error.message.match(/Cannot find (?:module|package) '([^']+)'/);
+      const moduleName = moduleMatch?.[1] ?? 'unknown module';
+      throw new Error(`Cannot resolve '${moduleName}'. ${moduleErrorDetail}`);
+    }
+    throw error;
+  }
+
+  if (!isRecord(imported)) {
+    throw new Error(`${exportNoun} must export an object, got ${Array.isArray(imported) ? 'array' : typeof imported}`);
+  }
+
+  return imported;
+}

--- a/packages/preflight/src/loadConfig.ts
+++ b/packages/preflight/src/loadConfig.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { z } from 'zod';
 
 import { isRecord } from './isRecord.ts';
+import { jitiImport } from './jitiImport.ts';
 import type { PreflightConfig, ResolvedPreflightConfig } from './types.ts';
 
 /** Default config values when no config file is found. */
@@ -60,13 +61,11 @@ export async function loadConfig(overridePath?: string): Promise<ResolvedPreflig
     return { ...DEFAULT_CONFIG };
   }
 
-  const { createJiti } = await import('jiti');
-  const jiti = createJiti(resolvedPath);
-  const imported: unknown = await jiti.import(resolvedPath);
-
-  if (!isRecord(imported)) {
-    throw new Error(`Config file must export an object, got ${Array.isArray(imported) ? 'array' : typeof imported}`);
-  }
+  const imported = await jitiImport(
+    resolvedPath,
+    'External packages imported by the config file must be installed in the project.',
+    'Config file',
+  );
 
   // Support both default export and named exports
   const raw = imported.default !== undefined && isRecord(imported.default) ? imported.default : imported;


### PR DESCRIPTION
Closes #140 

## What

Wraps the `jiti.import()` call in `loadConfig` with a try/catch that catches `MODULE_NOT_FOUND` and `ERR_MODULE_NOT_FOUND` errors and rethrows with an actionable message. Extracts the shared jiti-import-with-error-handling pattern from both `loadConfig` and `loadPreflightCollection` into a new `jitiImport` helper to deduplicate the logic and resolve a cyclomatic complexity lint violation.

## Why

`loadPreflightCollection` already guarded against module-resolution errors from `jiti.import()`, but `loadConfig` did not. If a config file imported an uninstalled package, the user would see a raw Node.js error instead of a helpful message. Adding the guard to `loadConfig` pushed its cyclomatic complexity past the lint threshold, motivating the extraction of a shared helper.

## Details

### Features

- `loadConfig` now catches `MODULE_NOT_FOUND` and `ERR_MODULE_NOT_FOUND` errors with a message indicating the external package must be installed.
- Falls back to `'unknown module'` when the error message doesn't match the expected pattern.
- Non-module-resolution errors pass through unchanged.

### Refactoring

- Extract `jitiImport` helper (`packages/preflight/src/jitiImport.ts`) encapsulating jiti instance creation, import, module-error handling, and record validation.
- Both `loadConfig` and `loadPreflightCollection` now delegate to `jitiImport`, removing ~15 duplicated lines from each.

### Tests

- Add three tests to `loadConfig.test.ts`: parameterized test for both error codes, unknown-module fallback, and non-module error passthrough.