### PR TITLE
#161 Create preflight collection for nmr

### DIFF
--- a/.config/preflight.config.ts
+++ b/.config/preflight.config.ts
@@ -1,0 +1,8 @@
+import { definePreflightConfig } from '@williamthorsen/preflight';
+
+/** Preflight configuration for this monorepo. */
+export default definePreflightConfig({
+  compile: {
+    include: '*.ts',
+  },
+});

--- a/.preflight/collections/__tests__/nmr.test.ts
+++ b/.preflight/collections/__tests__/nmr.test.ts
@@ -1,0 +1,158 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import collection from '../nmr.ts';
+
+const [checklist] = collection.checklists;
+const checks = checklist.checks;
+
+/** Find a check by name prefix. */
+function findCheck(prefix: string) {
+  const check = checks.find((c) => c.name.startsWith(prefix));
+  if (!check) throw new Error(`No check found with prefix "${prefix}"`);
+  return check;
+}
+
+let tempDir: string;
+let cwdSpy: MockInstance;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'preflight-nmr-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+});
+
+/** Write a package.json to the temp directory. */
+function writePackageJson(content: Record<string, unknown>): void {
+  writeFileSync(join(tempDir, 'package.json'), JSON.stringify(content));
+}
+
+describe('@williamthorsen/nmr in devDependencies', () => {
+  const check = findCheck('@williamthorsen/nmr in devDependencies');
+
+  it('passes when nmr is in devDependencies', () => {
+    writePackageJson({ devDependencies: { '@williamthorsen/nmr': '^0.9.0' } });
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when nmr is not in devDependencies', () => {
+    writePackageJson({ devDependencies: {} });
+
+    expect(check.check()).toBe(false);
+  });
+
+  it('fails when package.json is missing', () => {
+    expect(check.check()).toBe(false);
+  });
+});
+
+describe('@williamthorsen/nmr >= minimum version', () => {
+  const check = findCheck('@williamthorsen/nmr >=');
+
+  it('passes when version meets minimum', () => {
+    writePackageJson({ devDependencies: { '@williamthorsen/nmr': '^0.9.0' } });
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when version is below minimum', () => {
+    writePackageJson({ devDependencies: { '@williamthorsen/nmr': '^0.1.0' } });
+
+    expect(check.check()).toBe(false);
+  });
+
+  it('passes when using workspace: protocol (exempt)', () => {
+    writePackageJson({ devDependencies: { '@williamthorsen/nmr': 'workspace:*' } });
+
+    expect(check.check()).toBe(true);
+  });
+});
+
+describe('pnpm-workspace.yaml exists', () => {
+  const check = findCheck('pnpm-workspace.yaml');
+
+  it('passes when file exists', () => {
+    writeFileSync(join(tempDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n');
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when file is missing', () => {
+    expect(check.check()).toBe(false);
+  });
+});
+
+describe('package.json has packageManager field', () => {
+  const check = findCheck('package.json has packageManager');
+
+  it('passes when field is present', () => {
+    writePackageJson({ packageManager: 'pnpm@10.33.0' });
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when field is missing', () => {
+    writePackageJson({ name: 'test' });
+
+    expect(check.check()).toBe(false);
+  });
+});
+
+describe('.tool-versions does not list pnpm', () => {
+  const check = findCheck('.tool-versions does not list pnpm');
+
+  it('passes when file is absent', () => {
+    expect(check.check()).toBe(true);
+  });
+
+  it('passes when file exists without pnpm', () => {
+    writeFileSync(join(tempDir, '.tool-versions'), 'nodejs 22.0.0\n');
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when file lists pnpm', () => {
+    writeFileSync(join(tempDir, '.tool-versions'), 'nodejs 22.0.0\npnpm 10.0.0\n');
+
+    expect(check.check()).toBe(false);
+  });
+});
+
+describe('.config/nmr.config.ts uses defineConfig', () => {
+  const check = findCheck('.config/nmr.config.ts uses defineConfig');
+
+  it('is skipped when config file is absent', () => {
+    expect(check.skip?.()).toBe('no nmr config file');
+  });
+
+  it('is not skipped when config file exists', () => {
+    mkdirSync(join(tempDir, '.config'), { recursive: true });
+    writeFileSync(join(tempDir, '.config/nmr.config.ts'), 'export default defineConfig({});\n');
+
+    expect(check.skip?.()).toBe(false);
+  });
+
+  it('passes when config file uses defineConfig', () => {
+    mkdirSync(join(tempDir, '.config'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.config/nmr.config.ts'),
+      'import { defineConfig } from "@williamthorsen/nmr";\nexport default defineConfig({});\n',
+    );
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when config file does not use defineConfig', () => {
+    mkdirSync(join(tempDir, '.config'), { recursive: true });
+    writeFileSync(join(tempDir, '.config/nmr.config.ts'), 'export default {};\n');
+
+    expect(check.check()).toBe(false);
+  });
+});

--- a/.preflight/collections/default.js
+++ b/.preflight/collections/default.js
@@ -1,0 +1,251 @@
+/** @noformat — @generated. Do not edit. Compiled by preflight. */
+/* eslint-disable */
+
+
+// packages/preflight/dist/esm/authoring.js
+function definePreflightCollection(collection) {
+  return collection;
+}
+
+// packages/preflight/dist/esm/check-utils/filesystem.js
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+function fileExists(relativePath) {
+  return existsSync(join(process.cwd(), relativePath));
+}
+function readFile(relativePath) {
+  const fullPath = join(process.cwd(), relativePath);
+  if (!existsSync(fullPath)) return void 0;
+  return readFileSync(fullPath, "utf8");
+}
+function fileContains(relativePath, pattern) {
+  const content = readFile(relativePath);
+  if (content === void 0) return false;
+  return pattern.test(content);
+}
+function fileDoesNotContain(relativePath, pattern) {
+  const content = readFile(relativePath);
+  if (content === void 0) return true;
+  return !pattern.test(content);
+}
+
+// packages/preflight/dist/esm/isRecord.js
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// packages/preflight/dist/esm/check-utils/semver.js
+function compareVersions(a, b) {
+  const partsA = a.split(".").map(Number);
+  const partsB = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+// packages/preflight/dist/esm/check-utils/package-json.js
+function readPackageJson() {
+  const content = readFile("package.json");
+  if (content === void 0) return void 0;
+  const parsed = JSON.parse(content);
+  if (!isRecord(parsed)) return void 0;
+  return Object.fromEntries(Object.entries(parsed));
+}
+function hasPackageJsonField(field, expectedValue) {
+  const pkg = readPackageJson();
+  if (pkg === void 0) return false;
+  if (expectedValue !== void 0) return pkg[field] === expectedValue;
+  return field in pkg;
+}
+function hasMinDevDependencyVersion(name, minVersion, options) {
+  const pkg = readPackageJson();
+  if (pkg === void 0) return false;
+  const devDeps = pkg.devDependencies;
+  if (!isRecord(devDeps) || !(name in devDeps)) return false;
+  const range = devDeps[name];
+  if (typeof range !== "string") return false;
+  if (options?.exempt?.(range)) return true;
+  const versionMatch = /(\d+\.\d+\.\d+)/.exec(range)?.[1];
+  if (versionMatch === void 0) return false;
+  return compareVersions(versionMatch, minVersion) >= 0;
+}
+
+// .preflight/collections/default.ts
+var releaseKit = {
+  name: "release-kit",
+  checks: [
+    {
+      name: "@williamthorsen/release-kit >= 4.0.0 in devDependencies",
+      check: () => hasMinDevDependencyVersion("@williamthorsen/release-kit", "4.0.0", {
+        exempt: (range) => range.startsWith("workspace:")
+      }),
+      fix: "pnpm add --save-dev @williamthorsen/release-kit@^4.0.0"
+    },
+    {
+      name: "release.yaml workflow exists",
+      check: () => fileExists(".github/workflows/release.yaml"),
+      fix: "Add .github/workflows/release.yaml using the release workflow template"
+    },
+    {
+      name: "release workflow references release.reusable.yaml",
+      check: () => fileContains(
+        ".github/workflows/release.yaml",
+        /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/
+      ),
+      fix: "Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1"
+    },
+    {
+      name: "publish.yaml workflow exists",
+      check: () => fileExists(".github/workflows/publish.yaml"),
+      fix: "Add .github/workflows/publish.yaml using the publish workflow template"
+    },
+    {
+      name: "publish workflow references publish.reusable.yaml",
+      check: () => fileContains(
+        ".github/workflows/publish.yaml",
+        /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/
+      ),
+      fix: "Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1"
+    }
+  ]
+};
+var syncLabels = {
+  name: "sync-labels",
+  checks: [
+    {
+      name: "sync-labels.yaml workflow exists",
+      check: () => fileExists(".github/workflows/sync-labels.yaml"),
+      fix: "Add .github/workflows/sync-labels.yaml using the sync-labels workflow template"
+    },
+    {
+      name: "sync-labels workflow references sync-labels.reusable.yaml",
+      check: () => fileContains(
+        ".github/workflows/sync-labels.yaml",
+        /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)sync-labels\.reusable\.yaml/
+      ),
+      fix: "Update sync-labels.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@sync-labels-workflow-v1"
+    },
+    {
+      name: ".github/labels.yaml exists",
+      check: () => fileExists(".github/labels.yaml"),
+      fix: "Add .github/labels.yaml with repo-specific label definitions (use release-kit sync-labels generate)"
+    }
+  ]
+};
+var codeQuality = {
+  name: "code-quality",
+  checks: [
+    {
+      name: "code-quality.yaml workflow exists",
+      check: () => fileExists(".github/workflows/code-quality.yaml"),
+      fix: "Add .github/workflows/code-quality.yaml using the code-quality workflow template"
+    },
+    {
+      name: "code-quality workflow references @v5",
+      check: () => fileContains(
+        ".github/workflows/code-quality.yaml",
+        /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/
+      ),
+      fix: "Update code-quality.yaml to reference code-quality-pnpm-workflow.yaml@v5"
+    },
+    {
+      name: "code-quality workflow does not reference pnpm-version (requires @v5)",
+      check: () => !fileContains(
+        ".github/workflows/code-quality.yaml",
+        /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/
+      ) || fileDoesNotContain(".github/workflows/code-quality.yaml", /pnpm-version/),
+      fix: "Remove pnpm-version from code-quality.yaml \u2014 v5 workflow infers the version from packageManager"
+    },
+    {
+      name: "code-quality workflow does not reference GH_PACKAGES_TOKEN",
+      check: () => fileDoesNotContain(".github/workflows/code-quality.yaml", /GH_PACKAGES_TOKEN/),
+      fix: "Remove all references to GH_PACKAGES_TOKEN from code-quality.yaml"
+    }
+  ]
+};
+var repoSetupChecks = [
+  {
+    name: ".envrc exists",
+    check: () => fileExists(".envrc"),
+    fix: "Add .envrc to repo root"
+  },
+  {
+    name: ".config/wt.toml exists",
+    check: () => fileExists(".config/wt.toml"),
+    fix: "Add .config/wt.toml for worktree configuration"
+  },
+  {
+    name: ".editorconfig exists",
+    check: () => fileExists(".editorconfig"),
+    fix: "Add .editorconfig to repo root"
+  },
+  {
+    name: "lefthook.yml exists",
+    check: () => fileExists("lefthook.yml"),
+    fix: "Add lefthook.yml for git hook management"
+  },
+  {
+    name: ".claude/CLAUDE.md exists",
+    check: () => fileExists(".claude/CLAUDE.md"),
+    fix: "Add .claude/CLAUDE.md with project-specific agent instructions"
+  },
+  {
+    name: ".agents/PROJECT.md exists",
+    check: () => fileExists(".agents/PROJECT.md"),
+    fix: "Add .agents/PROJECT.md with project context for AI agents"
+  },
+  {
+    name: ".agents/preferences.yaml has project.slug and project.ticket_prefix",
+    check: () => preferencesHasRequiredFields(),
+    fix: "Add .agents/preferences.yaml with project.slug and project.ticket_prefix fields"
+  },
+  {
+    name: ".audit-ci/config.dev.json5 exists",
+    check: () => fileExists(".audit-ci/config.dev.json5"),
+    fix: "Add .audit-ci/config.dev.json5 for dev dependency audit configuration"
+  },
+  {
+    name: ".audit-ci/config.prod.json5 exists",
+    check: () => fileExists(".audit-ci/config.prod.json5"),
+    fix: "Add .audit-ci/config.prod.json5 for prod dependency audit configuration"
+  },
+  {
+    name: 'package.json has "type": "module"',
+    check: () => hasPackageJsonField("type", "module"),
+    fix: 'Add "type": "module" to package.json'
+  },
+  {
+    name: "package.json has packageManager field",
+    check: () => hasPackageJsonField("packageManager"),
+    fix: 'Add "packageManager" field to package.json (e.g., "pnpm@10.33.0")'
+  },
+  {
+    name: ".tool-versions does not contain pnpm",
+    check: () => toolVersionsHasNoPnpm(),
+    fix: "Remove pnpm from .tool-versions \u2014 manage via packageManager field and corepack"
+  }
+];
+var repoSetup = {
+  name: "repo-setup",
+  checks: repoSetupChecks
+};
+var default_default = definePreflightCollection({
+  checklists: [releaseKit, syncLabels, codeQuality, repoSetup]
+});
+function preferencesHasRequiredFields() {
+  const content = readFile(".agents/preferences.yaml");
+  if (content === void 0) return false;
+  const hasSlug = /^\s+slug:\s*\S/m.test(content);
+  const hasTicketPrefix = /^\s+ticket_prefix:\s*\S/m.test(content);
+  return hasSlug && hasTicketPrefix;
+}
+function toolVersionsHasNoPnpm() {
+  const content = readFile(".tool-versions");
+  if (content === void 0) return true;
+  return !/^pnpm\s/m.test(content);
+}
+export {
+  default_default as default
+};

--- a/.preflight/collections/default.ts
+++ b/.preflight/collections/default.ts
@@ -1,0 +1,207 @@
+/**
+ * Drift-detection collection for convention compliance across repos.
+ *
+ * Run from a target repo's working directory:
+ *   preflight run --file <path-to>/default.js
+ */
+import type { PreflightCheck, PreflightChecklist } from '@williamthorsen/preflight';
+import {
+  definePreflightCollection,
+  fileContains,
+  fileDoesNotContain,
+  fileExists,
+  hasMinDevDependencyVersion,
+  hasPackageJsonField,
+  readFile,
+} from '@williamthorsen/preflight';
+
+const releaseKit: PreflightChecklist = {
+  name: 'release-kit',
+  checks: [
+    {
+      name: '@williamthorsen/release-kit >= 4.0.0 in devDependencies',
+      check: () =>
+        hasMinDevDependencyVersion('@williamthorsen/release-kit', '4.0.0', {
+          exempt: (range) => range.startsWith('workspace:'),
+        }),
+      fix: 'pnpm add --save-dev @williamthorsen/release-kit@^4.0.0',
+    },
+    {
+      name: 'release.yaml workflow exists',
+      check: () => fileExists('.github/workflows/release.yaml'),
+      fix: 'Add .github/workflows/release.yaml using the release workflow template',
+    },
+    {
+      name: 'release workflow references release.reusable.yaml',
+      check: () =>
+        fileContains(
+          '.github/workflows/release.yaml',
+          /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/,
+        ),
+      fix: 'Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1',
+    },
+    {
+      name: 'publish.yaml workflow exists',
+      check: () => fileExists('.github/workflows/publish.yaml'),
+      fix: 'Add .github/workflows/publish.yaml using the publish workflow template',
+    },
+    {
+      name: 'publish workflow references publish.reusable.yaml',
+      check: () =>
+        fileContains(
+          '.github/workflows/publish.yaml',
+          /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/,
+        ),
+      fix: 'Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1',
+    },
+  ],
+};
+
+const syncLabels: PreflightChecklist = {
+  name: 'sync-labels',
+  checks: [
+    {
+      name: 'sync-labels.yaml workflow exists',
+      check: () => fileExists('.github/workflows/sync-labels.yaml'),
+      fix: 'Add .github/workflows/sync-labels.yaml using the sync-labels workflow template',
+    },
+    {
+      name: 'sync-labels workflow references sync-labels.reusable.yaml',
+      check: () =>
+        fileContains(
+          '.github/workflows/sync-labels.yaml',
+          /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)sync-labels\.reusable\.yaml/,
+        ),
+      fix: 'Update sync-labels.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@sync-labels-workflow-v1',
+    },
+    {
+      name: '.github/labels.yaml exists',
+      check: () => fileExists('.github/labels.yaml'),
+      fix: 'Add .github/labels.yaml with repo-specific label definitions (use release-kit sync-labels generate)',
+    },
+  ],
+};
+
+const codeQuality: PreflightChecklist = {
+  name: 'code-quality',
+  checks: [
+    {
+      name: 'code-quality.yaml workflow exists',
+      check: () => fileExists('.github/workflows/code-quality.yaml'),
+      fix: 'Add .github/workflows/code-quality.yaml using the code-quality workflow template',
+    },
+    {
+      name: 'code-quality workflow references @v5',
+      check: () =>
+        fileContains(
+          '.github/workflows/code-quality.yaml',
+          /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/,
+        ),
+      fix: 'Update code-quality.yaml to reference code-quality-pnpm-workflow.yaml@v5',
+    },
+    {
+      name: 'code-quality workflow does not reference pnpm-version (requires @v5)',
+      check: () =>
+        !fileContains(
+          '.github/workflows/code-quality.yaml',
+          /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/,
+        ) || fileDoesNotContain('.github/workflows/code-quality.yaml', /pnpm-version/),
+      fix: 'Remove pnpm-version from code-quality.yaml — v5 workflow infers the version from packageManager',
+    },
+    {
+      name: 'code-quality workflow does not reference GH_PACKAGES_TOKEN',
+      check: () => fileDoesNotContain('.github/workflows/code-quality.yaml', /GH_PACKAGES_TOKEN/),
+      fix: 'Remove all references to GH_PACKAGES_TOKEN from code-quality.yaml',
+    },
+  ],
+};
+
+const repoSetupChecks: PreflightCheck[] = [
+  {
+    name: '.envrc exists',
+    check: () => fileExists('.envrc'),
+    fix: 'Add .envrc to repo root',
+  },
+  {
+    name: '.config/wt.toml exists',
+    check: () => fileExists('.config/wt.toml'),
+    fix: 'Add .config/wt.toml for worktree configuration',
+  },
+  {
+    name: '.editorconfig exists',
+    check: () => fileExists('.editorconfig'),
+    fix: 'Add .editorconfig to repo root',
+  },
+  {
+    name: 'lefthook.yml exists',
+    check: () => fileExists('lefthook.yml'),
+    fix: 'Add lefthook.yml for git hook management',
+  },
+  {
+    name: '.claude/CLAUDE.md exists',
+    check: () => fileExists('.claude/CLAUDE.md'),
+    fix: 'Add .claude/CLAUDE.md with project-specific agent instructions',
+  },
+  {
+    name: '.agents/PROJECT.md exists',
+    check: () => fileExists('.agents/PROJECT.md'),
+    fix: 'Add .agents/PROJECT.md with project context for AI agents',
+  },
+  {
+    name: '.agents/preferences.yaml has project.slug and project.ticket_prefix',
+    check: () => preferencesHasRequiredFields(),
+    fix: 'Add .agents/preferences.yaml with project.slug and project.ticket_prefix fields',
+  },
+  {
+    name: '.audit-ci/config.dev.json5 exists',
+    check: () => fileExists('.audit-ci/config.dev.json5'),
+    fix: 'Add .audit-ci/config.dev.json5 for dev dependency audit configuration',
+  },
+  {
+    name: '.audit-ci/config.prod.json5 exists',
+    check: () => fileExists('.audit-ci/config.prod.json5'),
+    fix: 'Add .audit-ci/config.prod.json5 for prod dependency audit configuration',
+  },
+  {
+    name: 'package.json has "type": "module"',
+    check: () => hasPackageJsonField('type', 'module'),
+    fix: 'Add "type": "module" to package.json',
+  },
+  {
+    name: 'package.json has packageManager field',
+    check: () => hasPackageJsonField('packageManager'),
+    fix: 'Add "packageManager" field to package.json (e.g., "pnpm@10.33.0")',
+  },
+  {
+    name: '.tool-versions does not contain pnpm',
+    check: () => toolVersionsHasNoPnpm(),
+    fix: 'Remove pnpm from .tool-versions — manage via packageManager field and corepack',
+  },
+];
+
+const repoSetup: PreflightChecklist = {
+  name: 'repo-setup',
+  checks: repoSetupChecks,
+};
+
+export default definePreflightCollection({
+  checklists: [releaseKit, syncLabels, codeQuality, repoSetup],
+});
+
+// -- Collection-specific helpers ----------------------------------------------
+
+/** Verify that .agents/preferences.yaml contains project.slug and project.ticket_prefix. */
+function preferencesHasRequiredFields(): boolean {
+  const content = readFile('.agents/preferences.yaml');
+  if (content === undefined) return false;
+  const hasSlug = /^\s+slug:\s*\S/m.test(content);
+  const hasTicketPrefix = /^\s+ticket_prefix:\s*\S/m.test(content);
+  return hasSlug && hasTicketPrefix;
+}
+
+/** Check that .tool-versions does not list pnpm. Pass if the file is absent. */
+function toolVersionsHasNoPnpm(): boolean {
+  const content = readFile('.tool-versions');
+  if (content === undefined) return true;
+  return !/^pnpm\s/m.test(content);
+}

--- a/.preflight/collections/nmr.js
+++ b/.preflight/collections/nmr.js
@@ -23,11 +23,6 @@ function fileContains(relativePath, pattern) {
   if (content === void 0) return false;
   return pattern.test(content);
 }
-function fileDoesNotContain(relativePath, pattern) {
-  const content = readFile(relativePath);
-  if (content === void 0) return true;
-  return !pattern.test(content);
-}
 
 // packages/preflight/dist/esm/isRecord.js
 function isRecord(value) {
@@ -78,215 +73,98 @@ function hasMinDevDependencyVersion(name, minVersion, options) {
   return compareVersions(versionMatch, minVersion) >= 0;
 }
 
-// .preflight/collections/nmr.ts
-var releaseKit = {
-  name: "release-kit",
-  checks: [
-    {
-      name: "@williamthorsen/release-kit >= 4.0.0 in devDependencies",
-      check: () => hasMinDevDependencyVersion("@williamthorsen/release-kit", "4.0.0", {
-        exempt: (range) => range.startsWith("workspace:")
-      }),
-      fix: "pnpm add --save-dev @williamthorsen/release-kit@^4.0.0"
-    },
-    {
-      name: "release.yaml workflow exists",
-      check: () => fileExists(".github/workflows/release.yaml"),
-      fix: "Add .github/workflows/release.yaml using the release workflow template"
-    },
-    {
-      name: "release workflow references release.reusable.yaml",
-      check: () => fileContains(
-        ".github/workflows/release.yaml",
-        /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/
-      ),
-      fix: "Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1"
-    },
-    {
-      name: "publish.yaml workflow exists",
-      check: () => fileExists(".github/workflows/publish.yaml"),
-      fix: "Add .github/workflows/publish.yaml using the publish workflow template"
-    },
-    {
-      name: "publish workflow references publish.reusable.yaml",
-      check: () => fileContains(
-        ".github/workflows/publish.yaml",
-        /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/
-      ),
-      fix: "Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1"
-    }
-  ]
-};
-var syncLabels = {
-  name: "sync-labels",
-  checks: [
-    {
-      name: "sync-labels.yaml workflow exists",
-      check: () => fileExists(".github/workflows/sync-labels.yaml"),
-      fix: "Add .github/workflows/sync-labels.yaml using the sync-labels workflow template"
-    },
-    {
-      name: "sync-labels workflow references sync-labels.reusable.yaml",
-      check: () => fileContains(
-        ".github/workflows/sync-labels.yaml",
-        /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)sync-labels\.reusable\.yaml/
-      ),
-      fix: "Update sync-labels.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@sync-labels-workflow-v1"
-    },
-    {
-      name: ".github/labels.yaml exists",
-      check: () => fileExists(".github/labels.yaml"),
-      fix: "Add .github/labels.yaml with repo-specific label definitions (use release-kit sync-labels generate)"
-    }
-  ]
-};
-var nmr = {
-  name: "nmr",
-  checks: [
-    {
-      name: "@williamthorsen/nmr in devDependencies",
-      check: () => hasDevDependency("@williamthorsen/nmr"),
-      fix: "pnpm add --save-dev @williamthorsen/nmr"
-    },
-    {
-      name: "__tests__/version-alignment.app.test.ts exists",
-      check: () => fileExists("__tests__/version-alignment.app.test.ts"),
-      fix: "Add __tests__/version-alignment.app.test.ts with version-alignment checks"
-    },
-    {
-      name: "version-alignment test contains checkNodeVersionConsistency (requires file)",
-      check: () => !fileExists("__tests__/version-alignment.app.test.ts") || fileContains("__tests__/version-alignment.app.test.ts", /checkNodeVersionConsistency/),
-      fix: "Update __tests__/version-alignment.app.test.ts to use checkNodeVersionConsistency"
-    },
-    {
-      name: "version-alignment test does not contain runConsistencyChecks (requires file)",
-      check: () => !fileExists("__tests__/version-alignment.app.test.ts") || fileDoesNotContain("__tests__/version-alignment.app.test.ts", /runConsistencyChecks/),
-      fix: "Replace runConsistencyChecks with checkNodeVersionConsistency in __tests__/version-alignment.app.test.ts"
-    },
-    {
-      name: "__tests__/consistency.app.test.ts does not exist",
-      check: () => !fileExists("__tests__/consistency.app.test.ts"),
-      fix: "Remove __tests__/consistency.app.test.ts \u2014 superseded by __tests__/version-alignment.app.test.ts"
-    },
-    {
-      name: "__tests__/nodejs-version-app.test.ts does not exist",
-      check: () => !fileExists("__tests__/nodejs-version-app.test.ts"),
-      fix: "Remove __tests__/nodejs-version-app.test.ts \u2014 superseded by __tests__/version-alignment.app.test.ts"
-    },
-    {
-      name: "__tests__/pnpm-version-app.test.ts does not exist",
-      check: () => !fileExists("__tests__/pnpm-version-app.test.ts"),
-      fix: "Remove __tests__/pnpm-version-app.test.ts \u2014 superseded by __tests__/version-alignment.app.test.ts"
-    }
-  ]
-};
-var codeQuality = {
-  name: "code-quality",
-  checks: [
-    {
-      name: "code-quality.yaml workflow exists",
-      check: () => fileExists(".github/workflows/code-quality.yaml"),
-      fix: "Add .github/workflows/code-quality.yaml using the code-quality workflow template"
-    },
-    {
-      name: "code-quality workflow references @v5",
-      check: () => fileContains(
-        ".github/workflows/code-quality.yaml",
-        /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/
-      ),
-      fix: "Update code-quality.yaml to reference code-quality-pnpm-workflow.yaml@v5"
-    },
-    {
-      name: "code-quality workflow does not reference pnpm-version (requires @v5)",
-      check: () => !fileContains(
-        ".github/workflows/code-quality.yaml",
-        /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/
-      ) || fileDoesNotContain(".github/workflows/code-quality.yaml", /pnpm-version/),
-      fix: "Remove pnpm-version from code-quality.yaml \u2014 v5 workflow infers the version from packageManager"
-    },
-    {
-      name: "code-quality workflow does not reference GH_PACKAGES_TOKEN",
-      check: () => fileDoesNotContain(".github/workflows/code-quality.yaml", /GH_PACKAGES_TOKEN/),
-      fix: "Remove all references to GH_PACKAGES_TOKEN from code-quality.yaml"
-    }
-  ]
-};
-var repoSetupChecks = [
-  {
-    name: ".envrc exists",
-    check: () => fileExists(".envrc"),
-    fix: "Add .envrc to repo root"
+// packages/nmr/package.json
+var package_default = {
+  name: "@williamthorsen/nmr",
+  version: "0.9.0",
+  private: false,
+  description: "Context-aware script runner for PNPM monorepos",
+  keywords: [
+    "monorepo",
+    "pnpm",
+    "script-runner",
+    "workspace"
+  ],
+  license: "MIT",
+  author: "William Thorsen <william@thorsen.dev> (https://github.com/williamthorsen)",
+  type: "module",
+  exports: {
+    ".": "./dist/esm/index.js",
+    "./tests": "./dist/esm/tests/consistency.js"
   },
-  {
-    name: ".config/wt.toml exists",
-    check: () => fileExists(".config/wt.toml"),
-    fix: "Add .config/wt.toml for worktree configuration"
+  bin: {
+    "ensure-prepublish-hooks": "bin/ensure-prepublish-hooks.js",
+    nmr: "bin/nmr.js",
+    "nmr-report-overrides": "bin/nmr-report-overrides.js",
+    "nmr-sync-pnpm-version": "bin/nmr-sync-pnpm-version.js"
   },
-  {
-    name: ".editorconfig exists",
-    check: () => fileExists(".editorconfig"),
-    fix: "Add .editorconfig to repo root"
+  files: [
+    "bin",
+    "dist"
+  ],
+  scripts: {
+    prepare: "tsx ../../config/generateVersion.ts && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json"
   },
-  {
-    name: "lefthook.yml exists",
-    check: () => fileExists("lefthook.yml"),
-    fix: "Add lefthook.yml for git hook management"
+  dependencies: {
+    jiti: "2.6.1",
+    "js-yaml": "4.1.1",
+    zod: "4.3.6"
   },
-  {
-    name: ".claude/CLAUDE.md exists",
-    check: () => fileExists(".claude/CLAUDE.md"),
-    fix: "Add .claude/CLAUDE.md with project-specific agent instructions"
-  },
-  {
-    name: ".agents/PROJECT.md exists",
-    check: () => fileExists(".agents/PROJECT.md"),
-    fix: "Add .agents/PROJECT.md with project context for AI agents"
-  },
-  {
-    name: ".agents/preferences.yaml has project.slug and project.ticket_prefix",
-    check: () => preferencesHasRequiredFields(),
-    fix: "Add .agents/preferences.yaml with project.slug and project.ticket_prefix fields"
-  },
-  {
-    name: ".audit-ci/config.dev.json5 exists",
-    check: () => fileExists(".audit-ci/config.dev.json5"),
-    fix: "Add .audit-ci/config.dev.json5 for dev dependency audit configuration"
-  },
-  {
-    name: ".audit-ci/config.prod.json5 exists",
-    check: () => fileExists(".audit-ci/config.prod.json5"),
-    fix: "Add .audit-ci/config.prod.json5 for prod dependency audit configuration"
-  },
-  {
-    name: 'package.json has "type": "module"',
-    check: () => hasPackageJsonField("type", "module"),
-    fix: 'Add "type": "module" to package.json'
-  },
-  {
-    name: "package.json has packageManager field",
-    check: () => hasPackageJsonField("packageManager"),
-    fix: 'Add "packageManager" field to package.json (e.g., "pnpm@10.33.0")'
-  },
-  {
-    name: ".tool-versions does not contain pnpm",
-    check: () => toolVersionsHasNoPnpm(),
-    fix: "Remove pnpm from .tool-versions \u2014 manage via packageManager field and corepack"
+  publishConfig: {
+    access: "public"
   }
-];
-var repoSetup = {
-  name: "repo-setup",
-  checks: repoSetupChecks
 };
+
+// .preflight/collections/nmr.ts
+var MIN_VERSION = package_default.version;
 var nmr_default = definePreflightCollection({
-  checklists: [releaseKit, syncLabels, nmr, codeQuality, repoSetup]
+  checklists: [
+    {
+      name: "nmr",
+      checks: [
+        {
+          name: "@williamthorsen/nmr in devDependencies",
+          severity: "error",
+          check: () => hasDevDependency("@williamthorsen/nmr"),
+          fix: "pnpm add --save-dev @williamthorsen/nmr"
+        },
+        {
+          name: `@williamthorsen/nmr >= ${MIN_VERSION}`,
+          severity: "error",
+          check: () => hasMinDevDependencyVersion("@williamthorsen/nmr", MIN_VERSION, {
+            exempt: (range) => range.startsWith("workspace:")
+          }),
+          fix: `pnpm add --save-dev @williamthorsen/nmr@^${MIN_VERSION}`
+        },
+        {
+          name: "pnpm-workspace.yaml exists",
+          severity: "error",
+          check: () => fileExists("pnpm-workspace.yaml"),
+          fix: "Create pnpm-workspace.yaml with workspace package globs"
+        },
+        {
+          name: "package.json has packageManager field",
+          severity: "warn",
+          check: () => hasPackageJsonField("packageManager"),
+          fix: 'Add "packageManager" field to package.json (e.g., "pnpm@10.33.0")'
+        },
+        {
+          name: ".tool-versions does not list pnpm",
+          severity: "warn",
+          check: () => toolVersionsHasNoPnpm(),
+          fix: "Remove pnpm from .tool-versions \u2014 manage via packageManager field and corepack"
+        },
+        {
+          name: ".config/nmr.config.ts uses defineConfig",
+          severity: "recommend",
+          skip: () => !fileExists(".config/nmr.config.ts") ? "no nmr config file" : false,
+          check: () => fileContains(".config/nmr.config.ts", /defineConfig/),
+          fix: "Wrap your config export with defineConfig() from @williamthorsen/nmr for type safety"
+        }
+      ]
+    }
+  ]
 });
-function preferencesHasRequiredFields() {
-  const content = readFile(".agents/preferences.yaml");
-  if (content === void 0) return false;
-  const hasSlug = /^\s+slug:\s*\S/m.test(content);
-  const hasTicketPrefix = /^\s+ticket_prefix:\s*\S/m.test(content);
-  return hasSlug && hasTicketPrefix;
-}
 function toolVersionsHasNoPnpm() {
   const content = readFile(".tool-versions");
   if (content === void 0) return true;

--- a/.preflight/collections/nmr.ts
+++ b/.preflight/collections/nmr.ts
@@ -1,14 +1,16 @@
 /**
- * Drift-detection collection for convention compliance across repos.
+ * Preflight collection for consumers of @williamthorsen/nmr.
+ *
+ * Verifies that the consuming repo's nmr setup is current and correctly configured.
+ * The minimum version is read from the nmr package's package.json and inlined by
+ * esbuild at compile time.
  *
  * Run from a target repo's working directory:
  *   preflight run --file <path-to>/nmr.js
  */
-import type { PreflightCheck, PreflightChecklist } from '@williamthorsen/preflight';
 import {
   definePreflightCollection,
   fileContains,
-  fileDoesNotContain,
   fileExists,
   hasDevDependency,
   hasMinDevDependencyVersion,
@@ -16,234 +18,61 @@ import {
   readFile,
 } from '@williamthorsen/preflight';
 
-const releaseKit: PreflightChecklist = {
-  name: 'release-kit',
-  checks: [
-    {
-      name: '@williamthorsen/release-kit >= 4.0.0 in devDependencies',
-      check: () =>
-        hasMinDevDependencyVersion('@williamthorsen/release-kit', '4.0.0', {
-          exempt: (range) => range.startsWith('workspace:'),
-        }),
-      fix: 'pnpm add --save-dev @williamthorsen/release-kit@^4.0.0',
-    },
-    {
-      name: 'release.yaml workflow exists',
-      check: () => fileExists('.github/workflows/release.yaml'),
-      fix: 'Add .github/workflows/release.yaml using the release workflow template',
-    },
-    {
-      name: 'release workflow references release.reusable.yaml',
-      check: () =>
-        fileContains(
-          '.github/workflows/release.yaml',
-          /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/,
-        ),
-      fix: 'Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1',
-    },
-    {
-      name: 'publish.yaml workflow exists',
-      check: () => fileExists('.github/workflows/publish.yaml'),
-      fix: 'Add .github/workflows/publish.yaml using the publish workflow template',
-    },
-    {
-      name: 'publish workflow references publish.reusable.yaml',
-      check: () =>
-        fileContains(
-          '.github/workflows/publish.yaml',
-          /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/,
-        ),
-      fix: 'Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1',
-    },
-  ],
-};
+import nmrPackageJson from '../../packages/nmr/package.json';
 
-const syncLabels: PreflightChecklist = {
-  name: 'sync-labels',
-  checks: [
-    {
-      name: 'sync-labels.yaml workflow exists',
-      check: () => fileExists('.github/workflows/sync-labels.yaml'),
-      fix: 'Add .github/workflows/sync-labels.yaml using the sync-labels workflow template',
-    },
-    {
-      name: 'sync-labels workflow references sync-labels.reusable.yaml',
-      check: () =>
-        fileContains(
-          '.github/workflows/sync-labels.yaml',
-          /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)sync-labels\.reusable\.yaml/,
-        ),
-      fix: 'Update sync-labels.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@sync-labels-workflow-v1',
-    },
-    {
-      name: '.github/labels.yaml exists',
-      check: () => fileExists('.github/labels.yaml'),
-      fix: 'Add .github/labels.yaml with repo-specific label definitions (use release-kit sync-labels generate)',
-    },
-  ],
-};
-
-const nmr: PreflightChecklist = {
-  name: 'nmr',
-  checks: [
-    {
-      name: '@williamthorsen/nmr in devDependencies',
-      check: () => hasDevDependency('@williamthorsen/nmr'),
-      fix: 'pnpm add --save-dev @williamthorsen/nmr',
-    },
-    {
-      name: '__tests__/version-alignment.app.test.ts exists',
-      check: () => fileExists('__tests__/version-alignment.app.test.ts'),
-      fix: 'Add __tests__/version-alignment.app.test.ts with version-alignment checks',
-    },
-    {
-      name: 'version-alignment test contains checkNodeVersionConsistency (requires file)',
-      check: () =>
-        !fileExists('__tests__/version-alignment.app.test.ts') ||
-        fileContains('__tests__/version-alignment.app.test.ts', /checkNodeVersionConsistency/),
-      fix: 'Update __tests__/version-alignment.app.test.ts to use checkNodeVersionConsistency',
-    },
-    {
-      name: 'version-alignment test does not contain runConsistencyChecks (requires file)',
-      check: () =>
-        !fileExists('__tests__/version-alignment.app.test.ts') ||
-        fileDoesNotContain('__tests__/version-alignment.app.test.ts', /runConsistencyChecks/),
-      fix: 'Replace runConsistencyChecks with checkNodeVersionConsistency in __tests__/version-alignment.app.test.ts',
-    },
-    {
-      name: '__tests__/consistency.app.test.ts does not exist',
-      check: () => !fileExists('__tests__/consistency.app.test.ts'),
-      fix: 'Remove __tests__/consistency.app.test.ts — superseded by __tests__/version-alignment.app.test.ts',
-    },
-    {
-      name: '__tests__/nodejs-version-app.test.ts does not exist',
-      check: () => !fileExists('__tests__/nodejs-version-app.test.ts'),
-      fix: 'Remove __tests__/nodejs-version-app.test.ts — superseded by __tests__/version-alignment.app.test.ts',
-    },
-    {
-      name: '__tests__/pnpm-version-app.test.ts does not exist',
-      check: () => !fileExists('__tests__/pnpm-version-app.test.ts'),
-      fix: 'Remove __tests__/pnpm-version-app.test.ts — superseded by __tests__/version-alignment.app.test.ts',
-    },
-  ],
-};
-
-const codeQuality: PreflightChecklist = {
-  name: 'code-quality',
-  checks: [
-    {
-      name: 'code-quality.yaml workflow exists',
-      check: () => fileExists('.github/workflows/code-quality.yaml'),
-      fix: 'Add .github/workflows/code-quality.yaml using the code-quality workflow template',
-    },
-    {
-      name: 'code-quality workflow references @v5',
-      check: () =>
-        fileContains(
-          '.github/workflows/code-quality.yaml',
-          /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/,
-        ),
-      fix: 'Update code-quality.yaml to reference code-quality-pnpm-workflow.yaml@v5',
-    },
-    {
-      name: 'code-quality workflow does not reference pnpm-version (requires @v5)',
-      check: () =>
-        !fileContains(
-          '.github/workflows/code-quality.yaml',
-          /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/,
-        ) || fileDoesNotContain('.github/workflows/code-quality.yaml', /pnpm-version/),
-      fix: 'Remove pnpm-version from code-quality.yaml — v5 workflow infers the version from packageManager',
-    },
-    {
-      name: 'code-quality workflow does not reference GH_PACKAGES_TOKEN',
-      check: () => fileDoesNotContain('.github/workflows/code-quality.yaml', /GH_PACKAGES_TOKEN/),
-      fix: 'Remove all references to GH_PACKAGES_TOKEN from code-quality.yaml',
-    },
-  ],
-};
-
-const repoSetupChecks: PreflightCheck[] = [
-  {
-    name: '.envrc exists',
-    check: () => fileExists('.envrc'),
-    fix: 'Add .envrc to repo root',
-  },
-  {
-    name: '.config/wt.toml exists',
-    check: () => fileExists('.config/wt.toml'),
-    fix: 'Add .config/wt.toml for worktree configuration',
-  },
-  {
-    name: '.editorconfig exists',
-    check: () => fileExists('.editorconfig'),
-    fix: 'Add .editorconfig to repo root',
-  },
-  {
-    name: 'lefthook.yml exists',
-    check: () => fileExists('lefthook.yml'),
-    fix: 'Add lefthook.yml for git hook management',
-  },
-  {
-    name: '.claude/CLAUDE.md exists',
-    check: () => fileExists('.claude/CLAUDE.md'),
-    fix: 'Add .claude/CLAUDE.md with project-specific agent instructions',
-  },
-  {
-    name: '.agents/PROJECT.md exists',
-    check: () => fileExists('.agents/PROJECT.md'),
-    fix: 'Add .agents/PROJECT.md with project context for AI agents',
-  },
-  {
-    name: '.agents/preferences.yaml has project.slug and project.ticket_prefix',
-    check: () => preferencesHasRequiredFields(),
-    fix: 'Add .agents/preferences.yaml with project.slug and project.ticket_prefix fields',
-  },
-  {
-    name: '.audit-ci/config.dev.json5 exists',
-    check: () => fileExists('.audit-ci/config.dev.json5'),
-    fix: 'Add .audit-ci/config.dev.json5 for dev dependency audit configuration',
-  },
-  {
-    name: '.audit-ci/config.prod.json5 exists',
-    check: () => fileExists('.audit-ci/config.prod.json5'),
-    fix: 'Add .audit-ci/config.prod.json5 for prod dependency audit configuration',
-  },
-  {
-    name: 'package.json has "type": "module"',
-    check: () => hasPackageJsonField('type', 'module'),
-    fix: 'Add "type": "module" to package.json',
-  },
-  {
-    name: 'package.json has packageManager field',
-    check: () => hasPackageJsonField('packageManager'),
-    fix: 'Add "packageManager" field to package.json (e.g., "pnpm@10.33.0")',
-  },
-  {
-    name: '.tool-versions does not contain pnpm',
-    check: () => toolVersionsHasNoPnpm(),
-    fix: 'Remove pnpm from .tool-versions — manage via packageManager field and corepack',
-  },
-];
-
-const repoSetup: PreflightChecklist = {
-  name: 'repo-setup',
-  checks: repoSetupChecks,
-};
+const MIN_VERSION = nmrPackageJson.version;
 
 export default definePreflightCollection({
-  checklists: [releaseKit, syncLabels, nmr, codeQuality, repoSetup],
+  checklists: [
+    {
+      name: 'nmr',
+      checks: [
+        {
+          name: '@williamthorsen/nmr in devDependencies',
+          severity: 'error',
+          check: () => hasDevDependency('@williamthorsen/nmr'),
+          fix: 'pnpm add --save-dev @williamthorsen/nmr',
+        },
+        {
+          name: `@williamthorsen/nmr >= ${MIN_VERSION}`,
+          severity: 'error',
+          check: () =>
+            hasMinDevDependencyVersion('@williamthorsen/nmr', MIN_VERSION, {
+              exempt: (range) => range.startsWith('workspace:'),
+            }),
+          fix: `pnpm add --save-dev @williamthorsen/nmr@^${MIN_VERSION}`,
+        },
+        {
+          name: 'pnpm-workspace.yaml exists',
+          severity: 'error',
+          check: () => fileExists('pnpm-workspace.yaml'),
+          fix: 'Create pnpm-workspace.yaml with workspace package globs',
+        },
+        {
+          name: 'package.json has packageManager field',
+          severity: 'warn',
+          check: () => hasPackageJsonField('packageManager'),
+          fix: 'Add "packageManager" field to package.json (e.g., "pnpm@10.33.0")',
+        },
+        {
+          name: '.tool-versions does not list pnpm',
+          severity: 'warn',
+          check: () => toolVersionsHasNoPnpm(),
+          fix: 'Remove pnpm from .tool-versions — manage via packageManager field and corepack',
+        },
+        {
+          name: '.config/nmr.config.ts uses defineConfig',
+          severity: 'recommend',
+          skip: () => (!fileExists('.config/nmr.config.ts') ? 'no nmr config file' : false),
+          check: () => fileContains('.config/nmr.config.ts', /defineConfig/),
+          fix: 'Wrap your config export with defineConfig() from @williamthorsen/nmr for type safety',
+        },
+      ],
+    },
+  ],
 });
 
 // -- Collection-specific helpers ----------------------------------------------
-
-/** Verify that .agents/preferences.yaml contains project.slug and project.ticket_prefix. */
-function preferencesHasRequiredFields(): boolean {
-  const content = readFile('.agents/preferences.yaml');
-  if (content === undefined) return false;
-  const hasSlug = /^\s+slug:\s*\S/m.test(content);
-  const hasTicketPrefix = /^\s+ticket_prefix:\s*\S/m.test(content);
-  return hasSlug && hasTicketPrefix;
-}
 
 /** Check that .tool-versions does not list pnpm. Pass if the file is absent. */
 function toolVersionsHasNoPnpm(): boolean {


### PR DESCRIPTION
Closes #161 

## What

Creates a dedicated preflight collection for `@williamthorsen/nmr` consumers with 6 checks covering dependency presence, minimum version, workspace configuration, and config file usage. Renames the existing monolithic collection from `nmr.ts` to `default.ts` and remove its nmr-specific checklist to avoid overlap with the new focused collection.

## Why

The existing `.preflight/collections/nmr.ts` mixed package-specific consumer checks with repo-specific conventions, violating the "one collection per source of truth" principle (#160). Separating nmr consumer checks into a dedicated collection makes it distributable to any repo using `@williamthorsen/nmr`.

## Details

### Features

- New `.preflight/collections/nmr.ts` with 6 checks: `@williamthorsen/nmr` in devDependencies (error), minimum version >= current (error), `pnpm-workspace.yaml` exists (error), `packageManager` field (warn), `.tool-versions` pnpm exclusion (warn), `defineConfig` usage in nmr config (recommend).
- Minimum version is read from `packages/nmr/package.json` and inlined by esbuild at compile time — no hardcoded version string.
- Renamed monolithic collection to `default.ts`, removed its `nmr` checklist.
- Added `.config/preflight.config.ts` with `include: '*.ts'` to prevent `preflight compile --all` from compiling test files in subdirectories.

### Tests

- 17 unit tests covering all 6 checks with pass/fail cases, skip condition for `defineConfig`, and `workspace:` protocol exemption for minimum version.