### PR TITLE
#128 Add severity levels, thresholds, and skip conditions

### DIFF
--- a/.preflight/distribution/nmr.js
+++ b/.preflight/distribution/nmr.js
@@ -13780,6 +13780,7 @@ function date4(params) {
 config(en_default());
 
 // packages/preflight/dist/esm/assertIsPreflightCollection.js
+var SeveritySchema = external_exports.enum(["error", "warn", "recommend"]);
 var FlatChecklistSchema = external_exports.looseObject({
   name: external_exports.string().min(1),
   checks: external_exports.array(external_exports.unknown())
@@ -13792,8 +13793,11 @@ var ChecklistSchema = external_exports.union([FlatChecklistSchema, StagedCheckli
   message: "Checklist cannot have both 'checks' and 'groups'"
 });
 var PreflightCollectionSchema = external_exports.looseObject({
-  fixLocation: external_exports.enum(["INLINE", "END"]).optional(),
   checklists: external_exports.array(ChecklistSchema),
+  defaultSeverity: SeveritySchema.optional(),
+  failOn: SeveritySchema.optional(),
+  fixLocation: external_exports.enum(["inline", "end"]).optional(),
+  reportOn: SeveritySchema.optional(),
   suites: external_exports.record(external_exports.string(), external_exports.array(external_exports.string())).optional()
 });
 

--- a/packages/preflight/__tests__/assertIsPreflightCollection.test.ts
+++ b/packages/preflight/__tests__/assertIsPreflightCollection.test.ts
@@ -134,7 +134,7 @@ describe(assertIsPreflightCollection, () => {
     expect(() =>
       assertIsPreflightCollection({
         checklists: [{ name: 'test', checks: [] }],
-        fixLocation: 'INLINE',
+        fixLocation: 'inline',
       }),
     ).not.toThrow();
   });
@@ -146,5 +146,80 @@ describe(assertIsPreflightCollection, () => {
         fixLocation: 'WRONG',
       }),
     ).toThrow(ZodError);
+  });
+
+  it('throws when fixLocation uses old uppercase casing', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        fixLocation: 'INLINE',
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it('accepts valid defaultSeverity', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        defaultSeverity: 'warn',
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws when defaultSeverity is invalid', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        defaultSeverity: 'critical',
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it('accepts valid failOn', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        failOn: 'recommend',
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws when failOn is invalid', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        failOn: 'none',
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it('accepts valid reportOn', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        reportOn: 'error',
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws when reportOn is invalid', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        reportOn: 'verbose',
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it('accepts a collection with all new fields', () => {
+    expect(() =>
+      assertIsPreflightCollection({
+        checklists: [{ name: 'test', checks: [] }],
+        defaultSeverity: 'warn',
+        failOn: 'warn',
+        reportOn: 'recommend',
+        fixLocation: 'end',
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -628,6 +628,23 @@ describe(runCommand, () => {
       );
     });
 
+    it('falls back to collection reportOn when CLI flag is absent', async () => {
+      const collection = makeCollection({ reportOn: 'warn' });
+      mockLoadPreflightCollection.mockResolvedValue(collection);
+      mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+      await runCommand({
+        names: ['deploy'],
+        collectionSource: { path: '.config/preflight/collections/default.ts' },
+        json: false,
+      });
+
+      expect(mockReportPreflight).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ reportOn: 'warn' }),
+      );
+    });
+
     it('passes reportOn to reportPreflight', async () => {
       const collection = makeCollection();
       mockLoadPreflightCollection.mockResolvedValue(collection);

--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -18,7 +18,12 @@ vi.mock('../src/config.ts', () => ({
 vi.mock('../src/runPreflight.ts', () => ({
   meetsThreshold: (severity: string, threshold: string) => {
     const rank: Record<string, number> = { error: 0, warn: 1, recommend: 2 };
-    return (rank[severity] ?? 0) <= (rank[threshold] ?? 0);
+    const severityRank = rank[severity];
+    const thresholdRank = rank[threshold];
+    if (severityRank === undefined || thresholdRank === undefined) {
+      throw new Error(`Invalid severity in meetsThreshold mock: severity="${severity}", threshold="${threshold}"`);
+    }
+    return severityRank <= thresholdRank;
   },
   runPreflight: mockRunPreflight,
 }));
@@ -346,7 +351,7 @@ describe(runCommand, () => {
     expect(mockRunPreflight).toHaveBeenCalledTimes(1);
     expect(mockRunPreflight).toHaveBeenCalledWith(
       collection.checklists[0],
-      expect.objectContaining({ defaultSeverity: 'error', failOn: 'error', reportOn: 'recommend' }),
+      expect.objectContaining({ defaultSeverity: 'error', failOn: 'error' }),
     );
     expect(exitCode).toBe(0);
   });

--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -16,6 +16,10 @@ vi.mock('../src/config.ts', () => ({
 }));
 
 vi.mock('../src/runPreflight.ts', () => ({
+  meetsThreshold: (severity: string, threshold: string) => {
+    const rank: Record<string, number> = { error: 0, warn: 1, recommend: 2 };
+    return (rank[severity] ?? 0) <= (rank[threshold] ?? 0);
+  },
   runPreflight: mockRunPreflight,
 }));
 
@@ -235,6 +239,59 @@ describe(parseRunArgs, () => {
       '--collection cannot be used with --url',
     );
   });
+
+  // --fail-on flag
+  it('parses --fail-on with valid severity', () => {
+    const result = parseRunArgs(['--fail-on', 'warn']);
+
+    expect(result.failOn).toBe('warn');
+  });
+
+  it('parses --fail-on= syntax', () => {
+    const result = parseRunArgs(['--fail-on=recommend']);
+
+    expect(result.failOn).toBe('recommend');
+  });
+
+  it('throws when --fail-on has an invalid value', () => {
+    expect(() => parseRunArgs(['--fail-on', 'critical'])).toThrow(
+      '--fail-on must be one of: error, warn, recommend (got "critical")',
+    );
+  });
+
+  it('throws when --fail-on has no value', () => {
+    expect(() => parseRunArgs(['--fail-on'])).toThrow('--fail-on requires a severity level');
+  });
+
+  // --report-on flag
+  it('parses --report-on with valid severity', () => {
+    const result = parseRunArgs(['--report-on', 'error']);
+
+    expect(result.reportOn).toBe('error');
+  });
+
+  it('parses --report-on= syntax', () => {
+    const result = parseRunArgs(['--report-on=warn']);
+
+    expect(result.reportOn).toBe('warn');
+  });
+
+  it('throws when --report-on has an invalid value', () => {
+    expect(() => parseRunArgs(['--report-on', 'debug'])).toThrow(
+      '--report-on must be one of: error, warn, recommend (got "debug")',
+    );
+  });
+
+  it('throws when --report-on has no value', () => {
+    expect(() => parseRunArgs(['--report-on'])).toThrow('--report-on requires a severity level');
+  });
+
+  it('omits failOn and reportOn when not specified', () => {
+    const result = parseRunArgs([]);
+
+    expect(result).not.toHaveProperty('failOn');
+    expect(result).not.toHaveProperty('reportOn');
+  });
 });
 
 describe(runCommand, () => {
@@ -287,7 +344,10 @@ describe(runCommand, () => {
     });
 
     expect(mockRunPreflight).toHaveBeenCalledTimes(1);
-    expect(mockRunPreflight).toHaveBeenCalledWith(collection.checklists[0]);
+    expect(mockRunPreflight).toHaveBeenCalledWith(
+      collection.checklists[0],
+      expect.objectContaining({ defaultSeverity: 'error', failOn: 'error', reportOn: 'recommend' }),
+    );
     expect(exitCode).toBe(0);
   });
 
@@ -368,8 +428,8 @@ describe(runCommand, () => {
 
   it('uses per-checklist fixLocation over collection default', async () => {
     const collection = makeCollection({
-      fixLocation: 'END',
-      checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }], fixLocation: 'INLINE' }],
+      fixLocation: 'end',
+      checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }], fixLocation: 'inline' }],
     });
     mockLoadPreflightCollection.mockResolvedValue(collection);
     mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
@@ -380,12 +440,15 @@ describe(runCommand, () => {
       json: false,
     });
 
-    expect(mockReportPreflight).toHaveBeenCalledWith(expect.anything(), { fixLocation: 'INLINE' });
+    expect(mockReportPreflight).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ fixLocation: 'inline' }),
+    );
   });
 
   it('falls back to collection-level fixLocation when checklist has none', async () => {
     const collection = makeCollection({
-      fixLocation: 'END',
+      fixLocation: 'end',
       checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }],
     });
     mockLoadPreflightCollection.mockResolvedValue(collection);
@@ -397,7 +460,10 @@ describe(runCommand, () => {
       json: false,
     });
 
