### PR TITLE
#150 Improve bin wrapper error messages for missing build output

### DIFF
--- a/packages/nmr/bin/ensure-prepublish-hooks.js
+++ b/packages/nmr/bin/ensure-prepublish-hooks.js
@@ -1,2 +1,11 @@
 #!/usr/bin/env node
-import('../dist/esm/cli-ensure-prepublish-hooks.js');
+try {
+  await import('../dist/esm/cli-ensure-prepublish-hooks.js');
+} catch (error) {
+  if (error.code === 'ERR_MODULE_NOT_FOUND') {
+    process.stderr.write('ensure-prepublish-hooks: build output not found — run `pnpm run build` first\n');
+  } else {
+    process.stderr.write(`ensure-prepublish-hooks: failed to load: ${error.message}\n`);
+  }
+  process.exit(1);
+}

--- a/packages/nmr/bin/nmr-report-overrides.js
+++ b/packages/nmr/bin/nmr-report-overrides.js
@@ -1,2 +1,11 @@
 #!/usr/bin/env node
-import('../dist/esm/cli-report-overrides.js');
+try {
+  await import('../dist/esm/cli-report-overrides.js');
+} catch (error) {
+  if (error.code === 'ERR_MODULE_NOT_FOUND') {
+    process.stderr.write('nmr-report-overrides: build output not found — run `pnpm run build` first\n');
+  } else {
+    process.stderr.write(`nmr-report-overrides: failed to load: ${error.message}\n`);
+  }
+  process.exit(1);
+}

--- a/packages/nmr/bin/nmr-sync-pnpm-version.js
+++ b/packages/nmr/bin/nmr-sync-pnpm-version.js
@@ -1,2 +1,11 @@
 #!/usr/bin/env node
-import('../dist/esm/cli-sync-pnpm-version.js');
+try {
+  await import('../dist/esm/cli-sync-pnpm-version.js');
+} catch (error) {
+  if (error.code === 'ERR_MODULE_NOT_FOUND') {
+    process.stderr.write('nmr-sync-pnpm-version: build output not found — run `pnpm run build` first\n');
+  } else {
+    process.stderr.write(`nmr-sync-pnpm-version: failed to load: ${error.message}\n`);
+  }
+  process.exit(1);
+}

--- a/packages/nmr/bin/nmr.js
+++ b/packages/nmr/bin/nmr.js
@@ -1,2 +1,11 @@
 #!/usr/bin/env node
-import('../dist/esm/cli.js');
+try {
+  await import('../dist/esm/cli.js');
+} catch (error) {
+  if (error.code === 'ERR_MODULE_NOT_FOUND') {
+    process.stderr.write('nmr: build output not found — run `pnpm run build` first\n');
+  } else {
+    process.stderr.write(`nmr: failed to load: ${error.message}\n`);
+  }
+  process.exit(1);
+}

--- a/packages/preflight/bin/preflight.js
+++ b/packages/preflight/bin/preflight.js
@@ -2,6 +2,10 @@
 try {
   await import('../dist/esm/bin/preflight.js');
 } catch (error) {
-  process.stderr.write(`preflight: failed to load: ${error.message}\n`);
+  if (error.code === 'ERR_MODULE_NOT_FOUND') {
+    process.stderr.write('preflight: build output not found — run `pnpm run build` first\n');
+  } else {
+    process.stderr.write(`preflight: failed to load: ${error.message}\n`);
+  }
   process.exit(1);
 }

--- a/packages/release-kit/bin/release-kit.js
+++ b/packages/release-kit/bin/release-kit.js
@@ -1,2 +1,11 @@
 #!/usr/bin/env node
-import('../dist/esm/bin/release-kit.js');
+try {
+  await import('../dist/esm/bin/release-kit.js');
+} catch (error) {
+  if (error.code === 'ERR_MODULE_NOT_FOUND') {
+    process.stderr.write('release-kit: build output not found — run `pnpm run build` first\n');
+  } else {
+    process.stderr.write(`release-kit: failed to load: ${error.message}\n`);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
Closes #150 

## What

Add try/catch with `ERR_MODULE_NOT_FOUND` detection to all six bin wrappers across `nmr`, `preflight`, and `release-kit`. Previously, five of the six wrappers used bare `import()` calls that produced cryptic unhandled rejections when `dist/` was missing, and `preflight`'s existing try/catch gave no actionable guidance.

## Why

Running a CLI before building is the most common cause of these errors, especially after a fresh clone. The improved wrappers now print a clear message (`build output not found — run pnpm run build first`) so developers know exactly what to do. This also aligns the wrappers with the pattern already adopted in `@codeassembly/run-core` and `@codeassembly/agents`.

## Details

### Fixes

- `nmr`, `nmr-report-overrides`, `nmr-sync-pnpm-version`, `ensure-prepublish-hooks`: wrap bare `import()` in try/catch with `ERR_MODULE_NOT_FOUND` detection and actionable error message.
- `release-kit`: same treatment.
- `preflight`: add `ERR_MODULE_NOT_FOUND` branch to existing try/catch.

## Test plan

- Remove `dist/` from one package and run its CLI; confirm the "build output not found" message appears.
- Rebuild and run the CLI; confirm normal operation is unaffected.