### PR TITLE
#166 Support configurable internal collections directory

### DIFF
--- a/packages/preflight/__tests__/cli.test.ts
+++ b/packages/preflight/__tests__/cli.test.ts
@@ -55,7 +55,7 @@ vi.mock('../src/loadRemoteCollection.ts', () => ({
   loadRemoteCollection: mockLoadRemoteCollection,
 }));
 
-import { parseRunArgs, runCommand } from '../src/cli.ts';
+import { parseRunArgs, resolveCollectionSource, runCommand } from '../src/cli.ts';
 
 function makeCollection(overrides?: Partial<PreflightCollection>): PreflightCollection {
   return {
@@ -68,51 +68,54 @@ function makeCollection(overrides?: Partial<PreflightCollection>): PreflightColl
 }
 
 describe(parseRunArgs, () => {
-  it('defaults to the default collection path when no flags are given', () => {
+  it('returns undefined source flags when no flags are given', () => {
     const result = parseRunArgs([]);
 
-    expect(result.collectionSource).toStrictEqual({ path: '.preflight/collections/default.ts' });
+    expect(result.collectionName).toBeUndefined();
+    expect(result.filePath).toBeUndefined();
+    expect(result.githubValue).toBeUndefined();
+    expect(result.localValue).toBeUndefined();
+    expect(result.urlValue).toBeUndefined();
     expect(result.json).toBe(false);
   });
 
-  it('parses positional names with default collection path', () => {
+  it('parses positional names', () => {
     const result = parseRunArgs(['deploy', 'infra']);
 
     expect(result.names).toStrictEqual(['deploy', 'infra']);
-    expect(result.collectionSource).toStrictEqual({ path: '.preflight/collections/default.ts' });
   });
 
-  // --collection flag (standalone, without --github)
-  it('resolves --collection to a local convention path', () => {
+  // --collection flag
+  it('parses --collection flag', () => {
     const result = parseRunArgs(['--collection', 'deploy']);
 
-    expect(result.collectionSource).toStrictEqual({ path: '.preflight/collections/deploy.ts' });
+    expect(result.collectionName).toBe('deploy');
   });
 
-  it('resolves --collection with a slash-separated path', () => {
+  it('parses --collection with a slash-separated path', () => {
     const result = parseRunArgs(['--collection', 'shared/deploy']);
 
-    expect(result.collectionSource).toStrictEqual({ path: '.preflight/collections/shared/deploy.ts' });
+    expect(result.collectionName).toBe('shared/deploy');
   });
 
-  it('resolves --collection= to a local convention path', () => {
+  it('parses --collection= syntax', () => {
     const result = parseRunArgs(['--collection=deploy']);
 
-    expect(result.collectionSource).toStrictEqual({ path: '.preflight/collections/deploy.ts' });
+    expect(result.collectionName).toBe('deploy');
   });
 
   // --file flag
   it('parses --file flag', () => {
     const result = parseRunArgs(['--file', 'custom/path.ts']);
 
-    expect(result.collectionSource).toStrictEqual({ path: 'custom/path.ts' });
+    expect(result.filePath).toBe('custom/path.ts');
     expect(result.names).toStrictEqual([]);
   });
 
   it('parses --file= syntax', () => {
     const result = parseRunArgs(['--file=custom/path.ts']);
 
-    expect(result.collectionSource).toStrictEqual({ path: 'custom/path.ts' });
+    expect(result.filePath).toBe('custom/path.ts');
   });
 
   it('throws when --file has no value', () => {
@@ -151,27 +154,25 @@ describe(parseRunArgs, () => {
   it('parses -c as short form of --collection', () => {
     const result = parseRunArgs(['-c', 'deploy']);
 
-    expect(result.collectionSource).toStrictEqual({ path: '.preflight/collections/deploy.ts' });
+    expect(result.collectionName).toBe('deploy');
   });
 
   it('parses -f as short form of --file', () => {
     const result = parseRunArgs(['-f', 'custom/path.ts']);
 
-    expect(result.collectionSource).toStrictEqual({ path: 'custom/path.ts' });
+    expect(result.filePath).toBe('custom/path.ts');
   });
 
   it('parses -g as short form of --github', () => {
-    const result = parseRunArgs(['-g', 'org/repo', '-c', 'nmr']);
+    const result = parseRunArgs(['-g', 'org/repo']);
 
-    expect(result.collectionSource).toStrictEqual({
-      url: 'https://raw.githubusercontent.com/org/repo/main/.preflight/collections/nmr.js',
-    });
+    expect(result.githubValue).toBe('org/repo');
   });
 
   it('parses -u as short form of --url', () => {
     const result = parseRunArgs(['-u', 'https://example.com/config.js']);
 
-    expect(result.collectionSource).toStrictEqual({ url: 'https://example.com/config.js' });
+    expect(result.urlValue).toBe('https://example.com/config.js');
   });
 
   it('parses -j as short form of --json', () => {
@@ -193,36 +194,16 @@ describe(parseRunArgs, () => {
   });
 
   // --github flag
-  it('parses --github with --collection', () => {
-    const result = parseRunArgs(['--github', 'org/repo@v1', '--collection', 'nmr']);
+  it('parses --github with ref', () => {
+    const result = parseRunArgs(['--github', 'org/repo@v1']);
 
-    expect(result.collectionSource).toStrictEqual({
-      url: 'https://raw.githubusercontent.com/org/repo/v1/.preflight/collections/nmr.js',
-    });
+    expect(result.githubValue).toBe('org/repo@v1');
   });
 
-  it('parses --github= with --collection=', () => {
-    const result = parseRunArgs(['--github=org/repo', '--collection=nmr']);
+  it('parses --github= syntax', () => {
+    const result = parseRunArgs(['--github=org/repo']);
 
-    expect(result.collectionSource).toStrictEqual({
-      url: 'https://raw.githubusercontent.com/org/repo/main/.preflight/collections/nmr.js',
-    });
-  });
-
-  it('defaults --github ref to main', () => {
-    const result = parseRunArgs(['--github', 'org/repo', '--collection', 'nmr']);
-
-    expect(result.collectionSource).toStrictEqual({
-      url: 'https://raw.githubusercontent.com/org/repo/main/.preflight/collections/nmr.js',
-    });
-  });
-
-  it('defaults --github collection to default when --collection is omitted', () => {
-    const result = parseRunArgs(['--github', 'org/repo']);
-
-    expect(result.collectionSource).toStrictEqual({
-      url: 'https://raw.githubusercontent.com/org/repo/main/.preflight/collections/default.js',
-    });
+    expect(result.githubValue).toBe('org/repo');
   });
 
   it('throws when --github has no value', () => {
@@ -241,13 +222,13 @@ describe(parseRunArgs, () => {
   it('parses --url flag with space-separated value', () => {
     const result = parseRunArgs(['--url', 'https://example.com/config.js']);
 
-    expect(result.collectionSource).toStrictEqual({ url: 'https://example.com/config.js' });
+    expect(result.urlValue).toBe('https://example.com/config.js');
   });
 
   it('parses --url= syntax', () => {
     const result = parseRunArgs(['--url=https://example.com/config.js']);
 
-    expect(result.collectionSource).toStrictEqual({ url: 'https://example.com/config.js' });
+    expect(result.urlValue).toBe('https://example.com/config.js');
   });
 
   it('throws when --url has no value', () => {
@@ -259,37 +240,16 @@ describe(parseRunArgs, () => {
   });
 
   // --local flag
-  it('resolves --local to a .js file under .preflight/collections/', () => {
+  it('parses --local flag', () => {
     const result = parseRunArgs(['--local', '/path/to/repo']);
 
-    expect(result.collectionSource).toStrictEqual({
-      path: '/path/to/repo/.preflight/collections/default.js',
-    });
-  });
-
-  it('resolves --local with --collection to a named .js file', () => {
-    const result = parseRunArgs(['--local', '/path/to/repo', '--collection', 'deploy']);
-
-    expect(result.collectionSource).toStrictEqual({
-      path: '/path/to/repo/.preflight/collections/deploy.js',
-    });
+    expect(result.localValue).toBe('/path/to/repo');
   });
 
   it('parses -l as short form of --local', () => {
     const result = parseRunArgs(['-l', '/path/to/repo']);
 
-    expect(result.collectionSource).toStrictEqual({
-      path: '/path/to/repo/.preflight/collections/default.js',
-    });
-  });
-
-  it('resolves --local with a relative path against cwd', () => {
-    const result = parseRunArgs(['--local', '../sibling-repo']);
-    const expected = path.resolve(process.cwd(), '../sibling-repo');
-
-    expect(result.collectionSource).toStrictEqual({
-      path: `${expected}/.preflight/collections/default.js`,
-    });
+    expect(result.localValue).toBe('/path/to/repo');
   });
 
   it('throws when --local has no value', () => {
@@ -345,18 +305,6 @@ describe(parseRunArgs, () => {
     );
   });
 
-  it('throws when --collection is combined with --file', () => {
-    expect(() => parseRunArgs(['--file', 'path.ts', '--collection', 'deploy'])).toThrow(
-      '--collection cannot be used with --file',
-    );
-  });
-
-  it('throws when --collection is combined with --url', () => {
-    expect(() => parseRunArgs(['--url', 'https://example.com/config.js', '--collection', 'deploy'])).toThrow(
-      '--collection cannot be used with --url',
-    );
-  });
-
   // --fail-on flag
   it('parses --fail-on with valid severity', () => {
     const result = parseRunArgs(['--fail-on', 'warn']);
@@ -408,6 +356,138 @@ describe(parseRunArgs, () => {
 
     expect(result).not.toHaveProperty('failOn');
     expect(result).not.toHaveProperty('reportOn');
+  });
+});
+
+describe(resolveCollectionSource, () => {
+  /** Build args with defaults for internal config. */
+  function resolve(overrides: Partial<Parameters<typeof resolveCollectionSource>[0]> = {}) {
+    return resolveCollectionSource({
+      filePath: undefined,
+      githubValue: undefined,
+      localValue: undefined,
+      urlValue: undefined,
+      collectionName: undefined,
+      internalDir: '.',
+      internalExtension: '.ts',
+      ...overrides,
+    });
+  }
+
+  it('resolves default collection path with default internal config', () => {
+    expect(resolve()).toStrictEqual({ path: '.preflight/collections/default.ts' });
+  });
+
+  it('resolves named collection with default internal config', () => {
+    expect(resolve({ collectionName: 'deploy' })).toStrictEqual({ path: '.preflight/collections/deploy.ts' });
+  });
+
+  it('resolves slash-separated collection name', () => {
+    expect(resolve({ collectionName: 'shared/deploy' })).toStrictEqual({
+      path: '.preflight/collections/shared/deploy.ts',
+    });
+  });
+
+  it('applies custom internal dir and extension', () => {
+    expect(resolve({ internalDir: 'internal', internalExtension: '.int.ts' })).toStrictEqual({
+      path: '.preflight/collections/internal/default.int.ts',
+    });
+  });
+
+  it('applies custom internal dir with named collection', () => {
+    expect(resolve({ collectionName: 'deploy', internalDir: 'internal', internalExtension: '.int.ts' })).toStrictEqual({
+      path: '.preflight/collections/internal/deploy.int.ts',
+    });
+  });
+
+  it('resolves --file to a path source', () => {
+    expect(resolve({ filePath: 'custom/path.ts' })).toStrictEqual({ path: 'custom/path.ts' });
+  });
+
+  it('resolves --github without ref to a URL with main ref', () => {
+    expect(resolve({ githubValue: 'org/repo', collectionName: 'nmr' })).toStrictEqual({
+      url: 'https://raw.githubusercontent.com/org/repo/main/.preflight/collections/nmr.js',
+    });
+  });
+
+  it('resolves --github with ref to a URL with that ref', () => {
+    expect(resolve({ githubValue: 'org/repo@v1', collectionName: 'nmr' })).toStrictEqual({
+      url: 'https://raw.githubusercontent.com/org/repo/v1/.preflight/collections/nmr.js',
+    });
+  });
+
+  it('defaults --github collection to "default"', () => {
+    expect(resolve({ githubValue: 'org/repo' })).toStrictEqual({
+      url: 'https://raw.githubusercontent.com/org/repo/main/.preflight/collections/default.js',
+    });
+  });
+
+  it('resolves --local to a .js path under .preflight/collections/', () => {
+    expect(resolve({ localValue: '/path/to/repo' })).toStrictEqual({
+      path: '/path/to/repo/.preflight/collections/default.js',
+    });
+  });
+
+  it('resolves --local with --collection to a named .js file', () => {
+    expect(resolve({ localValue: '/path/to/repo', collectionName: 'deploy' })).toStrictEqual({
+      path: '/path/to/repo/.preflight/collections/deploy.js',
+    });
+  });
+
+  it('resolves --local with a relative path against cwd', () => {
+    const expected = path.resolve(process.cwd(), '../sibling-repo');
+
+    expect(resolve({ localValue: '../sibling-repo' })).toStrictEqual({
+      path: `${expected}/.preflight/collections/default.js`,
+    });
+  });
+
+  it('resolves --url to a URL source', () => {
+    expect(resolve({ urlValue: 'https://example.com/config.js' })).toStrictEqual({
+      url: 'https://example.com/config.js',
+    });
+  });
+
+  it('throws when --collection is combined with --file', () => {
+    expect(() => resolve({ filePath: 'path.ts', collectionName: 'deploy' })).toThrow(
+      '--collection cannot be used with --file',
+    );
+  });
+
+  it('throws when --collection is combined with --url', () => {
+    expect(() => resolve({ urlValue: 'https://example.com/config.js', collectionName: 'deploy' })).toThrow(
+      '--collection cannot be used with --url',
+    );
+  });
+
+  it('ignores internal config when --file is used', () => {
+    expect(
+      resolve({ filePath: 'custom/path.ts', internalDir: 'internal', internalExtension: '.int.ts' }),
+    ).toStrictEqual({
+      path: 'custom/path.ts',
+    });
+  });
+
+  it('ignores internal config when --github is used', () => {
+    expect(resolve({ githubValue: 'org/repo', internalDir: 'internal', internalExtension: '.int.ts' })).toStrictEqual({
+      url: 'https://raw.githubusercontent.com/org/repo/main/.preflight/collections/default.js',
+    });
+  });
+
+  it('ignores internal config when --local is used', () => {
+    expect(
+      resolve({ localValue: '/path/to/repo', internalDir: 'internal', internalExtension: '.int.ts' }),
+    ).toStrictEqual({
+      path: '/path/to/repo/.preflight/collections/default.js',
+    });
+  });
+
+  it('ignores internal config when --url is used', () => {
+    expect(
+      resolve({ urlValue: 'https://example.com/config.js', internalDir: 'internal', internalExtension: '.int.ts' }),
+    ).toStrictEqual({
+      url: 'https://example.com/config.js',
+    });
   });
 });
 

--- a/packages/preflight/__tests__/loadConfig.test.ts
+++ b/packages/preflight/__tests__/loadConfig.test.ts
@@ -183,14 +183,14 @@ describe(loadConfig, () => {
 
   it('throws when internal.dir is not a string', async () => {
     mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ internal: { dir: 42 } });
+    mockJitiImport.mockResolvedValue({ default: { internal: { dir: 42 } } });
 
     await expect(loadConfig('config.ts')).rejects.toThrow(ZodError);
   });
 
   it('throws when internal.extension is not a string', async () => {
     mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ internal: { extension: false } });
+    mockJitiImport.mockResolvedValue({ default: { internal: { extension: false } } });
 
     await expect(loadConfig('config.ts')).rejects.toThrow(ZodError);
   });

--- a/packages/preflight/__tests__/loadConfig.test.ts
+++ b/packages/preflight/__tests__/loadConfig.test.ts
@@ -27,6 +27,7 @@ describe(loadConfig, () => {
 
     expect(config).toStrictEqual({
       compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: undefined },
+      internal: { dir: '.', extension: '.ts' },
     });
   });
 
@@ -146,5 +147,51 @@ describe(loadConfig, () => {
 
     expect(config.compile.srcDir).toBe('named/src');
     expect(config.compile.outDir).toBe('named/out');
+  });
+
+  it('resolves internal block from config', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({
+      default: { internal: { dir: 'internal', extension: '.int.ts' } },
+    });
+
+    const config = await loadConfig('config.ts');
+
+    expect(config.internal.dir).toBe('internal');
+    expect(config.internal.extension).toBe('.int.ts');
+  });
+
+  it('applies internal defaults when internal block is absent', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ default: {} });
+
+    const config = await loadConfig('config.ts');
+
+    expect(config.internal.dir).toBe('.');
+    expect(config.internal.extension).toBe('.ts');
+  });
+
+  it('applies internal defaults for missing fields within internal block', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ default: { internal: { dir: 'custom' } } });
+
+    const config = await loadConfig('config.ts');
+
+    expect(config.internal.dir).toBe('custom');
+    expect(config.internal.extension).toBe('.ts');
+  });
+
+  it('throws when internal.dir is not a string', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ internal: { dir: 42 } });
+
+    await expect(loadConfig('config.ts')).rejects.toThrow(ZodError);
+  });
+
+  it('throws when internal.extension is not a string', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ internal: { extension: false } });
+
+    await expect(loadConfig('config.ts')).rejects.toThrow(ZodError);
   });
 });

--- a/packages/preflight/__tests__/route.test.ts
+++ b/packages/preflight/__tests__/route.test.ts
@@ -200,6 +200,44 @@ describe(routeCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("unknown flag '--bad'"));
   });
 
+  it('returns 1 and writes to stderr when resolveCollectionSource throws', async () => {
+    mockParseRunArgs.mockReturnValue({
+      names: [],
+      collectionName: 'deploy',
+      filePath: 'path.ts',
+      githubValue: undefined,
+      localValue: undefined,
+      urlValue: undefined,
+      json: false,
+    });
+    mockResolveCollectionSource.mockImplementation(() => {
+      throw new Error('--collection cannot be used with --file');
+    });
+
+    const exitCode = await routeCommand(['run', '--file', 'path.ts', '--collection', 'deploy']);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--collection cannot be used with --file'));
+  });
+
+  it('returns 1 and writes to stderr when loadConfig rejects', async () => {
+    mockParseRunArgs.mockReturnValue({
+      names: [],
+      collectionName: undefined,
+      filePath: undefined,
+      githubValue: undefined,
+      localValue: undefined,
+      urlValue: undefined,
+      json: false,
+    });
+    mockLoadConfig.mockRejectedValue(new Error('bad config'));
+
+    const exitCode = await routeCommand(['run']);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('bad config'));
+  });
+
   it('shows compile help and returns 0 for compile --help', async () => {
     const exitCode = await routeCommand(['compile', '--help']);
 

--- a/packages/preflight/__tests__/route.test.ts
+++ b/packages/preflight/__tests__/route.test.ts
@@ -4,10 +4,17 @@ const mockRunCommand = vi.hoisted(() => vi.fn());
 const mockInitCommand = vi.hoisted(() => vi.fn());
 const mockCompileCommand = vi.hoisted(() => vi.fn());
 const mockParseRunArgs = vi.hoisted(() => vi.fn());
+const mockResolveCollectionSource = vi.hoisted(() => vi.fn());
+const mockLoadConfig = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/cli.ts', () => ({
   parseRunArgs: mockParseRunArgs,
+  resolveCollectionSource: mockResolveCollectionSource,
   runCommand: mockRunCommand,
+}));
+
+vi.mock('../src/loadConfig.ts', () => ({
+  loadConfig: mockLoadConfig,
 }));
 
 vi.mock('../src/compile/compileCommand.ts', () => ({
@@ -31,6 +38,11 @@ describe(routeCommand, () => {
   beforeEach(() => {
     infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: undefined },
+      internal: { dir: '.', extension: '.ts' },
+    });
+    mockResolveCollectionSource.mockReturnValue({ path: '.preflight/collections/default.ts' });
   });
 
   afterEach(() => {
@@ -39,6 +51,8 @@ describe(routeCommand, () => {
     mockCompileCommand.mockReset();
     mockInitCommand.mockReset();
     mockParseRunArgs.mockReset();
+    mockResolveCollectionSource.mockReset();
+    mockLoadConfig.mockReset();
   });
 
   it('shows help and returns 0 when no arguments are given', async () => {
@@ -122,7 +136,11 @@ describe(routeCommand, () => {
   it('delegates to runCommand for run subcommand', async () => {
     mockParseRunArgs.mockReturnValue({
       names: ['deploy'],
-      collectionSource: { path: '.preflight/collections/default.ts' },
+      collectionName: undefined,
+      filePath: undefined,
+      githubValue: undefined,
+      localValue: undefined,
+      urlValue: undefined,
       json: false,
     });
     mockRunCommand.mockResolvedValue(0);
@@ -130,29 +148,37 @@ describe(routeCommand, () => {
     const exitCode = await routeCommand(['run', 'deploy']);
 
     expect(mockParseRunArgs).toHaveBeenCalledWith(['deploy']);
-    expect(mockRunCommand).toHaveBeenCalledWith({
-      names: ['deploy'],
-      collectionSource: { path: '.preflight/collections/default.ts' },
-      json: false,
-    });
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        names: ['deploy'],
+        collectionSource: { path: '.preflight/collections/default.ts' },
+        json: false,
+      }),
+    );
     expect(exitCode).toBe(0);
   });
 
   it('passes --json flag through to runCommand', async () => {
     mockParseRunArgs.mockReturnValue({
       names: [],
-      collectionSource: { path: '.preflight/collections/default.ts' },
+      collectionName: undefined,
+      filePath: undefined,
+      githubValue: undefined,
+      localValue: undefined,
+      urlValue: undefined,
       json: true,
     });
     mockRunCommand.mockResolvedValue(0);
 
     const exitCode = await routeCommand(['run', '--json']);
 
-    expect(mockRunCommand).toHaveBeenCalledWith({
-      names: [],
-      collectionSource: { path: '.preflight/collections/default.ts' },
-      json: true,
-    });
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        names: [],
+        collectionSource: { path: '.preflight/collections/default.ts' },
+        json: true,
+      }),
+    );
     expect(exitCode).toBe(0);
   });
 
@@ -252,7 +278,11 @@ describe(routeCommand, () => {
     it('routes flags to run when no subcommand is given', async () => {
       mockParseRunArgs.mockReturnValue({
         names: [],
-        collectionSource: { path: 'foo.ts' },
+        collectionName: undefined,
+        filePath: 'foo.ts',
+        githubValue: undefined,
+        localValue: undefined,
+        urlValue: undefined,
         json: false,
       });
       mockRunCommand.mockResolvedValue(0);
@@ -266,7 +296,11 @@ describe(routeCommand, () => {
     it('routes positional args to run as checklist names', async () => {
       mockParseRunArgs.mockReturnValue({
         names: ['onboarding'],
-        collectionSource: { path: '.preflight/collections/default.ts' },
+        collectionName: undefined,
+        filePath: undefined,
+        githubValue: undefined,
+        localValue: undefined,
+        urlValue: undefined,
         json: false,
       });
       mockRunCommand.mockResolvedValue(0);
@@ -294,7 +328,11 @@ describe(routeCommand, () => {
     it('does not suggest for prefixes shorter than 3 characters', async () => {
       mockParseRunArgs.mockReturnValue({
         names: ['co'],
-        collectionSource: { path: '.preflight/collections/default.ts' },
+        collectionName: undefined,
+        filePath: undefined,
+        githubValue: undefined,
+        localValue: undefined,
+        urlValue: undefined,
         json: false,
       });
       mockRunCommand.mockResolvedValue(0);
@@ -308,7 +346,11 @@ describe(routeCommand, () => {
     it('does not suggest when input matches a subcommand exactly', async () => {
       mockParseRunArgs.mockReturnValue({
         names: [],
-        collectionSource: { path: '.preflight/collections/default.ts' },
+        collectionName: undefined,
+        filePath: undefined,
+        githubValue: undefined,
+        localValue: undefined,
+        urlValue: undefined,
         json: false,
       });
       mockRunCommand.mockResolvedValue(0);

--- a/packages/preflight/src/bin/route.ts
+++ b/packages/preflight/src/bin/route.ts
@@ -191,7 +191,14 @@ async function handleRun(flags: string[]): Promise<number> {
     return 1;
   }
 
-  const config = await loadConfig();
+  let config;
+  try {
+    config = await loadConfig();
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return 1;
+  }
 
   let collectionSource;
   try {

--- a/packages/preflight/src/bin/route.ts
+++ b/packages/preflight/src/bin/route.ts
@@ -11,6 +11,11 @@ import { VERSION } from '../version.ts';
 const SUBCOMMANDS = ['compile', 'init'];
 const MIN_PREFIX_LENGTH = 3;
 
+/** Extract a displayable message from an unknown thrown value. */
+function extractMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function showHelp(): void {
   console.info(`
 Usage: preflight [names...] [options]
@@ -135,8 +140,7 @@ export async function routeCommand(args: string[]): Promise<number> {
     try {
       return await compileCommand(flags);
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      process.stderr.write(`Error: ${message}\n`);
+      process.stderr.write(`Error: ${extractMessage(error)}\n`);
       return 1;
     }
   }
@@ -186,8 +190,7 @@ async function handleRun(flags: string[]): Promise<number> {
   try {
     parsed = parseRunArgs(flags);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Error: ${message}\n`);
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
     return 1;
   }
 
@@ -195,8 +198,7 @@ async function handleRun(flags: string[]): Promise<number> {
   try {
     config = await loadConfig();
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Error: ${message}\n`);
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
     return 1;
   }
 
@@ -212,18 +214,15 @@ async function handleRun(flags: string[]): Promise<number> {
       internalExtension: config.internal.extension,
     });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Error: ${message}\n`);
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
     return 1;
   }
 
-  const options: Parameters<typeof runCommand>[0] = {
+  return runCommand({
     collectionSource,
     json: parsed.json,
     names: parsed.names,
-  };
-  if (parsed.failOn !== undefined) options.failOn = parsed.failOn;
-  if (parsed.reportOn !== undefined) options.reportOn = parsed.reportOn;
-
-  return runCommand(options);
+    ...(parsed.failOn !== undefined && { failOn: parsed.failOn }),
+    ...(parsed.reportOn !== undefined && { reportOn: parsed.reportOn }),
+  });
 }

--- a/packages/preflight/src/bin/route.ts
+++ b/packages/preflight/src/bin/route.ts
@@ -2,9 +2,10 @@ import process from 'node:process';
 
 import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
-import { parseRunArgs, runCommand } from '../cli.ts';
+import { parseRunArgs, resolveCollectionSource, runCommand } from '../cli.ts';
 import { compileCommand } from '../compile/compileCommand.ts';
 import { initCommand } from '../init/initCommand.ts';
+import { loadConfig } from '../loadConfig.ts';
 import { VERSION } from '../version.ts';
 
 const SUBCOMMANDS = ['compile', 'init'];
@@ -190,5 +191,32 @@ async function handleRun(flags: string[]): Promise<number> {
     return 1;
   }
 
-  return runCommand(parsed);
+  const config = await loadConfig();
+
+  let collectionSource;
+  try {
+    collectionSource = resolveCollectionSource({
+      filePath: parsed.filePath,
+      githubValue: parsed.githubValue,
+      localValue: parsed.localValue,
+      urlValue: parsed.urlValue,
+      collectionName: parsed.collectionName,
+      internalDir: config.internal.dir,
+      internalExtension: config.internal.extension,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return 1;
+  }
+
+  const options: Parameters<typeof runCommand>[0] = {
+    collectionSource,
+    json: parsed.json,
+    names: parsed.names,
+  };
+  if (parsed.failOn !== undefined) options.failOn = parsed.failOn;
+  if (parsed.reportOn !== undefined) options.reportOn = parsed.reportOn;
+
+  return runCommand(options);
 }

--- a/packages/preflight/src/cli.ts
+++ b/packages/preflight/src/cli.ts
@@ -29,11 +29,15 @@ const VALID_SEVERITIES = new Set<string>(['error', 'warn', 'recommend']);
 export type CollectionSource = { path: string } | { url: string };
 
 interface ParsedRunArgs {
-  collectionSource: CollectionSource;
+  collectionName: string | undefined;
   failOn?: Severity;
+  filePath: string | undefined;
+  githubValue: string | undefined;
   json: boolean;
+  localValue: string | undefined;
   names: string[];
   reportOn?: Severity;
+  urlValue: string | undefined;
 }
 
 const runFlagSchema = {
@@ -149,33 +153,37 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   const failOn = parsed.failOn !== undefined ? parseSeverityFlag('--fail-on', parsed.failOn) : undefined;
   const reportOn = parsed.reportOn !== undefined ? parseSeverityFlag('--report-on', parsed.reportOn) : undefined;
 
-  const collectionSource = resolveCollectionSource({
+  const parsedArgs: ParsedRunArgs = {
+    collectionName: parsed.collection,
     filePath: parsed.file,
     githubValue: parsed.github,
+    json: parsed.json,
     localValue: parsed.local,
+    names: positionals,
     urlValue: parsed.url,
-    collectionName: parsed.collection,
-  });
-
-  const parsedArgs: ParsedRunArgs = { collectionSource, json: parsed.json, names: positionals };
+  };
   if (failOn !== undefined) parsedArgs.failOn = failOn;
   if (reportOn !== undefined) parsedArgs.reportOn = reportOn;
   return parsedArgs;
 }
 
 /** Validate flag co-dependencies and build the CollectionSource from parsed flag state. */
-function resolveCollectionSource({
+export function resolveCollectionSource({
   filePath,
   githubValue,
   localValue,
   urlValue,
   collectionName,
+  internalDir,
+  internalExtension,
 }: {
   filePath: string | undefined;
   githubValue: string | undefined;
   localValue: string | undefined;
   urlValue: string | undefined;
   collectionName: string | undefined;
+  internalDir: string;
+  internalExtension: string;
 }): CollectionSource {
   if (filePath !== undefined) {
     if (collectionName !== undefined) {
@@ -200,7 +208,7 @@ function resolveCollectionSource({
     return { url: urlValue };
   }
   const name = collectionName ?? 'default';
-  return { path: `${COLLECTIONS_DIR}/${name}.ts` };
+  return { path: path.join(COLLECTIONS_DIR, internalDir, `${name}${internalExtension}`) };
 }
 
 /** Resolve the effective fixLocation for a checklist, falling back to the collection-level default. */

--- a/packages/preflight/src/loadConfig.ts
+++ b/packages/preflight/src/loadConfig.ts
@@ -14,6 +14,10 @@ const DEFAULT_CONFIG: ResolvedPreflightConfig = {
     outDir: '.preflight/collections',
     include: undefined,
   },
+  internal: {
+    dir: '.',
+    extension: '.ts',
+  },
 };
 
 /** Ordered lookup paths for the config file, resolved relative to `process.cwd()`. */
@@ -26,6 +30,12 @@ const PreflightConfigSchema = z.looseObject({
       srcDir: z.string().optional(),
       outDir: z.string().optional(),
       include: z.string().optional(),
+    })
+    .optional(),
+  internal: z
+    .looseObject({
+      dir: z.string().optional(),
+      extension: z.string().optional(),
     })
     .optional(),
 });
@@ -77,11 +87,16 @@ export async function loadConfig(overridePath?: string): Promise<ResolvedPreflig
   // Guard is redundant at runtime (Zod already validated) but needed for type narrowing
   // because `raw` is `Record<string, unknown> & PreflightConfig` after the assertion.
   const compile = isRecord(raw.compile) ? raw.compile : undefined;
+  const internal = isRecord(raw.internal) ? raw.internal : undefined;
   return {
     compile: {
       srcDir: typeof compile?.srcDir === 'string' ? compile.srcDir : DEFAULT_CONFIG.compile.srcDir,
       outDir: typeof compile?.outDir === 'string' ? compile.outDir : DEFAULT_CONFIG.compile.outDir,
       include: typeof compile?.include === 'string' ? compile.include : undefined,
+    },
+    internal: {
+      dir: typeof internal?.dir === 'string' ? internal.dir : DEFAULT_CONFIG.internal.dir,
+      extension: typeof internal?.extension === 'string' ? internal.extension : DEFAULT_CONFIG.internal.extension,
     },
   };
 }

--- a/packages/preflight/src/types.ts
+++ b/packages/preflight/src/types.ts
@@ -249,6 +249,10 @@ export interface PreflightConfig {
     outDir?: string;
     include?: string;
   };
+  internal?: {
+    dir?: string;
+    extension?: string;
+  };
 }
 
 /** Fully-resolved config with defaults applied, returned by `loadConfig`. */
@@ -257,6 +261,10 @@ export interface ResolvedPreflightConfig {
     srcDir: string;
     outDir: string;
     include: string | undefined;
+  };
+  internal: {
+    dir: string;
+    extension: string;
   };
 }
 


### PR DESCRIPTION
Closes #166 

## What

Adds an `internal` config block to preflight with `dir` and `extension` fields that control where default (no-source-flag) collections are resolved from. Extracts `resolveCollectionSource` from `parseRunArgs` into a standalone function so that async config loading can feed internal config values into source resolution.

## Why

After #161 introduced distributable collections alongside repo-specific ones, the flat `.preflight/collections/` directory had no structural signal distinguishing distributable from internal collections. Directory separation and filename disambiguation allow the `compile.include` glob to target distributable collections without maintaining an exclusion list.

## Details

### Features

- Added `internal?: { dir?: string; extension?: string }` to `PreflightConfig` with Zod validation. `ResolvedPreflightConfig` provides fully-resolved defaults (`'.'` and `'.ts'`).
- Default collection resolution path now uses `path.join(COLLECTIONS_DIR, internalDir, name + internalExtension)`, with `path.join` normalizing the `'.'` default for backward compatibility.
- Source flags (`--file`, `--github`, `--local`, `--url`) are unaffected by internal config.

### Fixes

- Wrapped `loadConfig()` and `resolveCollectionSource()` in try/catch blocks in `handleRun` so errors produce clean stderr messages and exit code 1, consistent with the `parseRunArgs` error path.

### Refactoring

- Extracted `resolveCollectionSource` from `parseRunArgs` into a standalone exported function. `parseRunArgs` now returns raw flag values; `handleRun` orchestrates config loading, source resolution, and command execution.
- Extracted `extractMessage` helper to deduplicate error-to-string boilerplate across four catch blocks in `route.ts`.
- Inlined the `options` object at the `runCommand` call site using conditional spreads, removing the mutable intermediate variable.

### Tests

- 5 new config loading tests covering the `internal` block (valid values, defaults, Zod validation errors).
- Dedicated `resolveCollectionSource` test suite covering default resolution, named collections, custom `internalDir`/`internalExtension`, all source flag types, mutual-exclusivity guards, and error paths.
- Route-level tests for `resolveCollectionSource` and `loadConfig` failure propagation.

## Test plan

- [x] `nmr test` passes from preflight package (424 tests)
- [x] `nmr check` passes from repo root