-    expect(mockReportPreflight).toHaveBeenCalledWith(expect.anything(), { fixLocation: 'END' });
+    expect(mockReportPreflight).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ fixLocation: 'end' }),
+    );
   });
 
   it('reports collection loading errors to stderr', async () => {
@@ -417,7 +483,19 @@ describe(runCommand, () => {
     const collection = makeCollection();
     mockLoadPreflightCollection.mockResolvedValue(collection);
     mockRunPreflight.mockResolvedValue({
-      results: [{ name: 'a', status: 'passed', durationMs: 10 }],
+      results: [
+        {
+          name: 'a',
+          status: 'passed',
+          ok: true,
+          severity: 'error',
+          detail: null,
+          fix: null,
+          error: null,
+          progress: null,
+          durationMs: 10,
+        },
+      ],
       passed: true,
       durationMs: 10,
     });
@@ -455,14 +533,47 @@ describe(runCommand, () => {
     mockRunPreflight
       .mockResolvedValueOnce({
         results: [
-          { name: 'a', status: 'passed', durationMs: 10 },
-          { name: 'b', status: 'failed', durationMs: 5 },
+          {
+            name: 'a',
+            status: 'passed',
+            ok: true,
+            severity: 'error',
+            detail: null,
+            fix: null,
+            error: null,
+            progress: null,
+            durationMs: 10,
+          },
+          {
+            name: 'b',
+            status: 'failed',
+            ok: false,
+            severity: 'error',
+            detail: null,
+            fix: null,
+            error: null,
+            progress: null,
+            durationMs: 5,
+          },
         ],
         passed: false,
         durationMs: 15,
       })
       .mockResolvedValueOnce({
-        results: [{ name: 'c', status: 'skipped', durationMs: 0 }],
+        results: [
+          {
+            name: 'c',
+            status: 'skipped',
+            ok: null,
+            severity: 'error',
+            skipReason: 'precondition',
+            detail: null,
+            fix: null,
+            error: null,
+            progress: null,
+            durationMs: 0,
+          },
+        ],
         passed: false,
         durationMs: 0,
       });
@@ -477,6 +588,77 @@ describe(runCommand, () => {
       expect.objectContaining({ name: 'deploy', passed: 1, failed: 1, skipped: 0, allPassed: false }),
       expect.objectContaining({ name: 'infra', passed: 0, failed: 0, skipped: 1, allPassed: false }),
     ]);
+  });
+
+  describe('threshold cascade', () => {
+    it('uses CLI --fail-on flag over collection default', async () => {
+      const collection = makeCollection({ failOn: 'error' });
+      mockLoadPreflightCollection.mockResolvedValue(collection);
+      mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+      await runCommand({
+        names: ['deploy'],
+        collectionSource: { path: '.config/preflight/collections/default.ts' },
+        json: false,
+        failOn: 'warn',
+      });
+
+      expect(mockRunPreflight).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ failOn: 'warn' }));
+    });
+
+    it('falls back to collection failOn when CLI flag is absent', async () => {
+      const collection = makeCollection({ failOn: 'recommend' });
+      mockLoadPreflightCollection.mockResolvedValue(collection);
+      mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+      await runCommand({
+        names: ['deploy'],
+        collectionSource: { path: '.config/preflight/collections/default.ts' },
+        json: false,
+      });
+
+      expect(mockRunPreflight).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ failOn: 'recommend' }),
+      );
+    });
+
+    it('passes reportOn to reportPreflight', async () => {
+      const collection = makeCollection();
+      mockLoadPreflightCollection.mockResolvedValue(collection);
+      mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+      await runCommand({
+        names: ['deploy'],
+        collectionSource: { path: '.config/preflight/collections/default.ts' },
+        json: false,
+        reportOn: 'warn',
+      });
+
+      expect(mockReportPreflight).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ reportOn: 'warn' }),
+      );
+    });
+
+    it('passes reportOn to formatJsonReport', async () => {
+      const collection = makeCollection();
+      mockLoadPreflightCollection.mockResolvedValue(collection);
+      mockRunPreflight.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+      mockFormatJsonReport.mockReturnValue('{"allPassed":true}');
+
+      await runCommand({
+        names: ['deploy'],
+        collectionSource: { path: '.config/preflight/collections/default.ts' },
+        json: true,
+        reportOn: 'error',
+      });
+
+      expect(mockFormatJsonReport).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ reportOn: 'error' }),
+      );
+    });
   });
 
   describe('JSON mode', () => {
@@ -562,10 +744,13 @@ describe(runCommand, () => {
         json: true,
       });
 
-      expect(mockFormatJsonReport).toHaveBeenCalledWith([
-        { name: 'deploy', report: report1 },
-        { name: 'infra', report: report2 },
-      ]);
+      expect(mockFormatJsonReport).toHaveBeenCalledWith(
+        [
+          { name: 'deploy', report: report1 },
+          { name: 'infra', report: report2 },
+        ],
+        expect.objectContaining({ reportOn: 'recommend' }),
+      );
     });
 
     it('emits JSON error to stdout when runPreflight throws', async () => {

--- a/packages/preflight/__tests__/config.test.ts
+++ b/packages/preflight/__tests__/config.test.ts
@@ -140,11 +140,11 @@ describe(loadPreflightCollection, () => {
   it('loads a collection from a default export with fixLocation', async () => {
     const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
     mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ default: { checklists: validChecklists, fixLocation: 'INLINE' } });
+    mockJitiImport.mockResolvedValue({ default: { checklists: validChecklists, fixLocation: 'inline' } });
 
     const collection = await loadPreflightCollection();
 
-    expect(collection.fixLocation).toBe('INLINE');
+    expect(collection.fixLocation).toBe('inline');
   });
 
   it('returns a valid collection with flat checklists', async () => {
@@ -161,11 +161,11 @@ describe(loadPreflightCollection, () => {
   it('carries through fixLocation when present', async () => {
     const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
     mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ checklists: validChecklists, fixLocation: 'INLINE' });
+    mockJitiImport.mockResolvedValue({ checklists: validChecklists, fixLocation: 'inline' });
 
     const collection = await loadPreflightCollection();
 
-    expect(collection.fixLocation).toBe('INLINE');
+    expect(collection.fixLocation).toBe('inline');
   });
 
   it('omits fixLocation when the module does not export it', async () => {

--- a/packages/preflight/__tests__/formatJsonReport.test.ts
+++ b/packages/preflight/__tests__/formatJsonReport.test.ts
@@ -1,9 +1,55 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatJsonReport } from '../src/formatJsonReport.ts';
-import type { PreflightReport } from '../src/types.ts';
+import type { FailedResult, PassedResult, PreflightReport, PreflightResult, SkippedResult } from '../src/types.ts';
 
-function makeReport(overrides?: Partial<PreflightReport>): PreflightReport {
+function makePassedResult(overrides?: Partial<PassedResult>): PassedResult {
+  return {
+    name: 'check',
+    status: 'passed',
+    ok: true,
+    severity: 'error',
+    detail: null,
+    fix: null,
+    error: null,
+    progress: null,
+    durationMs: 10,
+    ...overrides,
+  };
+}
+
+function makeFailedResult(overrides?: Partial<FailedResult>): FailedResult {
+  return {
+    name: 'check',
+    status: 'failed',
+    ok: false,
+    severity: 'error',
+    detail: null,
+    fix: null,
+    error: null,
+    progress: null,
+    durationMs: 5,
+    ...overrides,
+  };
+}
+
+function makeSkippedResult(overrides?: Partial<SkippedResult>): SkippedResult {
+  return {
+    name: 'check',
+    status: 'skipped',
+    ok: null,
+    severity: 'error',
+    skipReason: 'precondition',
+    detail: null,
+    fix: null,
+    error: null,
+    progress: null,
+    durationMs: 0,
+    ...overrides,
+  };
+}
+
+function makeReport(overrides?: Partial<PreflightReport> & { results?: PreflightResult[] }): PreflightReport {
   return { results: [], passed: true, durationMs: 0, ...overrides };
 }
 
@@ -18,11 +64,7 @@ describe(formatJsonReport, () => {
 
   it('returns correct summary counts for a single checklist', () => {
     const report = makeReport({
-      results: [
-        { name: 'a', status: 'passed', durationMs: 10 },
-        { name: 'b', status: 'failed', durationMs: 5 },
-        { name: 'c', status: 'skipped', durationMs: 0 },
-      ],
+      results: [makePassedResult({ name: 'a' }), makeFailedResult({ name: 'b' }), makeSkippedResult({ name: 'c' })],
       passed: false,
       durationMs: 15,
     });
@@ -30,24 +72,21 @@ describe(formatJsonReport, () => {
     const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
 
     expect(parsed).toMatchObject({
-      passedCount: 1,
-      failedCount: 1,
-      skippedCount: 1,
+      passed: 1,
+      failed: 1,
+      skipped: 1,
       allPassed: false,
     });
   });
 
   it('aggregates counts across multiple checklists', () => {
     const report1 = makeReport({
-      results: [
-        { name: 'a', status: 'passed', durationMs: 10 },
-        { name: 'b', status: 'passed', durationMs: 5 },
-      ],
+      results: [makePassedResult({ name: 'a' }), makePassedResult({ name: 'b' })],
       passed: true,
       durationMs: 15,
     });
     const report2 = makeReport({
-      results: [{ name: 'c', status: 'failed', durationMs: 3 }],
+      results: [makeFailedResult({ name: 'c' })],
       passed: false,
       durationMs: 3,
     });
@@ -60,9 +99,9 @@ describe(formatJsonReport, () => {
     );
 
     expect(parsed).toMatchObject({
-      passedCount: 2,
-      failedCount: 1,
-      skippedCount: 0,
+      passed: 2,
+      failed: 1,
+      skipped: 0,
       allPassed: false,
       checklists: expect.arrayContaining([expect.anything(), expect.anything()]),
     });
@@ -70,7 +109,7 @@ describe(formatJsonReport, () => {
 
   it('includes checklist-level allPassed and counts', () => {
     const report = makeReport({
-      results: [{ name: 'a', status: 'passed', durationMs: 10 }],
+      results: [makePassedResult({ name: 'a' })],
       passed: true,
       durationMs: 10,
     });
@@ -82,9 +121,9 @@ describe(formatJsonReport, () => {
         {
           name: 'deploy',
           allPassed: true,
-          passedCount: 1,
-          failedCount: 0,
-          skippedCount: 0,
+          passed: 1,
+          failed: 0,
+          skipped: 0,
           durationMs: 10,
         },
       ],
@@ -93,10 +132,7 @@ describe(formatJsonReport, () => {
 
   it('sets top-level allPassed to true when checks are skipped but none failed', () => {
     const report = makeReport({
-      results: [
-        { name: 'a', status: 'skipped', durationMs: 0 },
-        { name: 'b', status: 'skipped', durationMs: 0 },
-      ],
+      results: [makeSkippedResult({ name: 'a' }), makeSkippedResult({ name: 'b' })],
       passed: true,
       durationMs: 0,
     });
@@ -105,15 +141,15 @@ describe(formatJsonReport, () => {
 
     expect(parsed).toMatchObject({
       allPassed: true,
-      passedCount: 0,
-      failedCount: 0,
-      skippedCount: 2,
+      passed: 0,
+      failed: 0,
+      skipped: 2,
     });
   });
 
   it('emits the expected top-level shape with no summary wrapper', () => {
     const report = makeReport({
-      results: [{ name: 'a', status: 'passed', durationMs: 10 }],
+      results: [makePassedResult({ name: 'a' })],
       passed: true,
       durationMs: 10,
     });
@@ -123,19 +159,12 @@ describe(formatJsonReport, () => {
     // eslint-disable-next-line unicorn/no-array-sort -- toSorted requires Node 20+; engine target is >=18.17.0
     const topLevelKeys = Object.keys(parsed).sort();
 
-    expect(topLevelKeys).toStrictEqual([
-      'allPassed',
-      'checklists',
-      'durationMs',
-      'failedCount',
-      'passedCount',
-      'skippedCount',
-    ]);
+    expect(topLevelKeys).toStrictEqual(['allPassed', 'checklists', 'durationMs', 'failed', 'passed', 'skipped']);
   });
 
   it('serializes error as a string message', () => {
     const report = makeReport({
-      results: [{ name: 'a', status: 'failed', error: new Error('connection refused'), durationMs: 5 }],
+      results: [makeFailedResult({ name: 'a', error: new Error('connection refused') })],
       passed: false,
       durationMs: 5,
     });
@@ -147,32 +176,72 @@ describe(formatJsonReport, () => {
     });
   });
 
-  it('omits optional fields when undefined', () => {
+  it('includes all fields as non-optional (null, not absent)', () => {
     const report = makeReport({
-      results: [{ name: 'a', status: 'passed', durationMs: 10 }],
+      results: [makePassedResult({ name: 'a' })],
       passed: true,
       durationMs: 10,
     });
 
     const output = formatJsonReport([{ name: 'deploy', report }]);
+    const parsed: unknown = JSON.parse(output);
 
-    expect(output).not.toContain('"fix"');
-    expect(output).not.toContain('"error"');
-    expect(output).not.toContain('"detail"');
-    expect(output).not.toContain('"progress"');
+    expect(parsed).toMatchObject({
+      checklists: [
+        {
+          checks: [
+            {
+              name: 'a',
+              status: 'passed',
+              ok: true,
+              severity: 'error',
+              skipReason: null,
+              detail: null,
+              fix: null,
+              error: null,
+              progress: null,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('includes severity, ok, and skipReason on every check entry', () => {
+    const report = makeReport({
+      results: [
+        makePassedResult({ name: 'a', severity: 'warn' }),
+        makeFailedResult({ name: 'b', severity: 'error' }),
+        makeSkippedResult({ name: 'c', severity: 'recommend', skipReason: 'n/a' }),
+      ],
+      passed: false,
+      durationMs: 15,
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+    expect(parsed).toMatchObject({
+      checklists: [
+        {
+          checks: [
+            { severity: 'warn', ok: true, skipReason: null },
+            { severity: 'error', ok: false, skipReason: null },
+            { severity: 'recommend', ok: null, skipReason: 'n/a' },
+          ],
+        },
+      ],
+    });
   });
 
   it('includes optional fields when present', () => {
     const report = makeReport({
       results: [
-        {
+        makeFailedResult({
           name: 'a',
-          status: 'failed',
           fix: 'run npm install',
           detail: 'missing dependency',
           progress: { type: 'fraction', passedCount: 3, count: 5 },
-          durationMs: 10,
-        },
+        }),
       ],
       passed: false,
       durationMs: 10,
@@ -198,12 +267,10 @@ describe(formatJsonReport, () => {
   it('serializes percent-based progress', () => {
     const report = makeReport({
       results: [
-        {
+        makePassedResult({
           name: 'a',
-          status: 'passed',
           progress: { type: 'percent', percent: 75 },
-          durationMs: 10,
-        },
+        }),
       ],
       passed: true,
       durationMs: 10,
@@ -213,6 +280,44 @@ describe(formatJsonReport, () => {
 
     expect(parsed).toMatchObject({
       checklists: [{ checks: [{ progress: { type: 'percent', percent: 75 } }] }],
+    });
+  });
+
+  describe('reporting threshold', () => {
+    it('excludes results below the reporting threshold', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'error-check', severity: 'error' }),
+          makePassedResult({ name: 'recommend-check', severity: 'recommend' }),
+        ],
+        passed: true,
+        durationMs: 20,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }], { reportOn: 'error' }));
+
+      expect(parsed).toMatchObject({
+        checklists: [{ checks: [{ name: 'error-check' }] }],
+      });
+    });
+
+    it('counts only visible results', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'a', severity: 'error' }),
+          makeFailedResult({ name: 'b', severity: 'recommend' }),
+        ],
+        passed: false,
+        durationMs: 15,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }], { reportOn: 'error' }));
+
+      expect(parsed).toMatchObject({
+        passed: 1,
+        failed: 0,
+        skipped: 0,
+      });
     });
   });
 });

--- a/packages/preflight/__tests__/loadRemoteCollection.validation.test.ts
+++ b/packages/preflight/__tests__/loadRemoteCollection.validation.test.ts
@@ -49,7 +49,7 @@ describe('loadRemoteCollection validation', () => {
 
   it('carries through fixLocation when exported', async () => {
     const jsBody = `
-      export const fixLocation = 'INLINE';
+      export const fixLocation = 'inline';
       export const checklists = [
         { name: 'test', checks: [{ name: 'check-a', check: () => true }] },
       ];
@@ -58,7 +58,7 @@ describe('loadRemoteCollection validation', () => {
 
     const collection = await loadRemoteCollection({ url: 'https://example.com/config.js' });
 
-    expect(collection.fixLocation).toBe('INLINE');
+    expect(collection.fixLocation).toBe('inline');
   });
 
   it('omits fixLocation when not exported', async () => {

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -1,9 +1,55 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatSummaryCounts, reportPreflight } from '../src/reportPreflight.ts';
-import type { PreflightReport } from '../src/types.ts';
+import type { FailedResult, PassedResult, PreflightReport, PreflightResult, SkippedResult } from '../src/types.ts';
 
-function makeReport(overrides?: Partial<PreflightReport>): PreflightReport {
+function makePassedResult(overrides?: Partial<PassedResult>): PassedResult {
+  return {
+    name: 'check',
+    status: 'passed',
+    ok: true,
+    severity: 'error',
+    detail: null,
+    fix: null,
+    error: null,
+    progress: null,
+    durationMs: 10,
+    ...overrides,
+  };
+}
+
+function makeFailedResult(overrides?: Partial<FailedResult>): FailedResult {
+  return {
+    name: 'check',
+    status: 'failed',
+    ok: false,
+    severity: 'error',
+    detail: null,
+    fix: null,
+    error: null,
+    progress: null,
+    durationMs: 5,
+    ...overrides,
+  };
+}
+
+function makeSkippedResult(overrides?: Partial<SkippedResult>): SkippedResult {
+  return {
+    name: 'check',
+    status: 'skipped',
+    ok: null,
+    severity: 'error',
+    skipReason: 'precondition',
+    detail: null,
+    fix: null,
+    error: null,
+    progress: null,
+    durationMs: 0,
+    ...overrides,
+  };
+}
+
+function makeReport(overrides?: Partial<PreflightReport> & { results?: PreflightResult[] }): PreflightReport {
   return {
     results: [],
     passed: true,
@@ -13,9 +59,9 @@ function makeReport(overrides?: Partial<PreflightReport>): PreflightReport {
 }
 
 describe(reportPreflight, () => {
-  it('shows passed checks with checkmark icon', () => {
+  it('shows passed checks with green circle icon', () => {
     const report = makeReport({
-      results: [{ name: 'check-a', status: 'passed', durationMs: 10 }],
+      results: [makePassedResult({ name: 'check-a', durationMs: 10 })],
     });
 
     const output = reportPreflight(report);
@@ -23,9 +69,9 @@ describe(reportPreflight, () => {
     expect(output).toContain('\u{1F7E2} check-a (10ms)');
   });
 
-  it('shows failed checks with cross icon', () => {
+  it('shows error-failed checks with red circle icon', () => {
     const report = makeReport({
-      results: [{ name: 'check-b', status: 'failed', durationMs: 5 }],
+      results: [makeFailedResult({ name: 'check-b', severity: 'error' })],
       passed: false,
     });
 
@@ -34,22 +80,54 @@ describe(reportPreflight, () => {
     expect(output).toContain('\u{1F534} check-b (5ms)');
   });
 
-  it('shows skipped checks with circle icon', () => {
+  it('shows warn-failed checks with orange circle icon', () => {
     const report = makeReport({
-      results: [{ name: 'check-c', status: 'skipped', durationMs: 0 }],
+      results: [makeFailedResult({ name: 'check-warn', severity: 'warn' })],
+      passed: false,
     });
 
     const output = reportPreflight(report);
 
-    expect(output).toContain('\u26D4 check-c (0ms)');
+    expect(output).toContain('\u{1F7E0} check-warn (5ms)');
+  });
+
+  it('shows recommend-failed checks with yellow circle icon', () => {
+    const report = makeReport({
+      results: [makeFailedResult({ name: 'check-rec', severity: 'recommend' })],
+      passed: false,
+    });
+
+    const output = reportPreflight(report);
+
+    expect(output).toContain('\u{1F7E1} check-rec (5ms)');
+  });
+
+  it('shows n/a-skipped checks with white circle icon', () => {
+    const report = makeReport({
+      results: [makeSkippedResult({ name: 'check-na', skipReason: 'n/a' })],
+    });
+
+    const output = reportPreflight(report);
+
+    expect(output).toContain('\u26AA check-na (0ms)');
+  });
+
+  it('shows precondition-skipped checks with no-entry icon', () => {
+    const report = makeReport({
+      results: [makeSkippedResult({ name: 'check-pre', skipReason: 'precondition' })],
+    });
+
+    const output = reportPreflight(report);
+
+    expect(output).toContain('\u26D4 check-pre (0ms)');
   });
 
   it('renders the summary line', () => {
     const report = makeReport({
       results: [
-        { name: 'a', status: 'passed', durationMs: 10 },
-        { name: 'b', status: 'failed', durationMs: 20 },
-        { name: 'c', status: 'skipped', durationMs: 0 },
+        makePassedResult({ name: 'a', durationMs: 10 }),
+        makeFailedResult({ name: 'b', durationMs: 20 }),
+        makeSkippedResult({ name: 'c' }),
       ],
       passed: false,
       durationMs: 142,
@@ -57,133 +135,102 @@ describe(reportPreflight, () => {
 
     const output = reportPreflight(report);
 
-    expect(output).toContain('🟢 1 passed, 🔴 1 failed, ⛔ 1 skipped (142ms)');
+    expect(output).toContain('\u{1F7E2} 1 passed, \u{1F534} 1 failed, \u26D4 1 skipped (142ms)');
   });
 
   it('omits zero counts from the summary line', () => {
     const report = makeReport({
-      results: [
-        { name: 'a', status: 'passed', durationMs: 10 },
-        { name: 'b', status: 'passed', durationMs: 15 },
-      ],
+      results: [makePassedResult({ name: 'a', durationMs: 10 }), makePassedResult({ name: 'b', durationMs: 15 })],
       durationMs: 25,
     });
 
     const output = reportPreflight(report);
 
-    expect(output).toContain('🟢 2 passed (25ms)');
+    expect(output).toContain('\u{1F7E2} 2 passed (25ms)');
     expect(output).not.toContain('failed');
     expect(output).not.toContain('skipped');
   });
 
-  describe('INLINE mode', () => {
+  describe('inline mode', () => {
     it('shows error and fix below failed check', () => {
       const report = makeReport({
         results: [
-          {
+          makeFailedResult({
             name: 'broken',
-            status: 'failed',
             error: new Error('Something went wrong'),
             fix: 'Run npm install',
-            durationMs: 5,
-          },
+          }),
         ],
         passed: false,
       });
 
-      const output = reportPreflight(report, { fixLocation: 'INLINE' });
+      const output = reportPreflight(report, { fixLocation: 'inline' });
       const lines = output.split('\n');
 
       expect(output).toContain('Error: Something went wrong');
       expect(output).toContain('Fix: Run npm install');
 
-      // Error line must immediately follow the check line (no blank line)
       const checkLineIndex = lines.findIndex((l) => l.includes('broken'));
       const errorLineIndex = lines.findIndex((l) => l.includes('Error: Something went wrong'));
       expect(errorLineIndex).toBe(checkLineIndex + 1);
     });
 
-    it('shows fix without error when error is absent', () => {
+    it('shows fix without error when error is null', () => {
       const report = makeReport({
-        results: [
-          {
-            name: 'broken',
-            status: 'failed',
-            fix: 'Run npm install',
-            durationMs: 5,
-          },
-        ],
+        results: [makeFailedResult({ name: 'broken', fix: 'Run npm install' })],
         passed: false,
       });
 
-      const output = reportPreflight(report, { fixLocation: 'INLINE' });
+      const output = reportPreflight(report, { fixLocation: 'inline' });
 
       expect(output).toContain('Fix: Run npm install');
       expect(output).not.toContain('Error:');
     });
 
-    it('shows error without fix when fix is absent', () => {
+    it('shows error without fix when fix is null', () => {
       const report = makeReport({
-        results: [
-          {
-            name: 'broken',
-            status: 'failed',
-            error: new Error('Missing file'),
-            durationMs: 5,
-          },
-        ],
+        results: [makeFailedResult({ name: 'broken', error: new Error('Missing file') })],
         passed: false,
       });
 
-      const output = reportPreflight(report, { fixLocation: 'INLINE' });
+      const output = reportPreflight(report, { fixLocation: 'inline' });
 
       expect(output).toContain('Error: Missing file');
       expect(output).not.toContain('Fix:');
     });
   });
 
-  describe('END mode', () => {
+  describe('end mode', () => {
     it('shows error inline and collects fixes at the bottom', () => {
       const report = makeReport({
         results: [
-          {
+          makeFailedResult({
             name: 'broken',
-            status: 'failed',
             error: new Error('Bad config'),
             fix: 'Update config file',
-            durationMs: 5,
-          },
+          }),
         ],
         passed: false,
       });
 
-      const output = reportPreflight(report, { fixLocation: 'END' });
+      const output = reportPreflight(report, { fixLocation: 'end' });
 
-      // Error should appear right after the check line
       const lines = output.split('\n');
       const errorLineIndex = lines.findIndex((l) => l.includes('Error: Bad config'));
       const checkLineIndex = lines.findIndex((l) => l.includes('broken'));
       expect(errorLineIndex).toBe(checkLineIndex + 1);
 
-      // Fix should appear in a Fixes section at the bottom
       expect(output).toContain('Fixes:');
       expect(output).toContain('  Update config file');
     });
 
     it('omits Fixes section when no fixes are present', () => {
       const report = makeReport({
-        results: [
-          {
-            name: 'broken',
-            status: 'failed',
-            error: new Error('Unknown error'),
-            durationMs: 5,
-          },
-        ],
+        results: [makeFailedResult({ name: 'broken', error: new Error('Unknown error') })],
         passed: false,
       });
 
-      const output = reportPreflight(report, { fixLocation: 'END' });
+      const output = reportPreflight(report, { fixLocation: 'end' });
 
       expect(output).toContain('Error: Unknown error');
       expect(output).not.toContain('Fixes:');
@@ -193,7 +240,7 @@ describe(reportPreflight, () => {
   describe('detail and progress rendering', () => {
     it('renders detail inline after duration', () => {
       const report = makeReport({
-        results: [{ name: 'check-a', status: 'passed', durationMs: 10, detail: 'some info' }],
+        results: [makePassedResult({ name: 'check-a', durationMs: 10, detail: 'some info' })],
       });
 
       const output = reportPreflight(report);
@@ -204,12 +251,10 @@ describe(reportPreflight, () => {
     it('renders fraction progress', () => {
       const report = makeReport({
         results: [
-          {
+          makeFailedResult({
             name: 'check-b',
-            status: 'failed',
-            durationMs: 5,
             progress: { type: 'fraction', passedCount: 7, count: 10 },
-          },
+          }),
         ],
         passed: false,
       });
@@ -221,7 +266,7 @@ describe(reportPreflight, () => {
 
     it('renders percent progress', () => {
       const report = makeReport({
-        results: [{ name: 'check-c', status: 'failed', durationMs: 3, progress: { type: 'percent', percent: 85 } }],
+        results: [makeFailedResult({ name: 'check-c', durationMs: 3, progress: { type: 'percent', percent: 85 } })],
         passed: false,
       });
 
@@ -233,13 +278,11 @@ describe(reportPreflight, () => {
     it('renders both detail and progress as separate segments', () => {
       const report = makeReport({
         results: [
-          {
+          makeFailedResult({
             name: 'check-d',
-            status: 'failed',
-            durationMs: 5,
             detail: 'some detail',
             progress: { type: 'fraction', passedCount: 7, count: 10 },
-          },
+          }),
         ],
         passed: false,
       });
@@ -252,13 +295,12 @@ describe(reportPreflight, () => {
     it('renders detail and progress on passing checks', () => {
       const report = makeReport({
         results: [
-          {
+          makePassedResult({
             name: 'check-e',
-            status: 'passed',
             durationMs: 2,
             detail: 'all good',
             progress: { type: 'percent', percent: 100 },
-          },
+          }),
         ],
       });
 
@@ -267,9 +309,9 @@ describe(reportPreflight, () => {
       expect(output).toContain('\u{1F7E2} check-e (2ms) \u2014 all good \u2014 100%');
     });
 
-    it('omits detail segment when detail is undefined', () => {
+    it('omits detail segment when detail is null', () => {
       const report = makeReport({
-        results: [{ name: 'check-f', status: 'passed', durationMs: 1 }],
+        results: [makePassedResult({ name: 'check-f', durationMs: 1 })],
       });
 
       const output = reportPreflight(report);
@@ -279,16 +321,14 @@ describe(reportPreflight, () => {
     });
   });
 
-  it('defaults to END mode when no options are provided', () => {
+  it('defaults to end mode when no options are provided', () => {
     const report = makeReport({
       results: [
-        {
+        makeFailedResult({
           name: 'broken',
-          status: 'failed',
           error: new Error('Oops'),
           fix: 'Fix it',
-          durationMs: 5,
-        },
+        }),
       ],
       passed: false,
     });
@@ -299,19 +339,60 @@ describe(reportPreflight, () => {
     expect(output).toContain('  Fix it');
     expect(output).not.toContain('Fix: Fix it');
   });
+
+  describe('reporting threshold', () => {
+    it('excludes results below the reporting threshold', () => {
+      const report = makeReport({
+        results: [
+          makeFailedResult({ name: 'error-check', severity: 'error' }),
+          makeFailedResult({ name: 'recommend-check', severity: 'recommend' }),
+        ],
+        passed: false,
+      });
+
+      const output = reportPreflight(report, { reportOn: 'error' });
+
+      expect(output).toContain('error-check');
+      expect(output).not.toContain('recommend-check');
+    });
+
+    it('counts only visible results in the summary', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'error-pass', severity: 'error' }),
+          makePassedResult({ name: 'recommend-pass', severity: 'recommend' }),
+        ],
+      });
+
+      const output = reportPreflight(report, { reportOn: 'error' });
+
+      expect(output).toContain('\u{1F7E2} 1 passed');
+      expect(output).not.toContain('2 passed');
+    });
+
+    it('defaults reportOn to recommend (show all)', () => {
+      const report = makeReport({
+        results: [makePassedResult({ name: 'recommend-check', severity: 'recommend' })],
+      });
+
+      const output = reportPreflight(report);
+
+      expect(output).toContain('recommend-check');
+    });
+  });
 });
 
 describe(formatSummaryCounts, () => {
   it('includes all non-zero counts with icons', () => {
-    expect(formatSummaryCounts(3, 1, 2)).toBe('🟢 3 passed, 🔴 1 failed, ⛔ 2 skipped');
+    expect(formatSummaryCounts(3, 1, 2)).toBe('\u{1F7E2} 3 passed, \u{1F534} 1 failed, \u26D4 2 skipped');
   });
 
   it('omits zero counts', () => {
-    expect(formatSummaryCounts(5, 0, 0)).toBe('🟢 5 passed');
+    expect(formatSummaryCounts(5, 0, 0)).toBe('\u{1F7E2} 5 passed');
   });
 
   it('omits passed when zero', () => {
-    expect(formatSummaryCounts(0, 2, 1)).toBe('🔴 2 failed, ⛔ 1 skipped');
+    expect(formatSummaryCounts(0, 2, 1)).toBe('\u{1F534} 2 failed, \u26D4 1 skipped');
   });
 
   it('returns empty string when all counts are zero', () => {

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -370,6 +370,35 @@ describe(reportPreflight, () => {
       expect(output).not.toContain('2 passed');
     });
 
+    it('hides precondition result when its severity is below the reporting threshold', () => {
+      const report = makeReport({
+        results: [
+          makeSkippedResult({ name: 'precond', severity: 'recommend', skipReason: 'precondition' }),
+          makeFailedResult({ name: 'error-check', severity: 'error' }),
+        ],
+        passed: false,
+      });
+
+      const output = reportPreflight(report, { reportOn: 'error' });
+
+      expect(output).toContain('error-check');
+      expect(output).not.toContain('precond');
+    });
+
+    it('shows only skipped dependents whose severity meets the reporting threshold', () => {
+      const report = makeReport({
+        results: [
+          makeSkippedResult({ name: 'high-sev-dep', severity: 'error', skipReason: 'precondition' }),
+          makeSkippedResult({ name: 'low-sev-dep', severity: 'recommend', skipReason: 'precondition' }),
+        ],
+      });
+
+      const output = reportPreflight(report, { reportOn: 'warn' });
+
+      expect(output).toContain('high-sev-dep');
+      expect(output).not.toContain('low-sev-dep');
+    });
+
     it('defaults reportOn to recommend (show all)', () => {
       const report = makeReport({
         results: [makePassedResult({ name: 'recommend-check', severity: 'recommend' })],

--- a/packages/preflight/__tests__/resolveCollectionExports.test.ts
+++ b/packages/preflight/__tests__/resolveCollectionExports.test.ts
@@ -19,9 +19,9 @@ describe(resolveCollectionExports, () => {
 
   it('forwards fixLocation when defined', () => {
     const checklists = [{ name: 'a', checks: [] }];
-    const result = resolveCollectionExports({ checklists, fixLocation: 'INLINE' });
+    const result = resolveCollectionExports({ checklists, fixLocation: 'inline' });
 
-    expect(result).toStrictEqual({ checklists, fixLocation: 'INLINE' });
+    expect(result).toStrictEqual({ checklists, fixLocation: 'inline' });
   });
 
   it('omits fixLocation when undefined', () => {
@@ -49,9 +49,9 @@ describe(resolveCollectionExports, () => {
   it('forwards both fixLocation and suites from a default export', () => {
     const checklists = [{ name: 'a', checks: [] }];
     const suites = { ci: ['a'] };
-    const result = resolveCollectionExports({ default: { checklists, fixLocation: 'END', suites } });
+    const result = resolveCollectionExports({ default: { checklists, fixLocation: 'end', suites } });
 
-    expect(result).toStrictEqual({ checklists, fixLocation: 'END', suites });
+    expect(result).toStrictEqual({ checklists, fixLocation: 'end', suites });
   });
 
   it('throws when checklists is missing', () => {

--- a/packages/preflight/__tests__/runPreflight.test.ts
+++ b/packages/preflight/__tests__/runPreflight.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { runPreflight } from '../src/runPreflight.ts';
+import { meetsThreshold, runPreflight } from '../src/runPreflight.ts';
 import type { PreflightChecklist, PreflightStagedChecklist } from '../src/types.ts';
 
 describe(runPreflight, () => {
@@ -16,6 +16,8 @@ describe(runPreflight, () => {
       expect(report.passed).toBe(true);
       expect(report.results).toHaveLength(1);
       expect(report.results[0]?.status).toBe('passed');
+      expect(report.results[0]?.ok).toBe(true);
+      expect(report.results[0]?.severity).toBe('error');
       expect(report.results[0]?.durationMs).toBeGreaterThanOrEqual(0);
     });
 
@@ -29,6 +31,7 @@ describe(runPreflight, () => {
 
       expect(report.passed).toBe(false);
       expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.ok).toBe(false);
       expect(report.results[0]?.fix).toBe('Do something');
     });
 
@@ -132,6 +135,22 @@ describe(runPreflight, () => {
       expect(report.results[1]?.status).toBe('skipped');
     });
 
+    it('assigns precondition skipReason to dependent checks', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'gated',
+        preconditions: [{ name: 'pre-fail', check: () => false }],
+        checks: [{ name: 'should-skip', check: () => true }],
+      };
+
+      const report = await runPreflight(checklist);
+      const skipped = report.results[1];
+
+      expect(skipped?.status).toBe('skipped');
+      if (skipped?.status === 'skipped') {
+        expect(skipped.skipReason).toBe('precondition');
+      }
+    });
+
     it('runs checks when all preconditions pass', async () => {
       const checklist: PreflightChecklist = {
         name: 'gated',
@@ -191,6 +210,40 @@ describe(runPreflight, () => {
       expect(report.results[1]?.status).toBe('skipped');
       expect(report.results[2]?.status).toBe('skipped');
     });
+
+    it('continues staged progression when failure is below failOn threshold', async () => {
+      const checklist: PreflightStagedChecklist = {
+        name: 'staged-threshold',
+        groups: [
+          [{ name: 'g1-warn-fail', check: () => false, severity: 'warn' }],
+          [{ name: 'g2-runs', check: () => true }],
+        ],
+      };
+
+      const report = await runPreflight(checklist, { failOn: 'error' });
+
+      expect(report.passed).toBe(true);
+      expect(report.results).toHaveLength(2);
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[1]?.status).toBe('passed');
+    });
+
+    it('halts staged progression when failure meets failOn threshold', async () => {
+      const checklist: PreflightStagedChecklist = {
+        name: 'staged-threshold',
+        groups: [
+          [{ name: 'g1-warn-fail', check: () => false, severity: 'warn' }],
+          [{ name: 'g2-skipped', check: () => true }],
+        ],
+      };
+
+      const report = await runPreflight(checklist, { failOn: 'warn' });
+
+      expect(report.passed).toBe(false);
+      expect(report.results).toHaveLength(2);
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[1]?.status).toBe('skipped');
+    });
   });
 
   describe('structured check outcomes', () => {
@@ -242,7 +295,7 @@ describe(runPreflight, () => {
       expect(report.results[0]?.progress).toStrictEqual({ type: 'percent', percent: 85 });
     });
 
-    it('does not set detail or progress on skipped results', async () => {
+    it('sets null for detail and progress on skipped results', async () => {
       const checklist: PreflightChecklist = {
         name: 'outcome',
         preconditions: [{ name: 'pre-fail', check: () => false }],
@@ -252,8 +305,8 @@ describe(runPreflight, () => {
       const report = await runPreflight(checklist);
 
       const skipped = report.results.find((r) => r.status === 'skipped');
-      expect(skipped?.detail).toBeUndefined();
-      expect(skipped?.progress).toBeUndefined();
+      expect(skipped?.detail).toBeNull();
+      expect(skipped?.progress).toBeNull();
     });
 
     it('handles async CheckOutcome', async () => {
@@ -269,6 +322,199 @@ describe(runPreflight, () => {
     });
   });
 
+  describe('severity', () => {
+    it('defaults severity to error', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'severity',
+        checks: [{ name: 'default', check: () => true }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results[0]?.severity).toBe('error');
+    });
+
+    it('uses check-level severity when provided', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'severity',
+        checks: [{ name: 'warn-check', check: () => true, severity: 'warn' }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results[0]?.severity).toBe('warn');
+    });
+
+    it('falls back to defaultSeverity from options', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'severity',
+        checks: [{ name: 'no-severity', check: () => true }],
+      };
+
+      const report = await runPreflight(checklist, { defaultSeverity: 'recommend' });
+
+      expect(report.results[0]?.severity).toBe('recommend');
+    });
+
+    it('prefers check-level severity over defaultSeverity', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'severity',
+        checks: [{ name: 'explicit', check: () => true, severity: 'error' }],
+      };
+
+      const report = await runPreflight(checklist, { defaultSeverity: 'recommend' });
+
+      expect(report.results[0]?.severity).toBe('error');
+    });
+  });
+
+  describe('failure threshold', () => {
+    it('passes when a failed check is below the failOn threshold', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'threshold',
+        checks: [{ name: 'warn-fail', check: () => false, severity: 'warn' }],
+      };
+
+      const report = await runPreflight(checklist, { failOn: 'error' });
+
+      expect(report.passed).toBe(true);
+    });
+
+    it('fails when a failed check meets the failOn threshold', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'threshold',
+        checks: [{ name: 'warn-fail', check: () => false, severity: 'warn' }],
+      };
+
+      const report = await runPreflight(checklist, { failOn: 'warn' });
+
+      expect(report.passed).toBe(false);
+    });
+
+    it('fails when a failed check exceeds the failOn threshold', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'threshold',
+        checks: [{ name: 'error-fail', check: () => false, severity: 'error' }],
+      };
+
+      const report = await runPreflight(checklist, { failOn: 'recommend' });
+
+      expect(report.passed).toBe(false);
+    });
+  });
+
+  describe('skip conditions', () => {
+    it('skips a check when skip returns a reason string', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'skip',
+        checks: [{ name: 'not-applicable', check: () => true, skip: () => 'tool not installed' }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results[0]?.status).toBe('skipped');
+      if (report.results[0]?.status === 'skipped') {
+        expect(report.results[0].skipReason).toBe('n/a');
+        expect(report.results[0].detail).toBe('tool not installed');
+      }
+    });
+
+    it('runs a check when skip returns false', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'skip',
+        checks: [{ name: 'applicable', check: () => true, skip: () => false }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results[0]?.status).toBe('passed');
+    });
+
+    it('supports async skip functions', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'skip',
+        checks: [{ name: 'async-skip', check: () => true, skip: () => Promise.resolve('skipped async') }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results[0]?.status).toBe('skipped');
+    });
+
+    it('treats skip function throws as check failures', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'skip',
+        checks: [
+          {
+            name: 'skip-throws',
+            check: () => true,
+            skip: () => {
+              throw new Error('skip error');
+            },
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.error?.message).toBe('skip error');
+    });
+
+    it('evaluates skip before running the check function', async () => {
+      let checkCalled = false;
+      const checklist: PreflightChecklist = {
+        name: 'skip',
+        checks: [
+          {
+            name: 'skip-first',
+            check: () => {
+              checkCalled = true;
+              return true;
+            },
+            skip: () => 'skipped',
+          },
+        ],
+      };
+
+      await runPreflight(checklist);
+
+      expect(checkCalled).toBe(false);
+    });
+  });
+
+  describe('result shape', () => {
+    it('sets null for optional fields on passed results', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'shape',
+        checks: [{ name: 'simple', check: () => true }],
+      };
+
+      const report = await runPreflight(checklist);
+      const result = report.results[0];
+
+      expect(result?.detail).toBeNull();
+      expect(result?.fix).toBeNull();
+      expect(result?.error).toBeNull();
+      expect(result?.progress).toBeNull();
+    });
+
+    it('sets null for optional fields on failed results without extras', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'shape',
+        checks: [{ name: 'simple-fail', check: () => false }],
+      };
+
+      const report = await runPreflight(checklist);
+      const result = report.results[0];
+
+      expect(result?.detail).toBeNull();
+      expect(result?.fix).toBeNull();
+      expect(result?.error).toBeNull();
+      expect(result?.progress).toBeNull();
+    });
+  });
+
   it('computes total duration', async () => {
     const checklist: PreflightChecklist = {
       name: 'timing',
@@ -278,5 +524,21 @@ describe(runPreflight, () => {
     const report = await runPreflight(checklist);
 
     expect(report.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe(meetsThreshold, () => {
+  it.each([
+    { severity: 'error', threshold: 'error', expected: true },
+    { severity: 'error', threshold: 'warn', expected: true },
+    { severity: 'error', threshold: 'recommend', expected: true },
+    { severity: 'warn', threshold: 'error', expected: false },
+    { severity: 'warn', threshold: 'warn', expected: true },
+    { severity: 'warn', threshold: 'recommend', expected: true },
+    { severity: 'recommend', threshold: 'error', expected: false },
+    { severity: 'recommend', threshold: 'warn', expected: false },
+    { severity: 'recommend', threshold: 'recommend', expected: true },
+  ] as const)('returns $expected for severity=$severity, threshold=$threshold', ({ severity, threshold, expected }) => {
+    expect(meetsThreshold(severity, threshold)).toBe(expected);
   });
 });

--- a/packages/preflight/src/assertIsPreflightCollection.ts
+++ b/packages/preflight/src/assertIsPreflightCollection.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 
 import type { PreflightCollection } from './types.ts';
 
+/** Schema for valid severity levels. */
+const SeveritySchema = z.enum(['error', 'warn', 'recommend']);
+
 /** Schema for a flat checklist (has `checks`, no `groups`). */
 const FlatChecklistSchema = z.looseObject({
   name: z.string().min(1),
@@ -22,8 +25,11 @@ const ChecklistSchema = z
 
 /** Structural schema for a PreflightCollection. */
 const PreflightCollectionSchema = z.looseObject({
-  fixLocation: z.enum(['INLINE', 'END']).optional(),
   checklists: z.array(ChecklistSchema),
+  defaultSeverity: SeveritySchema.optional(),
+  failOn: SeveritySchema.optional(),
+  fixLocation: z.enum(['inline', 'end']).optional(),
+  reportOn: SeveritySchema.optional(),
   suites: z.record(z.string(), z.array(z.string())).optional(),
 });
 

--- a/packages/preflight/src/bin/route.ts
+++ b/packages/preflight/src/bin/route.ts
@@ -24,6 +24,8 @@ Run options:
   --url <url>                        Fetch collection from a URL
   --collection <name>                Collection name (default: "default")
   --json                             Output results as JSON
+  --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
+  --report-on <severity>             Report this severity or above (error, warn, recommend)
 
 Global options:
   --help, -h           Show this help message
@@ -45,6 +47,8 @@ Collection source (mutually exclusive):
 Options:
   --collection <name>                Collection name (default: "default")
   --json                             Output results as JSON
+  --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
+  --report-on <severity>             Report this severity or above (error, warn, recommend)
   --help, -h                         Show this help message
 
 Defaults to .config/preflight/collections/default.ts when no source is given.

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -8,7 +8,7 @@ import { loadRemoteCollection, type LoadRemoteCollectionOptions } from './loadRe
 import { reportPreflight } from './reportPreflight.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
 import { resolveRequestedNames } from './resolveRequestedNames.ts';
-import { runPreflight } from './runPreflight.ts';
+import { meetsThreshold, runPreflight } from './runPreflight.ts';
 import type {
   ChecklistSummary,
   FixLocation,
@@ -16,15 +16,21 @@ import type {
   PreflightCollection,
   PreflightReport,
   PreflightStagedChecklist,
+  Severity,
 } from './types.ts';
+
+/** Valid severity values for CLI flag validation. */
+const VALID_SEVERITIES = new Set<string>(['error', 'warn', 'recommend']);
 
 /** Discriminated union describing how to locate the preflight collection. */
 export type CollectionSource = { path: string } | { url: string };
 
 interface ParsedRunArgs {
   collectionSource: CollectionSource;
+  failOn?: Severity;
   json: boolean;
   names: string[];
+  reportOn?: Severity;
 }
 
 /** Extract a flag value from either `--flag value` or `--flag=value` form, advancing the index when needed. */
@@ -75,6 +81,17 @@ function parseGitHubArg(value: string): { repo: string; ref: string } {
   return { repo, ref };
 }
 
+/** Validate and narrow a string to a Severity value. */
+function parseSeverityFlag(flagName: string, value: string): Severity {
+  if (!VALID_SEVERITIES.has(value)) {
+    throw new Error(`${flagName} must be one of: error, warn, recommend (got "${value}")`);
+  }
+  // Validated above; narrow without assertion by returning the matched literal.
+  if (value === 'error') return 'error';
+  if (value === 'warn') return 'warn';
+  return 'recommend';
+}
+
 /** Convention path for internal collections, relative to the repo root. */
 const COLLECTIONS_DIR = '.config/preflight/collections';
 
@@ -92,6 +109,8 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   let urlValue: string | undefined;
   let collectionName: string | undefined;
   let json = false;
+  let failOn: Severity | undefined;
+  let reportOn: Severity | undefined;
 
   for (let i = 0; i < flags.length; i++) {
     const arg = flags[i] ?? '';
@@ -126,6 +145,26 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
       const { value, nextIndex } = extractFlagValue('--collection', arg, flags, i, 'a collection name');
       i = nextIndex;
       collectionName = value;
+    } else if (arg === '--fail-on' || arg.startsWith('--fail-on=')) {
+      const { value, nextIndex } = extractFlagValue(
+        '--fail-on',
+        arg,
+        flags,
+        i,
+        'a severity level (error, warn, recommend)',
+      );
+      i = nextIndex;
+      failOn = parseSeverityFlag('--fail-on', value);
+    } else if (arg === '--report-on' || arg.startsWith('--report-on=')) {
+      const { value, nextIndex } = extractFlagValue(
+        '--report-on',
+        arg,
+        flags,
+        i,
+        'a severity level (error, warn, recommend)',
+      );
+      i = nextIndex;
+      reportOn = parseSeverityFlag('--report-on', value);
     } else if (arg.startsWith('-')) {
       throw new Error(`unknown flag '${arg}'`);
     } else {
@@ -135,7 +174,10 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
 
   const collectionSource = resolveCollectionSource({ filePath, githubValue, urlValue, collectionName });
 
-  return { collectionSource, json, names };
+  const result: ParsedRunArgs = { collectionSource, json, names };
+  if (failOn !== undefined) result.failOn = failOn;
+  if (reportOn !== undefined) result.reportOn = reportOn;
+  return result;
 }
 
 /** Validate flag co-dependencies and build the CollectionSource from parsed flag state. */
@@ -176,15 +218,16 @@ function resolveFixLocation(
   checklist: PreflightChecklist | PreflightStagedChecklist,
   collectionDefault?: FixLocation,
 ): FixLocation {
-  return checklist.fixLocation ?? collectionDefault ?? 'END';
+  return checklist.fixLocation ?? collectionDefault ?? 'end';
 }
 
-/** Build a checklist summary from a report and its checklist name. */
-function summarizeReport(name: string, report: PreflightReport): ChecklistSummary {
+/** Build a checklist summary from a report, filtering results by reporting threshold. */
+function summarizeReport(name: string, report: PreflightReport, reportOn: Severity): ChecklistSummary {
   let passed = 0;
   let failed = 0;
   let skipped = 0;
   for (const r of report.results) {
+    if (!meetsThreshold(r.severity, reportOn)) continue;
     if (r.status === 'passed') passed++;
     else if (r.status === 'failed') failed++;
     else skipped++;
@@ -192,10 +235,25 @@ function summarizeReport(name: string, report: PreflightReport): ChecklistSummar
   return { name, passed, failed, skipped, allPassed: report.passed, durationMs: report.durationMs };
 }
 
+/** Resolve threshold values from the cascade: CLI flag > collection field > default. */
+function resolveThresholds(
+  collection: PreflightCollection,
+  cliFailOn: Severity | undefined,
+  cliReportOn: Severity | undefined,
+): { defaultSeverity: Severity; failOn: Severity; reportOn: Severity } {
+  return {
+    defaultSeverity: collection.defaultSeverity ?? 'error',
+    failOn: cliFailOn ?? collection.failOn ?? 'error',
+    reportOn: cliReportOn ?? collection.reportOn ?? 'recommend',
+  };
+}
+
 interface RunCommandOptions {
-  names: string[];
   collectionSource: CollectionSource;
   json: boolean;
+  names: string[];
+  failOn?: Severity;
+  reportOn?: Severity;
 }
 
 /** Load a preflight collection from a path or URL source. */
@@ -214,7 +272,13 @@ async function loadCollection(source: CollectionSource): Promise<PreflightCollec
 }
 
 /** Run preflight checklists. Returns a numeric exit code. */
-export async function runCommand({ names, collectionSource, json }: RunCommandOptions): Promise<number> {
+export async function runCommand({
+  names,
+  collectionSource,
+  json,
+  failOn,
+  reportOn,
+}: RunCommandOptions): Promise<number> {
   let collection: PreflightCollection;
   try {
     collection = await loadCollection(collectionSource);
@@ -228,13 +292,16 @@ export async function runCommand({ names, collectionSource, json }: RunCommandOp
     return 1;
   }
 
-  return runSingleCollection(collection, { names, json });
+  return runSingleCollection(collection, names, json, failOn, reportOn);
 }
 
 /** Run checklists from a single collection. */
 async function runSingleCollection(
   collection: PreflightCollection,
-  { names, json }: { names: string[]; json: boolean },
+  names: string[],
+  json: boolean,
+  failOn: Severity | undefined,
+  reportOn: Severity | undefined,
 ): Promise<number> {
   // Resolve requested names (expanding suite names) and filter checklists
   let resolvedNames: string[];
@@ -258,21 +325,26 @@ async function runSingleCollection(
     return checklist !== undefined ? [checklist] : [];
   });
 
+  const thresholds = resolveThresholds(collection, failOn, reportOn);
+
   if (json) {
-    return runJsonMode(checklists);
+    return runJsonMode(checklists, thresholds);
   }
 
-  return runHumanMode(checklists, collection);
+  return runHumanMode(checklists, collection, thresholds);
 }
 
 /** Run checklists and emit a single JSON object to stdout. */
-async function runJsonMode(checklists: Array<PreflightChecklist | PreflightStagedChecklist>): Promise<number> {
+async function runJsonMode(
+  checklists: Array<PreflightChecklist | PreflightStagedChecklist>,
+  thresholds: { defaultSeverity: Severity; failOn: Severity; reportOn: Severity },
+): Promise<number> {
   const entries: Array<{ name: string; report: PreflightReport }> = [];
   let allPassed = true;
 
   try {
     for (const checklist of checklists) {
-      const report = await runPreflight(checklist);
+      const report = await runPreflight(checklist, thresholds);
       entries.push({ name: checklist.name, report });
       if (!report.passed) allPassed = false;
     }
@@ -282,7 +354,7 @@ async function runJsonMode(checklists: Array<PreflightChecklist | PreflightStage
     return 1;
   }
 
-  process.stdout.write(formatJsonReport(entries) + '\n');
+  process.stdout.write(formatJsonReport(entries, { reportOn: thresholds.reportOn }) + '\n');
   return allPassed ? 0 : 1;
 }
 
@@ -290,6 +362,7 @@ async function runJsonMode(checklists: Array<PreflightChecklist | PreflightStage
 async function runHumanMode(
   checklists: Array<PreflightChecklist | PreflightStagedChecklist>,
   collection: PreflightCollection,
+  thresholds: { defaultSeverity: Severity; failOn: Severity; reportOn: Severity },
 ): Promise<number> {
   const showHeader = checklists.length > 1;
   let allPassed = true;
@@ -300,9 +373,9 @@ async function runHumanMode(
       process.stdout.write(`\n--- ${checklist.name} ---\n\n`);
     }
 
-    const report = await runPreflight(checklist);
+    const report = await runPreflight(checklist, thresholds);
     const fixLocation = resolveFixLocation(checklist, collection.fixLocation);
-    const output = reportPreflight(report, { fixLocation });
+    const output = reportPreflight(report, { fixLocation, reportOn: thresholds.reportOn });
     process.stdout.write(output + '\n');
 
     if (!report.passed) {
@@ -310,7 +383,7 @@ async function runHumanMode(
     }
 
     if (showHeader) {
-      summaries.push(summarizeReport(checklist.name, report));
+      summaries.push(summarizeReport(checklist.name, report, thresholds.reportOn));
     }
   }
 

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -344,7 +344,10 @@ async function runJsonMode(
 
   try {
     for (const checklist of checklists) {
-      const report = await runPreflight(checklist, thresholds);
+      const report = await runPreflight(checklist, {
+        defaultSeverity: thresholds.defaultSeverity,
+        failOn: thresholds.failOn,
+      });
       entries.push({ name: checklist.name, report });
       if (!report.passed) allPassed = false;
     }
@@ -368,23 +371,32 @@ async function runHumanMode(
   let allPassed = true;
   const summaries: ChecklistSummary[] = [];
 
-  for (const checklist of checklists) {
-    if (showHeader) {
-      process.stdout.write(`\n--- ${checklist.name} ---\n\n`);
-    }
+  try {
+    for (const checklist of checklists) {
+      if (showHeader) {
+        process.stdout.write(`\n--- ${checklist.name} ---\n\n`);
+      }
 
-    const report = await runPreflight(checklist, thresholds);
-    const fixLocation = resolveFixLocation(checklist, collection.fixLocation);
-    const output = reportPreflight(report, { fixLocation, reportOn: thresholds.reportOn });
-    process.stdout.write(output + '\n');
+      const report = await runPreflight(checklist, {
+        defaultSeverity: thresholds.defaultSeverity,
+        failOn: thresholds.failOn,
+      });
+      const fixLocation = resolveFixLocation(checklist, collection.fixLocation);
+      const output = reportPreflight(report, { fixLocation, reportOn: thresholds.reportOn });
+      process.stdout.write(output + '\n');
 
-    if (!report.passed) {
-      allPassed = false;
-    }
+      if (!report.passed) {
+        allPassed = false;
+      }
 
-    if (showHeader) {
-      summaries.push(summarizeReport(checklist.name, report, thresholds.reportOn));
+      if (showHeader) {
+        summaries.push(summarizeReport(checklist.name, report, thresholds.reportOn));
+      }
     }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return 1;
   }
 
   if (summaries.length > 1) {

--- a/packages/preflight/src/formatJsonReport.ts
+++ b/packages/preflight/src/formatJsonReport.ts
@@ -59,7 +59,7 @@ export function formatJsonReport(entries: ChecklistEntry[], options?: FormatJson
   const totalDurationMs = checklists.reduce((sum, c) => sum + c.durationMs, 0);
 
   const output: JsonReport = {
-    allPassed: totalFailed === 0,
+    allPassed: entries.every(({ report }) => report.passed),
     passed: totalPassed,
     failed: totalFailed,
     skipped: totalSkipped,

--- a/packages/preflight/src/formatJsonReport.ts
+++ b/packages/preflight/src/formatJsonReport.ts
@@ -1,70 +1,44 @@
-import type { PreflightReport, PreflightResult, Progress } from './types.ts';
-import { isPercentProgress } from './types.ts';
+import { meetsThreshold } from './runPreflight.ts';
+import type {
+  JsonCheckEntry,
+  JsonChecklistEntry,
+  JsonReport,
+  PreflightReport,
+  PreflightResult,
+  Severity,
+} from './types.ts';
 
 interface ChecklistEntry {
   name: string;
   report: PreflightReport;
 }
 
-interface JsonCheckResult {
-  name: string;
-  status: 'passed' | 'failed' | 'skipped';
-  durationMs: number;
-  fix?: string;
-  error?: string;
-  detail?: string;
-  progress?: JsonProgress;
+/** Options controlling which results appear in JSON output. */
+export interface FormatJsonReportOptions {
+  reportOn?: Severity;
 }
 
-type JsonProgress = JsonFractionProgress | JsonPercentProgress;
-
-interface JsonFractionProgress {
-  type: 'fraction';
-  passedCount: number;
-  count: number;
-}
-
-interface JsonPercentProgress {
-  type: 'percent';
-  percent: number;
-}
-
-interface JsonChecklist {
-  name: string;
-  allPassed: boolean;
-  durationMs: number;
-  passedCount: number;
-  failedCount: number;
-  skippedCount: number;
-  checks: JsonCheckResult[];
-}
-
-interface JsonReport {
-  allPassed: boolean;
-  passedCount: number;
-  failedCount: number;
-  skippedCount: number;
-  durationMs: number;
-  checklists: JsonChecklist[];
-}
-
-/** Transform an array of checklist results into a JSON-serializable report object. */
-export function formatJsonReport(entries: ChecklistEntry[]): string {
+/** Transform an array of checklist results into a JSON-serializable report string. */
+export function formatJsonReport(entries: ChecklistEntry[], options?: FormatJsonReportOptions): string {
+  const reportOn = options?.reportOn ?? 'recommend';
   let totalPassed = 0;
   let totalFailed = 0;
   let totalSkipped = 0;
 
-  const checklists: JsonChecklist[] = entries.map(({ name, report }) => {
+  const checklists: JsonChecklistEntry[] = entries.map(({ name, report }) => {
     let passed = 0;
     let failed = 0;
     let skipped = 0;
 
-    const checks: JsonCheckResult[] = report.results.map((result) => {
+    // Filter results by reporting threshold.
+    const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
+
+    const checks: JsonCheckEntry[] = visibleResults.map((result) => {
       if (result.status === 'passed') passed++;
       else if (result.status === 'failed') failed++;
       else skipped++;
 
-      return buildCheckResult(result);
+      return buildCheckEntry(result);
     });
 
     totalPassed += passed;
@@ -75,9 +49,9 @@ export function formatJsonReport(entries: ChecklistEntry[]): string {
       name,
       allPassed: report.passed,
       durationMs: report.durationMs,
-      passedCount: passed,
-      failedCount: failed,
-      skippedCount: skipped,
+      passed,
+      failed,
+      skipped,
       checks,
     };
   });
@@ -86,9 +60,9 @@ export function formatJsonReport(entries: ChecklistEntry[]): string {
 
   const output: JsonReport = {
     allPassed: totalFailed === 0,
-    passedCount: totalPassed,
-    failedCount: totalFailed,
-    skippedCount: totalSkipped,
+    passed: totalPassed,
+    failed: totalFailed,
+    skipped: totalSkipped,
     durationMs: totalDurationMs,
     checklists,
   };
@@ -96,26 +70,40 @@ export function formatJsonReport(entries: ChecklistEntry[]): string {
   return JSON.stringify(output);
 }
 
-/** Build a single check result, omitting undefined optional fields. */
-function buildCheckResult(result: PreflightResult): JsonCheckResult {
-  const entry: JsonCheckResult = {
+/**
+ * Build a single JSON check entry, normalizing the union to include all fields.
+ *
+ * Non-skipped results get `skipReason: null` for uniform JSON shape.
+ * Error objects are serialized to their message string.
+ */
+function buildCheckEntry(result: PreflightResult): JsonCheckEntry {
+  const errorString = result.error !== null ? result.error.message : null;
+
+  if (result.status === 'skipped') {
+    return {
+      name: result.name,
+      status: result.status,
+      ok: result.ok,
+      severity: result.severity,
+      skipReason: result.skipReason,
+      detail: result.detail,
+      fix: result.fix,
+      error: errorString,
+      progress: result.progress,
+      durationMs: result.durationMs,
+    };
+  }
+
+  return {
     name: result.name,
     status: result.status,
+    ok: result.ok,
+    severity: result.severity,
+    skipReason: null,
+    detail: result.detail,
+    fix: result.fix,
+    error: errorString,
+    progress: result.progress,
     durationMs: result.durationMs,
   };
-
-  if (result.fix !== undefined) entry.fix = result.fix;
-  if (result.error !== undefined) entry.error = result.error.message;
-  if (result.detail !== undefined) entry.detail = result.detail;
-  if (result.progress !== undefined) entry.progress = serializeProgress(result.progress);
-
-  return entry;
-}
-
-/** Serialize a Progress union into a plain object with only the relevant fields. */
-function serializeProgress(progress: Progress): JsonProgress {
-  if (isPercentProgress(progress)) {
-    return { type: 'percent', percent: progress.percent };
-  }
-  return { type: 'fraction', passedCount: progress.passedCount, count: progress.count };
 }

--- a/packages/preflight/src/index.ts
+++ b/packages/preflight/src/index.ts
@@ -3,8 +3,13 @@ export type {
   ChecklistSummary,
   CheckOutcome,
   CheckReturnValue,
+  FailedResult,
   FixLocation,
   FractionProgress,
+  JsonCheckEntry,
+  JsonChecklistEntry,
+  JsonReport,
+  PassedResult,
   PercentProgress,
   PreflightCheck,
   PreflightChecklist,
@@ -14,8 +19,10 @@ export type {
   PreflightResult,
   PreflightStagedChecklist,
   Progress,
-  ReportOptions,
   ResolvedPreflightConfig,
+  Severity,
+  SkippedResult,
+  SkipResult,
 } from './types.ts';
 
 // Type guards

--- a/packages/preflight/src/index.ts
+++ b/packages/preflight/src/index.ts
@@ -41,9 +41,12 @@ export {
 export { loadConfig } from './loadConfig.ts';
 
 // Runner
+export type { RunPreflightOptions } from './runPreflight.ts';
 export { runPreflight } from './runPreflight.ts';
 
 // Reporter
 export { formatCombinedSummary } from './formatCombinedSummary.ts';
+export type { FormatJsonReportOptions } from './formatJsonReport.ts';
 export { formatJsonReport } from './formatJsonReport.ts';
+export type { ReportPreflightOptions } from './reportPreflight.ts';
 export { formatSummaryCounts, reportPreflight } from './reportPreflight.ts';

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -1,20 +1,35 @@
-import type { PreflightReport, PreflightResult, Progress, ReportOptions } from './types.ts';
+import { meetsThreshold } from './runPreflight.ts';
+import type { FixLocation, PreflightReport, PreflightResult, Progress, Severity } from './types.ts';
 import { isPercentProgress } from './types.ts';
 
 const ICON_PASSED = '\u{1F7E2}';
-const ICON_FAILED = '\u{1F534}';
-const ICON_SKIPPED = '\u26D4';
+const ICON_ERROR_FAILED = '\u{1F534}';
+const ICON_WARN_FAILED = '\u{1F7E0}';
+const ICON_RECOMMEND_FAILED = '\u{1F7E1}';
+const ICON_SKIPPED_NA = '\u26AA';
+const ICON_SKIPPED_PRECONDITION = '\u26D4';
+
+/** Options controlling how the report is formatted. */
+export interface ReportPreflightOptions {
+  fixLocation?: FixLocation;
+  reportOn?: Severity;
+}
 
 /** Format a duration in milliseconds for display. */
 function formatDuration(ms: number): string {
   return `${Math.round(ms)}ms`;
 }
 
-/** Return the status icon for a result. */
-function getIcon(status: PreflightResult['status']): string {
-  if (status === 'passed') return ICON_PASSED;
-  if (status === 'failed') return ICON_FAILED;
-  return ICON_SKIPPED;
+/** Return the status icon for a result based on status, severity, and skip reason. */
+function getIcon(result: PreflightResult): string {
+  if (result.status === 'passed') return ICON_PASSED;
+  if (result.status === 'skipped') {
+    return result.skipReason === 'precondition' ? ICON_SKIPPED_PRECONDITION : ICON_SKIPPED_NA;
+  }
+  // Failed result: icon depends on severity.
+  if (result.severity === 'warn') return ICON_WARN_FAILED;
+  if (result.severity === 'recommend') return ICON_RECOMMEND_FAILED;
+  return ICON_ERROR_FAILED;
 }
 
 /** Format a progress value for display. */
@@ -29,18 +44,18 @@ function formatProgress(progress: Progress): string {
 export function formatSummaryCounts(passed: number, failed: number, skipped: number): string {
   const parts: string[] = [];
   if (passed > 0) parts.push(`${ICON_PASSED} ${passed} passed`);
-  if (failed > 0) parts.push(`${ICON_FAILED} ${failed} failed`);
-  if (skipped > 0) parts.push(`${ICON_SKIPPED} ${skipped} skipped`);
+  if (failed > 0) parts.push(`${ICON_ERROR_FAILED} ${failed} failed`);
+  if (skipped > 0) parts.push(`${ICON_SKIPPED_PRECONDITION} ${skipped} skipped`);
   return parts.join(', ');
 }
 
 /** Collect inline detail lines (error and/or fix) for a failed result. */
 function collectInlineDetails(result: PreflightResult, includeFix: boolean): string[] {
   const details: string[] = [];
-  if (result.error !== undefined) {
+  if (result.error !== null) {
     details.push(`  Error: ${result.error.message}`);
   }
-  if (includeFix && result.fix !== undefined) {
+  if (includeFix && result.fix !== null) {
     details.push(`  Fix: ${result.fix}`);
   }
   return details;
@@ -49,48 +64,53 @@ function collectInlineDetails(result: PreflightResult, includeFix: boolean): str
 /**
  * Format a preflight report as a human-readable string for terminal output.
  *
- * In `END` mode (default), errors appear inline but fix messages are collected in a "Fixes" section at the bottom.
- * In `INLINE` mode, error and fix messages appear directly below each failed check.
+ * In `end` mode (default), errors appear inline but fix messages are collected in a "Fixes" section at the bottom.
+ * In `inline` mode, error and fix messages appear directly below each failed check.
+ * Results below the reporting threshold are omitted from output.
  */
-export function reportPreflight(report: PreflightReport, options?: ReportOptions): string {
-  const fixLocation = options?.fixLocation ?? 'END';
+export function reportPreflight(report: PreflightReport, options?: ReportPreflightOptions): string {
+  const fixLocation = options?.fixLocation ?? 'end';
+  const reportOn = options?.reportOn ?? 'recommend';
   const lines: string[] = [];
   const collectedFixes: string[] = [];
 
-  for (const result of report.results) {
-    const icon = getIcon(result.status);
+  // Filter results by reporting threshold.
+  const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
+
+  for (const result of visibleResults) {
+    const icon = getIcon(result);
     let checkLine = `${icon} ${result.name} (${formatDuration(result.durationMs)})`;
-    if (result.detail !== undefined) {
+    if (result.detail !== null) {
       checkLine += ` \u2014 ${result.detail}`;
     }
-    if (result.progress !== undefined) {
+    if (result.progress !== null) {
       checkLine += ` \u2014 ${formatProgress(result.progress)}`;
     }
     lines.push(checkLine);
 
     if (result.status === 'failed') {
-      const includeFix = fixLocation === 'INLINE';
+      const includeFix = fixLocation === 'inline';
       lines.push(...collectInlineDetails(result, includeFix));
 
-      if (!includeFix && result.fix !== undefined) {
+      if (!includeFix && result.fix !== null) {
         collectedFixes.push(result.fix);
       }
     }
   }
 
-  // Summary
+  // Summary counts from visible results only.
   let passed = 0;
   let failed = 0;
   let skipped = 0;
-  for (const r of report.results) {
+  for (const r of visibleResults) {
     if (r.status === 'passed') passed++;
     else if (r.status === 'failed') failed++;
     else skipped++;
   }
   lines.push('', `${formatSummaryCounts(passed, failed, skipped)} (${formatDuration(report.durationMs)})`);
 
-  // Collected fixes section for END mode
-  if (fixLocation === 'END' && collectedFixes.length > 0) {
+  // Collected fixes section for end mode.
+  if (fixLocation === 'end' && collectedFixes.length > 0) {
     lines.push('', 'Fixes:', ...collectedFixes.map((fix) => `  ${fix}`));
   }
 

--- a/packages/preflight/src/resolveCollectionExports.ts
+++ b/packages/preflight/src/resolveCollectionExports.ts
@@ -19,7 +19,10 @@ export function resolveCollectionExports(moduleRecord: Record<string, unknown>):
 
   return {
     checklists: source.checklists,
+    ...(source.defaultSeverity !== undefined && { defaultSeverity: source.defaultSeverity }),
+    ...(source.failOn !== undefined && { failOn: source.failOn }),
     ...(source.fixLocation !== undefined && { fixLocation: source.fixLocation }),
+    ...(source.reportOn !== undefined && { reportOn: source.reportOn }),
     ...(source.suites !== undefined && { suites: source.suites }),
   };
 }

--- a/packages/preflight/src/runPreflight.ts
+++ b/packages/preflight/src/runPreflight.ts
@@ -17,7 +17,6 @@ import { isFlatChecklist } from './types.ts';
 export interface RunPreflightOptions {
   defaultSeverity?: Severity;
   failOn?: Severity;
-  reportOn?: Severity;
 }
 
 /**

--- a/packages/preflight/src/runPreflight.ts
+++ b/packages/preflight/src/runPreflight.ts
@@ -1,84 +1,151 @@
 import { performance } from 'node:perf_hooks';
 
 import type {
+  FailedResult,
+  PassedResult,
   PreflightCheck,
   PreflightChecklist,
   PreflightReport,
   PreflightResult,
   PreflightStagedChecklist,
-  Progress,
+  Severity,
+  SkippedResult,
 } from './types.ts';
 import { isFlatChecklist } from './types.ts';
 
-/** Optional fields that may appear on a preflight result. */
-interface ResultOptions {
-  fix?: string;
-  error?: Error;
-  detail?: string;
-  progress?: Progress;
+/** Options controlling failure and severity defaults for a run. */
+export interface RunPreflightOptions {
+  defaultSeverity?: Severity;
+  failOn?: Severity;
+  reportOn?: Severity;
 }
 
-/** Build a result object, only including optional fields when defined. */
-function buildResult(
+/**
+ * Numeric rank for severity comparison. Lower rank = higher severity.
+ *
+ * A result "meets or exceeds" a threshold when its rank is <= the threshold's rank.
+ */
+const SEVERITY_RANK: Record<Severity, number> = {
+  error: 0,
+  warn: 1,
+  recommend: 2,
+};
+
+/** Return true if `severity` is at or above (more severe than or equal to) `threshold`. */
+export function meetsThreshold(severity: Severity, threshold: Severity): boolean {
+  return SEVERITY_RANK[severity] <= SEVERITY_RANK[threshold];
+}
+
+/** Resolve the effective severity for a check. */
+function resolveSeverity(check: PreflightCheck, defaultSeverity: Severity): Severity {
+  return check.severity ?? defaultSeverity;
+}
+
+/** Build a passed result. */
+function buildPassedResult(
   name: string,
-  status: PreflightResult['status'],
+  severity: Severity,
   durationMs: number,
-  options: ResultOptions = {},
-): PreflightResult {
-  const result: PreflightResult = { name, status, durationMs };
-  if (options.fix !== undefined) {
-    result.fix = options.fix;
-  }
-  if (options.error !== undefined) {
-    result.error = options.error;
-  }
-  if (options.detail !== undefined) {
-    result.detail = options.detail;
-  }
-  if (options.progress !== undefined) {
-    result.progress = options.progress;
-  }
-  return result;
+  detail: string | null,
+  fix: string | null,
+  progress: import('./types.ts').Progress | null,
+): PassedResult {
+  return { name, status: 'passed', ok: true, severity, detail, fix, error: null, progress, durationMs };
+}
+
+/** Build a failed result. */
+function buildFailedResult(
+  name: string,
+  severity: Severity,
+  durationMs: number,
+  detail: string | null,
+  fix: string | null,
+  error: Error | null,
+  progress: import('./types.ts').Progress | null,
+): FailedResult {
+  return { name, status: 'failed', ok: false, severity, detail, fix, error, progress, durationMs };
+}
+
+/** Build a skipped result. */
+function buildSkippedResult(
+  name: string,
+  severity: Severity,
+  skipReason: 'n/a' | 'precondition',
+  detail: string | null,
+  fix: string | null,
+): SkippedResult {
+  return {
+    name,
+    status: 'skipped',
+    ok: null,
+    severity,
+    skipReason,
+    detail,
+    fix,
+    error: null,
+    progress: null,
+    durationMs: 0,
+  };
 }
 
 /** Execute a single check and return its result. */
-async function executeCheck(check: PreflightCheck): Promise<PreflightResult> {
+async function executeCheck(check: PreflightCheck, defaultSeverity: Severity): Promise<PreflightResult> {
+  const severity = resolveSeverity(check, defaultSeverity);
+  const fix = check.fix ?? null;
+
+  // Evaluate skip condition before running the check.
+  if (check.skip !== undefined) {
+    const start = performance.now();
+    try {
+      const skipResult = await check.skip();
+      if (typeof skipResult === 'string') {
+        return buildSkippedResult(check.name, severity, 'n/a', skipResult, fix);
+      }
+    } catch (error_: unknown) {
+      const durationMs = performance.now() - start;
+      const error = error_ instanceof Error ? error_ : new Error(String(error_));
+      return buildFailedResult(check.name, severity, durationMs, null, fix, error, null);
+    }
+  }
+
   const start = performance.now();
   try {
     const raw = await check.check();
     const durationMs = performance.now() - start;
     if (typeof raw === 'boolean') {
-      return buildResult(
-        check.name,
-        raw ? 'passed' : 'failed',
-        durationMs,
-        check.fix !== undefined ? { fix: check.fix } : {},
-      );
+      if (raw) {
+        return buildPassedResult(check.name, severity, durationMs, null, fix, null);
+      }
+      return buildFailedResult(check.name, severity, durationMs, null, fix, null, null);
     }
-    const opts: ResultOptions = {};
-    if (check.fix !== undefined) opts.fix = check.fix;
-    if (raw.detail !== undefined) opts.detail = raw.detail;
-    if (raw.progress !== undefined) opts.progress = raw.progress;
-    return buildResult(check.name, raw.ok ? 'passed' : 'failed', durationMs, opts);
+    const detail = raw.detail ?? null;
+    const progress = raw.progress ?? null;
+    if (raw.ok) {
+      return buildPassedResult(check.name, severity, durationMs, detail, fix, progress);
+    }
+    return buildFailedResult(check.name, severity, durationMs, detail, fix, null, progress);
   } catch (error_: unknown) {
     const durationMs = performance.now() - start;
     const error = error_ instanceof Error ? error_ : new Error(String(error_));
-    const opts: ResultOptions = { error };
-    if (check.fix !== undefined) opts.fix = check.fix;
-    return buildResult(check.name, 'failed', durationMs, opts);
+    return buildFailedResult(check.name, severity, durationMs, null, fix, error, null);
   }
 }
 
-/** Mark a check as skipped with zero duration. */
-function skipCheck(check: PreflightCheck): PreflightResult {
-  return buildResult(check.name, 'skipped', 0, check.fix !== undefined ? { fix: check.fix } : {});
+/** Mark a check as skipped due to a failed precondition. */
+function skipCheck(check: PreflightCheck, defaultSeverity: Severity): PreflightResult {
+  const severity = resolveSeverity(check, defaultSeverity);
+  return buildSkippedResult(check.name, severity, 'precondition', null, check.fix ?? null);
 }
 
 /** Run preconditions concurrently. Return true if all passed. */
-async function runPreconditions(preconditions: PreflightCheck[], results: PreflightResult[]): Promise<boolean> {
+async function runPreconditions(
+  preconditions: PreflightCheck[],
+  results: PreflightResult[],
+  defaultSeverity: Severity,
+): Promise<boolean> {
   if (preconditions.length === 0) return true;
 
-  const preconditionResults = await Promise.all(preconditions.map(executeCheck));
+  const preconditionResults = await Promise.all(preconditions.map((c) => executeCheck(c, defaultSeverity)));
   results.push(...preconditionResults);
 
   return preconditionResults.every((r) => r.status === 'passed');
@@ -89,13 +156,14 @@ async function runFlatChecks(
   checklist: PreflightChecklist,
   results: PreflightResult[],
   preconditionsPassed: boolean,
+  defaultSeverity: Severity,
 ): Promise<void> {
   if (!preconditionsPassed) {
-    results.push(...checklist.checks.map(skipCheck));
+    results.push(...checklist.checks.map((c) => skipCheck(c, defaultSeverity)));
     return;
   }
 
-  const checkResults = await Promise.all(checklist.checks.map(executeCheck));
+  const checkResults = await Promise.all(checklist.checks.map((c) => executeCheck(c, defaultSeverity)));
   results.push(...checkResults);
 }
 
@@ -104,10 +172,12 @@ async function runStagedChecks(
   checklist: PreflightStagedChecklist,
   results: PreflightResult[],
   preconditionsPassed: boolean,
+  defaultSeverity: Severity,
+  failOn: Severity,
 ): Promise<void> {
   if (!preconditionsPassed) {
     for (const group of checklist.groups) {
-      results.push(...group.map(skipCheck));
+      results.push(...group.map((c) => skipCheck(c, defaultSeverity)));
     }
     return;
   }
@@ -115,14 +185,15 @@ async function runStagedChecks(
   let shouldSkipRemaining = false;
   for (const group of checklist.groups) {
     if (shouldSkipRemaining) {
-      results.push(...group.map(skipCheck));
+      results.push(...group.map((c) => skipCheck(c, defaultSeverity)));
       continue;
     }
 
-    const groupResults = await Promise.all(group.map(executeCheck));
+    const groupResults = await Promise.all(group.map((c) => executeCheck(c, defaultSeverity)));
     results.push(...groupResults);
 
-    if (groupResults.some((r) => r.status === 'failed')) {
+    // Halt subsequent groups only when a failure meets the failure threshold.
+    if (groupResults.some((r) => r.status === 'failed' && meetsThreshold(r.severity, failOn))) {
       shouldSkipRemaining = true;
     }
   }
@@ -133,20 +204,28 @@ async function runStagedChecks(
  *
  * Preconditions run first. If any fails, all subsequent checks are skipped.
  * Flat checklists run all checks concurrently. Staged checklists run groups
- * sequentially, bailing on later groups when an earlier group has a failure.
+ * sequentially, bailing on later groups when an earlier group has a failure
+ * at or above the failure threshold.
  */
-export async function runPreflight(checklist: PreflightChecklist | PreflightStagedChecklist): Promise<PreflightReport> {
+export async function runPreflight(
+  checklist: PreflightChecklist | PreflightStagedChecklist,
+  options: RunPreflightOptions = {},
+): Promise<PreflightReport> {
+  const defaultSeverity = options.defaultSeverity ?? 'error';
+  const failOn = options.failOn ?? 'error';
   const start = performance.now();
   const results: PreflightResult[] = [];
 
-  const preconditionsPassed = await runPreconditions(checklist.preconditions ?? [], results);
+  const preconditionsPassed = await runPreconditions(checklist.preconditions ?? [], results, defaultSeverity);
 
   await (isFlatChecklist(checklist)
-    ? runFlatChecks(checklist, results, preconditionsPassed)
-    : runStagedChecks(checklist, results, preconditionsPassed));
+    ? runFlatChecks(checklist, results, preconditionsPassed, defaultSeverity)
+    : runStagedChecks(checklist, results, preconditionsPassed, defaultSeverity, failOn));
 
   const durationMs = performance.now() - start;
-  const passed = results.every((r) => r.status !== 'failed');
+
+  // The run passes when no failed result has severity at or above the failure threshold.
+  const passed = !results.some((r) => r.status === 'failed' && meetsThreshold(r.severity, failOn));
 
   return { results, passed, durationMs };
 }

--- a/packages/preflight/src/types.ts
+++ b/packages/preflight/src/types.ts
@@ -1,5 +1,28 @@
+// ---------------------------------------------------------------------------
+// Severity
+// ---------------------------------------------------------------------------
+
+/** Severity levels for assertive checks, ordered from most to least urgent. */
+export type Severity = 'error' | 'warn' | 'recommend';
+
+// ---------------------------------------------------------------------------
+// Skip conditions
+// ---------------------------------------------------------------------------
+
+/**
+ * Return value from a skip function.
+ *
+ * - `false`: the check is applicable; run it.
+ * - `string`: the check is not applicable; skip it with this reason as detail.
+ */
+export type SkipResult = false | string;
+
+// ---------------------------------------------------------------------------
+// Check outcomes
+// ---------------------------------------------------------------------------
+
 /** Placement of fix messages in the report output. */
-export type FixLocation = 'INLINE' | 'END';
+export type FixLocation = 'inline' | 'end';
 
 /** Progress expressed as a fraction with passed and total counts. */
 export interface FractionProgress {
@@ -32,45 +55,108 @@ export interface CheckOutcome {
 /** The value a check function may return (or resolve to). */
 export type CheckReturnValue = boolean | CheckOutcome;
 
-/** A single check to run during preflight. */
+// ---------------------------------------------------------------------------
+// Check definition
+// ---------------------------------------------------------------------------
+
+/** A single preflight check. */
 export interface PreflightCheck {
+  /** Display name shown in output. */
   name: string;
+
+  /** Assert a condition. Return true/false or a CheckOutcome. */
   check: () => CheckReturnValue | Promise<CheckReturnValue>;
+
+  /**
+   * Severity of this check. Determines failure and reporting behavior.
+   * Default: collection's `defaultSeverity`, falling back to 'error'.
+   */
+  severity?: Severity;
+
+  /**
+   * Skip condition. When provided, evaluated before the check runs.
+   * Return `false` to run the check, or a reason string to skip it.
+   */
+  skip?: () => SkipResult | Promise<SkipResult>;
+
+  /** Remediation message shown when the check fails. */
   fix?: string;
 }
 
-/** The outcome of running a single check. */
-export interface PreflightResult {
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+
+/** Shared fields present on every result regardless of outcome. */
+interface PreflightResultBase {
+  /** Check name. */
   name: string;
-  status: 'passed' | 'failed' | 'skipped';
-  fix?: string;
-  error?: Error;
-  detail?: string;
-  progress?: Progress;
+
+  /** Resolved severity for this check. */
+  severity: Severity;
+
+  /** Diagnostic detail (failure reason, skip reason, or supplementary info). */
+  detail: string | null;
+
+  /** Remediation message, carried from the check definition. */
+  fix: string | null;
+
+  /** Error thrown by the check function, if any. */
+  error: Error | null;
+
+  /** Progress data, if the check reported it. */
+  progress: Progress | null;
+
+  /** Wall-clock time to execute the check, in milliseconds. */
   durationMs: number;
 }
 
-/** Aggregate report from running a checklist. */
+/** Result for a check that ran and passed. */
+export interface PassedResult extends PreflightResultBase {
+  status: 'passed';
+  ok: true;
+}
+
+/** Result for a check that ran and failed. */
+export interface FailedResult extends PreflightResultBase {
+  status: 'failed';
+  ok: false;
+}
+
+/** Result for a check that was skipped. */
+export interface SkippedResult extends PreflightResultBase {
+  status: 'skipped';
+  ok: null;
+  /** Why the check was skipped. */
+  skipReason: 'n/a' | 'precondition';
+}
+
+/**
+ * The outcome of running a single check, discriminated by `status`.
+ *
+ * - `passed`: check ran and the condition was met.
+ * - `failed`: check ran and the condition was not met.
+ * - `skipped`: check did not run (`skipReason` explains why).
+ */
+export type PreflightResult = PassedResult | FailedResult | SkippedResult;
+
+// ---------------------------------------------------------------------------
+// Reports
+// ---------------------------------------------------------------------------
+
+/** Aggregate report from running a single checklist. */
 export interface PreflightReport {
+  /** Individual check results. */
   results: PreflightResult[];
+
+  /**
+   * True when no check at or above the failure threshold has `ok: false`.
+   * Skipped checks do not affect this.
+   */
   passed: boolean;
+
+  /** Total wall-clock time for the checklist, in milliseconds. */
   durationMs: number;
-}
-
-/** A flat checklist where all checks run concurrently. */
-export interface PreflightChecklist {
-  name: string;
-  preconditions?: PreflightCheck[];
-  checks: PreflightCheck[];
-  fixLocation?: FixLocation;
-}
-
-/** A staged checklist where groups run sequentially and checks within each group run concurrently. */
-export interface PreflightStagedChecklist {
-  name: string;
-  preconditions?: PreflightCheck[];
-  groups: PreflightCheck[][];
-  fixLocation?: FixLocation;
 }
 
 /** Per-checklist aggregate for the combined summary table. */
@@ -83,16 +169,77 @@ export interface ChecklistSummary {
   durationMs: number;
 }
 
-/** Options controlling how the report is formatted. */
-export interface ReportOptions {
+// ---------------------------------------------------------------------------
+// Checklists
+// ---------------------------------------------------------------------------
+
+/** A flat checklist where all checks run concurrently. */
+export interface PreflightChecklist {
+  name: string;
+
+  /**
+   * Gating checks. If any precondition fails, all downstream checks are skipped.
+   *
+   * Reporting of precondition results and skipped dependent checks follows the
+   * same reporting-threshold rule as all other results: a result appears in
+   * output only when its severity is at or above the reporting threshold.
+   * Each dependent check's own severity determines whether its skipped entry
+   * is shown.
+   */
+  preconditions?: PreflightCheck[];
+
+  checks: PreflightCheck[];
+
   fixLocation?: FixLocation;
 }
 
-/** A collection of checklists with an optional default fixLocation. */
-export interface PreflightCollection {
+/** A staged checklist where groups run sequentially; checks within each group run concurrently. */
+export interface PreflightStagedChecklist {
+  name: string;
+  preconditions?: PreflightCheck[];
+  groups: PreflightCheck[][];
   fixLocation?: FixLocation;
+}
+
+/** Distinguish a flat checklist from a staged checklist by the presence of `checks`. */
+export function isFlatChecklist(
+  checklist: PreflightChecklist | PreflightStagedChecklist,
+): checklist is PreflightChecklist {
+  return 'checks' in checklist;
+}
+
+// ---------------------------------------------------------------------------
+// Collection
+// ---------------------------------------------------------------------------
+
+/** A collection of checklists with shared configuration. */
+export interface PreflightCollection {
+  /** Checklists in this collection. */
   checklists: Array<PreflightChecklist | PreflightStagedChecklist>;
+
+  /** Named subsets of checklists. */
   suites?: Record<string, string[]>;
+
+  /**
+   * Default severity for checks that don't declare one.
+   * Default: 'error'.
+   */
+  defaultSeverity?: Severity;
+
+  /**
+   * Minimum severity at which a failed check causes the run to fail.
+   * Default: 'error'.
+   */
+  failOn?: Severity;
+
+  /**
+   * Minimum severity at which results appear in output.
+   * Default: 'recommend' (show all assertive results).
+   */
+  reportOn?: Severity;
+
+  /** Default placement of fix messages across all checklists. */
+  fixLocation?: FixLocation;
 }
 
 /** Repo-level settings for the preflight CLI (user-facing, all fields optional). */
@@ -111,9 +258,46 @@ export interface ResolvedPreflightConfig {
   };
 }
 
-/** Distinguish a flat checklist from a staged checklist by the presence of `checks`. */
-export function isFlatChecklist(
-  checklist: PreflightChecklist | PreflightStagedChecklist,
-): checklist is PreflightChecklist {
-  return 'checks' in checklist;
+// ---------------------------------------------------------------------------
+// JSON output
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a PreflightResult for JSON output.
+ *
+ * All fields are non-optional with explicit `null` for absent values. `skipReason` is
+ * present on every entry (not just skipped results) so JSON consumers see a uniform shape.
+ */
+export interface JsonCheckEntry {
+  name: string;
+  status: 'passed' | 'failed' | 'skipped';
+  ok: true | false | null;
+  severity: Severity;
+  skipReason: 'n/a' | 'precondition' | null;
+  detail: string | null;
+  fix: string | null;
+  error: string | null;
+  progress: Progress | null;
+  durationMs: number;
+}
+
+/** Shape of a single checklist entry in `--json` output. */
+export interface JsonChecklistEntry {
+  name: string;
+  passed: number;
+  failed: number;
+  skipped: number;
+  allPassed: boolean;
+  durationMs: number;
+  checks: JsonCheckEntry[];
+}
+
+/** Top-level shape of `--json` output. */
+export interface JsonReport {
+  allPassed: boolean;
+  passed: number;
+  failed: number;
+  skipped: number;
+  durationMs: number;
+  checklists: JsonChecklistEntry[];
 }


### PR DESCRIPTION
Closes #128 

## What

Adds three severity levels (`error`, `warn`, `recommend`), two thresholds (`failOn`, `reportOn`), and per-check skip conditions to the preflight system. `PreflightResult` becomes a discriminated union with non-optional fields and explicit `null`, and the CLI gains `--fail-on` and `--report-on` flags with a collection-to-CLI cascade.

## Why

Preflight checks had a single pass/fail outcome with no way to express advisory checks, mark checks as not applicable, or control which severity of failure blocks a deployment. This was discovered while building the `nmr.ts` collection (#125), which needs checks ranging from hard requirements to recommendations.

## Details

### Features

- `PreflightCheck` gains optional `severity` and `skip` fields. Severity defaults to `error`; skip functions return `false` (run the check) or a reason string (skip it).
- `PreflightCollection` gains `defaultSeverity`, `failOn`, and `reportOn` fields. Resolution cascade: CLI flag > collection field > default.
- `--fail-on` and `--report-on` CLI flags parse and validate severity values.
- Human output uses distinct icons per severity: 🟢 passed, 🔴 error-failed, 🟠 warn-failed, 🟡 recommend-failed, ⚪ skipped (n/a), ⛔ skipped (precondition).
- JSON output includes `severity`, `ok`, and `skipReason` on every check entry. `skipReason` is `null` on non-skipped entries for uniform shape.
- Staged checklist progression halts only on failures at or above the `failOn` threshold.

### Fixes

- `allPassed` in JSON output now derives from `report.passed` instead of re-counting filtered visible failures, which diverged when `failOn` and `reportOn` differed.
- `runHumanMode` gains a try/catch around `runPreflight` to match the error handling in `runJsonMode`.

### Refactoring

- `PreflightResult` is a discriminated union (`PassedResult | FailedResult | SkippedResult`) with all fields non-optional using explicit `null`.
- `FixLocation` normalized from `'INLINE' | 'END'` to `'inline' | 'end'`.
- `ReportOptions` removed from public API; replaced by `ReportPreflightOptions`, `FormatJsonReportOptions`, and `RunPreflightOptions` (all exported).
- JSON count fields renamed from `passedCount`/`failedCount`/`skippedCount` to `passed`/`failed`/`skipped`.
- Local JSON interface duplicates in `formatJsonReport.ts` replaced by shared types from `types.ts`.
- `meetsThreshold`/`severityRank` utilities exported from `runPreflight.ts` for consistent severity comparison.

### Tests

- 350 tests passing across 8 test files.
- New coverage: severity resolution, skip conditions (sync, async, throwing), threshold-aware `report.passed`, staged progression with thresholds, reporting threshold filtering, JSON field shape, CLI flag parsing/validation, Zod schema for new fields, threshold cascade (including `reportOn` collection fallback), and precondition visibility filtering.