### PR TITLE
#162 Create dedicated release-kit preflight collection

### DIFF
--- a/.preflight/collections/__tests__/release-kit.test.ts
+++ b/.preflight/collections/__tests__/release-kit.test.ts
@@ -1,0 +1,217 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import collection from '../release-kit.ts';
+
+const [checklist] = collection.checklists;
+const checks = checklist.checks;
+
+/** Find a check by name prefix. */
+function findCheck(prefix: string) {
+  const check = checks.find((c) => c.name.startsWith(prefix));
+  if (!check) throw new Error(`No check found with prefix "${prefix}"`);
+  return check;
+}
+
+let tempDir: string;
+let cwdSpy: MockInstance;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'preflight-release-kit-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+});
+
+/** Write a package.json to the temp directory. */
+function writePackageJson(content: Record<string, unknown>): void {
+  writeFileSync(join(tempDir, 'package.json'), JSON.stringify(content));
+}
+
+describe('@williamthorsen/release-kit in devDependencies', () => {
+  const check = findCheck('@williamthorsen/release-kit in devDependencies');
+
+  it('passes when release-kit is in devDependencies', () => {
+    writePackageJson({ devDependencies: { '@williamthorsen/release-kit': '^4.4.0' } });
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when release-kit is not in devDependencies', () => {
+    writePackageJson({ devDependencies: {} });
+
+    expect(check.check()).toBe(false);
+  });
+
+  it('fails when package.json is missing', () => {
+    expect(check.check()).toBe(false);
+  });
+});
+
+describe('@williamthorsen/release-kit >= minimum version', () => {
+  const check = findCheck('@williamthorsen/release-kit >=');
+
+  it('passes when version meets minimum', () => {
+    writePackageJson({ devDependencies: { '@williamthorsen/release-kit': '^4.4.0' } });
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when version is below minimum', () => {
+    writePackageJson({ devDependencies: { '@williamthorsen/release-kit': '^1.0.0' } });
+
+    expect(check.check()).toBe(false);
+  });
+
+  it('passes when using workspace: protocol (exempt)', () => {
+    writePackageJson({ devDependencies: { '@williamthorsen/release-kit': 'workspace:*' } });
+
+    expect(check.check()).toBe(true);
+  });
+});
+
+describe('release.yaml workflow exists', () => {
+  const check = findCheck('release.yaml workflow exists');
+
+  it('passes when file exists', () => {
+    mkdirSync(join(tempDir, '.github/workflows'), { recursive: true });
+    writeFileSync(join(tempDir, '.github/workflows/release.yaml'), 'name: Release\n');
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when file is missing', () => {
+    expect(check.check()).toBe(false);
+  });
+});
+
+describe('release workflow references release.reusable.yaml', () => {
+  const check = findCheck('release workflow references');
+
+  it('passes when workflow references the reusable workflow via remote path', () => {
+    mkdirSync(join(tempDir, '.github/workflows'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.github/workflows/release.yaml'),
+      'uses: williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1\n',
+    );
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('passes when workflow references the reusable workflow via local path', () => {
+    mkdirSync(join(tempDir, '.github/workflows'), { recursive: true });
+    writeFileSync(join(tempDir, '.github/workflows/release.yaml'), 'uses: ./.github/workflows/release.reusable.yaml\n');
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when workflow does not reference the reusable workflow', () => {
+    mkdirSync(join(tempDir, '.github/workflows'), { recursive: true });
+    writeFileSync(join(tempDir, '.github/workflows/release.yaml'), 'name: Release\n');
+
+    expect(check.check()).toBe(false);
+  });
+});
+
+describe('publish.yaml workflow exists', () => {
+  const check = findCheck('publish.yaml workflow exists');
+
+  it('passes when file exists', () => {
+    mkdirSync(join(tempDir, '.github/workflows'), { recursive: true });
+    writeFileSync(join(tempDir, '.github/workflows/publish.yaml'), 'name: Publish\n');
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when file is missing', () => {
+    expect(check.check()).toBe(false);
+  });
+});
+
+describe('publish workflow references publish.reusable.yaml', () => {
+  const check = findCheck('publish workflow references');
+
+  it('passes when workflow references the reusable workflow via remote path', () => {
+    mkdirSync(join(tempDir, '.github/workflows'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.github/workflows/publish.yaml'),
+      'uses: williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1\n',
+    );
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('passes when workflow references the reusable workflow via local path', () => {
+    mkdirSync(join(tempDir, '.github/workflows'), { recursive: true });
+    writeFileSync(join(tempDir, '.github/workflows/publish.yaml'), 'uses: ./.github/workflows/publish.reusable.yaml\n');
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when workflow does not reference the reusable workflow', () => {
+    mkdirSync(join(tempDir, '.github/workflows'), { recursive: true });
+    writeFileSync(join(tempDir, '.github/workflows/publish.yaml'), 'name: Publish\n');
+
+    expect(check.check()).toBe(false);
+  });
+});
+
+describe('config does not use removed tagPrefix', () => {
+  const check = findCheck('config does not use removed tagPrefix');
+
+  it('is skipped when config file is absent', () => {
+    expect(check.skip?.()).toBe('no release-kit config file');
+  });
+
+  it('is not skipped when config file exists', () => {
+    mkdirSync(join(tempDir, '.config'), { recursive: true });
+    writeFileSync(join(tempDir, '.config/release-kit.config.ts'), 'export default {};\n');
+
+    expect(check.skip?.()).toBe(false);
+  });
+
+  it('passes when config does not contain tagPrefix', () => {
+    mkdirSync(join(tempDir, '.config'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.config/release-kit.config.ts'),
+      'export default { components: [{ dir: "packages/core" }] };\n',
+    );
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when config contains tagPrefix', () => {
+    mkdirSync(join(tempDir, '.config'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.config/release-kit.config.ts'),
+      'export default { components: [{ dir: "packages/core", tagPrefix: "core-v" }] };\n',
+    );
+
+    expect(check.check()).toBe(false);
+  });
+});
+
+describe('git-cliff not in devDependencies', () => {
+  const check = findCheck('git-cliff not in devDependencies');
+
+  it('passes when git-cliff is not in devDependencies', () => {
+    writePackageJson({ devDependencies: {} });
+
+    expect(check.check()).toBe(true);
+  });
+
+  it('passes when package.json is missing', () => {
+    expect(check.check()).toBe(true);
+  });
+
+  it('fails when git-cliff is in devDependencies', () => {
+    writePackageJson({ devDependencies: { 'git-cliff': '^1.0.0' } });
+
+    expect(check.check()).toBe(false);
+  });
+});

--- a/.preflight/collections/default.js
+++ b/.preflight/collections/default.js
@@ -34,17 +34,6 @@ function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-// packages/preflight/dist/esm/check-utils/semver.js
-function compareVersions(a, b) {
-  const partsA = a.split(".").map(Number);
-  const partsB = b.split(".").map(Number);
-  for (let i = 0; i < 3; i++) {
-    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
-    if (diff !== 0) return diff;
-  }
-  return 0;
-}
-
 // packages/preflight/dist/esm/check-utils/package-json.js
 function readPackageJson() {
   const content = readFile("package.json");
@@ -59,58 +48,8 @@ function hasPackageJsonField(field, expectedValue) {
   if (expectedValue !== void 0) return pkg[field] === expectedValue;
   return field in pkg;
 }
-function hasMinDevDependencyVersion(name, minVersion, options) {
-  const pkg = readPackageJson();
-  if (pkg === void 0) return false;
-  const devDeps = pkg.devDependencies;
-  if (!isRecord(devDeps) || !(name in devDeps)) return false;
-  const range = devDeps[name];
-  if (typeof range !== "string") return false;
-  if (options?.exempt?.(range)) return true;
-  const versionMatch = /(\d+\.\d+\.\d+)/.exec(range)?.[1];
-  if (versionMatch === void 0) return false;
-  return compareVersions(versionMatch, minVersion) >= 0;
-}
 
 // .preflight/collections/default.ts
-var releaseKit = {
-  name: "release-kit",
-  checks: [
-    {
-      name: "@williamthorsen/release-kit >= 4.0.0 in devDependencies",
-      check: () => hasMinDevDependencyVersion("@williamthorsen/release-kit", "4.0.0", {
-        exempt: (range) => range.startsWith("workspace:")
-      }),
-      fix: "pnpm add --save-dev @williamthorsen/release-kit@^4.0.0"
-    },
-    {
-      name: "release.yaml workflow exists",
-      check: () => fileExists(".github/workflows/release.yaml"),
-      fix: "Add .github/workflows/release.yaml using the release workflow template"
-    },
-    {
-      name: "release workflow references release.reusable.yaml",
-      check: () => fileContains(
-        ".github/workflows/release.yaml",
-        /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/
-      ),
-      fix: "Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1"
-    },
-    {
-      name: "publish.yaml workflow exists",
-      check: () => fileExists(".github/workflows/publish.yaml"),
-      fix: "Add .github/workflows/publish.yaml using the publish workflow template"
-    },
-    {
-      name: "publish workflow references publish.reusable.yaml",
-      check: () => fileContains(
-        ".github/workflows/publish.yaml",
-        /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/
-      ),
-      fix: "Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1"
-    }
-  ]
-};
 var syncLabels = {
   name: "sync-labels",
   checks: [
@@ -232,7 +171,7 @@ var repoSetup = {
   checks: repoSetupChecks
 };
 var default_default = definePreflightCollection({
-  checklists: [releaseKit, syncLabels, codeQuality, repoSetup]
+  checklists: [syncLabels, codeQuality, repoSetup]
 });
 function preferencesHasRequiredFields() {
   const content = readFile(".agents/preferences.yaml");

--- a/.preflight/collections/default.ts
+++ b/.preflight/collections/default.ts
@@ -10,52 +10,9 @@ import {
   fileContains,
   fileDoesNotContain,
   fileExists,
-  hasMinDevDependencyVersion,
   hasPackageJsonField,
   readFile,
 } from '@williamthorsen/preflight';
-
-const releaseKit: PreflightChecklist = {
-  name: 'release-kit',
-  checks: [
-    {
-      name: '@williamthorsen/release-kit >= 4.0.0 in devDependencies',
-      check: () =>
-        hasMinDevDependencyVersion('@williamthorsen/release-kit', '4.0.0', {
-          exempt: (range) => range.startsWith('workspace:'),
-        }),
-      fix: 'pnpm add --save-dev @williamthorsen/release-kit@^4.0.0',
-    },
-    {
-      name: 'release.yaml workflow exists',
-      check: () => fileExists('.github/workflows/release.yaml'),
-      fix: 'Add .github/workflows/release.yaml using the release workflow template',
-    },
-    {
-      name: 'release workflow references release.reusable.yaml',
-      check: () =>
-        fileContains(
-          '.github/workflows/release.yaml',
-          /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/,
-        ),
-      fix: 'Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1',
-    },
-    {
-      name: 'publish.yaml workflow exists',
-      check: () => fileExists('.github/workflows/publish.yaml'),
-      fix: 'Add .github/workflows/publish.yaml using the publish workflow template',
-    },
-    {
-      name: 'publish workflow references publish.reusable.yaml',
-      check: () =>
-        fileContains(
-          '.github/workflows/publish.yaml',
-          /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/,
-        ),
-      fix: 'Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1',
-    },
-  ],
-};
 
 const syncLabels: PreflightChecklist = {
   name: 'sync-labels',
@@ -185,7 +142,7 @@ const repoSetup: PreflightChecklist = {
 };
 
 export default definePreflightCollection({
-  checklists: [releaseKit, syncLabels, codeQuality, repoSetup],
+  checklists: [syncLabels, codeQuality, repoSetup],
 });
 
 // -- Collection-specific helpers ----------------------------------------------

--- a/.preflight/collections/release-kit.js
+++ b/.preflight/collections/release-kit.js
@@ -1,0 +1,205 @@
+/** @noformat — @generated. Do not edit. Compiled by preflight. */
+/* eslint-disable */
+
+
+// packages/preflight/dist/esm/authoring.js
+function definePreflightCollection(collection) {
+  return collection;
+}
+
+// packages/preflight/dist/esm/check-utils/filesystem.js
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+function fileExists(relativePath) {
+  return existsSync(join(process.cwd(), relativePath));
+}
+function readFile(relativePath) {
+  const fullPath = join(process.cwd(), relativePath);
+  if (!existsSync(fullPath)) return void 0;
+  return readFileSync(fullPath, "utf8");
+}
+function fileContains(relativePath, pattern) {
+  const content = readFile(relativePath);
+  if (content === void 0) return false;
+  return pattern.test(content);
+}
+function fileDoesNotContain(relativePath, pattern) {
+  const content = readFile(relativePath);
+  if (content === void 0) return true;
+  return !pattern.test(content);
+}
+
+// packages/preflight/dist/esm/isRecord.js
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// packages/preflight/dist/esm/check-utils/semver.js
+function compareVersions(a, b) {
+  const partsA = a.split(".").map(Number);
+  const partsB = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+// packages/preflight/dist/esm/check-utils/package-json.js
+function readPackageJson() {
+  const content = readFile("package.json");
+  if (content === void 0) return void 0;
+  const parsed = JSON.parse(content);
+  if (!isRecord(parsed)) return void 0;
+  return Object.fromEntries(Object.entries(parsed));
+}
+function hasDevDependency(name) {
+  const pkg = readPackageJson();
+  if (pkg === void 0) return false;
+  const devDeps = pkg.devDependencies;
+  return isRecord(devDeps) && name in devDeps;
+}
+function hasMinDevDependencyVersion(name, minVersion, options) {
+  const pkg = readPackageJson();
+  if (pkg === void 0) return false;
+  const devDeps = pkg.devDependencies;
+  if (!isRecord(devDeps) || !(name in devDeps)) return false;
+  const range = devDeps[name];
+  if (typeof range !== "string") return false;
+  if (options?.exempt?.(range)) return true;
+  const versionMatch = /(\d+\.\d+\.\d+)/.exec(range)?.[1];
+  if (versionMatch === void 0) return false;
+  return compareVersions(versionMatch, minVersion) >= 0;
+}
+
+// packages/release-kit/package.json
+var package_default = {
+  name: "@williamthorsen/release-kit",
+  version: "4.4.0",
+  description: "Version-bumping and changelog-generation toolkit for release workflows",
+  keywords: [],
+  homepage: "https://github.com/williamthorsen/node-monorepo-tools/tree/main/packages/release-kit#readme",
+  bugs: {
+    url: "https://github.com/williamthorsen/node-monorepo-tools/issues"
+  },
+  repository: {
+    type: "git",
+    url: "https://github.com/williamthorsen/node-monorepo-tools.git",
+    directory: "packages/release-kit"
+  },
+  license: "UNLICENSED",
+  author: "William Thorsen <william@thorsen.dev> (https://github.com/williamthorsen)",
+  type: "module",
+  exports: {
+    ".": {
+      import: "./dist/esm/index.js"
+    }
+  },
+  bin: {
+    "release-kit": "./bin/release-kit.js"
+  },
+  files: [
+    "bin",
+    "dist/*",
+    "cliff.toml.template",
+    "presets/**",
+    "CHANGELOG.md"
+  ],
+  scripts: {
+    prepare: "tsx ../../config/generateVersion.ts && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json",
+    prepublishOnly: "nmr build",
+    test: "pnpm exec vitest --config=vitest.standalone.config.ts",
+    "test:coverage": "pnpm exec vitest --config=vitest.standalone.config.ts --coverage",
+    "test:integration": "pnpm exec vitest --config=vitest.integration.config.ts",
+    "test:watch": "pnpm exec vitest --config=vitest.standalone.config.ts --watch"
+  },
+  dependencies: {
+    "@williamthorsen/node-monorepo-core": "workspace:*",
+    glob: "13.0.6",
+    jiti: "2.6.1",
+    "js-yaml": "4.1.1"
+  },
+  devDependencies: {
+    "@types/js-yaml": "4.0.9",
+    "smol-toml": "1.6.1"
+  },
+  engines: {
+    node: ">=18.17.0"
+  },
+  publishConfig: {
+    access: "public",
+    registry: "https://registry.npmjs.org"
+  }
+};
+
+// .preflight/collections/release-kit.ts
+var MIN_VERSION = package_default.version;
+var release_kit_default = definePreflightCollection({
+  checklists: [
+    {
+      name: "release-kit",
+      checks: [
+        {
+          name: "@williamthorsen/release-kit in devDependencies",
+          severity: "error",
+          check: () => hasDevDependency("@williamthorsen/release-kit"),
+          fix: "pnpm add --save-dev @williamthorsen/release-kit"
+        },
+        {
+          name: `@williamthorsen/release-kit >= ${MIN_VERSION}`,
+          severity: "error",
+          check: () => hasMinDevDependencyVersion("@williamthorsen/release-kit", MIN_VERSION, {
+            exempt: (range) => range.startsWith("workspace:")
+          }),
+          fix: `pnpm add --save-dev @williamthorsen/release-kit@^${MIN_VERSION}`
+        },
+        {
+          name: "release.yaml workflow exists",
+          severity: "warn",
+          check: () => fileExists(".github/workflows/release.yaml"),
+          fix: "Add .github/workflows/release.yaml using the release workflow template"
+        },
+        {
+          name: "release workflow references release.reusable.yaml",
+          severity: "warn",
+          check: () => fileContains(
+            ".github/workflows/release.yaml",
+            /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/
+          ),
+          fix: "Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1"
+        },
+        {
+          name: "publish.yaml workflow exists",
+          severity: "warn",
+          check: () => fileExists(".github/workflows/publish.yaml"),
+          fix: "Add .github/workflows/publish.yaml using the publish workflow template"
+        },
+        {
+          name: "publish workflow references publish.reusable.yaml",
+          severity: "warn",
+          check: () => fileContains(
+            ".github/workflows/publish.yaml",
+            /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/
+          ),
+          fix: "Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1"
+        },
+        {
+          name: "config does not use removed tagPrefix",
+          severity: "error",
+          skip: () => !fileExists(".config/release-kit.config.ts") ? "no release-kit config file" : false,
+          check: () => fileDoesNotContain(".config/release-kit.config.ts", /tagPrefix/),
+          fix: "Remove 'tagPrefix' from .config/release-kit.config.ts \u2014 it is no longer supported; the default '{dir}-v' is used automatically"
+        },
+        {
+          name: "git-cliff not in devDependencies",
+          severity: "recommend",
+          check: () => !hasDevDependency("git-cliff"),
+          fix: "pnpm remove git-cliff \u2014 release-kit handles changelog generation directly"
+        }
+      ]
+    }
+  ]
+});
+export {
+  release_kit_default as default
+};

--- a/.preflight/collections/release-kit.ts
+++ b/.preflight/collections/release-kit.ts
@@ -1,0 +1,93 @@
+/**
+ * Preflight collection for consumers of @williamthorsen/release-kit.
+ *
+ * Verifies that the consuming repo's release-kit setup is current, workflows
+ * reference the correct reusable workflows, and config doesn't use removed fields.
+ * The minimum version is read from the release-kit package's package.json and
+ * inlined by esbuild at compile time.
+ *
+ * Run from a target repo's working directory:
+ *   preflight run --file <path-to>/release-kit.js
+ */
+import {
+  definePreflightCollection,
+  fileContains,
+  fileDoesNotContain,
+  fileExists,
+  hasDevDependency,
+  hasMinDevDependencyVersion,
+} from '@williamthorsen/preflight';
+
+import releaseKitPackageJson from '../../packages/release-kit/package.json';
+
+const MIN_VERSION = releaseKitPackageJson.version;
+
+export default definePreflightCollection({
+  checklists: [
+    {
+      name: 'release-kit',
+      checks: [
+        {
+          name: '@williamthorsen/release-kit in devDependencies',
+          severity: 'error',
+          check: () => hasDevDependency('@williamthorsen/release-kit'),
+          fix: 'pnpm add --save-dev @williamthorsen/release-kit',
+        },
+        {
+          name: `@williamthorsen/release-kit >= ${MIN_VERSION}`,
+          severity: 'error',
+          check: () =>
+            hasMinDevDependencyVersion('@williamthorsen/release-kit', MIN_VERSION, {
+              exempt: (range) => range.startsWith('workspace:'),
+            }),
+          fix: `pnpm add --save-dev @williamthorsen/release-kit@^${MIN_VERSION}`,
+        },
+        {
+          name: 'release.yaml workflow exists',
+          severity: 'warn',
+          check: () => fileExists('.github/workflows/release.yaml'),
+          fix: 'Add .github/workflows/release.yaml using the release workflow template',
+        },
+        {
+          name: 'release workflow references release.reusable.yaml',
+          severity: 'warn',
+          check: () =>
+            fileContains(
+              '.github/workflows/release.yaml',
+              /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/,
+            ),
+          fix: 'Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1',
+        },
+        {
+          name: 'publish.yaml workflow exists',
+          severity: 'warn',
+          check: () => fileExists('.github/workflows/publish.yaml'),
+          fix: 'Add .github/workflows/publish.yaml using the publish workflow template',
+        },
+        {
+          name: 'publish workflow references publish.reusable.yaml',
+          severity: 'warn',
+          check: () =>
+            fileContains(
+              '.github/workflows/publish.yaml',
+              /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/,
+            ),
+          fix: 'Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1',
+        },
+        {
+          name: 'config does not use removed tagPrefix',
+          severity: 'error',
+          skip: () => (!fileExists('.config/release-kit.config.ts') ? 'no release-kit config file' : false),
+          check: () => fileDoesNotContain('.config/release-kit.config.ts', /tagPrefix/),
+          fix: "Remove 'tagPrefix' from .config/release-kit.config.ts — it is no longer supported; the default '{dir}-v' is used automatically",
+        },
+        {
+          name: 'git-cliff not in devDependencies',
+          severity: 'recommend',
+          check: () => !hasDevDependency('git-cliff'),
+          fix: 'pnpm remove git-cliff — release-kit handles changelog generation directly',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Closes #162 

## What

Adds a dedicated preflight collection for `@williamthorsen/release-kit` consumers with 8 checks covering dependency presence, minimum version, workflow references, removed `tagPrefix` config field, and `git-cliff` deprecation. Removes the overlapping 5-check `release-kit` checklist from the `default.ts` collection.

## Why

Consumers of release-kit had no way to verify their setup was current. Per #160's "who fixes the drift?" rule, package-specific checks belong in dedicated collections rather than the catch-all default — same extraction pattern as #161 did for `nmr`.

## Details

### Features

- New `.preflight/collections/release-kit.ts` with 8 checks at appropriate severity levels (`error`, `warn`, `recommend`).
- Minimum version read dynamically from `packages/release-kit/package.json` via JSON import, inlined by esbuild at compile time.
- `tagPrefix` check skips gracefully when no config file exists.
- Removed overlapping `release-kit` checklist and unused imports from `default.ts`.

### Tests

- 23 tests covering all 8 checks, including pass/fail cases, skip conditions, `workspace:` protocol exemption, and both local and remote workflow reference patterns.

## Test plan

- [ ] `preflight compile --all` produces `release-kit.js`, `nmr.js`, and `default.js` without errors
- [ ] Run `release-kit.js` against a consumer repo to verify checks report correctly