### PR TITLE
#78 Add devBin config for source-repo binary substitution

### DIFF
--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -67,6 +67,8 @@ Given the `build` command for a package that defines its own build script:
 
 If no per-package override exists, the highest-tier value that is set wins. Set a script to `""` in `package.json` to skip it for that package.
 
+> **Tip:** If your repo uses `eslint-plugin-package-json/valid-scripts`, empty strings are flagged as invalid. Use `":"` (the POSIX null command) instead — nmr treats it as a regular override that exits successfully and does nothing.
+
 ### Script values
 
 Script values can be `string` or `string[]`. Arrays expand to chained `nmr` sub-invocations:
@@ -99,8 +101,25 @@ export default defineConfig({
 | ------------------ | ------------------------------------ | -------------------------------------------------------------- |
 | `workspaceScripts` | `Record<string, string \| string[]>` | Scripts added or overridden in the workspace registry (tier 2) |
 | `rootScripts`      | `Record<string, string \| string[]>` | Scripts added or overridden in the root registry (tier 2)      |
+| `devBin`           | `Record<string, string>`             | Map binary names to source-repo replacement commands           |
 
-Both fields are optional. Values follow the same `string | string[]` convention described in [script values](#script-values).
+`workspaceScripts` and `rootScripts` are optional. Values follow the same `string | string[]` convention described in [script values](#script-values).
+
+### `devBin` — source-repo binary substitution
+
+When developing a CLI tool inside the monorepo, the published binary may not reflect your latest source changes. `devBin` lets you map a binary name to a replacement command that runs from source:
+
+```ts
+export default defineConfig({
+  devBin: {
+    'my-cli': 'tsx packages/my-cli/src/cli.ts',
+  },
+});
+```
+
+When nmr resolves a command whose first token matches a `devBin` key, it replaces that token with the mapped command. Arguments are preserved. Relative paths in the replacement are resolved from the monorepo root.
+
+For example, if a workspace script resolves to `my-cli --verbose`, nmr rewrites it to `tsx /absolute/path/to/packages/my-cli/src/cli.ts --verbose`.
 
 ## Default script registries
 

--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -103,7 +103,7 @@ export default defineConfig({
 | `rootScripts`      | `Record<string, string \| string[]>` | Scripts added or overridden in the root registry (tier 2)      |
 | `devBin`           | `Record<string, string>`             | Map binary names to source-repo replacement commands           |
 
-`workspaceScripts` and `rootScripts` are optional. Values follow the same `string | string[]` convention described in [script values](#script-values).
+All fields are optional. `workspaceScripts` and `rootScripts` values follow the same `string | string[]` convention described in [script values](#script-values).
 
 ### `devBin` — source-repo binary substitution
 
@@ -120,6 +120,8 @@ export default defineConfig({
 When nmr resolves a command whose first token matches a `devBin` key, it replaces that token with the mapped command. Arguments are preserved. Relative paths in the replacement are resolved from the monorepo root.
 
 For example, if a workspace script resolves to `my-cli --verbose`, nmr rewrites it to `tsx /absolute/path/to/packages/my-cli/src/cli.ts --verbose`.
+
+> **Note:** Path resolution uses a heuristic: any non-flag token containing `/` is treated as a relative path. This works well for typical dev-tool commands but may incorrectly resolve URL-like values or glob patterns. Flags using `--flag=value` syntax are not resolved; use the spaced form `--flag value` for paths that need resolution.
 
 ## Default script registries
 

--- a/packages/nmr/__tests__/config.test.ts
+++ b/packages/nmr/__tests__/config.test.ts
@@ -32,6 +32,16 @@ describe('defineConfig', () => {
   it('accepts an empty config', () => {
     expect(defineConfig({})).toEqual({});
   });
+
+  it('accepts a config with devBin', () => {
+    const config = defineConfig({
+      devBin: {
+        'my-cli': 'tsx packages/my-cli/src/cli.ts',
+      },
+    });
+
+    expect(config.devBin).toEqual({ 'my-cli': 'tsx packages/my-cli/src/cli.ts' });
+  });
 });
 
 describe('loadConfig', () => {

--- a/packages/nmr/__tests__/config.test.ts
+++ b/packages/nmr/__tests__/config.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
+import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -63,5 +64,38 @@ describe('loadConfig', () => {
   it('returns empty config for a non-existent directory', async () => {
     const config = await loadConfig('/tmp/nonexistent-monorepo-root');
     expect(config).toEqual({});
+  });
+
+  it('loads a config with a valid devBin mapping', async () => {
+    const configDir = path.join(tmpDir, '.config');
+    fs.mkdirSync(configDir);
+    fs.writeFileSync(
+      path.join(configDir, 'nmr.config.ts'),
+      `export default { devBin: { 'my-cli': 'tsx packages/my-cli/src/cli.ts' } };`,
+    );
+
+    const config = await loadConfig(tmpDir);
+    expect(config.devBin).toEqual({ 'my-cli': 'tsx packages/my-cli/src/cli.ts' });
+  });
+
+  it('throws when devBin contains a non-string value', async () => {
+    const configDir = path.join(tmpDir, '.config');
+    fs.mkdirSync(configDir);
+    fs.writeFileSync(path.join(configDir, 'nmr.config.ts'), `export default { devBin: { 'my-cli': 123 } };`);
+
+    await expect(loadConfig(tmpDir)).rejects.toThrow('`devBin` must be a Record<string, string>');
+  });
+
+  it('loads a config without devBin (backward compatibility)', async () => {
+    const configDir = path.join(tmpDir, '.config');
+    fs.mkdirSync(configDir);
+    fs.writeFileSync(
+      path.join(configDir, 'nmr.config.ts'),
+      `export default { workspaceScripts: { hello: 'echo hello' } };`,
+    );
+
+    const config = await loadConfig(tmpDir);
+    expect(config.devBin).toBeUndefined();
+    expect(config.workspaceScripts).toEqual({ hello: 'echo hello' });
   });
 });

--- a/packages/nmr/__tests__/resolver.test.ts
+++ b/packages/nmr/__tests__/resolver.test.ts
@@ -56,12 +56,11 @@ describe(applyDevBin, () => {
     expect(result).toBe('node /repo/scripts/build.js --config /repo/config/build.json src/');
   });
 
-  it('leaves the runner binary (first token) as-is', () => {
-    const devBin = { 'my-cli': 'tsx packages/cli/index.ts' };
+  it('does not resolve the runner binary even if it contains a slash', () => {
+    const devBin = { 'my-cli': 'runners/tsx packages/cli/index.ts' };
     const result = applyDevBin('my-cli', devBin, monorepoRoot);
 
-    expect(result).toBe('tsx /repo/packages/cli/index.ts');
-    // tsx should not be resolved — it's the runner binary
+    expect(result).toBe('runners/tsx /repo/packages/cli/index.ts');
   });
 });
 

--- a/packages/nmr/__tests__/resolver.test.ts
+++ b/packages/nmr/__tests__/resolver.test.ts
@@ -5,12 +5,65 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  applyDevBin,
   buildRootRegistry,
   buildWorkspaceRegistry,
   describeScript,
   expandScript,
   resolveScript,
 } from '../src/resolver.js';
+
+describe(applyDevBin, () => {
+  const monorepoRoot = '/repo';
+
+  it('replaces a matching first token with the devBin command', () => {
+    const devBin = { 'my-cli': 'tsx packages/my-cli/src/cli.ts' };
+    const result = applyDevBin('my-cli --verbose', devBin, monorepoRoot);
+
+    expect(result).toBe('tsx /repo/packages/my-cli/src/cli.ts --verbose');
+  });
+
+  it('replaces a command with no arguments', () => {
+    const devBin = { 'my-cli': 'tsx packages/my-cli/src/cli.ts' };
+    const result = applyDevBin('my-cli', devBin, monorepoRoot);
+
+    expect(result).toBe('tsx /repo/packages/my-cli/src/cli.ts');
+  });
+
+  it('returns the command unchanged when no match exists', () => {
+    const devBin = { 'other-cli': 'tsx other.ts' };
+    const result = applyDevBin('my-cli --flag', devBin, monorepoRoot);
+
+    expect(result).toBe('my-cli --flag');
+  });
+
+  it('returns the command unchanged when devBin is undefined', () => {
+    const result = applyDevBin('my-cli --flag', undefined, monorepoRoot);
+
+    expect(result).toBe('my-cli --flag');
+  });
+
+  it('returns the command unchanged when devBin is empty', () => {
+    const result = applyDevBin('my-cli --flag', {}, monorepoRoot);
+
+    expect(result).toBe('my-cli --flag');
+  });
+
+  it('resolves relative paths in replacement but not flags', () => {
+    const devBin = { build: 'node scripts/build.js --config config/build.json' };
+    const result = applyDevBin('build src/', devBin, monorepoRoot);
+
+    expect(result).toBe('node /repo/scripts/build.js --config /repo/config/build.json src/');
+  });
+
+  it('leaves the runner binary (first token) as-is', () => {
+    const devBin = { 'my-cli': 'tsx packages/cli/index.ts' };
+    const result = applyDevBin('my-cli', devBin, monorepoRoot);
+
+    expect(result).toBe('tsx /repo/packages/cli/index.ts');
+    // tsx should not be resolved — it's the runner binary
+  });
+});
 
 describe('expandScript', () => {
   it('returns a string script unchanged', () => {

--- a/packages/nmr/src/cli.ts
+++ b/packages/nmr/src/cli.ts
@@ -5,7 +5,7 @@ import process from 'node:process';
 
 import { resolveContext } from './context.js';
 import { generateHelp } from './help.js';
-import { buildRootRegistry, buildWorkspaceRegistry, resolveScript } from './resolver.js';
+import { applyDevBin, buildRootRegistry, buildWorkspaceRegistry, resolveScript } from './resolver.js';
 import { runCommand } from './runner.js';
 import { VERSION } from './version.js';
 
@@ -157,7 +157,8 @@ async function main(): Promise<void> {
     console.info(`Using override script: ${resolved.command}`);
   }
 
-  const fullCommand = resolved.command + passthrough;
+  const substitutedCommand = applyDevBin(resolved.command, context.config.devBin, context.monorepoRoot);
+  const fullCommand = substitutedCommand + passthrough;
   const code = runCommand(fullCommand, undefined, runOptions);
   process.exit(code);
 }

--- a/packages/nmr/src/config.ts
+++ b/packages/nmr/src/config.ts
@@ -6,6 +6,7 @@ import { createJiti } from 'jiti';
 import { isObject } from './helpers/type-guards.js';
 
 export interface NmrConfig {
+  devBin?: Record<string, string>;
   workspaceScripts?: Record<string, string | string[]>;
   rootScripts?: Record<string, string | string[]>;
 }
@@ -53,6 +54,30 @@ function validateScriptField(
   return value[fieldName];
 }
 
+/** Narrow an unknown value to a record of plain strings. */
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!isObject(value)) return false;
+  for (const v of Object.values(value)) {
+    if (typeof v !== 'string') return false;
+  }
+  return true;
+}
+
+/** Validate and extract a `Record<string, string>` field from the raw config object. */
+function validateStringRecordField(
+  value: Record<string, unknown>,
+  fieldName: string,
+  configPath: string,
+): Record<string, string> | undefined {
+  if (!(fieldName in value) || value[fieldName] === undefined) {
+    return undefined;
+  }
+  if (!isStringRecord(value[fieldName])) {
+    throw new Error(`Invalid nmr config at ${configPath}: \`${fieldName}\` must be a Record<string, string>`);
+  }
+  return value[fieldName];
+}
+
 /** Validate that a loaded value conforms to the expected `NmrConfig` shape. */
 function validateConfig(value: unknown, configPath: string): NmrConfig {
   if (!isObject(value)) {
@@ -60,6 +85,9 @@ function validateConfig(value: unknown, configPath: string): NmrConfig {
   }
 
   const config: NmrConfig = {};
+
+  const devBin = validateStringRecordField(value, 'devBin', configPath);
+  if (devBin) config.devBin = devBin;
 
   const workspaceScripts = validateScriptField(value, 'workspaceScripts', configPath);
   if (workspaceScripts) config.workspaceScripts = workspaceScripts;

--- a/packages/nmr/src/resolver.ts
+++ b/packages/nmr/src/resolver.ts
@@ -32,6 +32,11 @@ export function applyDevBin(command: string, devBin: Record<string, string> | un
  * Resolve relative paths in a replacement command against `monorepoRoot`.
  * The first token (the runner binary) is left as-is; subsequent tokens
  * that contain `/` and don't start with `-` are resolved.
+ *
+ * Limitations: any non-flag token containing `/` is treated as a path,
+ * which may incorrectly resolve URL-like values or glob patterns.
+ * Tokens using `--flag=path` syntax are skipped entirely because the
+ * leading `-` excludes them; use the spaced form `--flag path` instead.
  */
 function resolveReplacementPaths(replacement: string, monorepoRoot: string): string {
   const tokens = replacement.split(' ');

--- a/packages/nmr/src/resolver.ts
+++ b/packages/nmr/src/resolver.ts
@@ -11,7 +11,7 @@ import { getDefaultRootScripts, getDefaultWorkspaceScripts } from './resolve-scr
  * Relative paths in the replacement are resolved from `monorepoRoot`.
  */
 export function applyDevBin(command: string, devBin: Record<string, string> | undefined, monorepoRoot: string): string {
-  if (!devBin || Object.keys(devBin).length === 0) {
+  if (!devBin) {
     return command;
   }
 

--- a/packages/nmr/src/resolver.ts
+++ b/packages/nmr/src/resolver.ts
@@ -6,6 +6,45 @@ import { isObject } from './helpers/type-guards.js';
 import type { ScriptRegistry, ScriptValue } from './resolve-scripts.js';
 import { getDefaultRootScripts, getDefaultWorkspaceScripts } from './resolve-scripts.js';
 
+/**
+ * Replace the first token of a command with a `devBin` substitute.
+ * Relative paths in the replacement are resolved from `monorepoRoot`.
+ */
+export function applyDevBin(command: string, devBin: Record<string, string> | undefined, monorepoRoot: string): string {
+  if (!devBin || Object.keys(devBin).length === 0) {
+    return command;
+  }
+
+  const spaceIndex = command.indexOf(' ');
+  const firstToken = spaceIndex === -1 ? command : command.slice(0, spaceIndex);
+  const rest = spaceIndex === -1 ? '' : command.slice(spaceIndex);
+
+  const replacement = devBin[firstToken];
+  if (replacement === undefined) {
+    return command;
+  }
+
+  const resolvedReplacement = resolveReplacementPaths(replacement, monorepoRoot);
+  return resolvedReplacement + rest;
+}
+
+/**
+ * Resolve relative paths in a replacement command against `monorepoRoot`.
+ * The first token (the runner binary) is left as-is; subsequent tokens
+ * that contain `/` and don't start with `-` are resolved.
+ */
+function resolveReplacementPaths(replacement: string, monorepoRoot: string): string {
+  const tokens = replacement.split(' ');
+  return tokens
+    .map((token, index) => {
+      if (index === 0) return token;
+      if (token.startsWith('-')) return token;
+      if (!token.includes('/')) return token;
+      return path.resolve(monorepoRoot, token);
+    })
+    .join(' ');
+}
+
 export interface ResolvedScript {
   command: string;
   source: 'default' | 'package';


### PR DESCRIPTION
Closes #78 

## What

Adds a `devBin` config field to nmr that maps binary names to replacement commands, with relative paths resolved from the monorepo root. Documents `":"` as the recommended way to disable a script when `eslint-plugin-package-json/valid-scripts` forbids empty strings.

## Why

When a monorepo is the source for a CLI tool that nmr's default scripts reference, the binary doesn't exist until built. Workarounds required manual `tsx` overrides with different relative paths for root vs workspace contexts. `devBin` eliminates this asymmetry by resolving from a single root-relative path regardless of execution context.

## Details

### Features

- `devBin?: Record<string, string>` field on `NmrConfig` with `validateStringRecordField` validation
- `applyDevBin` function performs first-token substitution: matches the command's first token against `devBin` keys and replaces it with the mapped command while preserving arguments
- `resolveReplacementPaths` resolves relative paths in replacement commands against the monorepo root (first token exempted as the runner binary)
- Wired into `cli.ts` between script resolution and passthrough-arg concatenation; delegated paths (`-R`, `-F`) excluded since child nmr invocations handle their own resolution

### Documentation

- `devBin` section in README with usage example and path-resolution heuristic limitations
- Tip documenting `":"` (POSIX null command) as an alternative to `""` for disabling scripts

### Tests

- 7 `applyDevBin` unit tests: substitution with/without args, no match, undefined/empty map, path resolution, runner-binary preservation with path-like token
- 3 `loadConfig` integration tests: valid `devBin` loaded, invalid non-string value throws, backward compatibility without `devBin`