### PR TITLE
#169 Default to batch compilation when no arguments given

### DIFF
--- a/.config/nmr.config.ts
+++ b/.config/nmr.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   rootScripts: {
     build: ['build:workspaces', 'build:preflight'],
     'build:workspaces': 'pnpm --recursive exec nmr build',
-    'build:preflight': 'preflight compile --all',
+    'build:preflight': 'preflight compile',
   },
 });

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ out/
 local/
 tmp/
 *.local
+*.local.*
 *.private.env.json
 *.tmp
 

--- a/packages/preflight/README.md
+++ b/packages/preflight/README.md
@@ -96,7 +96,7 @@ interface PreflightConfig {
   compile?: {
     srcDir?: string; // default: '.preflight/collections'
     outDir?: string; // default: '.preflight/collections'
-    include?: string; // glob pattern to filter files during compile --all
+    include?: string; // glob pattern to filter files during batch compile
   };
 }
 ```
@@ -294,10 +294,10 @@ preflight compile .preflight/collections/default.ts
 Or compile all sources from the config's `srcDir` at once:
 
 ```bash
-preflight compile --all
+preflight compile
 ```
 
-Use `compile.include` in your config to filter which files `--all` compiles:
+Use `compile.include` in your config to filter which files are compiled:
 
 ```ts
 export default definePreflightConfig({
@@ -393,17 +393,15 @@ preflight run [names...] [options]
 Bundle TypeScript collection(s) into self-contained ESM file(s).
 
 ```
-preflight compile <file> [options]
-preflight compile --all
+preflight compile [<file>] [options]
 ```
 
 | Flag                  | Description                              | Default                       |
 | --------------------- | ---------------------------------------- | ----------------------------- |
 | `<file>`              | Input TypeScript file                    | —                             |
-| `--all, -a`           | Compile all sources from config `srcDir` | —                             |
-| `--output, -o <path>` | Output file path                         | Input path with `.ts` → `.js` |
+| `--output, -o <path>` | Output file path (single-file mode only) | Input path with `.ts` → `.js` |
 
-When neither `<file>` nor `--all` is given, an error with a usage hint is printed. `--output` cannot be used with `--all`.
+If no file is given, all sources from the config's `srcDir` are compiled.
 
 ### `preflight init`
 

--- a/packages/preflight/__tests__/compileCommand.test.ts
+++ b/packages/preflight/__tests__/compileCommand.test.ts
@@ -118,18 +118,8 @@ describe(compileCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Too many arguments'));
   });
 
-  // No-args behavior (error with usage hint)
-  it('returns 1 with usage hint when no input and no --all', async () => {
-    const exitCode = await compileCommand([]);
-
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Use 'preflight compile <file>' or 'preflight compile --all'"),
-    );
-  });
-
-  // --all flag tests
-  it('compiles all .ts files from config srcDir with --all', async () => {
+  // No-args behavior (batch compile)
+  it('compiles all .ts files from config srcDir when no arguments given', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: undefined },
     });
