### PR TITLE
#145 Extract shared CLI argument-parsing utility into core

### DIFF
--- a/packages/core/__tests__/parseArgs.test.ts
+++ b/packages/core/__tests__/parseArgs.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FlagSchema } from '../src/parseArgs.ts';
+import { parseArgs } from '../src/parseArgs.ts';
+
+const emptySchema = {} satisfies FlagSchema;
+
+const mixedSchema = {
+  dryRun: { long: '--dry-run', type: 'boolean' as const },
+  output: { long: '--output', type: 'string' as const, short: '-o' },
+  verbose: { long: '--verbose', type: 'boolean' as const, short: '-v' },
+};
+
+describe(parseArgs, () => {
+  describe('empty argv', () => {
+    it('returns default flags and empty positionals', () => {
+      const result = parseArgs([], mixedSchema);
+
+      expect(result.flags).toStrictEqual({ dryRun: false, output: undefined, verbose: false });
+      expect(result.positionals).toStrictEqual([]);
+    });
+  });
+
+  describe('boolean flags', () => {
+    it('sets boolean flag to true when present via long form', () => {
+      const result = parseArgs(['--dry-run'], mixedSchema);
+
+      expect(result.flags.dryRun).toBe(true);
+    });
+
+    it('sets boolean flag to true when present via short alias', () => {
+      const result = parseArgs(['-v'], mixedSchema);
+
+      expect(result.flags.verbose).toBe(true);
+    });
+
+    it('defaults boolean flags to false when absent', () => {
+      const result = parseArgs(['positional'], mixedSchema);
+
+      expect(result.flags.dryRun).toBe(false);
+      expect(result.flags.verbose).toBe(false);
+    });
+
+    it('throws when boolean flag is given a value via = form', () => {
+      expect(() => parseArgs(['--dry-run=true'], mixedSchema)).toThrow("flag '--dry-run' does not accept a value");
+    });
+  });
+
+  describe('string flags', () => {
+    it('parses --flag=value form', () => {
+      const result = parseArgs(['--output=dist/out.js'], mixedSchema);
+
+      expect(result.flags.output).toBe('dist/out.js');
+    });
+
+    it('parses --flag value (space-separated) form', () => {
+      const result = parseArgs(['--output', 'dist/out.js'], mixedSchema);
+
+      expect(result.flags.output).toBe('dist/out.js');
+    });
+
+    it('parses short alias with space-separated value', () => {
+      const result = parseArgs(['-o', 'dist/out.js'], mixedSchema);
+
+      expect(result.flags.output).toBe('dist/out.js');
+    });
+
+    it('throws when --flag= has an empty value', () => {
+      expect(() => parseArgs(['--output='], mixedSchema)).toThrow('--output requires a value');
+    });
+
+    it('throws when string flag is at end of argv with no value', () => {
+      expect(() => parseArgs(['--output'], mixedSchema)).toThrow('--output requires a value');
+    });
+
+    it('throws when string flag is followed by another flag', () => {
+      expect(() => parseArgs(['--output', '--dry-run'], mixedSchema)).toThrow('--output requires a value');
+    });
+
+    it('defaults string flags to undefined when absent', () => {
+      const result = parseArgs([], mixedSchema);
+
+      expect(result.flags.output).toBeUndefined();
+    });
+  });
+
+  describe('unknown flags', () => {
+    it('throws for unknown long flag', () => {
+      expect(() => parseArgs(['--unknown'], mixedSchema)).toThrow("unknown flag '--unknown'");
+    });
+
+    it('throws for unknown short flag', () => {
+      expect(() => parseArgs(['-x'], mixedSchema)).toThrow("unknown flag '-x'");
+    });
+
+    it('throws for unknown long flag with = form', () => {
+      expect(() => parseArgs(['--unknown=val'], mixedSchema)).toThrow("unknown flag '--unknown'");
+    });
+  });
+
+  describe('positionals', () => {
+    it('collects positional arguments in order', () => {
+      const result = parseArgs(['foo', 'bar', 'baz'], emptySchema);
+
+      expect(result.positionals).toStrictEqual(['foo', 'bar', 'baz']);
+    });
+
+    it('treats bare - as a positional, not a flag', () => {
+      const result = parseArgs(['-'], emptySchema);
+
+      expect(result.positionals).toStrictEqual(['-']);
+    });
+
+    it('collects positionals interleaved with flags', () => {
+      const result = parseArgs(['foo', '--dry-run', 'bar'], mixedSchema);
+
+      expect(result.positionals).toStrictEqual(['foo', 'bar']);
+      expect(result.flags.dryRun).toBe(true);
+    });
+  });
+
+  describe('-- delimiter', () => {
+    it('stops flag parsing after --', () => {
+      const result = parseArgs(['--dry-run', '--', '--output', 'val'], mixedSchema);
+
+      expect(result.flags.dryRun).toBe(true);
+      expect(result.flags.output).toBeUndefined();
+      expect(result.positionals).toStrictEqual(['--output', 'val']);
+    });
+
+    it('treats everything after -- as positionals', () => {
+      const result = parseArgs(['--', '--unknown'], emptySchema);
+
+      expect(result.positionals).toStrictEqual(['--unknown']);
+    });
+  });
+
+  describe('string flag accepts bare - as a value', () => {
+    it('treats - as a valid string value (stdin convention)', () => {
+      const result = parseArgs(['--output', '-'], mixedSchema);
+
+      expect(result.flags.output).toBe('-');
+    });
+  });
+
+  describe('empty schema', () => {
+    it('treats all non-flag args as positionals', () => {
+      const result = parseArgs(['a', 'b'], emptySchema);
+
+      expect(result.positionals).toStrictEqual(['a', 'b']);
+    });
+
+    it('throws on any flag', () => {
+      expect(() => parseArgs(['--anything'], emptySchema)).toThrow("unknown flag '--anything'");
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 // Placeholder — shared utilities will be added here as the monorepo grows.
 export const PACKAGE_NAME = '@williamthorsen/node-monorepo-core';
+export type { FlagDefinition, FlagSchema, ParsedArgs, ParsedFlags } from './parseArgs.js';
+export { parseArgs } from './parseArgs.js';
 export { printError, printSkip, printStep, printSuccess, reportWriteResult } from './terminal.js';
 export type { WriteOutcome, WriteResult } from './writeFileWithCheck.js';
 export { writeFileWithCheck } from './writeFileWithCheck.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 // Placeholder — shared utilities will be added here as the monorepo grows.
 export const PACKAGE_NAME = '@williamthorsen/node-monorepo-core';
 export type { FlagDefinition, FlagSchema, ParsedArgs, ParsedFlags } from './parseArgs.js';
-export { parseArgs } from './parseArgs.js';
+export { parseArgs, translateParseError } from './parseArgs.js';
 export { printError, printSkip, printStep, printSuccess, reportWriteResult } from './terminal.js';
 export type { WriteOutcome, WriteResult } from './writeFileWithCheck.js';
 export { writeFileWithCheck } from './writeFileWithCheck.js';

--- a/packages/core/src/parseArgs.ts
+++ b/packages/core/src/parseArgs.ts
@@ -19,11 +19,6 @@ export interface ParsedArgs<S extends FlagSchema> {
   positionals: string[];
 }
 
-/** Resolve a flag key from its long or short form, or return `undefined` if unknown. */
-function resolveKey(arg: string, longToKey: Map<string, string>, shortToKey: Map<string, string>): string | undefined {
-  return longToKey.get(arg) ?? shortToKey.get(arg);
-}
-
 /** Handle a `--flag=value` argument, returning the key and value to assign. */
 function handleEqualsForm(
   arg: string,
@@ -56,7 +51,7 @@ function handleBareFlag(
   shortToKey: Map<string, string>,
   definitions: Map<string, FlagDefinition>,
 ): { key: string; value: boolean | string; advance: number } {
-  const key = resolveKey(arg, longToKey, shortToKey);
+  const key = longToKey.get(arg) ?? shortToKey.get(arg);
   if (key === undefined) {
     throw new Error(`unknown flag '${arg}'`);
   }
@@ -162,4 +157,19 @@ function parseArgsInternal(
 export function parseArgs<S extends FlagSchema>(argv: string[], schema: S): ParsedArgs<S> {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- The internal parser works with dynamic keys; the generic return type is guaranteed by schema-driven initialization.
   return parseArgsInternal(argv, schema) as ParsedArgs<S>;
+}
+
+/**
+ * Translate a `parseArgs` error into a user-facing message.
+ *
+ * Rewrites the internal `"unknown flag '--x'"` format to `"Unknown option: --x"`;
+ * passes other messages through unchanged.
+ */
+export function translateParseError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const flagMatch = message.match(/^unknown flag '(.+)'$/);
+  if (flagMatch?.[1] !== undefined) {
+    return `Unknown option: ${flagMatch[1]}`;
+  }
+  return message;
 }

--- a/packages/core/src/parseArgs.ts
+++ b/packages/core/src/parseArgs.ts
@@ -1,0 +1,165 @@
+/** Schema entry describing a single CLI flag. */
+export interface FlagDefinition {
+  long: string;
+  type: 'boolean' | 'string';
+  short?: string;
+}
+
+/** Map of camelCase property names to their flag definitions. */
+export type FlagSchema = Record<string, FlagDefinition>;
+
+/** Infer the result type from a flag schema: booleans become `boolean`, strings become `string | undefined`. */
+export type ParsedFlags<S extends FlagSchema> = {
+  [K in keyof S]: S[K]['type'] extends 'boolean' ? boolean : string | undefined;
+};
+
+/** Return type of `parseArgs`: typed flags plus collected positionals. */
+export interface ParsedArgs<S extends FlagSchema> {
+  flags: ParsedFlags<S>;
+  positionals: string[];
+}
+
+/** Resolve a flag key from its long or short form, or return `undefined` if unknown. */
+function resolveKey(arg: string, longToKey: Map<string, string>, shortToKey: Map<string, string>): string | undefined {
+  return longToKey.get(arg) ?? shortToKey.get(arg);
+}
+
+/** Handle a `--flag=value` argument, returning the key and value to assign. */
+function handleEqualsForm(
+  arg: string,
+  eqIndex: number,
+  longToKey: Map<string, string>,
+  definitions: Map<string, FlagDefinition>,
+): { key: string; value: string } {
+  const longFlag = arg.slice(0, eqIndex);
+  const key = longToKey.get(longFlag);
+  if (key === undefined) {
+    throw new Error(`unknown flag '${longFlag}'`);
+  }
+  const def = definitions.get(key);
+  if (def?.type === 'boolean') {
+    throw new Error(`flag '${longFlag}' does not accept a value`);
+  }
+  const value = arg.slice(eqIndex + 1);
+  if (value === '') {
+    throw new Error(`${longFlag} requires a value`);
+  }
+  return { key, value };
+}
+
+/** Handle a bare `--flag` or `-f` argument, returning the key, value, and index advancement. */
+function handleBareFlag(
+  arg: string,
+  index: number,
+  argv: string[],
+  longToKey: Map<string, string>,
+  shortToKey: Map<string, string>,
+  definitions: Map<string, FlagDefinition>,
+): { key: string; value: boolean | string; advance: number } {
+  const key = resolveKey(arg, longToKey, shortToKey);
+  if (key === undefined) {
+    throw new Error(`unknown flag '${arg}'`);
+  }
+  const def = definitions.get(key);
+  if (def?.type === 'boolean') {
+    return { key, value: true, advance: 0 };
+  }
+  // String flag: consume next argument as value.
+  const next = argv[index + 1];
+  if (next === undefined || (next.startsWith('-') && next !== '-')) {
+    throw new Error(`${def?.long} requires a value`);
+  }
+  return { key, value: next, advance: 1 };
+}
+
+/**
+ * Build the lookup tables needed for flag resolution from a schema.
+ *
+ * Returns maps from long/short forms to schema keys, and from schema keys to definitions.
+ */
+function buildLookupTables(schema: FlagSchema): {
+  longToKey: Map<string, string>;
+  shortToKey: Map<string, string>;
+  definitions: Map<string, FlagDefinition>;
+} {
+  const longToKey = new Map<string, string>();
+  const shortToKey = new Map<string, string>();
+  const definitions = new Map<string, FlagDefinition>();
+
+  for (const [key, def] of Object.entries(schema)) {
+    longToKey.set(def.long, key);
+    definitions.set(key, def);
+    if (def.short !== undefined) {
+      shortToKey.set(def.short, key);
+    }
+  }
+
+  return { longToKey, shortToKey, definitions };
+}
+
+/**
+ * Internal implementation that works with untyped records.
+ *
+ * Separated from the public API to isolate the dynamic key manipulation
+ * from the generic type boundary.
+ */
+function parseArgsInternal(
+  argv: string[],
+  schema: FlagSchema,
+): { flags: Record<string, boolean | string | undefined>; positionals: string[] } {
+  const { longToKey, shortToKey, definitions } = buildLookupTables(schema);
+
+  const flags: Record<string, boolean | string | undefined> = {};
+  for (const [key, def] of Object.entries(schema)) {
+    flags[key] = def.type === 'boolean' ? false : undefined;
+  }
+
+  const positionals: string[] = [];
+  let pastDelimiter = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i] ?? '';
+
+    if (pastDelimiter) {
+      positionals.push(arg);
+      continue;
+    }
+
+    if (arg === '--') {
+      pastDelimiter = true;
+      continue;
+    }
+
+    // Check for --long=value form.
+    const eqIndex = arg.indexOf('=');
+    if (eqIndex !== -1 && arg.startsWith('--')) {
+      const { key, value } = handleEqualsForm(arg, eqIndex, longToKey, definitions);
+      flags[key] = value;
+      continue;
+    }
+
+    // Check for --long or -short form.
+    if (arg.startsWith('-') && arg !== '-') {
+      const { key, value, advance } = handleBareFlag(arg, i, argv, longToKey, shortToKey, definitions);
+      flags[key] = value;
+      i += advance;
+      continue;
+    }
+
+    // Positional (includes bare `-`).
+    positionals.push(arg);
+  }
+
+  return { flags, positionals };
+}
+
+/**
+ * Parse a pre-sliced argv array against a flag schema.
+ *
+ * Throws `Error` with a human-readable message on unknown flags or missing string-flag values.
+ * Does not call `console` or `process.exit`.
+ */
+export function parseArgs<S extends FlagSchema>(argv: string[], schema: S): ParsedArgs<S> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- The internal parser works with dynamic keys; the generic return type is guaranteed by schema-driven initialization.
+  return parseArgsInternal(argv, schema) as ParsedArgs<S>;
+}

--- a/packages/preflight/src/bin/route.ts
+++ b/packages/preflight/src/bin/route.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 
-import { parseArgs } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
 import { parseRunArgs, runCommand } from '../cli.ts';
 import { compileCommand } from '../compile/compileCommand.ts';
@@ -149,14 +149,7 @@ export async function routeCommand(args: string[]): Promise<number> {
     try {
       parsed = parseArgs(flags, initFlagSchema);
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      // Translate "unknown flag '--x'" to "Unknown option: --x".
-      const flagMatch = message.match(/^unknown flag '(.+)'$/);
-      if (flagMatch?.[1] !== undefined) {
-        process.stderr.write(`Error: Unknown option: ${flagMatch[1]}\n`);
-      } else {
-        process.stderr.write(`Error: ${message}\n`);
-      }
+      process.stderr.write(`Error: ${translateParseError(error)}\n`);
       return 1;
     }
 

--- a/packages/preflight/src/bin/route.ts
+++ b/packages/preflight/src/bin/route.ts
@@ -1,5 +1,7 @@
 import process from 'node:process';
 
+import { parseArgs } from '@williamthorsen/node-monorepo-core';
+
 import { parseRunArgs, runCommand } from '../cli.ts';
 import { compileCommand } from '../compile/compileCommand.ts';
 import { initCommand } from '../init/initCommand.ts';
@@ -122,7 +124,13 @@ export async function routeCommand(args: string[]): Promise<number> {
       showCompileHelp();
       return 0;
     }
-    return compileCommand(flags);
+    try {
+      return await compileCommand(flags);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Error: ${message}\n`);
+      return 1;
+    }
   }
 
   if (command === 'init') {
@@ -132,16 +140,27 @@ export async function routeCommand(args: string[]): Promise<number> {
       return 0;
     }
 
-    const knownInitFlags = new Set(['--dry-run', '--force', '--help', '-h']);
-    const unknownFlags = flags.filter((f) => !knownInitFlags.has(f));
-    if (unknownFlags.length > 0) {
-      process.stderr.write(`Error: Unknown option: ${unknownFlags[0]}\n`);
+    const initFlagSchema = {
+      dryRun: { long: '--dry-run', type: 'boolean' as const },
+      force: { long: '--force', type: 'boolean' as const },
+    };
+
+    let parsed;
+    try {
+      parsed = parseArgs(flags, initFlagSchema);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Translate "unknown flag '--x'" to "Unknown option: --x".
+      const flagMatch = message.match(/^unknown flag '(.+)'$/);
+      if (flagMatch?.[1] !== undefined) {
+        process.stderr.write(`Error: Unknown option: ${flagMatch[1]}\n`);
+      } else {
+        process.stderr.write(`Error: ${message}\n`);
+      }
       return 1;
     }
 
-    const dryRun = flags.includes('--dry-run');
-    const force = flags.includes('--force');
-    return initCommand({ dryRun, force });
+    return initCommand({ dryRun: parsed.flags.dryRun, force: parsed.flags.force });
   }
 
   // Check for typos before falling through to the default command

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -1,5 +1,7 @@
 import process from 'node:process';
 
+import { parseArgs } from '@williamthorsen/node-monorepo-core';
+
 import { loadPreflightCollection } from './config.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonError } from './formatJsonError.ts';
@@ -33,28 +35,15 @@ interface ParsedRunArgs {
   reportOn?: Severity;
 }
 
-/** Extract a flag value from either `--flag value` or `--flag=value` form, advancing the index when needed. */
-function extractFlagValue(
-  flagName: string,
-  arg: string,
-  flags: string[],
-  index: number,
-  errorHint: string,
-): { value: string; nextIndex: number } {
-  const eqPrefix = `${flagName}=`;
-  if (arg.startsWith(eqPrefix)) {
-    const value = arg.slice(eqPrefix.length);
-    if (value === '') {
-      throw new Error(`${flagName} requires ${errorHint}`);
-    }
-    return { value, nextIndex: index };
-  }
-  const next = flags[index + 1];
-  if (next === undefined || next.startsWith('-')) {
-    throw new Error(`${flagName} requires ${errorHint}`);
-  }
-  return { value: next, nextIndex: index + 1 };
-}
+const runFlagSchema = {
+  file: { long: '--file', type: 'string' as const },
+  github: { long: '--github', type: 'string' as const },
+  url: { long: '--url', type: 'string' as const },
+  collection: { long: '--collection', type: 'string' as const },
+  json: { long: '--json', type: 'boolean' as const },
+  failOn: { long: '--fail-on', type: 'string' as const },
+  reportOn: { long: '--report-on', type: 'string' as const },
+};
 
 /** Throw if a collection source flag has already been set. */
 function assertNoExistingSource(existing: string | undefined): void {
@@ -100,84 +89,69 @@ function buildGitHubCollectionUrl(repo: string, ref: string, collection: string)
   return `https://raw.githubusercontent.com/${repo}/${ref}/.preflight/distribution/${collection}.js`;
 }
 
-/** Parse run-subcommand flags into a structured object. */
-export function parseRunArgs(flags: string[]): ParsedRunArgs {
-  const names: string[] = [];
-  let sourceType: string | undefined;
-  let filePath: string | undefined;
-  let githubValue: string | undefined;
-  let urlValue: string | undefined;
-  let collectionName: string | undefined;
-  let json = false;
-  let failOn: Severity | undefined;
-  let reportOn: Severity | undefined;
+/** Map generic "requires a value" errors to domain-specific hints for run-subcommand flags. */
+const flagErrorHints: Record<string, string> = {
+  '--file': '--file requires a path argument',
+  '--github': '--github requires a repository argument (org/repo[@ref])',
+  '--url': '--url requires a URL argument',
+  '--collection': '--collection requires a collection name',
+  '--fail-on': '--fail-on requires a severity level (error, warn, recommend)',
+  '--report-on': '--report-on requires a severity level (error, warn, recommend)',
+};
 
-  for (let i = 0; i < flags.length; i++) {
-    const arg = flags[i] ?? '';
-
-    if (arg === '--json') {
-      json = true;
-    } else if (arg === '--file' || arg.startsWith('--file=')) {
-      assertNoExistingSource(sourceType);
-      const { value, nextIndex } = extractFlagValue('--file', arg, flags, i, 'a path argument');
-      i = nextIndex;
-      sourceType = 'file';
-      filePath = value;
-    } else if (arg === '--github' || arg.startsWith('--github=')) {
-      assertNoExistingSource(sourceType);
-      const { value, nextIndex } = extractFlagValue(
-        '--github',
-        arg,
-        flags,
-        i,
-        'a repository argument (org/repo[@ref])',
-      );
-      i = nextIndex;
-      sourceType = 'github';
-      githubValue = value;
-    } else if (arg === '--url' || arg.startsWith('--url=')) {
-      assertNoExistingSource(sourceType);
-      const { value, nextIndex } = extractFlagValue('--url', arg, flags, i, 'a URL argument');
-      i = nextIndex;
-      sourceType = 'url';
-      urlValue = value;
-    } else if (arg === '--collection' || arg.startsWith('--collection=')) {
-      const { value, nextIndex } = extractFlagValue('--collection', arg, flags, i, 'a collection name');
-      i = nextIndex;
-      collectionName = value;
-    } else if (arg === '--fail-on' || arg.startsWith('--fail-on=')) {
-      const { value, nextIndex } = extractFlagValue(
-        '--fail-on',
-        arg,
-        flags,
-        i,
-        'a severity level (error, warn, recommend)',
-      );
-      i = nextIndex;
-      failOn = parseSeverityFlag('--fail-on', value);
-    } else if (arg === '--report-on' || arg.startsWith('--report-on=')) {
-      const { value, nextIndex } = extractFlagValue(
-        '--report-on',
-        arg,
-        flags,
-        i,
-        'a severity level (error, warn, recommend)',
-      );
-      i = nextIndex;
-      reportOn = parseSeverityFlag('--report-on', value);
-    } else if (arg.startsWith('-')) {
-      throw new Error(`unknown flag '${arg}'`);
-    } else {
-      names.push(arg);
+/** Translate generic parseArgs errors into domain-specific messages where applicable. */
+function translateParseError(error: unknown): never {
+  if (error instanceof Error) {
+    const match = error.message.match(/^(--\S+) requires a value$/);
+    if (match?.[1] !== undefined) {
+      const hint = flagErrorHints[match[1]];
+      if (hint !== undefined) {
+        throw new Error(hint);
+      }
     }
   }
+  throw error;
+}
 
-  const collectionSource = resolveCollectionSource({ filePath, githubValue, urlValue, collectionName });
+/** Parse run-subcommand flags into a structured object. */
+export function parseRunArgs(flags: string[]): ParsedRunArgs {
+  let result;
+  try {
+    result = parseArgs(flags, runFlagSchema);
+  } catch (error: unknown) {
+    translateParseError(error);
+  }
+  const { flags: parsed, positionals } = result;
 
-  const result: ParsedRunArgs = { collectionSource, json, names };
-  if (failOn !== undefined) result.failOn = failOn;
-  if (reportOn !== undefined) result.reportOn = reportOn;
-  return result;
+  // Validate mutual exclusivity of source flags.
+  let sourceType: string | undefined;
+  if (parsed.file !== undefined) {
+    sourceType = 'file';
+  }
+  if (parsed.github !== undefined) {
+    assertNoExistingSource(sourceType);
+    sourceType = 'github';
+  }
+  if (parsed.url !== undefined) {
+    assertNoExistingSource(sourceType);
+    sourceType = 'url';
+  }
+
+  // Validate severity flags.
+  const failOn = parsed.failOn !== undefined ? parseSeverityFlag('--fail-on', parsed.failOn) : undefined;
+  const reportOn = parsed.reportOn !== undefined ? parseSeverityFlag('--report-on', parsed.reportOn) : undefined;
+
+  const collectionSource = resolveCollectionSource({
+    filePath: parsed.file,
+    githubValue: parsed.github,
+    urlValue: parsed.url,
+    collectionName: parsed.collection,
+  });
+
+  const parsedArgs: ParsedRunArgs = { collectionSource, json: parsed.json, names: positionals };
+  if (failOn !== undefined) parsedArgs.failOn = failOn;
+  if (reportOn !== undefined) parsedArgs.reportOn = reportOn;
+  return parsedArgs;
 }
 
 /** Validate flag co-dependencies and build the CollectionSource from parsed flag state. */

--- a/packages/preflight/src/compile/compileCommand.ts
+++ b/packages/preflight/src/compile/compileCommand.ts
@@ -2,30 +2,15 @@ import { existsSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
+import { parseArgs } from '@williamthorsen/node-monorepo-core';
+
 import { loadConfig } from '../loadConfig.ts';
 import { compileConfig } from './compileConfig.ts';
 import { validateCompiledOutput } from './validateCompiledOutput.ts';
 
-/** Extract a flag value from either `--flag value` or `--flag=value` form. */
-function extractFlagValue(
-  flagName: string,
-  arg: string,
-  args: string[],
-  index: number,
-): { value: string; nextIndex: number } | undefined {
-  const eqPrefix = `${flagName}=`;
-  if (arg.startsWith(eqPrefix)) {
-    const value = arg.slice(eqPrefix.length);
-    if (value === '') return undefined;
-    return { value, nextIndex: index };
-  }
-  if (arg === flagName) {
-    const next = args[index + 1];
-    if (next === undefined || next.startsWith('-')) return undefined;
-    return { value: next, nextIndex: index + 1 };
-  }
-  return undefined;
-}
+const compileFlagSchema = {
+  output: { long: '--output', type: 'string' as const, short: '-o' },
+};
 
 /**
  * Handle the `compile` subcommand: parse arguments, invoke the bundler, and report the result.
@@ -34,39 +19,33 @@ function extractFlagValue(
  * Returns a numeric exit code.
  */
 export async function compileCommand(args: string[]): Promise<number> {
-  let inputPath: string | undefined;
-  let outputPath: string | undefined;
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i] ?? '';
-
-    if (arg === '-o') {
-      const next = args[i + 1];
-      if (next === undefined || next.startsWith('-')) {
-        process.stderr.write('Error: --output requires a path argument\n');
-        return 1;
-      }
-      outputPath = next;
-      i += 1;
-    } else if (arg === '--output' || arg.startsWith('--output=')) {
-      const extracted = extractFlagValue('--output', arg, args, i);
-      if (extracted === undefined) {
-        process.stderr.write('Error: --output requires a path argument\n');
-        return 1;
-      }
-      outputPath = extracted.value;
-      i = extracted.nextIndex;
-    } else if (arg.startsWith('-')) {
-      process.stderr.write(`Error: Unknown option: ${arg}\n`);
-      return 1;
+  let parsed;
+  try {
+    parsed = parseArgs(args, compileFlagSchema);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    // Translate generic "requires a value" to domain hint.
+    if (message === '--output requires a value') {
+      process.stderr.write('Error: --output requires a path argument\n');
+    } else if (message.startsWith("unknown flag '")) {
+      // Convert "unknown flag '--x'" to "Unknown option: --x".
+      const flag = message.slice("unknown flag '".length, -1);
+      process.stderr.write(`Error: Unknown option: ${flag}\n`);
     } else {
-      if (inputPath !== undefined) {
-        process.stderr.write('Error: Too many arguments. Expected a single input file.\n');
-        return 1;
-      }
-      inputPath = arg;
+      process.stderr.write(`Error: ${message}\n`);
     }
+    return 1;
   }
+
+  const outputPath = parsed.flags.output;
+  const positionals = parsed.positionals;
+
+  if (positionals.length > 1) {
+    process.stderr.write('Error: Too many arguments. Expected a single input file.\n');
+    return 1;
+  }
+
+  const inputPath = positionals[0];
 
   // Explicit input file — compile just that one
   if (inputPath !== undefined) {

--- a/packages/preflight/src/compile/compileCommand.ts
+++ b/packages/preflight/src/compile/compileCommand.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-import { parseArgs } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
 import { loadConfig } from '../loadConfig.ts';
 import { compileConfig } from './compileConfig.ts';
@@ -27,12 +27,8 @@ export async function compileCommand(args: string[]): Promise<number> {
     // Translate generic "requires a value" to domain hint.
     if (message === '--output requires a value') {
       process.stderr.write('Error: --output requires a path argument\n');
-    } else if (message.startsWith("unknown flag '")) {
-      // Convert "unknown flag '--x'" to "Unknown option: --x".
-      const flag = message.slice("unknown flag '".length, -1);
-      process.stderr.write(`Error: Unknown option: ${flag}\n`);
     } else {
-      process.stderr.write(`Error: ${message}\n`);
+      process.stderr.write(`Error: ${translateParseError(error)}\n`);
     }
     return 1;
   }

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -338,23 +338,18 @@ describe(parseArgs, () => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
     vi.spyOn(console, 'info').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('exits with code 1 for an invalid bump type', () => {
-    expect(() => parseArgs(['--bump=invalid'])).toThrow(ExitError);
-    expect(process.exit).toHaveBeenCalledWith(1);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Invalid bump type'));
+  it('throws for an invalid bump type', () => {
+    expect(() => parseArgs(['--bump=invalid'])).toThrow('Invalid bump type');
   });
 
-  it('exits with code 1 for an unknown argument', () => {
-    expect(() => parseArgs(['--foo'])).toThrow(ExitError);
-    expect(process.exit).toHaveBeenCalledWith(1);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Unknown argument'));
+  it('throws for an unknown flag with the flag name in the message', () => {
+    expect(() => parseArgs(['--foo'])).toThrow('Unknown option: --foo');
   });
 
   it('exits with code 0 when --help is provided', () => {
@@ -363,16 +358,12 @@ describe(parseArgs, () => {
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining('npx @williamthorsen/release-kit prepare'));
   });
 
-  it('exits with code 1 when --force is used without --bump', () => {
-    expect(() => parseArgs(['--force'])).toThrow(ExitError);
-    expect(process.exit).toHaveBeenCalledWith(1);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--force requires --bump'));
+  it('throws when --force is used without --bump', () => {
+    expect(() => parseArgs(['--force'])).toThrow('--force requires --bump');
   });
 
-  it('exits with code 1 when --only value is empty', () => {
-    expect(() => parseArgs(['--only='])).toThrow(ExitError);
-    expect(process.exit).toHaveBeenCalledWith(1);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--only requires'));
+  it('throws when --only value is empty', () => {
+    expect(() => parseArgs(['--only='])).toThrow('--only requires');
   });
 });
 

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -31,9 +31,13 @@ vi.mock('../releasePrepare.ts', () => ({
   releasePrepare: mockReleasePrepare,
 }));
 
-vi.mock(import('@williamthorsen/node-monorepo-core'), () => ({
-  writeFileWithCheck: mockWriteFileWithCheck,
-}));
+vi.mock(import('@williamthorsen/node-monorepo-core'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    writeFileWithCheck: mockWriteFileWithCheck,
+  };
+});
 
 import { parseArgs, prepareCommand, RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from '../prepareCommand.ts';
 import type { PrepareResult } from '../types.ts';

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -2,7 +2,7 @@
 /* eslint n/hashbang: off, n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
 import { commitCommand } from '../commitCommand.ts';
 import { initCommand } from '../init/initCommand.ts';
@@ -229,13 +229,7 @@ if (command === 'init') {
   try {
     parsed = parseArgs(flags, initFlagSchema);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    const flagMatch = message.match(/^unknown flag '(.+)'$/);
-    if (flagMatch?.[1] !== undefined) {
-      console.error(`Error: Unknown option: ${flagMatch[1]}`);
-    } else {
-      console.error(`Error: ${message}`);
-    }
+    console.error(`Error: ${translateParseError(error)}`);
     process.exit(1);
   }
 
@@ -268,13 +262,7 @@ if (command === 'sync-labels') {
     try {
       syncParsed = parseArgs(subflags, syncLabelsInitFlagSchema);
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      const flagMatch = message.match(/^unknown flag '(.+)'$/);
-      if (flagMatch?.[1] !== undefined) {
-        console.error(`Error: Unknown option: ${flagMatch[1]}`);
-      } else {
-        console.error(`Error: ${message}`);
-      }
+      console.error(`Error: ${translateParseError(error)}`);
       process.exit(1);
     }
 

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -2,6 +2,8 @@
 /* eslint n/hashbang: off, n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
+import { parseArgs } from '@williamthorsen/node-monorepo-core';
+
 import { commitCommand } from '../commitCommand.ts';
 import { initCommand } from '../init/initCommand.ts';
 import { prepareCommand } from '../prepareCommand.ts';
@@ -217,16 +219,27 @@ if (command === 'init') {
     process.exit(0);
   }
 
-  const knownInitFlags = new Set(['--dry-run', '--force', '--with-config', '--help', '-h']);
-  const unknownFlags = flags.filter((f) => !knownInitFlags.has(f));
-  if (unknownFlags.length > 0) {
-    console.error(`Error: Unknown option: ${unknownFlags[0]}`);
+  const initFlagSchema = {
+    dryRun: { long: '--dry-run', type: 'boolean' as const },
+    force: { long: '--force', type: 'boolean' as const },
+    withConfig: { long: '--with-config', type: 'boolean' as const },
+  };
+
+  let parsed;
+  try {
+    parsed = parseArgs(flags, initFlagSchema);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    const flagMatch = message.match(/^unknown flag '(.+)'$/);
+    if (flagMatch?.[1] !== undefined) {
+      console.error(`Error: Unknown option: ${flagMatch[1]}`);
+    } else {
+      console.error(`Error: ${message}`);
+    }
     process.exit(1);
   }
 
-  const dryRun = flags.includes('--dry-run');
-  const force = flags.includes('--force');
-  const withConfig = flags.includes('--with-config');
+  const { dryRun, force, withConfig } = parsed.flags;
   const exitCode = initCommand({ dryRun, force, withConfig });
   process.exit(exitCode);
 }
@@ -246,15 +259,26 @@ if (command === 'sync-labels') {
       process.exit(0);
     }
 
-    const knownFlags = new Set(['--dry-run', '--force', '--help', '-h']);
-    const unknownFlags = subflags.filter((f) => !knownFlags.has(f));
-    if (unknownFlags.length > 0) {
-      console.error(`Error: Unknown option: ${unknownFlags[0]}`);
+    const syncLabelsInitFlagSchema = {
+      dryRun: { long: '--dry-run', type: 'boolean' as const },
+      force: { long: '--force', type: 'boolean' as const },
+    };
+
+    let syncParsed;
+    try {
+      syncParsed = parseArgs(subflags, syncLabelsInitFlagSchema);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      const flagMatch = message.match(/^unknown flag '(.+)'$/);
+      if (flagMatch?.[1] !== undefined) {
+        console.error(`Error: Unknown option: ${flagMatch[1]}`);
+      } else {
+        console.error(`Error: ${message}`);
+      }
       process.exit(1);
     }
 
-    const dryRun = subflags.includes('--dry-run');
-    const force = subflags.includes('--force');
+    const { dryRun, force } = syncParsed.flags;
     const exitCode = await syncLabelsInitCommand({ dryRun, force });
     process.exit(exitCode);
   }

--- a/packages/release-kit/src/commitCommand.ts
+++ b/packages/release-kit/src/commitCommand.ts
@@ -4,7 +4,7 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
-import { parseArgs } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
 import { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from './prepareCommand.ts';
 
@@ -23,13 +23,7 @@ export function commitCommand(argv: string[]): void {
   try {
     parsed = parseArgs(argv, commitFlagSchema);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    const flagMatch = message.match(/^unknown flag '(.+)'$/);
-    if (flagMatch?.[1] !== undefined) {
-      console.error(`Error: Unknown option: ${flagMatch[1]}`);
-    } else {
-      console.error(`Error: ${message}`);
-    }
+    console.error(`Error: ${translateParseError(error)}`);
     process.exit(1);
   }
 

--- a/packages/release-kit/src/commitCommand.ts
+++ b/packages/release-kit/src/commitCommand.ts
@@ -4,7 +4,13 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
+import { parseArgs } from '@williamthorsen/node-monorepo-core';
+
 import { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from './prepareCommand.ts';
+
+const commitFlagSchema = {
+  dryRun: { long: '--dry-run', type: 'boolean' as const },
+};
 
 /**
  * Orchestrate the CLI `commit` command.
@@ -13,14 +19,21 @@ import { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from './prepareCommand.ts';
  * changes, and creates a release commit with a formatted message.
  */
 export function commitCommand(argv: string[]): void {
-  const knownFlags = new Set(['--dry-run']);
-  const unknownFlags = argv.filter((f) => !knownFlags.has(f));
-  if (unknownFlags.length > 0) {
-    console.error(`Error: Unknown option: ${unknownFlags[0]}`);
+  let parsed;
+  try {
+    parsed = parseArgs(argv, commitFlagSchema);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    const flagMatch = message.match(/^unknown flag '(.+)'$/);
+    if (flagMatch?.[1] !== undefined) {
+      console.error(`Error: Unknown option: ${flagMatch[1]}`);
+    } else {
+      console.error(`Error: ${message}`);
+    }
     process.exit(1);
   }
 
-  const dryRun = argv.includes('--dry-run');
+  const dryRun = parsed.flags.dryRun;
 
   // Read tags file.
   let tagsContent: string;

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -2,7 +2,11 @@
 /* eslint unicorn/no-process-exit: off */
 
 import type { WriteResult } from '@williamthorsen/node-monorepo-core';
-import { parseArgs as coreParseArgs, writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
+import {
+  parseArgs as coreParseArgs,
+  translateParseError,
+  writeFileWithCheck,
+} from '@williamthorsen/node-monorepo-core';
 
 import { buildReleaseSummary } from './buildReleaseSummary.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
@@ -65,12 +69,7 @@ export function parseArgs(argv: string[]): {
   try {
     parsed = coreParseArgs(argv, prepareFlagSchema);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    const flagMatch = message.match(/^unknown flag '(.+)'$/);
-    if (flagMatch?.[1] !== undefined) {
-      throw new Error(`Unknown option: ${flagMatch[1]}`);
-    }
-    throw new Error(message);
+    throw new Error(translateParseError(error));
   }
 
   const { flags } = parsed;
@@ -90,9 +89,6 @@ export function parseArgs(argv: string[]): {
 
   let only: string[] | undefined;
   if (flags.only !== undefined) {
-    if (flags.only === '') {
-      throw new Error('--only requires a comma-separated list of component names');
-    }
     only = flags.only.split(',');
   }
 

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -2,7 +2,7 @@
 /* eslint unicorn/no-process-exit: off */
 
 import type { WriteResult } from '@williamthorsen/node-monorepo-core';
-import { writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
+import { parseArgs as coreParseArgs, writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
 
 import { buildReleaseSummary } from './buildReleaseSummary.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
@@ -46,6 +46,14 @@ Options:
 `);
 }
 
+const prepareFlagSchema = {
+  dryRun: { long: '--dry-run', type: 'boolean' as const },
+  force: { long: '--force', type: 'boolean' as const },
+  bump: { long: '--bump', type: 'string' as const },
+  only: { long: '--only', type: 'string' as const },
+  help: { long: '--help', type: 'boolean' as const, short: '-h' },
+};
+
 /** Parse CLI arguments into structured options. */
 export function parseArgs(argv: string[]): {
   dryRun: boolean;
@@ -53,45 +61,46 @@ export function parseArgs(argv: string[]): {
   bumpOverride: ReleaseType | undefined;
   only: string[] | undefined;
 } {
-  let dryRun = false;
-  let force = false;
-  let bumpOverride: ReleaseType | undefined;
-  let only: string[] | undefined;
-
-  for (const arg of argv) {
-    if (arg === '--dry-run') {
-      dryRun = true;
-    } else if (arg === '--force') {
-      force = true;
-    } else if (arg.startsWith('--bump=')) {
-      const value = arg.slice('--bump='.length);
-      if (!isReleaseType(value)) {
-        console.error(`Error: Invalid bump type "${value}". Must be one of: ${VALID_BUMP_TYPES.join(', ')}`);
-        process.exit(1);
-      }
-      bumpOverride = value;
-    } else if (arg.startsWith('--only=')) {
-      const value = arg.slice('--only='.length);
-      if (!value) {
-        console.error('Error: --only requires a comma-separated list of component names');
-        process.exit(1);
-      }
-      only = value.split(',');
-    } else if (arg === '--help' || arg === '-h') {
-      showHelp();
-      process.exit(0);
-    } else {
-      console.error(`Error: Unknown argument: ${arg}`);
-      process.exit(1);
-    }
+  let parsed;
+  try {
+    parsed = coreParseArgs(argv, prepareFlagSchema);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: Unknown argument: ${message.replace(/^unknown flag '(.+)'$/, '$1')}`);
+    process.exit(1);
   }
 
-  if (force && bumpOverride === undefined) {
+  const { flags } = parsed;
+
+  if (flags.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  let bumpOverride: ReleaseType | undefined;
+  if (flags.bump !== undefined) {
+    if (!isReleaseType(flags.bump)) {
+      console.error(`Error: Invalid bump type "${flags.bump}". Must be one of: ${VALID_BUMP_TYPES.join(', ')}`);
+      process.exit(1);
+    }
+    bumpOverride = flags.bump;
+  }
+
+  let only: string[] | undefined;
+  if (flags.only !== undefined) {
+    if (flags.only === '') {
+      console.error('Error: --only requires a comma-separated list of component names');
+      process.exit(1);
+    }
+    only = flags.only.split(',');
+  }
+
+  if (flags.force && bumpOverride === undefined) {
     console.error('Error: --force requires --bump to specify the version bump type');
     process.exit(1);
   }
 
-  return { dryRun, force, bumpOverride, only };
+  return { dryRun: flags.dryRun, force: flags.force, bumpOverride, only };
 }
 
 /**

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -54,7 +54,7 @@ const prepareFlagSchema = {
   help: { long: '--help', type: 'boolean' as const, short: '-h' },
 };
 
-/** Parse CLI arguments into structured options. */
+/** Parse CLI arguments into structured options. Throws on invalid input. */
 export function parseArgs(argv: string[]): {
   dryRun: boolean;
   force: boolean;
@@ -66,8 +66,11 @@ export function parseArgs(argv: string[]): {
     parsed = coreParseArgs(argv, prepareFlagSchema);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`Error: Unknown argument: ${message.replace(/^unknown flag '(.+)'$/, '$1')}`);
-    process.exit(1);
+    const flagMatch = message.match(/^unknown flag '(.+)'$/);
+    if (flagMatch?.[1] !== undefined) {
+      throw new Error(`Unknown option: ${flagMatch[1]}`);
+    }
+    throw new Error(message);
   }
 
   const { flags } = parsed;
@@ -80,8 +83,7 @@ export function parseArgs(argv: string[]): {
   let bumpOverride: ReleaseType | undefined;
   if (flags.bump !== undefined) {
     if (!isReleaseType(flags.bump)) {
-      console.error(`Error: Invalid bump type "${flags.bump}". Must be one of: ${VALID_BUMP_TYPES.join(', ')}`);
-      process.exit(1);
+      throw new Error(`Invalid bump type "${flags.bump}". Must be one of: ${VALID_BUMP_TYPES.join(', ')}`);
     }
     bumpOverride = flags.bump;
   }
@@ -89,15 +91,13 @@ export function parseArgs(argv: string[]): {
   let only: string[] | undefined;
   if (flags.only !== undefined) {
     if (flags.only === '') {
-      console.error('Error: --only requires a comma-separated list of component names');
-      process.exit(1);
+      throw new Error('--only requires a comma-separated list of component names');
     }
     only = flags.only.split(',');
   }
 
   if (flags.force && bumpOverride === undefined) {
-    console.error('Error: --force requires --bump to specify the version bump type');
-    process.exit(1);
+    throw new Error('--force requires --bump to specify the version bump type');
   }
 
   return { dryRun: flags.dryRun, force: flags.force, bumpOverride, only };
@@ -126,7 +126,16 @@ export function writeReleaseTags(tags: string[], dryRun: boolean): WriteResult |
  * 6. Writes `.release-tags` for CI consumption.
  */
 export async function prepareCommand(argv: string[]): Promise<void> {
-  const { dryRun, force, bumpOverride, only } = parseArgs(argv);
+  let dryRun: boolean;
+  let force: boolean;
+  let bumpOverride: ReleaseType | undefined;
+  let only: string[] | undefined;
+  try {
+    ({ dryRun, force, bumpOverride, only } = parseArgs(argv));
+  } catch (error: unknown) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
   const options = {
     dryRun,
     force,

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -3,7 +3,7 @@
 
 import { basename } from 'node:path';
 
-import { parseArgs } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
 import { detectPackageManager } from './detectPackageManager.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
@@ -26,13 +26,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
   try {
     parsed = parseArgs(argv, publishFlagSchema);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    const flagMatch = message.match(/^unknown flag '(.+)'$/);
-    if (flagMatch?.[1] !== undefined) {
-      console.error(`Error: Unknown option: ${flagMatch[1]}`);
-    } else {
-      console.error(`Error: ${message}`);
-    }
+    console.error(`Error: ${translateParseError(error)}`);
     process.exit(1);
   }
 

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -3,29 +3,41 @@
 
 import { basename } from 'node:path';
 
+import { parseArgs } from '@williamthorsen/node-monorepo-core';
+
 import { detectPackageManager } from './detectPackageManager.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
 import { publish } from './publish.ts';
 import { resolveReleaseTags } from './resolveReleaseTags.ts';
+
+const publishFlagSchema = {
+  dryRun: { long: '--dry-run', type: 'boolean' as const },
+  noGitChecks: { long: '--no-git-checks', type: 'boolean' as const },
+  provenance: { long: '--provenance', type: 'boolean' as const },
+  only: { long: '--only', type: 'string' as const },
+};
 
 /**
  * Orchestrate the CLI `publish` command: parse flags, discover workspaces, resolve tags from HEAD,
  * detect the package manager, validate `--only`, and delegate to `publish`.
  */
 export async function publishCommand(argv: string[]): Promise<void> {
-  const knownFlags = new Set(['--dry-run', '--no-git-checks', '--provenance']);
-  const unknownFlags = argv.filter((f) => !f.startsWith('--only=') && !knownFlags.has(f));
-  if (unknownFlags.length > 0) {
-    console.error(`Error: Unknown option: ${unknownFlags[0]}`);
+  let parsed;
+  try {
+    parsed = parseArgs(argv, publishFlagSchema);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    const flagMatch = message.match(/^unknown flag '(.+)'$/);
+    if (flagMatch?.[1] !== undefined) {
+      console.error(`Error: Unknown option: ${flagMatch[1]}`);
+    } else {
+      console.error(`Error: ${message}`);
+    }
     process.exit(1);
   }
 
-  const dryRun = argv.includes('--dry-run');
-  const noGitChecks = argv.includes('--no-git-checks');
-  const provenance = argv.includes('--provenance');
-
-  const onlyArg = argv.find((f) => f.startsWith('--only='));
-  const only = onlyArg?.slice('--only='.length).split(',');
+  const { dryRun, noGitChecks, provenance } = parsed.flags;
+  const only = parsed.flags.only?.split(',');
 
   // Discover workspaces to determine single-package vs monorepo mode
   let discoveredPaths: string[] | undefined;

--- a/packages/release-kit/src/tagCommand.ts
+++ b/packages/release-kit/src/tagCommand.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
 import { createTags } from './createTags.ts';
 
@@ -17,13 +17,7 @@ export function tagCommand(argv: string[]): void {
   try {
     parsed = parseArgs(argv, tagFlagSchema);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    const flagMatch = message.match(/^unknown flag '(.+)'$/);
-    if (flagMatch?.[1] !== undefined) {
-      console.error(`Error: Unknown option: ${flagMatch[1]}`);
-    } else {
-      console.error(`Error: ${message}`);
-    }
+    console.error(`Error: ${translateParseError(error)}`);
     process.exit(1);
   }
 

--- a/packages/release-kit/src/tagCommand.ts
+++ b/packages/release-kit/src/tagCommand.ts
@@ -1,22 +1,33 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
+import { parseArgs } from '@williamthorsen/node-monorepo-core';
+
 import { createTags } from './createTags.ts';
 
-/**
- * Orchestrate the CLI `tag` command: parse flags and delegate to `createTags`.
- */
+const tagFlagSchema = {
+  dryRun: { long: '--dry-run', type: 'boolean' as const },
+  noGitChecks: { long: '--no-git-checks', type: 'boolean' as const },
+};
+
+/** Orchestrate the CLI `tag` command: parse flags and delegate to `createTags`. */
 export function tagCommand(argv: string[]): void {
   // Help flags are handled upstream in the CLI entry point (bin/release-kit.ts).
-  const knownFlags = new Set(['--dry-run', '--no-git-checks']);
-  const unknownFlags = argv.filter((f) => !knownFlags.has(f));
-  if (unknownFlags.length > 0) {
-    console.error(`Error: Unknown option: ${unknownFlags[0]}`);
+  let parsed;
+  try {
+    parsed = parseArgs(argv, tagFlagSchema);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    const flagMatch = message.match(/^unknown flag '(.+)'$/);
+    if (flagMatch?.[1] !== undefined) {
+      console.error(`Error: Unknown option: ${flagMatch[1]}`);
+    } else {
+      console.error(`Error: ${message}`);
+    }
     process.exit(1);
   }
 
-  const dryRun = argv.includes('--dry-run');
-  const noGitChecks = argv.includes('--no-git-checks');
+  const { dryRun, noGitChecks } = parsed.flags;
 
   try {
     createTags({ dryRun, noGitChecks });


### PR DESCRIPTION
Closes #145

## What

Add a schema-driven `parseArgs` function to `@williamthorsen/node-monorepo-core` that handles boolean flags, string flags (both `--flag=value` and `--flag value`), short aliases, positional collection, the `--` delimiter, and unknown-flag errors. Migrate all CLI argument-parsing sites in preflight (3 sites) and release-kit (5 sites) to use it. A companion `translateParseError` helper normalizes internal error messages for consistent user-facing output.

## Why

Each CLI package hand-rolled identical parsing patterns — iterating flag arrays, matching `--flag=value` and `--flag value` forms, handling short aliases, collecting positionals, and reporting unknown flags. This duplication made it harder to improve error messages and diagnostics consistently, and each new flag required reimplementing the same boilerplate.

## Details

### Features

- `parseArgs<S extends FlagSchema>(argv: string[], schema: S): ParsedArgs<S>` — schema-driven parser with return type inferred from the schema via mapped types
- `translateParseError(error: unknown): string` — normalizes internal error messages (e.g., `"unknown flag '--x'"` → `"Unknown option: --x"`)
- Both exported from `@williamthorsen/node-monorepo-core`

### Refactoring

- **preflight**: replaced manual flag iteration in `parseRunArgs`, `compileCommand`, and `route.ts` init subcommand with `parseArgs` calls; deleted both copies of `extractFlagValue`; domain validation (source-flag mutual exclusivity, `--collection` co-dependencies, severity flag validation) preserved on top of parsed results
- **release-kit**: replaced `Set`/`includes`/`startsWith` parsing in `prepareCommand`, `commitCommand`, `tagCommand`, `publishCommand`, and `bin/release-kit.ts` init/sync-labels blocks with `parseArgs` calls; converted `prepareCommand.parseArgs` from `process.exit`-based to throw-based error handling; post-parse domain validation (bump type, `--force` requires `--bump`, `--only` monorepo check) preserved
- Added missing `sourceType = 'url'` assignment in `parseRunArgs` (dropped during migration)
- Fixed misleading error labels in `prepareCommand` catch block

### Tests

- 157-line test file for `parseArgs` covering boolean/string flags, short aliases, `--` delimiter, unknown flags, empty argv, edge cases (`--flag=` empty value, `-` alone as positional, missing value at end of argv)
- Updated `prepareCommand.unit.test.ts` to assert on thrown errors instead of mocked `process.exit`

## Test plan

- [ ] Verify `parseArgs` handles all flag forms correctly (covered by new unit tests)
- [ ] Verify preflight CLI behavior unchanged (`preflight run --file`, `--github`, `--url`, `--json`, `--fail-on`, `--report-on`)
- [ ] Verify release-kit CLI behavior unchanged (`release-kit prepare --bump=patch`, `commit --dry-run`, `tag`, `publish`, `init --force`)
- [ ] Verify unknown flags produce clear error messages across both packages