### PR TITLE
#130 Export reusable check-utils for collection authors

### DIFF
--- a/.preflight/collections/nmr.js
+++ b/.preflight/collections/nmr.js
@@ -7,9 +7,78 @@ function definePreflightCollection(collection) {
   return collection;
 }
 
-// .preflight/collections/nmr.ts
+// packages/preflight/dist/esm/check-utils/filesystem.js
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+function fileExists(relativePath) {
+  return existsSync(join(process.cwd(), relativePath));
+}
+function readFile(relativePath) {
+  const fullPath = join(process.cwd(), relativePath);
+  if (!existsSync(fullPath)) return void 0;
+  return readFileSync(fullPath, "utf8");
+}
+function fileContains(relativePath, pattern) {
+  const content = readFile(relativePath);
+  if (content === void 0) return false;
+  return pattern.test(content);
+}
+function fileDoesNotContain(relativePath, pattern) {
+  const content = readFile(relativePath);
+  if (content === void 0) return true;
+  return !pattern.test(content);
+}
+
+// packages/preflight/dist/esm/isRecord.js
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// packages/preflight/dist/esm/check-utils/semver.js
+function compareVersions(a, b) {
+  const partsA = a.split(".").map(Number);
+  const partsB = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+// packages/preflight/dist/esm/check-utils/package-json.js
+function readPackageJson() {
+  const content = readFile("package.json");
+  if (content === void 0) return void 0;
+  const parsed = JSON.parse(content);
+  if (!isRecord(parsed)) return void 0;
+  return Object.fromEntries(Object.entries(parsed));
+}
+function hasPackageJsonField(field, expectedValue) {
+  const pkg = readPackageJson();
+  if (pkg === void 0) return false;
+  if (expectedValue !== void 0) return pkg[field] === expectedValue;
+  return field in pkg;
+}
+function hasDevDependency(name) {
+  const pkg = readPackageJson();
+  if (pkg === void 0) return false;
+  const devDeps = pkg.devDependencies;
+  return isRecord(devDeps) && name in devDeps;
+}
+function hasMinDevDependencyVersion(name, minVersion, options) {
+  const pkg = readPackageJson();
+  if (pkg === void 0) return false;
+  const devDeps = pkg.devDependencies;
+  if (!isRecord(devDeps) || !(name in devDeps)) return false;
+  const range = devDeps[name];
+  if (typeof range !== "string") return false;
+  if (options?.exempt?.(range)) return true;
+  const versionMatch = /(\d+\.\d+\.\d+)/.exec(range)?.[1];
+  if (versionMatch === void 0) return false;
+  return compareVersions(versionMatch, minVersion) >= 0;
+}
+
+// .preflight/collections/nmr.ts
 var releaseKit = {
   name: "release-kit",
   checks: [
@@ -211,67 +280,6 @@ var repoSetup = {
 var nmr_default = definePreflightCollection({
   checklists: [releaseKit, syncLabels, nmr, codeQuality, repoSetup]
 });
-function fileExists(relativePath) {
-  return existsSync(join(process.cwd(), relativePath));
-}
-function readFile(relativePath) {
-  const fullPath = join(process.cwd(), relativePath);
-  if (!existsSync(fullPath)) return void 0;
-  return readFileSync(fullPath, "utf8");
-}
-function readPackageJson() {
-  const content = readFile("package.json");
-  if (content === void 0) return void 0;
-  const parsed = JSON.parse(content);
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return void 0;
-  return Object.fromEntries(Object.entries(parsed));
-}
-function isRecord(value) {
-  return typeof value === "object" && value !== null;
-}
-function hasDevDependency(name) {
-  const pkg = readPackageJson();
-  if (pkg === void 0) return false;
-  const devDeps = pkg.devDependencies;
-  return isRecord(devDeps) && name in devDeps;
-}
-function hasMinDevDependencyVersion(name, minVersion, options) {
-  const pkg = readPackageJson();
-  if (pkg === void 0) return false;
-  const devDeps = pkg.devDependencies;
-  if (!isRecord(devDeps) || !(name in devDeps)) return false;
-  const range = devDeps[name];
-  if (typeof range !== "string") return false;
-  if (options?.exempt?.(range)) return true;
-  const versionMatch = /(\d+\.\d+\.\d+)/.exec(range);
-  if (versionMatch === null) return false;
-  return compareVersions(versionMatch[1], minVersion) >= 0;
-}
-function compareVersions(a, b) {
-  const partsA = a.split(".").map(Number);
-  const partsB = b.split(".").map(Number);
-  for (let i = 0; i < 3; i++) {
-    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
-    if (diff !== 0) return diff;
-  }
-  return 0;
-}
-function hasPackageJsonField(field, expectedValue) {
-  const pkg = readPackageJson();
-  if (pkg === void 0) return false;
-  if (expectedValue !== void 0) return pkg[field] === expectedValue;
-  return field in pkg;
-}
-function fileContains(relativePath, pattern) {
-  const content = readFile(relativePath);
-  if (content === void 0) return false;
-  return pattern.test(content);
-}
-function fileDoesNotContain(relativePath, pattern) {
-  const content = readFile(relativePath);
-  if (content === void 0) return true;
-  return !pattern.test(content);
-}
 function preferencesHasRequiredFields() {
   const content = readFile(".agents/preferences.yaml");
   if (content === void 0) return false;

--- a/.preflight/collections/nmr.ts
+++ b/.preflight/collections/nmr.ts
@@ -5,7 +5,16 @@
  *   preflight run --file <path-to>/nmr.js
  */
 import type { PreflightCheck, PreflightChecklist } from '@williamthorsen/preflight';
-import { definePreflightCollection } from '@williamthorsen/preflight';
+import {
+  definePreflightCollection,
+  fileContains,
+  fileDoesNotContain,
+  fileExists,
+  hasDevDependency,
+  hasMinDevDependencyVersion,
+  hasPackageJsonField,
+  readFile,
+} from '@williamthorsen/preflight';
 
 const releaseKit: PreflightChecklist = {
   name: 'release-kit',
@@ -225,96 +234,7 @@ export default definePreflightCollection({
   checklists: [releaseKit, syncLabels, nmr, codeQuality, repoSetup],
 });
 
-// -- Helpers ------------------------------------------------------------------
-
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-
-/** Check whether a file exists relative to the working directory. */
-function fileExists(relativePath: string): boolean {
-  return existsSync(join(process.cwd(), relativePath));
-}
-
-/** Read a file relative to the working directory. Return undefined if it doesn't exist. */
-function readFile(relativePath: string): string | undefined {
-  const fullPath = join(process.cwd(), relativePath);
-  if (!existsSync(fullPath)) return undefined;
-  return readFileSync(fullPath, 'utf8');
-}
-
-/** Read and parse the root package.json. Return undefined if it doesn't exist. */
-function readPackageJson(): Record<string, unknown> | undefined {
-  const content = readFile('package.json');
-  if (content === undefined) return undefined;
-  const parsed: unknown = JSON.parse(content);
-  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined;
-  return Object.fromEntries(Object.entries(parsed));
-}
-
-/** Narrow an unknown value to a string-keyed record without type assertions. */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-/** Check whether a dev dependency is present in package.json. */
-function hasDevDependency(name: string): boolean {
-  const pkg = readPackageJson();
-  if (pkg === undefined) return false;
-  const devDeps = pkg.devDependencies;
-  return isRecord(devDeps) && name in devDeps;
-}
-
-/** Check whether a dev dependency exists and its semver range satisfies a minimum version. */
-function hasMinDevDependencyVersion(
-  name: string,
-  minVersion: string,
-  options?: { exempt?: (range: string) => boolean },
-): boolean {
-  const pkg = readPackageJson();
-  if (pkg === undefined) return false;
-  const devDeps = pkg.devDependencies;
-  if (!isRecord(devDeps) || !(name in devDeps)) return false;
-  const range = devDeps[name];
-  if (typeof range !== 'string') return false;
-  if (options?.exempt?.(range)) return true;
-  // Strip leading semver range operators to extract the base version.
-  const versionMatch = /(\d+\.\d+\.\d+)/.exec(range);
-  if (versionMatch === null) return false;
-  return compareVersions(versionMatch[1], minVersion) >= 0;
-}
-
-/** Compare two semver version strings. Return negative if a < b, 0 if equal, positive if a > b. */
-function compareVersions(a: string, b: string): number {
-  const partsA = a.split('.').map(Number);
-  const partsB = b.split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
-    if (diff !== 0) return diff;
-  }
-  return 0;
-}
-
-/** Check whether package.json has a field, optionally with a specific value. */
-function hasPackageJsonField(field: string, expectedValue?: string): boolean {
-  const pkg = readPackageJson();
-  if (pkg === undefined) return false;
-  if (expectedValue !== undefined) return pkg[field] === expectedValue;
-  return field in pkg;
-}
-
-/** Check whether a file contains content matching a regex. */
-function fileContains(relativePath: string, pattern: RegExp): boolean {
-  const content = readFile(relativePath);
-  if (content === undefined) return false;
-  return pattern.test(content);
-}
-
-/** Check that a file does not contain content matching a regex. Passes if the file is absent. */
-function fileDoesNotContain(relativePath: string, pattern: RegExp): boolean {
-  const content = readFile(relativePath);
-  if (content === undefined) return true;
-  return !pattern.test(content);
-}
+// -- Collection-specific helpers ----------------------------------------------
 
 /** Verify that .agents/preferences.yaml contains project.slug and project.ticket_prefix. */
 function preferencesHasRequiredFields(): boolean {
@@ -325,7 +245,7 @@ function preferencesHasRequiredFields(): boolean {
   return hasSlug && hasTicketPrefix;
 }
 
-/** Check that .tool-versions does not list pnpm. Passes if the file is absent. */
+/** Check that .tool-versions does not list pnpm. Pass if the file is absent. */
 function toolVersionsHasNoPnpm(): boolean {
   const content = readFile('.tool-versions');
   if (content === undefined) return true;

--- a/packages/preflight/__tests__/check-utils/filesystem.test.ts
+++ b/packages/preflight/__tests__/check-utils/filesystem.test.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { fileContains, fileDoesNotContain, fileExists, readFile } from '../../src/check-utils/filesystem.ts';
+
+let tempDir: string;
+let cwdSpy: MockInstance;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'preflight-fs-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+});
+
+describe(fileExists, () => {
+  it('returns true when the file exists', () => {
+    writeFileSync(join(tempDir, 'found.txt'), 'content');
+
+    expect(fileExists('found.txt')).toBe(true);
+  });
+
+  it('returns false when the file does not exist', () => {
+    expect(fileExists('missing.txt')).toBe(false);
+  });
+});
+
+describe(readFile, () => {
+  it('returns the file content as a string', () => {
+    writeFileSync(join(tempDir, 'hello.txt'), 'hello world');
+
+    expect(readFile('hello.txt')).toBe('hello world');
+  });
+
+  it('returns undefined when the file does not exist', () => {
+    expect(readFile('missing.txt')).toBeUndefined();
+  });
+});
+
+describe(fileContains, () => {
+  it('returns true when the file matches the pattern', () => {
+    writeFileSync(join(tempDir, 'data.txt'), 'version: 3.2.1');
+
+    expect(fileContains('data.txt', /version:\s*\d+/)).toBe(true);
+  });
+
+  it('returns false when the file does not match the pattern', () => {
+    writeFileSync(join(tempDir, 'data.txt'), 'no match here');
+
+    expect(fileContains('data.txt', /version:/)).toBe(false);
+  });
+
+  it('returns false when the file does not exist', () => {
+    expect(fileContains('missing.txt', /anything/)).toBe(false);
+  });
+});
+
+describe(fileDoesNotContain, () => {
+  it('returns true when the file does not match the pattern', () => {
+    writeFileSync(join(tempDir, 'clean.txt'), 'all good');
+
+    expect(fileDoesNotContain('clean.txt', /bad/)).toBe(true);
+  });
+
+  it('returns false when the file matches the pattern', () => {
+    writeFileSync(join(tempDir, 'dirty.txt'), 'contains bad stuff');
+
+    expect(fileDoesNotContain('dirty.txt', /bad/)).toBe(false);
+  });
+
+  it('returns true when the file does not exist', () => {
+    expect(fileDoesNotContain('missing.txt', /anything/)).toBe(true);
+  });
+});

--- a/packages/preflight/__tests__/check-utils/package-json.test.ts
+++ b/packages/preflight/__tests__/check-utils/package-json.test.ts
@@ -1,0 +1,134 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import {
+  hasDevDependency,
+  hasMinDevDependencyVersion,
+  hasPackageJsonField,
+  readPackageJson,
+} from '../../src/check-utils/package-json.ts';
+
+let tempDir: string;
+let cwdSpy: MockInstance;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'preflight-pkg-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+});
+
+function writePackageJson(content: Record<string, unknown>): void {
+  writeFileSync(join(tempDir, 'package.json'), JSON.stringify(content));
+}
+
+describe(readPackageJson, () => {
+  it('returns the parsed package.json', () => {
+    writePackageJson({ name: 'test-pkg', version: '1.0.0' });
+
+    const result = readPackageJson();
+
+    expect(result).toEqual({ name: 'test-pkg', version: '1.0.0' });
+  });
+
+  it('returns undefined when package.json does not exist', () => {
+    expect(readPackageJson()).toBeUndefined();
+  });
+
+  it('returns undefined when package.json is not an object', () => {
+    writeFileSync(join(tempDir, 'package.json'), '"not an object"');
+
+    expect(readPackageJson()).toBeUndefined();
+  });
+});
+
+describe(hasPackageJsonField, () => {
+  it('returns true when the field exists', () => {
+    writePackageJson({ type: 'module' });
+
+    expect(hasPackageJsonField('type')).toBe(true);
+  });
+
+  it('returns false when the field does not exist', () => {
+    writePackageJson({});
+
+    expect(hasPackageJsonField('type')).toBe(false);
+  });
+
+  it('returns true when the field matches the expected value', () => {
+    writePackageJson({ type: 'module' });
+
+    expect(hasPackageJsonField('type', 'module')).toBe(true);
+  });
+
+  it('returns false when the field does not match the expected value', () => {
+    writePackageJson({ type: 'commonjs' });
+
+    expect(hasPackageJsonField('type', 'module')).toBe(false);
+  });
+
+  it('returns false when package.json does not exist', () => {
+    expect(hasPackageJsonField('type')).toBe(false);
+  });
+});
+
+describe(hasDevDependency, () => {
+  it('returns true when the dependency is present', () => {
+    writePackageJson({ devDependencies: { vitest: '^1.0.0' } });
+
+    expect(hasDevDependency('vitest')).toBe(true);
+  });
+
+  it('returns false when the dependency is absent', () => {
+    writePackageJson({ devDependencies: {} });
+
+    expect(hasDevDependency('vitest')).toBe(false);
+  });
+
+  it('returns false when devDependencies is missing', () => {
+    writePackageJson({});
+
+    expect(hasDevDependency('vitest')).toBe(false);
+  });
+});
+
+describe(hasMinDevDependencyVersion, () => {
+  it('returns true when the version meets the minimum', () => {
+    writePackageJson({ devDependencies: { vitest: '^2.0.0' } });
+
+    expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(true);
+  });
+
+  it('returns false when the version is below the minimum', () => {
+    writePackageJson({ devDependencies: { vitest: '^0.34.0' } });
+
+    expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
+  });
+
+  it('returns false when the dependency is not present', () => {
+    writePackageJson({ devDependencies: {} });
+
+    expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
+  });
+
+  it('returns true when the exempt predicate matches', () => {
+    writePackageJson({ devDependencies: { core: 'workspace:*' } });
+
+    expect(
+      hasMinDevDependencyVersion('core', '1.0.0', {
+        exempt: (range) => range.startsWith('workspace:'),
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when the version range has no extractable version', () => {
+    writePackageJson({ devDependencies: { vitest: 'latest' } });
+
+    expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
+  });
+});

--- a/packages/preflight/__tests__/check-utils/semver.test.ts
+++ b/packages/preflight/__tests__/check-utils/semver.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareVersions } from '../../src/check-utils/semver.ts';
+
+describe(compareVersions, () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
+  });
+
+  it('returns negative when a < b (major)', () => {
+    expect(compareVersions('1.0.0', '2.0.0')).toBeLessThan(0);
+  });
+
+  it('returns positive when a > b (major)', () => {
+    expect(compareVersions('3.0.0', '2.0.0')).toBeGreaterThan(0);
+  });
+
+  it('returns negative when a < b (minor)', () => {
+    expect(compareVersions('1.1.0', '1.2.0')).toBeLessThan(0);
+  });
+
+  it('returns positive when a > b (patch)', () => {
+    expect(compareVersions('1.0.5', '1.0.3')).toBeGreaterThan(0);
+  });
+
+  it('treats missing parts as 0', () => {
+    expect(compareVersions('1.0', '1.0.0')).toBe(0);
+  });
+});

--- a/packages/preflight/src/check-utils/filesystem.ts
+++ b/packages/preflight/src/check-utils/filesystem.ts
@@ -1,0 +1,28 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Check whether a file exists relative to the working directory. */
+export function fileExists(relativePath: string): boolean {
+  return existsSync(join(process.cwd(), relativePath));
+}
+
+/** Read a file relative to the working directory. Return undefined if it doesn't exist. */
+export function readFile(relativePath: string): string | undefined {
+  const fullPath = join(process.cwd(), relativePath);
+  if (!existsSync(fullPath)) return undefined;
+  return readFileSync(fullPath, 'utf8');
+}
+
+/** Check whether a file contains content matching a regex. */
+export function fileContains(relativePath: string, pattern: RegExp): boolean {
+  const content = readFile(relativePath);
+  if (content === undefined) return false;
+  return pattern.test(content);
+}
+
+/** Check that a file does not contain content matching a regex. Pass if the file is absent. */
+export function fileDoesNotContain(relativePath: string, pattern: RegExp): boolean {
+  const content = readFile(relativePath);
+  if (content === undefined) return true;
+  return !pattern.test(content);
+}

--- a/packages/preflight/src/check-utils/index.ts
+++ b/packages/preflight/src/check-utils/index.ts
@@ -1,0 +1,3 @@
+export { fileContains, fileDoesNotContain, fileExists, readFile } from './filesystem.ts';
+export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
+export { compareVersions } from './semver.ts';

--- a/packages/preflight/src/check-utils/package-json.ts
+++ b/packages/preflight/src/check-utils/package-json.ts
@@ -1,0 +1,47 @@
+import { isRecord } from '../isRecord.ts';
+import { readFile } from './filesystem.ts';
+import { compareVersions } from './semver.ts';
+
+/** Read and parse the root package.json. Return undefined if it doesn't exist or isn't an object. */
+export function readPackageJson(): Record<string, unknown> | undefined {
+  const content = readFile('package.json');
+  if (content === undefined) return undefined;
+  const parsed: unknown = JSON.parse(content);
+  if (!isRecord(parsed)) return undefined;
+  return Object.fromEntries(Object.entries(parsed));
+}
+
+/** Check whether package.json has a field, optionally with a specific value. */
+export function hasPackageJsonField(field: string, expectedValue?: string): boolean {
+  const pkg = readPackageJson();
+  if (pkg === undefined) return false;
+  if (expectedValue !== undefined) return pkg[field] === expectedValue;
+  return field in pkg;
+}
+
+/** Check whether a dev dependency is present in package.json. */
+export function hasDevDependency(name: string): boolean {
+  const pkg = readPackageJson();
+  if (pkg === undefined) return false;
+  const devDeps = pkg.devDependencies;
+  return isRecord(devDeps) && name in devDeps;
+}
+
+/** Check whether a dev dependency meets a minimum version, with optional exemption predicate. */
+export function hasMinDevDependencyVersion(
+  name: string,
+  minVersion: string,
+  options?: { exempt?: (range: string) => boolean },
+): boolean {
+  const pkg = readPackageJson();
+  if (pkg === undefined) return false;
+  const devDeps = pkg.devDependencies;
+  if (!isRecord(devDeps) || !(name in devDeps)) return false;
+  const range = devDeps[name];
+  if (typeof range !== 'string') return false;
+  if (options?.exempt?.(range)) return true;
+  // Strip leading semver range operators to extract the base version.
+  const versionMatch = /(\d+\.\d+\.\d+)/.exec(range)?.[1];
+  if (versionMatch === undefined) return false;
+  return compareVersions(versionMatch, minVersion) >= 0;
+}

--- a/packages/preflight/src/check-utils/semver.ts
+++ b/packages/preflight/src/check-utils/semver.ts
@@ -1,0 +1,10 @@
+/** Compare two semver version strings. Return negative if a < b, 0 if equal, positive if a > b. */
+export function compareVersions(a: string, b: string): number {
+  const partsA = a.split('.').map(Number);
+  const partsB = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}

--- a/packages/preflight/src/index.ts
+++ b/packages/preflight/src/index.ts
@@ -36,3 +36,16 @@ export {
   definePreflightConfig,
   definePreflightStagedChecklist,
 } from './authoring.ts';
+
+// Check utilities
+export {
+  compareVersions,
+  fileContains,
+  fileDoesNotContain,
+  fileExists,
+  hasDevDependency,
+  hasMinDevDependencyVersion,
+  hasPackageJsonField,
+  readFile,
+  readPackageJson,
+} from './check-utils/index.ts';


### PR DESCRIPTION
Closes #130 

## What

Extract 9 inline helper functions from `.preflight/collections/nmr.ts` into `packages/preflight/src/check-utils/`, organized by domain (filesystem, package-json, semver). Re-export all functions from the main `@williamthorsen/preflight` entry point so collection authors can import them directly. Update the collection file to use the package imports instead of inline definitions.

## Why

Collection authors currently have to reimplement general-purpose helpers like `fileExists`, `hasDevDependency`, and `compareVersions` in every collection. Extracting them into the package gives authors a tested, documented set of building blocks that get bundled into compiled collections via esbuild.

## Details

### Features

- Add `src/check-utils/filesystem.ts`: `fileExists`, `readFile`, `fileContains`, `fileDoesNotContain`
- Add `src/check-utils/package-json.ts`: `readPackageJson`, `hasPackageJsonField`, `hasDevDependency`, `hasMinDevDependencyVersion`
- Add `src/check-utils/semver.ts`: `compareVersions`
- Re-export all 9 functions from the main `@williamthorsen/preflight` entry point

### Refactoring

- Replace inline helper definitions in `.preflight/collections/nmr.ts` with imports from the package
- Collection-specific helpers (`preferencesHasRequiredFields`, `toolVersionsHasNoPnpm`) remain inline
- Use the stricter `isRecord` from `src/isRecord.ts` (rejects arrays) instead of the inline version

### Tests

- Add `__tests__/check-utils/filesystem.test.ts` (10 tests)
- Add `__tests__/check-utils/package-json.test.ts` (14 tests)
- Add `__tests__/check-utils/semver.test.ts` (6 tests)

## Test plan

- [ ] Verify collection compiles: `preflight compile .preflight/collections/nmr.ts`
- [ ] Run compiled collection against a target repo to confirm checks still work