@@ -137,42 +127,28 @@ describe(compileCommand, () => {
     mockReaddirSync.mockReturnValue(['a.ts', 'b.ts', 'readme.md']);
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js' });
 
-    const exitCode = await compileCommand(['--all']);
+    const exitCode = await compileCommand([]);
 
     expect(exitCode).toBe(0);
     expect(mockCompileConfig).toHaveBeenCalledTimes(2);
     expect(stdoutSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('parses -a as short form of --all', async () => {
-    mockLoadConfig.mockResolvedValue({
-      compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: undefined },
-    });
-    mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValue(['a.ts']);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js' });
-
-    const exitCode = await compileCommand(['-a']);
-
-    expect(exitCode).toBe(0);
-    expect(mockCompileConfig).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns 1 when --all is combined with --output', async () => {
-    const exitCode = await compileCommand(['--all', '--output', 'out.js']);
+  it('returns 1 when --output is given without an input file', async () => {
+    const exitCode = await compileCommand(['--output', 'out.js']);
 
     expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--output cannot be used with --all'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--output requires an input file'));
   });
 
-  it('returns 1 when --all is combined with an input file', async () => {
-    const exitCode = await compileCommand(['input.ts', '--all']);
+  it('returns 1 for --all (removed flag)', async () => {
+    const exitCode = await compileCommand(['--all']);
 
     expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Cannot specify both an input file and --all'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown option: --all'));
   });
 
-  it('uses compile.include glob to filter files with --all', async () => {
+  it('uses compile.include glob to filter files during batch compile', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: 'shared/*.ts' },
     });
@@ -182,33 +158,33 @@ describe(compileCommand, () => {
     mockPicomatch.mockReturnValue(matchFn);
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js' });
 
-    const exitCode = await compileCommand(['--all']);
+    const exitCode = await compileCommand([]);
 
     expect(exitCode).toBe(0);
     expect(mockPicomatch).toHaveBeenCalledWith('shared/*.ts');
     expect(mockCompileConfig).toHaveBeenCalledTimes(2);
   });
 
-  it('returns 1 when srcDir does not exist with --all', async () => {
+  it('returns 1 when srcDir does not exist', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: undefined },
     });
     mockExistsSync.mockReturnValue(false);
 
-    const exitCode = await compileCommand(['--all']);
+    const exitCode = await compileCommand([]);
 
     expect(exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Source directory not found'));
   });
 
-  it('returns 1 when srcDir has no .ts files with --all', async () => {
+  it('returns 1 when srcDir has no .ts files', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: undefined },
     });
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['readme.md']);
 
-    const exitCode = await compileCommand(['--all']);
+    const exitCode = await compileCommand([]);
 
     expect(exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('No .ts files found'));
@@ -234,13 +210,13 @@ describe(compileCommand, () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js' });
     mockValidateCompiledOutput.mockRejectedValue(new Error('suite "ci" references unknown checklist "missing"'));
 
-    const exitCode = await compileCommand(['--all']);
+    const exitCode = await compileCommand([]);
 
     expect(exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('references unknown checklist'));
   });
 
-  it('returns 1 with structured error when readdirSync throws during --all', async () => {
+  it('returns 1 with structured error when readdirSync throws during batch compile', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: undefined },
     });
@@ -249,14 +225,14 @@ describe(compileCommand, () => {
       throw new Error('EACCES: permission denied');
     });
 
-    const exitCode = await compileCommand(['--all']);
+    const exitCode = await compileCommand([]);
 
     expect(exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to read source directory'));
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('EACCES'));
   });
 
-  it('returns 1 when glob matches only non-.ts files with --all', async () => {
+  it('returns 1 when glob matches only non-.ts files during batch compile', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: 'data/*' },
     });
