### PR TITLE
#154 Fix asymmetric mutual exclusivity check for --file flag

### DIFF
--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -303,6 +303,12 @@ describe(parseRunArgs, () => {
     );
   });
 
+  it('throws when --github and --file are combined (reverse order)', () => {
+    expect(() => parseRunArgs(['--github', 'org/repo', '--file', 'path.ts'])).toThrow(
+      'Cannot combine --file, --github, --local, and --url flags',
+    );
+  });
+
   it('throws when --file and --url are combined', () => {
     expect(() => parseRunArgs(['--file', 'path.ts', '--url', 'https://example.com/config.js'])).toThrow(
       'Cannot combine --file, --github, --local, and --url flags',

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -129,6 +129,7 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   // Validate mutual exclusivity of source flags.
   let sourceType: string | undefined;
   if (parsed.file !== undefined) {
+    assertNoExistingSource(sourceType);
     sourceType = 'file';
   }
   if (parsed.github !== undefined) {


### PR DESCRIPTION
Closes #154 

## What

Add the missing `assertNoExistingSource` guard to the `--file` branch in `parseRunArgs`, making the mutual-exclusivity check for source flags symmetric regardless of flag order.

## Why

The `--file` flag was the only source flag that did not call `assertNoExistingSource` before setting `sourceType`. This allowed conflicting combinations like `--github org/repo --file path.ts` to silently succeed, while the reverse order was correctly rejected.

## Details

### Fixes

- Add `assertNoExistingSource(sourceType)` call before `sourceType = 'file'` assignment in `packages/preflight/src/cli.ts`.

### Tests

- Add test case for reverse flag ordering (`--github` before `--file`) in `packages/preflight/__tests__/cli.test.ts`.