@@ -264,7 +240,7 @@ describe(compileCommand, () => {
     mockReaddirSync.mockReturnValue(['data/readme.md', 'data/config.json']);
     mockPicomatch.mockReturnValue(() => true);
 
-    const exitCode = await compileCommand(['--all']);
+    const exitCode = await compileCommand([]);
 
     expect(exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('No .ts files found'));

--- a/packages/preflight/__tests__/route.test.ts
+++ b/packages/preflight/__tests__/route.test.ts
@@ -244,7 +244,7 @@ describe(routeCommand, () => {
     expect(exitCode).toBe(0);
     const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('Usage: preflight compile');
-    expect(output).toContain('--all');
+    expect(output).toContain('If no file is given');
   });
 
   it('shows compile help and returns 0 for compile -h', async () => {

--- a/packages/preflight/src/bin/route.ts
+++ b/packages/preflight/src/bin/route.ts
@@ -23,7 +23,7 @@ Usage: preflight [names...] [options]
 
 Commands:
   run [names...]       Run preflight checklists (default)
-  compile [input]      Bundle TypeScript collection(s) into self-contained ESM file(s)
+  compile [file]       Bundle TypeScript collection(s) into self-contained ESM file(s)
   init                 Scaffold a starter config and collection
 
 Run options:
@@ -68,17 +68,17 @@ Defaults to .preflight/collections/default.ts when no source is given.
 
 function showCompileHelp(): void {
   console.info(`
-Usage: preflight compile <file> [options]
-       preflight compile --all
+Usage: preflight compile [<file>] [options]
 
 Bundle TypeScript collection(s) into self-contained ESM bundle(s).
+If no file is given, all sources from the config's srcDir are compiled.
 
 Modes:
+  preflight compile                  Compile all sources from the config's srcDir
   preflight compile <file>           Compile a single file
-  preflight compile --all, -a        Compile all sources from the config's srcDir
 
 Options:
-  --output, -o <path>  Output file path (default: input with .ts replaced by .js)
+  --output, -o <path>  Output file path (single-file mode only)
   --help, -h           Show this help message
 `);
 }

--- a/packages/preflight/src/compile/compileCommand.ts
+++ b/packages/preflight/src/compile/compileCommand.ts
@@ -10,7 +10,6 @@ import { compileConfig } from './compileConfig.ts';
 import { validateCompiledOutput } from './validateCompiledOutput.ts';
 
 const compileFlagSchema = {
-  all: { long: '--all', type: 'boolean' as const, short: '-a' },
   output: { long: '--output', type: 'string' as const, short: '-o' },
 };
 
@@ -36,12 +35,6 @@ export async function compileCommand(args: string[]): Promise<number> {
 
   const outputPath = parsed.flags.output;
   const positionals = parsed.positionals;
-  const useAll = parsed.flags.all;
-
-  if (useAll && outputPath !== undefined) {
-    process.stderr.write('Error: --output cannot be used with --all\n');
-    return 1;
-  }
 
   if (positionals.length > 1) {
     process.stderr.write('Error: Too many arguments. Expected a single input file.\n');
@@ -49,11 +42,6 @@ export async function compileCommand(args: string[]): Promise<number> {
   }
 
   const inputPath = positionals[0];
-
-  if (useAll && inputPath !== undefined) {
-    process.stderr.write('Error: Cannot specify both an input file and --all.\n');
-    return 1;
-  }
 
   // Explicit input file -- compile just that one
   if (inputPath !== undefined) {
@@ -69,16 +57,13 @@ export async function compileCommand(args: string[]): Promise<number> {
     }
   }
 
-  // Batch mode with --all
-  if (useAll) {
-    return compileBatch();
+  // No input file -- compile all sources from config
+  if (outputPath !== undefined) {
+    process.stderr.write('Error: --output requires an input file\n');
+    return 1;
   }
 
-  // No input and no --all -- show usage hint
-  process.stderr.write(
-    "Error: No input file specified. Use 'preflight compile <file>' or 'preflight compile --all'.\n",
-  );
-  return 1;
+  return compileBatch();
 }
 
 /** Collect `.ts` files matching the optional `include` glob, falling back to all `.ts` files. */


### PR DESCRIPTION
Closes #169 

## What

`preflight compile` with no arguments now compiles all sources from the config's `srcDir`, matching the convention established by `preflight run`. The `--all` / `-a` flag is removed entirely, and the compile command's argument handling is simplified from three validation branches to a clean fallthrough: if an input file is given, compile it; otherwise, batch compile all sources.

## Why

The previous behavior required an explicit `--all` flag for a safe, idempotent operation, adding friction without safety benefit. Removing the flag and defaulting to batch mode aligns `compile` with how `run` already works — no names means "all" — eliminating an inconsistency within the tool's own API.

## Details

### Features

- `preflight compile` with no arguments triggers batch compilation of all sources from the config's `srcDir`.
- Added validation: `--output` without a positional argument now returns a clear error, since batch mode does not support per-file output paths.
- Updated the `nmr.config.ts` build script to drop the now-unnecessary `--all` flag.

### Tests

- Replaced `--all`-based test invocations with no-args (`[]`) invocations throughout `compileCommand.test.ts`.
- Removed tests for `--all` flag conflicts (`--all` + `--output`, `--all` + input file, `-a` short form).
- Added tests for `--all` as an unknown flag and `--output` without an input file.
- Updated `route.test.ts` help text assertion to verify new default-mode description.