### PR TITLE
#157 Nest dependent checks in the preflight report

### DIFF
--- a/.preflight/collections/__tests__/nmr.test.ts
+++ b/.preflight/collections/__tests__/nmr.test.ts
@@ -7,11 +7,22 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 import collection from '../nmr.ts';
 
 const [checklist] = collection.checklists;
-const checks = checklist.checks;
 
-/** Find a check by name prefix. */
+/** Search nested checks recursively for a check matching a name prefix. */
+function searchChecks(prefix: string, checks: typeof checklist.checks): (typeof checks)[number] | undefined {
+  for (const check of checks) {
+    if (check.name.startsWith(prefix)) return check;
+    if (check.checks) {
+      const found = searchChecks(prefix, check.checks);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/** Find a check by name prefix, throwing if not found. */
 function findCheck(prefix: string) {
-  const check = checks.find((c) => c.name.startsWith(prefix));
+  const check = searchChecks(prefix, checklist.checks);
   if (!check) throw new Error(`No check found with prefix "${prefix}"`);
   return check;
 }

--- a/.preflight/collections/__tests__/release-kit.test.ts
+++ b/.preflight/collections/__tests__/release-kit.test.ts
@@ -10,11 +10,22 @@ import collection from '../release-kit.ts';
 const MIN_VERSION = releaseKitPackageJson.version;
 
 const [checklist] = collection.checklists;
-const checks = checklist.checks;
 
-/** Find a check by name prefix. */
+/** Search nested checks recursively for a check matching a name prefix. */
+function searchChecks(prefix: string, checks: typeof checklist.checks): (typeof checks)[number] | undefined {
+  for (const check of checks) {
+    if (check.name.startsWith(prefix)) return check;
+    if (check.checks) {
+      const found = searchChecks(prefix, check.checks);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/** Find a check by name prefix, throwing if not found. */
 function findCheck(prefix: string) {
-  const check = checks.find((c) => c.name.startsWith(prefix));
+  const check = searchChecks(prefix, checklist.checks);
   if (!check) throw new Error(`No check found with prefix "${prefix}"`);
   return check;
 }

--- a/.preflight/collections/default.js
+++ b/.preflight/collections/default.js
@@ -56,15 +56,17 @@ var syncLabels = {
     {
       name: "sync-labels.yaml workflow exists",
       check: () => fileExists(".github/workflows/sync-labels.yaml"),
-      fix: "Add .github/workflows/sync-labels.yaml using the sync-labels workflow template"
-    },
-    {
-      name: "sync-labels workflow references sync-labels.reusable.yaml",
-      check: () => fileContains(
-        ".github/workflows/sync-labels.yaml",
-        /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)sync-labels\.reusable\.yaml/
-      ),
-      fix: "Update sync-labels.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@sync-labels-workflow-v1"
+      fix: "Add .github/workflows/sync-labels.yaml using the sync-labels workflow template",
+      checks: [
+        {
+          name: "sync-labels workflow references sync-labels.reusable.yaml",
+          check: () => fileContains(
+            ".github/workflows/sync-labels.yaml",
+            /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)sync-labels\.reusable\.yaml/
+          ),
+          fix: "Update sync-labels.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@sync-labels-workflow-v1"
+        }
+      ]
     },
     {
       name: ".github/labels.yaml exists",
@@ -79,28 +81,32 @@ var codeQuality = {
     {
       name: "code-quality.yaml workflow exists",
       check: () => fileExists(".github/workflows/code-quality.yaml"),
-      fix: "Add .github/workflows/code-quality.yaml using the code-quality workflow template"
-    },
-    {
-      name: "code-quality workflow references @v5",
-      check: () => fileContains(
-        ".github/workflows/code-quality.yaml",
-        /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/
-      ),
-      fix: "Update code-quality.yaml to reference code-quality-pnpm-workflow.yaml@v5"
-    },
-    {
-      name: "code-quality workflow does not reference pnpm-version (requires @v5)",
-      check: () => !fileContains(
-        ".github/workflows/code-quality.yaml",
-        /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/
-      ) || fileDoesNotContain(".github/workflows/code-quality.yaml", /pnpm-version/),
-      fix: "Remove pnpm-version from code-quality.yaml \u2014 v5 workflow infers the version from packageManager"
-    },
-    {
-      name: "code-quality workflow does not reference GH_PACKAGES_TOKEN",
-      check: () => fileDoesNotContain(".github/workflows/code-quality.yaml", /GH_PACKAGES_TOKEN/),
-      fix: "Remove all references to GH_PACKAGES_TOKEN from code-quality.yaml"
+      fix: "Add .github/workflows/code-quality.yaml using the code-quality workflow template",
+      checks: [
+        {
+          name: "code-quality workflow references @v5",
+          check: () => fileContains(
+            ".github/workflows/code-quality.yaml",
+            /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/
+          ),
+          fix: "Update code-quality.yaml to reference code-quality-pnpm-workflow.yaml@v5",
+          checks: [
+            {
+              name: "code-quality workflow does not reference pnpm-version (requires @v5)",
+              check: () => !fileContains(
+                ".github/workflows/code-quality.yaml",
+                /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/
+              ) || fileDoesNotContain(".github/workflows/code-quality.yaml", /pnpm-version/),
+              fix: "Remove pnpm-version from code-quality.yaml \u2014 v5 workflow infers the version from packageManager"
+            }
+          ]
+        },
+        {
+          name: "code-quality workflow does not reference GH_PACKAGES_TOKEN",
+          check: () => fileDoesNotContain(".github/workflows/code-quality.yaml", /GH_PACKAGES_TOKEN/),
+          fix: "Remove all references to GH_PACKAGES_TOKEN from code-quality.yaml"
+        }
+      ]
     }
   ]
 };

--- a/.preflight/collections/default.ts
+++ b/.preflight/collections/default.ts
@@ -21,15 +21,17 @@ const syncLabels: PreflightChecklist = {
       name: 'sync-labels.yaml workflow exists',
       check: () => fileExists('.github/workflows/sync-labels.yaml'),
       fix: 'Add .github/workflows/sync-labels.yaml using the sync-labels workflow template',
-    },
-    {
-      name: 'sync-labels workflow references sync-labels.reusable.yaml',
-      check: () =>
-        fileContains(
-          '.github/workflows/sync-labels.yaml',
-          /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)sync-labels\.reusable\.yaml/,
-        ),
-      fix: 'Update sync-labels.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@sync-labels-workflow-v1',
+      checks: [
+        {
+          name: 'sync-labels workflow references sync-labels.reusable.yaml',
+          check: () =>
+            fileContains(
+              '.github/workflows/sync-labels.yaml',
+              /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)sync-labels\.reusable\.yaml/,
+            ),
+          fix: 'Update sync-labels.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@sync-labels-workflow-v1',
+        },
+      ],
     },
     {
       name: '.github/labels.yaml exists',
@@ -46,29 +48,33 @@ const codeQuality: PreflightChecklist = {
       name: 'code-quality.yaml workflow exists',
       check: () => fileExists('.github/workflows/code-quality.yaml'),
       fix: 'Add .github/workflows/code-quality.yaml using the code-quality workflow template',
-    },
-    {
-      name: 'code-quality workflow references @v5',
-      check: () =>
-        fileContains(
-          '.github/workflows/code-quality.yaml',
-          /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/,
-        ),
-      fix: 'Update code-quality.yaml to reference code-quality-pnpm-workflow.yaml@v5',
-    },
-    {
-      name: 'code-quality workflow does not reference pnpm-version (requires @v5)',
-      check: () =>
-        !fileContains(
-          '.github/workflows/code-quality.yaml',
-          /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/,
-        ) || fileDoesNotContain('.github/workflows/code-quality.yaml', /pnpm-version/),
-      fix: 'Remove pnpm-version from code-quality.yaml — v5 workflow infers the version from packageManager',
-    },
-    {
-      name: 'code-quality workflow does not reference GH_PACKAGES_TOKEN',
-      check: () => fileDoesNotContain('.github/workflows/code-quality.yaml', /GH_PACKAGES_TOKEN/),
-      fix: 'Remove all references to GH_PACKAGES_TOKEN from code-quality.yaml',
+      checks: [
+        {
+          name: 'code-quality workflow references @v5',
+          check: () =>
+            fileContains(
+              '.github/workflows/code-quality.yaml',
+              /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/,
+            ),
+          fix: 'Update code-quality.yaml to reference code-quality-pnpm-workflow.yaml@v5',
+          checks: [
+            {
+              name: 'code-quality workflow does not reference pnpm-version (requires @v5)',
+              check: () =>
+                !fileContains(
+                  '.github/workflows/code-quality.yaml',
+                  /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml@v5/,
+                ) || fileDoesNotContain('.github/workflows/code-quality.yaml', /pnpm-version/),
+              fix: 'Remove pnpm-version from code-quality.yaml — v5 workflow infers the version from packageManager',
+            },
+          ],
+        },
+        {
+          name: 'code-quality workflow does not reference GH_PACKAGES_TOKEN',
+          check: () => fileDoesNotContain('.github/workflows/code-quality.yaml', /GH_PACKAGES_TOKEN/),
+          fix: 'Remove all references to GH_PACKAGES_TOKEN from code-quality.yaml',
+        },
+      ],
     },
   ],
 };

--- a/.preflight/collections/demo.js
+++ b/.preflight/collections/demo.js
@@ -1,0 +1,272 @@
+/** @noformat — @generated. Do not edit. Compiled by preflight. */
+/* eslint-disable */
+
+
+// .preflight/collections/demo.ts
+import { execFileSync } from "node:child_process";
+
+// packages/preflight/dist/esm/authoring.js
+function definePreflightCollection(collection) {
+  return collection;
+}
+
+// packages/preflight/dist/esm/check-utils/filesystem.js
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+function fileExists(relativePath) {
+  return existsSync(join(process.cwd(), relativePath));
+}
+function readFile(relativePath) {
+  const fullPath = join(process.cwd(), relativePath);
+  if (!existsSync(fullPath)) return void 0;
+  return readFileSync(fullPath, "utf8");
+}
+function fileContains(relativePath, pattern) {
+  const content = readFile(relativePath);
+  if (content === void 0) return false;
+  return pattern.test(content);
+}
+
+// packages/preflight/dist/esm/isRecord.js
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// packages/preflight/dist/esm/check-utils/package-json.js
+function readPackageJson() {
+  const content = readFile("package.json");
+  if (content === void 0) return void 0;
+  const parsed = JSON.parse(content);
+  if (!isRecord(parsed)) return void 0;
+  return Object.fromEntries(Object.entries(parsed));
+}
+function hasPackageJsonField(field, expectedValue) {
+  const pkg = readPackageJson();
+  if (pkg === void 0) return false;
+  if (expectedValue !== void 0) return pkg[field] === expectedValue;
+  return field in pkg;
+}
+function hasDevDependency(name) {
+  const pkg = readPackageJson();
+  if (pkg === void 0) return false;
+  const devDeps = pkg.devDependencies;
+  return isRecord(devDeps) && name in devDeps;
+}
+
+// .preflight/collections/demo.ts
+function commandExists(name) {
+  try {
+    execFileSync("which", [name], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+var projectFoundations = {
+  name: "project-foundations",
+  preconditions: [
+    {
+      name: "package.json exists",
+      check: () => fileExists("package.json")
+    }
+  ],
+  checks: [
+    {
+      name: 'ESM project ("type": "module")',
+      check: () => hasPackageJsonField("type", "module"),
+      fix: 'Add "type": "module" to package.json'
+    },
+    {
+      name: "packageManager field is set",
+      check: () => hasPackageJsonField("packageManager"),
+      fix: 'Add "packageManager" to package.json (e.g., "pnpm@10.x.x")'
+    },
+    {
+      name: "pnpm-workspace.yaml exists",
+      check: () => fileExists("pnpm-workspace.yaml"),
+      fix: "Create pnpm-workspace.yaml with workspace package globs",
+      checks: [
+        {
+          name: "workspace includes packages/*",
+          check: () => fileContains("pnpm-workspace.yaml", /packages\/\*/)
+        }
+      ]
+    },
+    {
+      name: ".editorconfig exists",
+      check: () => fileExists(".editorconfig"),
+      fix: "Add .editorconfig to repo root"
+    },
+    {
+      name: "jq is installed",
+      severity: "warn",
+      check: () => commandExists("jq"),
+      fix: "brew install jq \u2014 required for JSON processing in shell scripts and CI pipelines"
+    }
+  ]
+};
+var ciWorkflows = {
+  name: "ci-workflows",
+  checks: [
+    {
+      name: "actionlint is installed",
+      severity: "warn",
+      check: () => commandExists("actionlint"),
+      fix: "brew install actionlint \u2014 catches workflow syntax errors before they fail in CI",
+      checks: [
+        {
+          name: "shellcheck is installed",
+          severity: "warn",
+          check: () => commandExists("shellcheck"),
+          fix: "brew install shellcheck \u2014 actionlint uses shellcheck to lint run: blocks in workflows"
+        }
+      ]
+    },
+    {
+      name: "code-quality.yaml workflow exists",
+      check: () => fileExists(".github/workflows/code-quality.yaml"),
+      checks: [
+        {
+          name: "references reusable workflow",
+          check: () => fileContains(
+            ".github/workflows/code-quality.yaml",
+            /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml/
+          )
+        }
+      ]
+    },
+    {
+      name: "deploy-preview.yaml workflow exists",
+      severity: "warn",
+      check: () => fileExists(".github/workflows/deploy-preview.yaml"),
+      fix: "Add .github/workflows/deploy-preview.yaml for PR preview deployments",
+      checks: [
+        {
+          name: "references staging environment",
+          severity: "warn",
+          check: () => fileContains(".github/workflows/deploy-preview.yaml", /environment:\s*staging/)
+        },
+        {
+          name: "pins runner to ubuntu-latest",
+          severity: "warn",
+          check: () => fileContains(".github/workflows/deploy-preview.yaml", /runs-on:\s*ubuntu-latest/)
+        }
+      ]
+    }
+  ]
+};
+var optionalIntegrations = {
+  name: "optional-integrations",
+  checks: [
+    {
+      name: "Docker",
+      skip: () => !fileExists("Dockerfile") ? "no Dockerfile" : false,
+      check: () => true,
+      checks: [
+        {
+          name: "docker-compose.yaml exists",
+          check: () => fileExists("docker-compose.yaml")
+        }
+      ]
+    },
+    {
+      name: "Renovate",
+      skip: () => !fileExists("renovate.json") ? "no renovate.json" : false,
+      check: () => true,
+      checks: [
+        {
+          name: "extends recommended preset",
+          check: () => fileContains("renovate.json", /extends.*config:recommended/)
+        }
+      ]
+    },
+    {
+      name: "lefthook in devDependencies",
+      check: () => hasDevDependency("lefthook"),
+      fix: "pnpm add --save-dev lefthook",
+      checks: [
+        {
+          name: "lefthook.yml exists",
+          check: () => fileExists("lefthook.yml"),
+          fix: "Add lefthook.yml for git hook management",
+          checks: [
+            {
+              name: "pre-commit hook configured",
+              check: () => fileContains("lefthook.yml", /pre-commit:/),
+              fix: "Add a pre-commit section to lefthook.yml",
+              checks: [
+                {
+                  name: "formatter runs on pre-commit",
+                  check: () => fileContains("lefthook.yml", /prettier/),
+                  checks: [
+                    {
+                      name: "unknown files are ignored",
+                      check: () => fileContains("lefthook.yml", /--ignore-unknown/)
+                    }
+                  ]
+                },
+                {
+                  name: "linter runs on pre-commit",
+                  severity: "recommend",
+                  check: () => fileContains("lefthook.yml", /eslint|lint/),
+                  fix: "Add an ESLint command to the pre-commit hook"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+var publishingPipeline = {
+  name: "publishing-pipeline",
+  groups: [
+    // Stage 1: Build infrastructure — can the project compile at all?
+    [
+      {
+        name: "shared build script exists",
+        check: () => fileExists("config/build.ts"),
+        fix: "Add config/build.ts \u2014 packages depend on the shared esbuild configuration"
+      },
+      {
+        name: "shared Vitest config exists",
+        check: () => fileExists("config/vitest.config.ts"),
+        fix: "Add config/vitest.config.ts \u2014 packages inherit the shared test configuration"
+      }
+    ],
+    // Stage 2: Compliance — is the project legally publishable?
+    // npm publish warns on missing license; corporate consumers cannot use unlicensed packages.
+    [
+      {
+        name: "LICENSE file exists",
+        check: () => fileExists("LICENSE") || fileExists("LICENSE.md"),
+        fix: "Add a LICENSE file \u2014 npm publish will warn and corporate consumers cannot use unlicensed packages"
+      },
+      {
+        name: ".npmrc configures save-exact",
+        check: () => fileContains(".npmrc", /save-exact\s*=\s*true/),
+        fix: "Add save-exact=true to .npmrc for reproducible installs"
+      }
+    ],
+    // Stage 3: Release automation — are the workflows in place?
+    // No point verifying release workflows if the package can't be legally published.
+    [
+      {
+        name: "release workflow exists",
+        check: () => fileExists(".github/workflows/release.yaml")
+      },
+      {
+        name: "publish workflow exists",
+        check: () => fileExists(".github/workflows/publish.yaml")
+      }
+    ]
+  ],
+  fixLocation: "inline"
+};
+var demo_default = definePreflightCollection({
+  checklists: [projectFoundations, ciWorkflows, optionalIntegrations, publishingPipeline]
+});
+export {
+  demo_default as default
+};

--- a/.preflight/collections/demo.ts
+++ b/.preflight/collections/demo.ts
@@ -131,13 +131,33 @@ const optionalIntegrations: PreflightChecklist = {
       ],
     },
     {
-      name: 'Lefthook',
-      check: () => fileExists('lefthook.yml'),
-      fix: 'Add lefthook.yml for git hook management',
+      name: 'lefthook in devDependencies',
+      check: () => hasDevDependency('lefthook'),
+      fix: 'pnpm add --save-dev lefthook',
       checks: [
         {
-          name: 'pre-commit hook configured',
-          check: () => fileContains('lefthook.yml', /pre-commit:/),
+          name: 'lefthook.yml exists',
+          check: () => fileExists('lefthook.yml'),
+          fix: 'Add lefthook.yml for git hook management',
+          checks: [
+            {
+              name: 'pre-commit hook configured',
+              check: () => fileContains('lefthook.yml', /pre-commit:/),
+              fix: 'Add a pre-commit section to lefthook.yml',
+              checks: [
+                {
+                  name: 'linter runs on pre-commit',
+                  severity: 'recommend',
+                  check: () => fileContains('lefthook.yml', /eslint|lint/),
+                  fix: 'Add an ESLint command to the pre-commit hook',
+                },
+                {
+                  name: 'unknown files are ignored',
+                  check: () => fileContains('lefthook.yml', /--ignore-unknown/),
+                },
+              ],
+            },
+          ],
         },
       ],
     },

--- a/.preflight/collections/demo.ts
+++ b/.preflight/collections/demo.ts
@@ -8,6 +8,8 @@
  * Run from the repo root:
  *   preflight run --file .preflight/collections/demo.js
  */
+import { execFileSync } from 'node:child_process';
+
 import type { PreflightChecklist, PreflightStagedChecklist } from '@williamthorsen/preflight';
 import {
   definePreflightCollection,
@@ -16,6 +18,16 @@ import {
   hasDevDependency,
   hasPackageJsonField,
 } from '@williamthorsen/preflight';
+
+/** Return true if a CLI command is available on PATH. */
+function commandExists(name: string): boolean {
+  try {
+    execFileSync('which', [name], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 // -- Flat checklist with preconditions and nested checks ----------------------
 // Demonstrates: precondition gating, passing hierarchy with indentation.
@@ -55,6 +67,12 @@ const projectFoundations: PreflightChecklist = {
       check: () => fileExists('.editorconfig'),
       fix: 'Add .editorconfig to repo root',
     },
+    {
+      name: 'jq is installed',
+      severity: 'warn',
+      check: () => commandExists('jq'),
+      fix: 'brew install jq — required for JSON processing in shell scripts and CI pipelines',
+    },
   ],
 };
 
@@ -65,6 +83,20 @@ const projectFoundations: PreflightChecklist = {
 const ciWorkflows: PreflightChecklist = {
   name: 'ci-workflows',
   checks: [
+    {
+      name: 'actionlint is installed',
+      severity: 'warn',
+      check: () => commandExists('actionlint'),
+      fix: 'brew install actionlint — catches workflow syntax errors before they fail in CI',
+      checks: [
+        {
+          name: 'shellcheck is installed',
+          severity: 'warn',
+          check: () => commandExists('shellcheck'),
+          fix: 'brew install shellcheck — actionlint uses shellcheck to lint run: blocks in workflows',
+        },
+      ],
+    },
     {
       name: 'code-quality.yaml workflow exists',
       check: () => fileExists('.github/workflows/code-quality.yaml'),

--- a/.preflight/collections/demo.ts
+++ b/.preflight/collections/demo.ts
@@ -1,0 +1,204 @@
+/**
+ * Demo collection showcasing preflight features.
+ *
+ * Exercises nested checks, N/A suppression, staged groups with halt-on-failure,
+ * preconditions, mixed severities, and fix messages — all against real files in
+ * this repo.
+ *
+ * Run from the repo root:
+ *   preflight run --file .preflight/collections/demo.js
+ */
+import type { PreflightChecklist, PreflightStagedChecklist } from '@williamthorsen/preflight';
+import {
+  definePreflightCollection,
+  fileContains,
+  fileExists,
+  hasDevDependency,
+  hasPackageJsonField,
+} from '@williamthorsen/preflight';
+
+// -- Flat checklist with preconditions and nested checks ----------------------
+// Demonstrates: precondition gating, passing hierarchy with indentation.
+
+const projectFoundations: PreflightChecklist = {
+  name: 'project-foundations',
+  preconditions: [
+    {
+      name: 'package.json exists',
+      check: () => fileExists('package.json'),
+    },
+  ],
+  checks: [
+    {
+      name: 'ESM project ("type": "module")',
+      check: () => hasPackageJsonField('type', 'module'),
+      fix: 'Add "type": "module" to package.json',
+      checks: [
+        {
+          name: 'packageManager field is set',
+          check: () => hasPackageJsonField('packageManager'),
+          fix: 'Add "packageManager" to package.json (e.g., "pnpm@10.x.x")',
+        },
+      ],
+    },
+    {
+      name: 'pnpm-workspace.yaml exists',
+      check: () => fileExists('pnpm-workspace.yaml'),
+      fix: 'Create pnpm-workspace.yaml with workspace package globs',
+      checks: [
+        {
+          name: 'workspace includes packages/*',
+          check: () => fileContains('pnpm-workspace.yaml', /packages\/\*/),
+        },
+      ],
+    },
+    {
+      name: '.editorconfig exists',
+      check: () => fileExists('.editorconfig'),
+      fix: 'Add .editorconfig to repo root',
+    },
+  ],
+};
+
+// -- Flat checklist with nested checks and intentional failure ----------------
+// Demonstrates: failed parent (🟠) with skipped children (⛔), passing
+// hierarchy, and mixed severities.
+
+const ciWorkflows: PreflightChecklist = {
+  name: 'ci-workflows',
+  checks: [
+    {
+      name: 'code-quality.yaml workflow exists',
+      check: () => fileExists('.github/workflows/code-quality.yaml'),
+      checks: [
+        {
+          name: 'references reusable workflow',
+          check: () =>
+            fileContains(
+              '.github/workflows/code-quality.yaml',
+              /uses:\s*williamthorsen\/.github\/.github\/workflows\/code-quality-pnpm-workflow\.yaml/,
+            ),
+        },
+      ],
+    },
+    {
+      name: 'deploy-preview.yaml workflow exists',
+      severity: 'warn',
+      check: () => fileExists('.github/workflows/deploy-preview.yaml'),
+      fix: 'Add .github/workflows/deploy-preview.yaml for PR preview deployments',
+      checks: [
+        {
+          name: 'references staging environment',
+          severity: 'warn',
+          check: () => fileContains('.github/workflows/deploy-preview.yaml', /environment:\s*staging/),
+        },
+        {
+          name: 'pins runner to ubuntu-latest',
+          severity: 'warn',
+          check: () => fileContains('.github/workflows/deploy-preview.yaml', /runs-on:\s*ubuntu-latest/),
+        },
+      ],
+    },
+  ],
+};
+
+// -- Flat checklist with skip conditions (N/A suppression) --------------------
+// Demonstrates: N/A subtrees are invisible — Docker and Renovate sections
+// vanish entirely because the parent's skip returns a reason string. Only
+// Lefthook (which exists) appears in output.
+
+const optionalIntegrations: PreflightChecklist = {
+  name: 'optional-integrations',
+  checks: [
+    {
+      name: 'Docker',
+      skip: () => (!fileExists('Dockerfile') ? 'no Dockerfile' : false),
+      check: () => true,
+      checks: [
+        {
+          name: 'docker-compose.yaml exists',
+          check: () => fileExists('docker-compose.yaml'),
+        },
+      ],
+    },
+    {
+      name: 'Renovate',
+      skip: () => (!fileExists('renovate.json') ? 'no renovate.json' : false),
+      check: () => true,
+      checks: [
+        {
+          name: 'extends recommended preset',
+          check: () => fileContains('renovate.json', /extends.*config:recommended/),
+        },
+      ],
+    },
+    {
+      name: 'Lefthook',
+      check: () => fileExists('lefthook.yml'),
+      fix: 'Add lefthook.yml for git hook management',
+      checks: [
+        {
+          name: 'pre-commit hook configured',
+          check: () => fileContains('lefthook.yml', /pre-commit:/),
+        },
+      ],
+    },
+  ],
+};
+
+// -- Staged checklist with halt-on-failure ------------------------------------
+// Demonstrates: groups run sequentially. A failure in group 2 (missing LICENSE)
+// halts group 3 — its checks appear as ⛔ skipped.
+
+const releaseReadiness: PreflightStagedChecklist = {
+  name: 'release-readiness',
+  groups: [
+    // Group 1: repository metadata (all pass)
+    [
+      {
+        name: 'package.json has "repository" field',
+        check: () => hasPackageJsonField('repository'),
+        fix: 'Add "repository" to package.json',
+      },
+      {
+        name: 'package.json has "homepage" field',
+        check: () => hasPackageJsonField('homepage'),
+        fix: 'Add "homepage" to package.json',
+      },
+    ],
+    // Group 2: open-source readiness (LICENSE fails → halts group 3)
+    [
+      {
+        name: 'CHANGELOG.md exists',
+        check: () => fileExists('CHANGELOG.md'),
+      },
+      {
+        name: 'LICENSE file exists',
+        check: () => fileExists('LICENSE') || fileExists('LICENSE.md'),
+        fix: 'Add a LICENSE file to the repo root',
+      },
+    ],
+    // Group 3: publishing automation (skipped because group 2 failed)
+    [
+      {
+        name: 'release workflow exists',
+        check: () => fileExists('.github/workflows/release.yaml'),
+      },
+      {
+        name: 'publish workflow exists',
+        check: () => fileExists('.github/workflows/publish.yaml'),
+      },
+      {
+        name: 'git-cliff not in devDependencies',
+        severity: 'recommend',
+        check: () => !hasDevDependency('git-cliff'),
+        fix: 'pnpm remove git-cliff — release-kit handles changelog generation',
+      },
+    ],
+  ],
+  fixLocation: 'inline',
+};
+
+export default definePreflightCollection({
+  checklists: [projectFoundations, ciWorkflows, optionalIntegrations, releaseReadiness],
+});

--- a/.preflight/collections/demo.ts
+++ b/.preflight/collections/demo.ts
@@ -33,13 +33,11 @@ const projectFoundations: PreflightChecklist = {
       name: 'ESM project ("type": "module")',
       check: () => hasPackageJsonField('type', 'module'),
       fix: 'Add "type": "module" to package.json',
-      checks: [
-        {
-          name: 'packageManager field is set',
-          check: () => hasPackageJsonField('packageManager'),
-          fix: 'Add "packageManager" to package.json (e.g., "pnpm@10.x.x")',
-        },
-      ],
+    },
+    {
+      name: 'packageManager field is set',
+      check: () => hasPackageJsonField('packageManager'),
+      fix: 'Add "packageManager" to package.json (e.g., "pnpm@10.x.x")',
     },
     {
       name: 'pnpm-workspace.yaml exists',

--- a/.preflight/collections/demo.ts
+++ b/.preflight/collections/demo.ts
@@ -171,38 +171,43 @@ const optionalIntegrations: PreflightChecklist = {
 };
 
 // -- Staged checklist with halt-on-failure ------------------------------------
-// Demonstrates: groups run sequentially. A failure in group 2 (missing LICENSE)
-// halts group 3 — its checks appear as ⛔ skipped.
+// Demonstrates: groups run sequentially, each depending on the previous.
+// A missing LICENSE in the compliance stage halts the release automation
+// stage — npm publish rejects packages without a license, so there's no
+// point verifying workflows that would produce unpublishable artifacts.
 
-const releaseReadiness: PreflightStagedChecklist = {
-  name: 'release-readiness',
+const publishingPipeline: PreflightStagedChecklist = {
+  name: 'publishing-pipeline',
   groups: [
-    // Group 1: repository metadata (all pass)
+    // Stage 1: Build infrastructure — can the project compile at all?
     [
       {
-        name: 'package.json has "repository" field',
-        check: () => hasPackageJsonField('repository'),
-        fix: 'Add "repository" to package.json',
+        name: 'shared build script exists',
+        check: () => fileExists('config/build.ts'),
+        fix: 'Add config/build.ts — packages depend on the shared esbuild configuration',
       },
       {
-        name: 'package.json has "homepage" field',
-        check: () => hasPackageJsonField('homepage'),
-        fix: 'Add "homepage" to package.json',
+        name: 'shared Vitest config exists',
+        check: () => fileExists('config/vitest.config.ts'),
+        fix: 'Add config/vitest.config.ts — packages inherit the shared test configuration',
       },
     ],
-    // Group 2: open-source readiness (LICENSE fails → halts group 3)
+    // Stage 2: Compliance — is the project legally publishable?
+    // npm publish warns on missing license; corporate consumers cannot use unlicensed packages.
     [
-      {
-        name: 'CHANGELOG.md exists',
-        check: () => fileExists('CHANGELOG.md'),
-      },
       {
         name: 'LICENSE file exists',
         check: () => fileExists('LICENSE') || fileExists('LICENSE.md'),
-        fix: 'Add a LICENSE file to the repo root',
+        fix: 'Add a LICENSE file — npm publish will warn and corporate consumers cannot use unlicensed packages',
+      },
+      {
+        name: '.npmrc configures save-exact',
+        check: () => fileContains('.npmrc', /save-exact\s*=\s*true/),
+        fix: 'Add save-exact=true to .npmrc for reproducible installs',
       },
     ],
-    // Group 3: publishing automation (skipped because group 2 failed)
+    // Stage 3: Release automation — are the workflows in place?
+    // No point verifying release workflows if the package can't be legally published.
     [
       {
         name: 'release workflow exists',
@@ -212,17 +217,11 @@ const releaseReadiness: PreflightStagedChecklist = {
         name: 'publish workflow exists',
         check: () => fileExists('.github/workflows/publish.yaml'),
       },
-      {
-        name: 'git-cliff not in devDependencies',
-        severity: 'recommend',
-        check: () => !hasDevDependency('git-cliff'),
-        fix: 'pnpm remove git-cliff — release-kit handles changelog generation',
-      },
     ],
   ],
   fixLocation: 'inline',
 };
 
 export default definePreflightCollection({
-  checklists: [projectFoundations, ciWorkflows, optionalIntegrations, releaseReadiness],
+  checklists: [projectFoundations, ciWorkflows, optionalIntegrations, publishingPipeline],
 });

--- a/.preflight/collections/demo.ts
+++ b/.preflight/collections/demo.ts
@@ -146,14 +146,20 @@ const optionalIntegrations: PreflightChecklist = {
               fix: 'Add a pre-commit section to lefthook.yml',
               checks: [
                 {
+                  name: 'formatter runs on pre-commit',
+                  check: () => fileContains('lefthook.yml', /prettier/),
+                  checks: [
+                    {
+                      name: 'unknown files are ignored',
+                      check: () => fileContains('lefthook.yml', /--ignore-unknown/),
+                    },
+                  ],
+                },
+                {
                   name: 'linter runs on pre-commit',
                   severity: 'recommend',
                   check: () => fileContains('lefthook.yml', /eslint|lint/),
                   fix: 'Add an ESLint command to the pre-commit hook',
-                },
-                {
-                  name: 'unknown files are ignored',
-                  check: () => fileContains('lefthook.yml', /--ignore-unknown/),
                 },
               ],
             },

--- a/.preflight/collections/nmr.js
+++ b/.preflight/collections/nmr.js
@@ -126,15 +126,17 @@ var nmr_default = definePreflightCollection({
           name: "@williamthorsen/nmr in devDependencies",
           severity: "error",
           check: () => hasDevDependency("@williamthorsen/nmr"),
-          fix: "pnpm add --save-dev @williamthorsen/nmr"
-        },
-        {
-          name: `@williamthorsen/nmr >= ${MIN_VERSION}`,
-          severity: "error",
-          check: () => hasMinDevDependencyVersion("@williamthorsen/nmr", MIN_VERSION, {
-            exempt: (range) => range.startsWith("workspace:")
-          }),
-          fix: `pnpm add --save-dev @williamthorsen/nmr@^${MIN_VERSION}`
+          fix: "pnpm add --save-dev @williamthorsen/nmr",
+          checks: [
+            {
+              name: `@williamthorsen/nmr >= ${MIN_VERSION}`,
+              severity: "error",
+              check: () => hasMinDevDependencyVersion("@williamthorsen/nmr", MIN_VERSION, {
+                exempt: (range) => range.startsWith("workspace:")
+              }),
+              fix: `pnpm add --save-dev @williamthorsen/nmr@^${MIN_VERSION}`
+            }
+          ]
         },
         {
           name: "pnpm-workspace.yaml exists",

--- a/.preflight/collections/nmr.ts
+++ b/.preflight/collections/nmr.ts
@@ -32,15 +32,17 @@ export default definePreflightCollection({
           severity: 'error',
           check: () => hasDevDependency('@williamthorsen/nmr'),
           fix: 'pnpm add --save-dev @williamthorsen/nmr',
-        },
-        {
-          name: `@williamthorsen/nmr >= ${MIN_VERSION}`,
-          severity: 'error',
-          check: () =>
-            hasMinDevDependencyVersion('@williamthorsen/nmr', MIN_VERSION, {
-              exempt: (range) => range.startsWith('workspace:'),
-            }),
-          fix: `pnpm add --save-dev @williamthorsen/nmr@^${MIN_VERSION}`,
+          checks: [
+            {
+              name: `@williamthorsen/nmr >= ${MIN_VERSION}`,
+              severity: 'error',
+              check: () =>
+                hasMinDevDependencyVersion('@williamthorsen/nmr', MIN_VERSION, {
+                  exempt: (range) => range.startsWith('workspace:'),
+                }),
+              fix: `pnpm add --save-dev @williamthorsen/nmr@^${MIN_VERSION}`,
+            },
+          ],
         },
         {
           name: 'pnpm-workspace.yaml exists',

--- a/.preflight/collections/release-kit.js
+++ b/.preflight/collections/release-kit.js
@@ -143,45 +143,51 @@ var release_kit_default = definePreflightCollection({
           name: "@williamthorsen/release-kit in devDependencies",
           severity: "error",
           check: () => hasDevDependency("@williamthorsen/release-kit"),
-          fix: "pnpm add --save-dev @williamthorsen/release-kit"
-        },
-        {
-          name: `@williamthorsen/release-kit >= ${MIN_VERSION}`,
-          severity: "error",
-          check: () => hasMinDevDependencyVersion("@williamthorsen/release-kit", MIN_VERSION, {
-            exempt: (range) => range.startsWith("workspace:")
-          }),
-          fix: `pnpm add --save-dev @williamthorsen/release-kit@^${MIN_VERSION}`
+          fix: "pnpm add --save-dev @williamthorsen/release-kit",
+          checks: [
+            {
+              name: `@williamthorsen/release-kit >= ${MIN_VERSION}`,
+              severity: "error",
+              check: () => hasMinDevDependencyVersion("@williamthorsen/release-kit", MIN_VERSION, {
+                exempt: (range) => range.startsWith("workspace:")
+              }),
+              fix: `pnpm add --save-dev @williamthorsen/release-kit@^${MIN_VERSION}`
+            }
+          ]
         },
         {
           name: "release.yaml workflow exists",
           severity: "warn",
           check: () => fileExists(".github/workflows/release.yaml"),
-          fix: "Add .github/workflows/release.yaml using the release workflow template"
-        },
-        {
-          name: "release workflow references release.reusable.yaml",
-          severity: "warn",
-          check: () => fileContains(
-            ".github/workflows/release.yaml",
-            /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/
-          ),
-          fix: "Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1"
+          fix: "Add .github/workflows/release.yaml using the release workflow template",
+          checks: [
+            {
+              name: "release workflow references release.reusable.yaml",
+              severity: "warn",
+              check: () => fileContains(
+                ".github/workflows/release.yaml",
+                /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/
+              ),
+              fix: "Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1"
+            }
+          ]
         },
         {
           name: "publish.yaml workflow exists",
           severity: "warn",
           check: () => fileExists(".github/workflows/publish.yaml"),
-          fix: "Add .github/workflows/publish.yaml using the publish workflow template"
-        },
-        {
-          name: "publish workflow references publish.reusable.yaml",
-          severity: "warn",
-          check: () => fileContains(
-            ".github/workflows/publish.yaml",
-            /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/
-          ),
-          fix: "Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1"
+          fix: "Add .github/workflows/publish.yaml using the publish workflow template",
+          checks: [
+            {
+              name: "publish workflow references publish.reusable.yaml",
+              severity: "warn",
+              check: () => fileContains(
+                ".github/workflows/publish.yaml",
+                /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/
+              ),
+              fix: "Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1"
+            }
+          ]
         },
         {
           name: "config does not use removed tagPrefix",

--- a/.preflight/collections/release-kit.ts
+++ b/.preflight/collections/release-kit.ts
@@ -32,47 +32,53 @@ export default definePreflightCollection({
           severity: 'error',
           check: () => hasDevDependency('@williamthorsen/release-kit'),
           fix: 'pnpm add --save-dev @williamthorsen/release-kit',
-        },
-        {
-          name: `@williamthorsen/release-kit >= ${MIN_VERSION}`,
-          severity: 'error',
-          check: () =>
-            hasMinDevDependencyVersion('@williamthorsen/release-kit', MIN_VERSION, {
-              exempt: (range) => range.startsWith('workspace:'),
-            }),
-          fix: `pnpm add --save-dev @williamthorsen/release-kit@^${MIN_VERSION}`,
+          checks: [
+            {
+              name: `@williamthorsen/release-kit >= ${MIN_VERSION}`,
+              severity: 'error',
+              check: () =>
+                hasMinDevDependencyVersion('@williamthorsen/release-kit', MIN_VERSION, {
+                  exempt: (range) => range.startsWith('workspace:'),
+                }),
+              fix: `pnpm add --save-dev @williamthorsen/release-kit@^${MIN_VERSION}`,
+            },
+          ],
         },
         {
           name: 'release.yaml workflow exists',
           severity: 'warn',
           check: () => fileExists('.github/workflows/release.yaml'),
           fix: 'Add .github/workflows/release.yaml using the release workflow template',
-        },
-        {
-          name: 'release workflow references release.reusable.yaml',
-          severity: 'warn',
-          check: () =>
-            fileContains(
-              '.github/workflows/release.yaml',
-              /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/,
-            ),
-          fix: 'Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1',
+          checks: [
+            {
+              name: 'release workflow references release.reusable.yaml',
+              severity: 'warn',
+              check: () =>
+                fileContains(
+                  '.github/workflows/release.yaml',
+                  /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/,
+                ),
+              fix: 'Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1',
+            },
+          ],
         },
         {
           name: 'publish.yaml workflow exists',
           severity: 'warn',
           check: () => fileExists('.github/workflows/publish.yaml'),
           fix: 'Add .github/workflows/publish.yaml using the publish workflow template',
-        },
-        {
-          name: 'publish workflow references publish.reusable.yaml',
-          severity: 'warn',
-          check: () =>
-            fileContains(
-              '.github/workflows/publish.yaml',
-              /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/,
-            ),
-          fix: 'Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1',
+          checks: [
+            {
+              name: 'publish workflow references publish.reusable.yaml',
+              severity: 'warn',
+              check: () =>
+                fileContains(
+                  '.github/workflows/publish.yaml',
+                  /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/,
+                ),
+              fix: 'Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1',
+            },
+          ],
         },
         {
           name: 'config does not use removed tagPrefix',

--- a/packages/preflight/__tests__/formatJsonReport.test.ts
+++ b/packages/preflight/__tests__/formatJsonReport.test.ts
@@ -307,6 +307,20 @@ describe(formatJsonReport, () => {
       });
     });
 
+    it('places result without depth property at the top level of the tree', () => {
+      const report = makeReport({
+        results: [makePassedResult({ name: 'no-depth-check' })],
+        passed: true,
+        durationMs: 10,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+      expect(parsed).toMatchObject({
+        checklists: [{ checks: [{ name: 'no-depth-check', checks: [] }] }],
+      });
+    });
+
     it('reconstructs multi-level nesting from flat depth-first results', () => {
       const report = makeReport({
         results: [

--- a/packages/preflight/__tests__/formatJsonReport.test.ts
+++ b/packages/preflight/__tests__/formatJsonReport.test.ts
@@ -283,6 +283,161 @@ describe(formatJsonReport, () => {
     });
   });
 
+  describe('nested checks', () => {
+    it('nests child results under their parent checks array', () => {
+      const report = makeReport({
+        results: [makePassedResult({ name: 'parent', depth: 0 }), makePassedResult({ name: 'child', depth: 1 })],
+        passed: true,
+        durationMs: 20,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+      expect(parsed).toMatchObject({
+        checklists: [
+          {
+            checks: [
+              {
+                name: 'parent',
+                checks: [{ name: 'child', checks: [] }],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('reconstructs multi-level nesting from flat depth-first results', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'A', depth: 0 }),
+          makePassedResult({ name: 'A1', depth: 1 }),
+          makePassedResult({ name: 'A2', depth: 1 }),
+          makePassedResult({ name: 'B', depth: 0 }),
+          makePassedResult({ name: 'B1', depth: 1 }),
+        ],
+        passed: true,
+        durationMs: 50,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+      expect(parsed).toMatchObject({
+        checklists: [
+          {
+            checks: [
+              {
+                name: 'A',
+                checks: [
+                  { name: 'A1', checks: [] },
+                  { name: 'A2', checks: [] },
+                ],
+              },
+              {
+                name: 'B',
+                checks: [{ name: 'B1', checks: [] }],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('produces empty checks array for leaf entries', () => {
+      const report = makeReport({
+        results: [makePassedResult({ name: 'leaf', depth: 0 })],
+        passed: true,
+        durationMs: 10,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+      expect(parsed).toMatchObject({
+        checklists: [{ checks: [{ name: 'leaf', checks: [] }] }],
+      });
+    });
+
+    it('includes n/a subtrees in JSON output', () => {
+      const report = makeReport({
+        results: [
+          makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
+          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 1 }),
+        ],
+        passed: true,
+        durationMs: 0,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+      expect(parsed).toMatchObject({
+        checklists: [
+          {
+            checks: [
+              {
+                name: 'na-parent',
+                checks: [{ name: 'na-child' }],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('counts all results across nesting levels in summary', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'parent', depth: 0 }),
+          makePassedResult({ name: 'child-pass', depth: 1 }),
+          makeFailedResult({ name: 'child-fail', depth: 1 }),
+          makeSkippedResult({ name: 'child-skip', depth: 1 }),
+        ],
+        passed: false,
+        durationMs: 30,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+      expect(parsed).toMatchObject({
+        passed: 2,
+        failed: 1,
+        skipped: 1,
+        checklists: [{ passed: 2, failed: 1, skipped: 1 }],
+      });
+    });
+
+    it('reconstructs three levels of nesting', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'L0', depth: 0 }),
+          makePassedResult({ name: 'L1', depth: 1 }),
+          makePassedResult({ name: 'L2', depth: 2 }),
+        ],
+        passed: true,
+        durationMs: 30,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+      expect(parsed).toMatchObject({
+        checklists: [
+          {
+            checks: [
+              {
+                name: 'L0',
+                checks: [
+                  {
+                    name: 'L1',
+                    checks: [{ name: 'L2', checks: [] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
   describe('reporting threshold', () => {
     it('excludes results below the reporting threshold', () => {
       const report = makeReport({

--- a/packages/preflight/__tests__/formatJsonReport.test.ts
+++ b/packages/preflight/__tests__/formatJsonReport.test.ts
@@ -14,6 +14,7 @@ function makePassedResult(overrides?: Partial<PassedResult>): PassedResult {
     error: null,
     progress: null,
     durationMs: 10,
+    depth: 0,
     ...overrides,
   };
 }
@@ -29,6 +30,7 @@ function makeFailedResult(overrides?: Partial<FailedResult>): FailedResult {
     error: null,
     progress: null,
     durationMs: 5,
+    depth: 0,
     ...overrides,
   };
 }
@@ -45,6 +47,7 @@ function makeSkippedResult(overrides?: Partial<SkippedResult>): SkippedResult {
     error: null,
     progress: null,
     durationMs: 0,
+    depth: 0,
     ...overrides,
   };
 }
@@ -307,9 +310,9 @@ describe(formatJsonReport, () => {
       });
     });
 
-    it('places result without depth property at the top level of the tree', () => {
+    it('places depth-0 result at the top level of the tree', () => {
       const report = makeReport({
-        results: [makePassedResult({ name: 'no-depth-check' })],
+        results: [makePassedResult({ name: 'top-check', depth: 0 })],
         passed: true,
         durationMs: 10,
       });
@@ -317,7 +320,7 @@ describe(formatJsonReport, () => {
       const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
 
       expect(parsed).toMatchObject({
-        checklists: [{ checks: [{ name: 'no-depth-check', checks: [] }] }],
+        checklists: [{ checks: [{ name: 'top-check', checks: [] }] }],
       });
     });
 

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -14,6 +14,7 @@ function makePassedResult(overrides?: Partial<PassedResult>): PassedResult {
     error: null,
     progress: null,
     durationMs: 10,
+    depth: 0,
     ...overrides,
   };
 }
@@ -29,6 +30,7 @@ function makeFailedResult(overrides?: Partial<FailedResult>): FailedResult {
     error: null,
     progress: null,
     durationMs: 5,
+    depth: 0,
     ...overrides,
   };
 }
@@ -45,6 +47,7 @@ function makeSkippedResult(overrides?: Partial<SkippedResult>): SkippedResult {
     error: null,
     progress: null,
     durationMs: 0,
+    depth: 0,
     ...overrides,
   };
 }
@@ -358,15 +361,15 @@ describe(reportPreflight, () => {
       expect(lines[2]).toBe('    \u{1F7E2} grandchild (3ms)');
     });
 
-    it('renders result without depth property at depth 0 (no indentation)', () => {
+    it('renders top-level result at depth 0 with no indentation', () => {
       const report = makeReport({
-        results: [makePassedResult({ name: 'no-depth-check', durationMs: 7 })],
+        results: [makePassedResult({ name: 'top-check', depth: 0, durationMs: 7 })],
       });
 
       const output = reportPreflight(report);
       const lines = output.split('\n');
 
-      expect(lines[0]).toBe('\u{1F7E2} no-depth-check (7ms)');
+      expect(lines[0]).toBe('\u{1F7E2} top-check (7ms)');
     });
 
     it('suppresses n/a subtrees from output', () => {

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -102,14 +102,14 @@ describe(reportPreflight, () => {
     expect(output).toContain('\u{1F7E1} check-rec (5ms)');
   });
 
-  it('shows n/a-skipped checks with white circle icon', () => {
+  it('suppresses standalone n/a-skipped checks from output', () => {
     const report = makeReport({
       results: [makeSkippedResult({ name: 'check-na', skipReason: 'n/a' })],
     });
 
     const output = reportPreflight(report);
 
-    expect(output).toContain('\u26AA check-na (0ms)');
+    expect(output).not.toContain('check-na');
   });
 
   it('shows precondition-skipped checks with no-entry icon', () => {
@@ -369,7 +369,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      expect(output).toContain('na-parent');
+      expect(output).not.toContain('na-parent');
       expect(output).not.toContain('na-child');
       expect(output).toContain('next-sibling');
     });
@@ -450,10 +450,11 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      // na-parent counts as skipped, na-child is suppressed, sibling counts as passed.
+      // na-parent and na-child are both suppressed; only sibling counts as passed.
       expect(output).toContain('\u{1F7E2} 1 passed');
-      expect(output).toContain('\u26D4 1 skipped');
-      expect(output).not.toContain('2 skipped');
+      expect(output).not.toContain('skipped');
+      expect(output).not.toContain('na-parent');
+      expect(output).not.toContain('na-child');
     });
 
     it('resumes output after n/a subtree at same depth', () => {
@@ -467,7 +468,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      expect(output).toContain('na-check');
+      expect(output).not.toContain('na-check');
       expect(output).not.toContain('na-child');
       expect(output).toContain('sibling');
     });

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -105,14 +105,14 @@ describe(reportPreflight, () => {
     expect(output).toContain('\u{1F7E1} check-rec (5ms)');
   });
 
-  it('suppresses standalone n/a-skipped checks from output', () => {
+  it('shows n/a-skipped checks with white circle icon', () => {
     const report = makeReport({
       results: [makeSkippedResult({ name: 'check-na', skipReason: 'n/a' })],
     });
 
     const output = reportPreflight(report);
 
-    expect(output).not.toContain('check-na');
+    expect(output).toContain('\u26AA check-na (0ms)');
   });
 
   it('shows precondition-skipped checks with no-entry icon', () => {
@@ -372,7 +372,7 @@ describe(reportPreflight, () => {
       expect(lines[0]).toBe('\u{1F7E2} top-check (7ms)');
     });
 
-    it('suppresses n/a subtrees from output', () => {
+    it('shows n/a parent but suppresses descendants', () => {
       const report = makeReport({
         results: [
           makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
@@ -383,7 +383,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      expect(output).not.toContain('na-parent');
+      expect(output).toContain('na-parent');
       expect(output).not.toContain('na-child');
       expect(output).toContain('next-sibling');
     });
@@ -452,7 +452,7 @@ describe(reportPreflight, () => {
       expect(output).toContain('\u{1F7E2} 2 passed, \u{1F534} 1 failed');
     });
 
-    it('excludes suppressed n/a children from summary counts', () => {
+    it('counts n/a parent but excludes suppressed descendants from summary', () => {
       const report = makeReport({
         results: [
           makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
@@ -464,10 +464,10 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      // na-parent and na-child are both suppressed; only sibling counts as passed.
+      // na-parent counts as skipped; na-child is suppressed; sibling counts as passed.
       expect(output).toContain('\u{1F7E2} 1 passed');
-      expect(output).not.toContain('skipped');
-      expect(output).not.toContain('na-parent');
+      expect(output).toContain('\u{26D4} 1 skipped');
+      expect(output).toContain('na-parent');
       expect(output).not.toContain('na-child');
     });
 
@@ -482,7 +482,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report);
 
-      expect(output).not.toContain('na-check');
+      expect(output).toContain('na-check');
       expect(output).not.toContain('na-child');
       expect(output).toContain('sibling');
     });

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -171,7 +171,7 @@ describe(reportPreflight, () => {
       const lines = output.split('\n');
 
       expect(output).toContain('Error: Something went wrong');
-      expect(output).toContain('Fix: Run npm install');
+      expect(output).toContain('\u{1F48A} Run npm install');
 
       const checkLineIndex = lines.findIndex((l) => l.includes('broken'));
       const errorLineIndex = lines.findIndex((l) => l.includes('Error: Something went wrong'));
@@ -186,7 +186,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report, { fixLocation: 'inline' });
 
-      expect(output).toContain('Fix: Run npm install');
+      expect(output).toContain('\u{1F48A} Run npm install');
       expect(output).not.toContain('Error:');
     });
 
@@ -199,7 +199,7 @@ describe(reportPreflight, () => {
       const output = reportPreflight(report, { fixLocation: 'inline' });
 
       expect(output).toContain('Error: Missing file');
-      expect(output).not.toContain('Fix:');
+      expect(output).not.toContain('\u{1F48A}');
     });
   });
 
@@ -224,7 +224,7 @@ describe(reportPreflight, () => {
       expect(errorLineIndex).toBe(checkLineIndex + 1);
 
       expect(output).toContain('Fixes:');
-      expect(output).toContain('  Update config file');
+      expect(output).toContain(`  \u{1F48A} Update config file`);
     });
 
     it('omits Fixes section when no fixes are present', () => {
@@ -339,7 +339,7 @@ describe(reportPreflight, () => {
     const output = reportPreflight(report);
 
     expect(output).toContain('Fixes:');
-    expect(output).toContain('  Fix it');
+    expect(output).toContain(`  \u{1F48A} Fix it`);
     expect(output).not.toContain('Fix: Fix it');
   });
 
@@ -408,7 +408,7 @@ describe(reportPreflight, () => {
       const childLine = lines.findIndex((l) => l.includes('child'));
       expect(lines[childLine]).toMatch(/^ {2}/);
       expect(lines[childLine + 1]).toBe('    Error: child error');
-      expect(lines[childLine + 2]).toBe('    Fix: fix child');
+      expect(lines[childLine + 2]).toBe('    \u{1F48A} fix child');
     });
 
     it('collects fixes from nested failed checks in end mode', () => {
@@ -431,9 +431,9 @@ describe(reportPreflight, () => {
       const childLine = lines.findIndex((l) => l.includes('child'));
       expect(lines[childLine + 1]).toBe('    Error: child error');
       expect(output).toContain('Fixes:');
-      expect(output).toContain('  fix the child');
-      // Fix should not appear inline.
-      expect(output).not.toContain('Fix: fix the child');
+      expect(output).toContain(`  \u{1F48A} fix the child`);
+      // Fix should not appear inline after the error line.
+      expect(lines[childLine + 2]).not.toContain('fix the child');
     });
 
     it('includes nested results in summary counts', () => {

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -397,6 +397,31 @@ describe(reportPreflight, () => {
       expect(lines[childLine + 2]).toBe('    Fix: fix child');
     });
 
+    it('collects fixes from nested failed checks in end mode', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'parent', depth: 0 }),
+          makeFailedResult({
+            name: 'child',
+            depth: 1,
+            error: new Error('child error'),
+            fix: 'fix the child',
+          }),
+        ],
+        passed: false,
+      });
+
+      const output = reportPreflight(report, { fixLocation: 'end' });
+      const lines = output.split('\n');
+
+      const childLine = lines.findIndex((l) => l.includes('child'));
+      expect(lines[childLine + 1]).toBe('    Error: child error');
+      expect(output).toContain('Fixes:');
+      expect(output).toContain('  fix the child');
+      // Fix should not appear inline.
+      expect(output).not.toContain('Fix: fix the child');
+    });
+
     it('includes nested results in summary counts', () => {
       const report = makeReport({
         results: [
@@ -411,6 +436,24 @@ describe(reportPreflight, () => {
       const output = reportPreflight(report);
 
       expect(output).toContain('\u{1F7E2} 2 passed, \u{1F534} 1 failed');
+    });
+
+    it('excludes suppressed n/a children from summary counts', () => {
+      const report = makeReport({
+        results: [
+          makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
+          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 1 }),
+          makePassedResult({ name: 'sibling', depth: 0, durationMs: 10 }),
+        ],
+        durationMs: 50,
+      });
+
+      const output = reportPreflight(report);
+
+      // na-parent counts as skipped, na-child is suppressed, sibling counts as passed.
+      expect(output).toContain('\u{1F7E2} 1 passed');
+      expect(output).toContain('\u26D4 1 skipped');
+      expect(output).not.toContain('2 skipped');
     });
 
     it('resumes output after n/a subtree at same depth', () => {

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -340,6 +340,96 @@ describe(reportPreflight, () => {
     expect(output).not.toContain('Fix: Fix it');
   });
 
+  describe('nested checks', () => {
+    it('indents nested results by depth', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'parent', depth: 0, durationMs: 10 }),
+          makePassedResult({ name: 'child', depth: 1, durationMs: 5 }),
+          makePassedResult({ name: 'grandchild', depth: 2, durationMs: 3 }),
+        ],
+      });
+
+      const output = reportPreflight(report);
+      const lines = output.split('\n');
+
+      expect(lines[0]).toBe('\u{1F7E2} parent (10ms)');
+      expect(lines[1]).toBe('  \u{1F7E2} child (5ms)');
+      expect(lines[2]).toBe('    \u{1F7E2} grandchild (3ms)');
+    });
+
+    it('suppresses n/a subtrees from output', () => {
+      const report = makeReport({
+        results: [
+          makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
+          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 1 }),
+          makePassedResult({ name: 'next-sibling', depth: 0, durationMs: 10 }),
+        ],
+      });
+
+      const output = reportPreflight(report);
+
+      expect(output).toContain('na-parent');
+      expect(output).not.toContain('na-child');
+      expect(output).toContain('next-sibling');
+    });
+
+    it('indents inline detail lines at parent depth', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'parent', depth: 0 }),
+          makeFailedResult({
+            name: 'child',
+            depth: 1,
+            error: new Error('child error'),
+            fix: 'fix child',
+          }),
+        ],
+        passed: false,
+      });
+
+      const output = reportPreflight(report, { fixLocation: 'inline' });
+      const lines = output.split('\n');
+
+      const childLine = lines.findIndex((l) => l.includes('child'));
+      expect(lines[childLine]).toMatch(/^ {2}/);
+      expect(lines[childLine + 1]).toBe('    Error: child error');
+      expect(lines[childLine + 2]).toBe('    Fix: fix child');
+    });
+
+    it('includes nested results in summary counts', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'parent', depth: 0 }),
+          makePassedResult({ name: 'child', depth: 1 }),
+          makeFailedResult({ name: 'child-fail', depth: 1 }),
+        ],
+        passed: false,
+        durationMs: 50,
+      });
+
+      const output = reportPreflight(report);
+
+      expect(output).toContain('\u{1F7E2} 2 passed, \u{1F534} 1 failed');
+    });
+
+    it('resumes output after n/a subtree at same depth', () => {
+      const report = makeReport({
+        results: [
+          makeSkippedResult({ name: 'na-check', skipReason: 'n/a', depth: 1 }),
+          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 2 }),
+          makePassedResult({ name: 'sibling', depth: 1, durationMs: 5 }),
+        ],
+      });
+
+      const output = reportPreflight(report);
+
+      expect(output).toContain('na-check');
+      expect(output).not.toContain('na-child');
+      expect(output).toContain('sibling');
+    });
+  });
+
   describe('reporting threshold', () => {
     it('excludes results below the reporting threshold', () => {
       const report = makeReport({

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -171,7 +171,7 @@ describe(reportPreflight, () => {
       const lines = output.split('\n');
 
       expect(output).toContain('Error: Something went wrong');
-      expect(output).toContain('\u{1F48A} Run npm install');
+      expect(output).toContain('\u{1F48A} Fix: Run npm install');
 
       const checkLineIndex = lines.findIndex((l) => l.includes('broken'));
       const errorLineIndex = lines.findIndex((l) => l.includes('Error: Something went wrong'));
@@ -186,7 +186,7 @@ describe(reportPreflight, () => {
 
       const output = reportPreflight(report, { fixLocation: 'inline' });
 
-      expect(output).toContain('\u{1F48A} Run npm install');
+      expect(output).toContain('\u{1F48A} Fix: Run npm install');
       expect(output).not.toContain('Error:');
     });
 
@@ -408,7 +408,7 @@ describe(reportPreflight, () => {
       const childLine = lines.findIndex((l) => l.includes('child'));
       expect(lines[childLine]).toMatch(/^ {2}/);
       expect(lines[childLine + 1]).toBe('    Error: child error');
-      expect(lines[childLine + 2]).toBe('    \u{1F48A} fix child');
+      expect(lines[childLine + 2]).toBe('    \u{1F48A} Fix: fix child');
     });
 
     it('collects fixes from nested failed checks in end mode', () => {

--- a/packages/preflight/__tests__/reportPreflight.test.ts
+++ b/packages/preflight/__tests__/reportPreflight.test.ts
@@ -358,6 +358,17 @@ describe(reportPreflight, () => {
       expect(lines[2]).toBe('    \u{1F7E2} grandchild (3ms)');
     });
 
+    it('renders result without depth property at depth 0 (no indentation)', () => {
+      const report = makeReport({
+        results: [makePassedResult({ name: 'no-depth-check', durationMs: 7 })],
+      });
+
+      const output = reportPreflight(report);
+      const lines = output.split('\n');
+
+      expect(lines[0]).toBe('\u{1F7E2} no-depth-check (7ms)');
+    });
+
     it('suppresses n/a subtrees from output', () => {
       const report = makeReport({
         results: [

--- a/packages/preflight/__tests__/runPreflight.test.ts
+++ b/packages/preflight/__tests__/runPreflight.test.ts
@@ -151,6 +151,28 @@ describe(runPreflight, () => {
       expect(skipped.skipReason).toBe('precondition');
     });
 
+    it('skips nested children of checks under a failing precondition', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'gated-nested',
+        preconditions: [{ name: 'pre-fail', check: () => false }],
+        checks: [
+          {
+            name: 'parent',
+            check: () => true,
+            checks: [{ name: 'child', check: () => true }],
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results).toHaveLength(3);
+      const child = report.results[2];
+      assert(child?.status === 'skipped');
+      expect(child.skipReason).toBe('precondition');
+      expect(child.depth).toBe(1);
+    });
+
     it('runs checks when all preconditions pass', async () => {
       const checklist: PreflightChecklist = {
         name: 'gated',

--- a/packages/preflight/__tests__/runPreflight.test.ts
+++ b/packages/preflight/__tests__/runPreflight.test.ts
@@ -525,6 +525,189 @@ describe(runPreflight, () => {
 
     expect(report.durationMs).toBeGreaterThanOrEqual(0);
   });
+
+  describe('nested checks', () => {
+    it('executes children of a passing check', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'parent',
+            check: () => true,
+            checks: [{ name: 'child', check: () => true }],
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results).toHaveLength(2);
+      expect(report.results[0]?.name).toBe('parent');
+      expect(report.results[0]?.status).toBe('passed');
+      expect(report.results[0]?.depth).toBe(0);
+      expect(report.results[1]?.name).toBe('child');
+      expect(report.results[1]?.status).toBe('passed');
+      expect(report.results[1]?.depth).toBe(1);
+    });
+
+    it('skips children of a failed check with precondition reason', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'parent',
+            check: () => false,
+            checks: [{ name: 'child', check: () => true }],
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results).toHaveLength(2);
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[1]?.name).toBe('child');
+      expect(report.results[1]?.status).toBe('skipped');
+      if (report.results[1]?.status === 'skipped') {
+        expect(report.results[1].skipReason).toBe('precondition');
+      }
+      expect(report.results[1]?.depth).toBe(1);
+    });
+
+    it('skips children of an n/a-skipped check with n/a reason', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'parent',
+            check: () => true,
+            skip: () => 'not applicable',
+            checks: [{ name: 'child', check: () => true }],
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results).toHaveLength(2);
+      expect(report.results[0]?.status).toBe('skipped');
+      expect(report.results[1]?.name).toBe('child');
+      expect(report.results[1]?.status).toBe('skipped');
+      if (report.results[1]?.status === 'skipped') {
+        expect(report.results[1].skipReason).toBe('n/a');
+      }
+    });
+
+    it('produces depth-first ordering for multi-level nesting', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'A',
+            check: () => true,
+            checks: [
+              { name: 'A1', check: () => true },
+              { name: 'A2', check: () => true },
+            ],
+          },
+          {
+            name: 'B',
+            check: () => true,
+            checks: [
+              { name: 'B1', check: () => true },
+              { name: 'B2', check: () => true },
+            ],
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+      const names = report.results.map((r) => r.name);
+
+      expect(names).toStrictEqual(['A', 'A1', 'A2', 'B', 'B1', 'B2']);
+    });
+
+    it('assigns correct depth values at three levels', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'L0',
+            check: () => true,
+            checks: [
+              {
+                name: 'L1',
+                check: () => true,
+                checks: [{ name: 'L2', check: () => true }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results.map((r) => ({ name: r.name, depth: r.depth }))).toStrictEqual([
+        { name: 'L0', depth: 0 },
+        { name: 'L1', depth: 1 },
+        { name: 'L2', depth: 2 },
+      ]);
+    });
+
+    it('recursively skips all descendants when parent fails', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'parent',
+            check: () => false,
+            checks: [
+              {
+                name: 'child',
+                check: () => true,
+                checks: [{ name: 'grandchild', check: () => true }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results).toHaveLength(3);
+      expect(report.results[1]?.status).toBe('skipped');
+      expect(report.results[2]?.status).toBe('skipped');
+      expect(report.results[2]?.depth).toBe(2);
+    });
+
+    it('includes nested results in pass/fail determination', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'parent',
+            check: () => true,
+            checks: [{ name: 'child-fails', check: () => false }],
+          },
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.passed).toBe(false);
+    });
+
+    it('defaults depth to 0 for top-level checks without nesting', async () => {
+      const checklist: PreflightChecklist = {
+        name: 'flat',
+        checks: [{ name: 'top-level', check: () => true }],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results[0]?.depth).toBe(0);
+    });
+  });
 });
 
 describe(meetsThreshold, () => {

--- a/packages/preflight/__tests__/runPreflight.test.ts
+++ b/packages/preflight/__tests__/runPreflight.test.ts
@@ -147,7 +147,7 @@ describe(runPreflight, () => {
       const report = await runPreflight(checklist);
       const skipped = report.results[1];
 
-      assert(skipped?.status === 'skipped');
+      assert.ok(skipped?.status === 'skipped');
       expect(skipped.skipReason).toBe('precondition');
     });
 
@@ -168,7 +168,7 @@ describe(runPreflight, () => {
 
       expect(report.results).toHaveLength(3);
       const child = report.results[2];
-      assert(child?.status === 'skipped');
+      assert.ok(child?.status === 'skipped');
       expect(child.skipReason).toBe('precondition');
       expect(child.depth).toBe(1);
     });
@@ -506,7 +506,7 @@ describe(runPreflight, () => {
       const report = await runPreflight(checklist);
 
       const result = report.results[0];
-      assert(result?.status === 'skipped');
+      assert.ok(result?.status === 'skipped');
       expect(result.skipReason).toBe('n/a');
       expect(result.detail).toBe('tool not installed');
     });
@@ -660,7 +660,7 @@ describe(runPreflight, () => {
       expect(report.results[0]?.status).toBe('failed');
       expect(report.results[1]?.name).toBe('child');
       const child = report.results[1];
-      assert(child?.status === 'skipped');
+      assert.ok(child?.status === 'skipped');
       expect(child.skipReason).toBe('precondition');
       expect(child.depth).toBe(1);
     });
@@ -684,7 +684,7 @@ describe(runPreflight, () => {
       expect(report.results[0]?.status).toBe('skipped');
       expect(report.results[1]?.name).toBe('child');
       const child = report.results[1];
-      assert(child?.status === 'skipped');
+      assert.ok(child?.status === 'skipped');
       expect(child.skipReason).toBe('n/a');
     });
 

--- a/packages/preflight/__tests__/runPreflight.test.ts
+++ b/packages/preflight/__tests__/runPreflight.test.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert';
+
 import { describe, expect, it } from 'vitest';
 
 import { meetsThreshold, runPreflight } from '../src/runPreflight.ts';
@@ -145,10 +147,8 @@ describe(runPreflight, () => {
       const report = await runPreflight(checklist);
       const skipped = report.results[1];
 
-      expect(skipped?.status).toBe('skipped');
-      if (skipped?.status === 'skipped') {
-        expect(skipped.skipReason).toBe('precondition');
-      }
+      assert(skipped?.status === 'skipped');
+      expect(skipped.skipReason).toBe('precondition');
     });
 
     it('runs checks when all preconditions pass', async () => {
@@ -243,6 +243,77 @@ describe(runPreflight, () => {
       expect(report.results).toHaveLength(2);
       expect(report.results[0]?.status).toBe('failed');
       expect(report.results[1]?.status).toBe('skipped');
+    });
+
+    it('executes nested checks within a staged group', async () => {
+      const checklist: PreflightStagedChecklist = {
+        name: 'staged-nested',
+        groups: [
+          [
+            {
+              name: 'g1-parent',
+              check: () => true,
+              checks: [{ name: 'g1-child', check: () => true }],
+            },
+          ],
+          [{ name: 'g2-runs', check: () => true }],
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results).toHaveLength(3);
+      expect(report.results[0]?.name).toBe('g1-parent');
+      expect(report.results[0]?.depth).toBe(0);
+      expect(report.results[1]?.name).toBe('g1-child');
+      expect(report.results[1]?.depth).toBe(1);
+      expect(report.results[2]?.name).toBe('g2-runs');
+      expect(report.results[2]?.status).toBe('passed');
+    });
+
+    it('does not halt subsequent groups when only a nested child fails', async () => {
+      const checklist: PreflightStagedChecklist = {
+        name: 'staged-nested-child-fail',
+        groups: [
+          [
+            {
+              name: 'g1-parent',
+              check: () => true,
+              checks: [{ name: 'g1-child-fail', check: () => false }],
+            },
+          ],
+          [{ name: 'g2-runs', check: () => true }],
+        ],
+      };
+
+      const report = await runPreflight(checklist);
+
+      expect(report.results).toHaveLength(3);
+      expect(report.results[1]?.name).toBe('g1-child-fail');
+      expect(report.results[1]?.status).toBe('failed');
+      expect(report.results[2]?.name).toBe('g2-runs');
+      expect(report.results[2]?.status).toBe('passed');
+    });
+
+    it('does not halt subsequent groups when nested child fails below failOn', async () => {
+      const checklist: PreflightStagedChecklist = {
+        name: 'staged-nested-threshold',
+        groups: [
+          [
+            {
+              name: 'g1-parent',
+              check: () => true,
+              checks: [{ name: 'g1-child-warn', check: () => false, severity: 'warn' }],
+            },
+          ],
+          [{ name: 'g2-runs', check: () => true }],
+        ],
+      };
+
+      const report = await runPreflight(checklist, { failOn: 'error' });
+
+      expect(report.results[2]?.name).toBe('g2-runs');
+      expect(report.results[2]?.status).toBe('passed');
     });
   });
 
@@ -412,11 +483,10 @@ describe(runPreflight, () => {
 
       const report = await runPreflight(checklist);
 
-      expect(report.results[0]?.status).toBe('skipped');
-      if (report.results[0]?.status === 'skipped') {
-        expect(report.results[0].skipReason).toBe('n/a');
-        expect(report.results[0].detail).toBe('tool not installed');
-      }
+      const result = report.results[0];
+      assert(result?.status === 'skipped');
+      expect(result.skipReason).toBe('n/a');
+      expect(result.detail).toBe('tool not installed');
     });
 
     it('runs a check when skip returns false', async () => {
@@ -567,11 +637,10 @@ describe(runPreflight, () => {
       expect(report.results).toHaveLength(2);
       expect(report.results[0]?.status).toBe('failed');
       expect(report.results[1]?.name).toBe('child');
-      expect(report.results[1]?.status).toBe('skipped');
-      if (report.results[1]?.status === 'skipped') {
-        expect(report.results[1].skipReason).toBe('precondition');
-      }
-      expect(report.results[1]?.depth).toBe(1);
+      const child = report.results[1];
+      assert(child?.status === 'skipped');
+      expect(child.skipReason).toBe('precondition');
+      expect(child.depth).toBe(1);
     });
 
     it('skips children of an n/a-skipped check with n/a reason', async () => {
@@ -592,10 +661,9 @@ describe(runPreflight, () => {
       expect(report.results).toHaveLength(2);
       expect(report.results[0]?.status).toBe('skipped');
       expect(report.results[1]?.name).toBe('child');
-      expect(report.results[1]?.status).toBe('skipped');
-      if (report.results[1]?.status === 'skipped') {
-        expect(report.results[1].skipReason).toBe('n/a');
-      }
+      const child = report.results[1];
+      assert(child?.status === 'skipped');
+      expect(child.skipReason).toBe('n/a');
     });
 
     it('produces depth-first ordering for multi-level nesting', async () => {

--- a/packages/preflight/src/formatJsonReport.ts
+++ b/packages/preflight/src/formatJsonReport.ts
@@ -93,7 +93,7 @@ function buildCheckEntries(
   while (index < results.length) {
     const result = results[index];
     if (result === undefined) break;
-    const depth = result.depth ?? 0;
+    const depth = result.depth;
 
     // Stop when we encounter a result shallower than what we expect at this level.
     if (depth < expectedDepth) break;

--- a/packages/preflight/src/formatJsonReport.ts
+++ b/packages/preflight/src/formatJsonReport.ts
@@ -77,6 +77,10 @@ export function formatJsonReport(entries: ChecklistEntry[], options?: FormatJson
  *
  * Consumes results at `expectedDepth` as siblings, recursing into deeper results
  * as children. Returns the parsed entries and the index of the first unconsumed result.
+ *
+ * Assumes contiguous, monotonically increasing depths as produced by `runPreflight`.
+ * A depth gap (e.g., depth 0 followed by depth 2 with no depth 1) will silently
+ * promote the deeper result to the nearest parent level.
  */
 function buildCheckEntries(
   results: PreflightResult[],

--- a/packages/preflight/src/formatJsonReport.ts
+++ b/packages/preflight/src/formatJsonReport.ts
@@ -33,13 +33,15 @@ export function formatJsonReport(entries: ChecklistEntry[], options?: FormatJson
     // Filter results by reporting threshold.
     const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
 
-    const checks: JsonCheckEntry[] = visibleResults.map((result) => {
+    // Count all visible results (flat count across all nesting levels).
+    for (const result of visibleResults) {
       if (result.status === 'passed') passed++;
       else if (result.status === 'failed') failed++;
       else skipped++;
+    }
 
-      return buildCheckEntry(result);
-    });
+    // Reconstruct tree from flat depth-first results.
+    const { entries: checks } = buildCheckEntries(visibleResults, 0, 0);
 
     totalPassed += passed;
     totalFailed += failed;
@@ -71,12 +73,46 @@ export function formatJsonReport(entries: ChecklistEntry[], options?: FormatJson
 }
 
 /**
+ * Reconstruct a tree of check entries from a flat depth-first results slice.
+ *
+ * Consumes results at `expectedDepth` as siblings, recursing into deeper results
+ * as children. Returns the parsed entries and the index of the first unconsumed result.
+ */
+function buildCheckEntries(
+  results: PreflightResult[],
+  startIndex: number,
+  expectedDepth: number,
+): { entries: JsonCheckEntry[]; nextIndex: number } {
+  const entries: JsonCheckEntry[] = [];
+  let index = startIndex;
+
+  while (index < results.length) {
+    const result = results[index];
+    if (result === undefined) break;
+    const depth = result.depth ?? 0;
+
+    // Stop when we encounter a result shallower than what we expect at this level.
+    if (depth < expectedDepth) break;
+
+    index++;
+
+    // Recursively collect children (results at depth + 1 and deeper).
+    const { entries: children, nextIndex } = buildCheckEntries(results, index, depth + 1);
+    index = nextIndex;
+
+    entries.push(buildCheckEntry(result, children));
+  }
+
+  return { entries, nextIndex: index };
+}
+
+/**
  * Build a single JSON check entry, normalizing the union to include all fields.
  *
  * Non-skipped results get `skipReason: null` for uniform JSON shape.
  * Error objects are serialized to their message string.
  */
-function buildCheckEntry(result: PreflightResult): JsonCheckEntry {
+function buildCheckEntry(result: PreflightResult, children: JsonCheckEntry[] = []): JsonCheckEntry {
   const errorString = result.error !== null ? result.error.message : null;
 
   if (result.status === 'skipped') {
@@ -91,6 +127,7 @@ function buildCheckEntry(result: PreflightResult): JsonCheckEntry {
       error: errorString,
       progress: result.progress,
       durationMs: result.durationMs,
+      checks: children,
     };
   }
 
@@ -105,5 +142,6 @@ function buildCheckEntry(result: PreflightResult): JsonCheckEntry {
     error: errorString,
     progress: result.progress,
     durationMs: result.durationMs,
+    checks: children,
   };
 }

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -82,7 +82,7 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
   let suppressBelowDepth: number | null = null;
 
   for (const result of visibleResults) {
-    const depth = result.depth ?? 0;
+    const depth = result.depth;
 
     // Suppress N/A subtrees: skip the N/A parent and all deeper results.
     if (suppressBelowDepth !== null) {
@@ -123,7 +123,7 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
   let skipped = 0;
   let countSuppressBelowDepth: number | null = null;
   for (const r of visibleResults) {
-    const d = r.depth ?? 0;
+    const d = r.depth;
     if (countSuppressBelowDepth !== null) {
       if (d > countSuppressBelowDepth) continue;
       countSuppressBelowDepth = null;

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -77,9 +77,26 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
   // Filter results by reporting threshold.
   const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
 
+  // Track N/A subtree suppression: when a result is skipped with n/a reason,
+  // skip all immediately following results with greater depth.
+  let suppressBelowDepth: number | null = null;
+
   for (const result of visibleResults) {
+    const depth = result.depth ?? 0;
+
+    // Suppress N/A subtrees: skip results deeper than the N/A parent.
+    if (suppressBelowDepth !== null) {
+      if (depth > suppressBelowDepth) continue;
+      suppressBelowDepth = null;
+    }
+
+    if (result.status === 'skipped' && result.skipReason === 'n/a') {
+      suppressBelowDepth = depth;
+    }
+
+    const indent = '  '.repeat(depth);
     const icon = getIcon(result);
-    let checkLine = `${icon} ${result.name} (${formatDuration(result.durationMs)})`;
+    let checkLine = `${indent}${icon} ${result.name} (${formatDuration(result.durationMs)})`;
     if (result.detail !== null) {
       checkLine += ` \u2014 ${result.detail}`;
     }
@@ -90,7 +107,8 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
 
     if (result.status === 'failed') {
       const includeFix = fixLocation === 'inline';
-      lines.push(...collectInlineDetails(result, includeFix));
+      const details = collectInlineDetails(result, includeFix);
+      lines.push(...details.map((line) => `${indent}${line}`));
 
       if (!includeFix && result.fix !== null) {
         collectedFixes.push(result.fix);

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -84,7 +84,7 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
   for (const result of visibleResults) {
     const depth = result.depth ?? 0;
 
-    // Suppress N/A subtrees: skip results deeper than the N/A parent.
+    // Suppress N/A subtrees: skip the N/A parent and all deeper results.
     if (suppressBelowDepth !== null) {
       if (depth > suppressBelowDepth) continue;
       suppressBelowDepth = null;
@@ -92,6 +92,7 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
 
     if (result.status === 'skipped' && result.skipReason === 'n/a') {
       suppressBelowDepth = depth;
+      continue;
     }
 
     const indent = '  '.repeat(depth);
@@ -129,6 +130,7 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
     }
     if (r.status === 'skipped' && r.skipReason === 'n/a') {
       countSuppressBelowDepth = d;
+      continue;
     }
     if (r.status === 'passed') passed++;
     else if (r.status === 'failed') failed++;

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -84,7 +84,7 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
   for (const result of visibleResults) {
     const depth = result.depth;
 
-    // Suppress N/A subtrees: skip the N/A parent and all deeper results.
+    // Suppress N/A descendants: show the N/A parent, hide deeper results.
     if (suppressBelowDepth !== null) {
       if (depth > suppressBelowDepth) continue;
       suppressBelowDepth = null;
@@ -92,7 +92,6 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
 
     if (result.status === 'skipped' && result.skipReason === 'n/a') {
       suppressBelowDepth = depth;
-      continue;
     }
 
     const indent = '  '.repeat(depth);
@@ -117,7 +116,7 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
     }
   }
 
-  // Summary counts from visible results, applying N/A subtree suppression.
+  // Summary counts from visible results, suppressing N/A descendants only.
   let passed = 0;
   let failed = 0;
   let skipped = 0;
@@ -130,7 +129,6 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
     }
     if (r.status === 'skipped' && r.skipReason === 'n/a') {
       countSuppressBelowDepth = d;
-      continue;
     }
     if (r.status === 'passed') passed++;
     else if (r.status === 'failed') failed++;

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -116,11 +116,20 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
     }
   }
 
-  // Summary counts from visible results only.
+  // Summary counts from visible results, applying N/A subtree suppression.
   let passed = 0;
   let failed = 0;
   let skipped = 0;
+  let countSuppressBelowDepth: number | null = null;
   for (const r of visibleResults) {
+    const d = r.depth ?? 0;
+    if (countSuppressBelowDepth !== null) {
+      if (d > countSuppressBelowDepth) continue;
+      countSuppressBelowDepth = null;
+    }
+    if (r.status === 'skipped' && r.skipReason === 'n/a') {
+      countSuppressBelowDepth = d;
+    }
     if (r.status === 'passed') passed++;
     else if (r.status === 'failed') failed++;
     else skipped++;

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -57,7 +57,7 @@ function collectInlineDetails(result: PreflightResult, includeFix: boolean): str
     details.push(`  Error: ${result.error.message}`);
   }
   if (includeFix && result.fix !== null) {
-    details.push(`  ${ICON_FIX} ${result.fix}`);
+    details.push(`  ${ICON_FIX} Fix: ${result.fix}`);
   }
   return details;
 }
@@ -78,7 +78,11 @@ function* iterateWithNaSuppression(results: PreflightResult[]): Generator<Prefli
 }
 
 /** Count passed, failed, and skipped results after N/A descendant suppression. */
-function countResults(results: PreflightResult[]): { passed: number; failed: number; skipped: number } {
+function countResults(results: PreflightResult[]): {
+  passed: number;
+  failed: number;
+  skipped: number;
+} {
   let passed = 0;
   let failed = 0;
   let skipped = 0;

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -8,6 +8,7 @@ const ICON_WARN_FAILED = '\u{1F7E0}';
 const ICON_RECOMMEND_FAILED = '\u{1F7E1}';
 const ICON_SKIPPED_NA = '\u26AA';
 const ICON_SKIPPED_PRECONDITION = '\u26D4';
+const ICON_FIX = '\u{1F48A}';
 
 /** Options controlling how the report is formatted. */
 export interface ReportPreflightOptions {
@@ -56,7 +57,7 @@ function collectInlineDetails(result: PreflightResult, includeFix: boolean): str
     details.push(`  Error: ${result.error.message}`);
   }
   if (includeFix && result.fix !== null) {
-    details.push(`  Fix: ${result.fix}`);
+    details.push(`  ${ICON_FIX} ${result.fix}`);
   }
   return details;
 }
@@ -131,7 +132,7 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
   lines.push('', `${formatSummaryCounts(passed, failed, skipped)} (${formatDuration(report.durationMs)})`);
 
   if (fixLocation === 'end' && collectedFixes.length > 0) {
-    lines.push('', 'Fixes:', ...collectedFixes.map((fix) => `  ${fix}`));
+    lines.push('', 'Fixes:', ...collectedFixes.map((fix) => `  ${ICON_FIX} ${fix}`));
   }
 
   return lines.join('\n');

--- a/packages/preflight/src/reportPreflight.ts
+++ b/packages/preflight/src/reportPreflight.ts
@@ -61,6 +61,34 @@ function collectInlineDetails(result: PreflightResult, includeFix: boolean): str
   return details;
 }
 
+/** Iterate visible results, skipping N/A descendants (depth > N/A parent). */
+function* iterateWithNaSuppression(results: PreflightResult[]): Generator<PreflightResult> {
+  let suppressBelowDepth: number | null = null;
+  for (const result of results) {
+    if (suppressBelowDepth !== null) {
+      if (result.depth > suppressBelowDepth) continue;
+      suppressBelowDepth = null;
+    }
+    if (result.status === 'skipped' && result.skipReason === 'n/a') {
+      suppressBelowDepth = result.depth;
+    }
+    yield result;
+  }
+}
+
+/** Count passed, failed, and skipped results after N/A descendant suppression. */
+function countResults(results: PreflightResult[]): { passed: number; failed: number; skipped: number } {
+  let passed = 0;
+  let failed = 0;
+  let skipped = 0;
+  for (const r of iterateWithNaSuppression(results)) {
+    if (r.status === 'passed') passed++;
+    else if (r.status === 'failed') failed++;
+    else skipped++;
+  }
+  return { passed, failed, skipped };
+}
+
 /**
  * Format a preflight report as a human-readable string for terminal output.
  *
@@ -74,27 +102,10 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
   const lines: string[] = [];
   const collectedFixes: string[] = [];
 
-  // Filter results by reporting threshold.
   const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
 
-  // Track N/A subtree suppression: when a result is skipped with n/a reason,
-  // skip all immediately following results with greater depth.
-  let suppressBelowDepth: number | null = null;
-
-  for (const result of visibleResults) {
-    const depth = result.depth;
-
-    // Suppress N/A descendants: show the N/A parent, hide deeper results.
-    if (suppressBelowDepth !== null) {
-      if (depth > suppressBelowDepth) continue;
-      suppressBelowDepth = null;
-    }
-
-    if (result.status === 'skipped' && result.skipReason === 'n/a') {
-      suppressBelowDepth = depth;
-    }
-
-    const indent = '  '.repeat(depth);
+  for (const result of iterateWithNaSuppression(visibleResults)) {
+    const indent = '  '.repeat(result.depth);
     const icon = getIcon(result);
     let checkLine = `${indent}${icon} ${result.name} (${formatDuration(result.durationMs)})`;
     if (result.detail !== null) {
@@ -116,27 +127,9 @@ export function reportPreflight(report: PreflightReport, options?: ReportPreflig
     }
   }
 
-  // Summary counts from visible results, suppressing N/A descendants only.
-  let passed = 0;
-  let failed = 0;
-  let skipped = 0;
-  let countSuppressBelowDepth: number | null = null;
-  for (const r of visibleResults) {
-    const d = r.depth;
-    if (countSuppressBelowDepth !== null) {
-      if (d > countSuppressBelowDepth) continue;
-      countSuppressBelowDepth = null;
-    }
-    if (r.status === 'skipped' && r.skipReason === 'n/a') {
-      countSuppressBelowDepth = d;
-    }
-    if (r.status === 'passed') passed++;
-    else if (r.status === 'failed') failed++;
-    else skipped++;
-  }
+  const { passed, failed, skipped } = countResults(visibleResults);
   lines.push('', `${formatSummaryCounts(passed, failed, skipped)} (${formatDuration(report.durationMs)})`);
 
-  // Collected fixes section for end mode.
   if (fixLocation === 'end' && collectedFixes.length > 0) {
     lines.push('', 'Fixes:', ...collectedFixes.map((fix) => `  ${fix}`));
   }

--- a/packages/preflight/src/runPreflight.ts
+++ b/packages/preflight/src/runPreflight.ts
@@ -48,7 +48,7 @@ function buildPassedResult(
   detail: string | null,
   fix: string | null,
   progress: import('./types.ts').Progress | null,
-  depth: number = 0,
+  depth = 0,
 ): PassedResult {
   return { name, status: 'passed', ok: true, severity, detail, fix, error: null, progress, durationMs, depth };
 }
@@ -62,7 +62,7 @@ function buildFailedResult(
   fix: string | null,
   error: Error | null,
   progress: import('./types.ts').Progress | null,
-  depth: number = 0,
+  depth = 0,
 ): FailedResult {
   return { name, status: 'failed', ok: false, severity, detail, fix, error, progress, durationMs, depth };
 }
@@ -74,7 +74,7 @@ function buildSkippedResult(
   skipReason: 'n/a' | 'precondition',
   detail: string | null,
   fix: string | null,
-  depth: number = 0,
+  depth = 0,
 ): SkippedResult {
   return {
     name,
@@ -96,11 +96,7 @@ function buildSkippedResult(
  *
  * Returns the check's own result followed by all descendant results in depth-first order.
  */
-async function executeCheck(
-  check: PreflightCheck,
-  defaultSeverity: Severity,
-  depth: number = 0,
-): Promise<PreflightResult[]> {
+async function executeCheck(check: PreflightCheck, defaultSeverity: Severity, depth = 0): Promise<PreflightResult[]> {
   const severity = resolveSeverity(check, defaultSeverity);
   const fix = check.fix ?? null;
   const children = check.checks ?? [];
@@ -216,7 +212,7 @@ function skipCheck(
   check: PreflightCheck,
   defaultSeverity: Severity,
   skipReason: 'n/a' | 'precondition' = 'precondition',
-  depth: number = 0,
+  depth = 0,
 ): PreflightResult {
   const severity = resolveSeverity(check, defaultSeverity);
   return buildSkippedResult(check.name, severity, skipReason, null, check.fix ?? null, depth);

--- a/packages/preflight/src/runPreflight.ts
+++ b/packages/preflight/src/runPreflight.ts
@@ -279,8 +279,12 @@ async function runStagedChecks(
     const groupResults = await runSiblingChecks(group, defaultSeverity, 0);
     results.push(...groupResults);
 
-    // Halt subsequent groups only when a failure meets the failure threshold.
-    if (groupResults.some((r) => r.status === 'failed' && meetsThreshold(r.severity, failOn))) {
+    // Only top-level group results (depth 0) determine whether to halt subsequent groups,
+    // consistent with how precondition pass/fail uses only depth-0 results.
+    const topLevelFailed = groupResults
+      .filter((r) => (r.depth ?? 0) === 0)
+      .some((r) => r.status === 'failed' && meetsThreshold(r.severity, failOn));
+    if (topLevelFailed) {
       shouldSkipRemaining = true;
     }
   }

--- a/packages/preflight/src/runPreflight.ts
+++ b/packages/preflight/src/runPreflight.ts
@@ -235,7 +235,7 @@ async function runPreconditions(
   results.push(...flat);
 
   // Only top-level precondition results (depth 0) determine pass/fail.
-  return flat.filter((r) => (r.depth ?? 0) === 0).every((r) => r.status === 'passed');
+  return flat.filter((r) => r.depth === 0).every((r) => r.status === 'passed');
 }
 
 /** Run a flat checklist: all checks concurrently. */
@@ -282,7 +282,7 @@ async function runStagedChecks(
     // Only top-level group results (depth 0) determine whether to halt subsequent groups,
     // consistent with how precondition pass/fail uses only depth-0 results.
     const topLevelFailed = groupResults
-      .filter((r) => (r.depth ?? 0) === 0)
+      .filter((r) => r.depth === 0)
       .some((r) => r.status === 'failed' && meetsThreshold(r.severity, failOn));
     if (topLevelFailed) {
       shouldSkipRemaining = true;

--- a/packages/preflight/src/runPreflight.ts
+++ b/packages/preflight/src/runPreflight.ts
@@ -48,8 +48,9 @@ function buildPassedResult(
   detail: string | null,
   fix: string | null,
   progress: import('./types.ts').Progress | null,
+  depth: number = 0,
 ): PassedResult {
-  return { name, status: 'passed', ok: true, severity, detail, fix, error: null, progress, durationMs };
+  return { name, status: 'passed', ok: true, severity, detail, fix, error: null, progress, durationMs, depth };
 }
 
 /** Build a failed result. */
@@ -61,8 +62,9 @@ function buildFailedResult(
   fix: string | null,
   error: Error | null,
   progress: import('./types.ts').Progress | null,
+  depth: number = 0,
 ): FailedResult {
-  return { name, status: 'failed', ok: false, severity, detail, fix, error, progress, durationMs };
+  return { name, status: 'failed', ok: false, severity, detail, fix, error, progress, durationMs, depth };
 }
 
 /** Build a skipped result. */
@@ -72,6 +74,7 @@ function buildSkippedResult(
   skipReason: 'n/a' | 'precondition',
   detail: string | null,
   fix: string | null,
+  depth: number = 0,
 ): SkippedResult {
   return {
     name,
@@ -84,13 +87,23 @@ function buildSkippedResult(
     error: null,
     progress: null,
     durationMs: 0,
+    depth,
   };
 }
 
-/** Execute a single check and return its result. */
-async function executeCheck(check: PreflightCheck, defaultSeverity: Severity): Promise<PreflightResult> {
+/**
+ * Execute a single check and recursively process its dependent checks.
+ *
+ * Returns the check's own result followed by all descendant results in depth-first order.
+ */
+async function executeCheck(
+  check: PreflightCheck,
+  defaultSeverity: Severity,
+  depth: number = 0,
+): Promise<PreflightResult[]> {
   const severity = resolveSeverity(check, defaultSeverity);
   const fix = check.fix ?? null;
+  const children = check.checks ?? [];
 
   // Evaluate skip condition before running the check.
   if (check.skip !== undefined) {
@@ -98,12 +111,16 @@ async function executeCheck(check: PreflightCheck, defaultSeverity: Severity): P
     try {
       const skipResult = await check.skip();
       if (typeof skipResult === 'string') {
-        return buildSkippedResult(check.name, severity, 'n/a', skipResult, fix);
+        const result = buildSkippedResult(check.name, severity, 'n/a', skipResult, fix, depth);
+        const childResults = skipAllDescendants(children, defaultSeverity, 'n/a', depth + 1);
+        return [result, ...childResults];
       }
     } catch (error_: unknown) {
       const durationMs = performance.now() - start;
       const error = error_ instanceof Error ? error_ : new Error(String(error_));
-      return buildFailedResult(check.name, severity, durationMs, null, fix, error, null);
+      const result = buildFailedResult(check.name, severity, durationMs, null, fix, error, null, depth);
+      const childResults = skipAllDescendants(children, defaultSeverity, 'precondition', depth + 1);
+      return [result, ...childResults];
     }
   }
 
@@ -111,29 +128,98 @@ async function executeCheck(check: PreflightCheck, defaultSeverity: Severity): P
   try {
     const raw = await check.check();
     const durationMs = performance.now() - start;
+    let result: PreflightResult;
     if (typeof raw === 'boolean') {
-      if (raw) {
-        return buildPassedResult(check.name, severity, durationMs, null, fix, null);
-      }
-      return buildFailedResult(check.name, severity, durationMs, null, fix, null, null);
+      result = raw
+        ? buildPassedResult(check.name, severity, durationMs, null, fix, null, depth)
+        : buildFailedResult(check.name, severity, durationMs, null, fix, null, null, depth);
+    } else {
+      const detail = raw.detail ?? null;
+      const progress = raw.progress ?? null;
+      result = raw.ok
+        ? buildPassedResult(check.name, severity, durationMs, detail, fix, progress, depth)
+        : buildFailedResult(check.name, severity, durationMs, detail, fix, null, progress, depth);
     }
-    const detail = raw.detail ?? null;
-    const progress = raw.progress ?? null;
-    if (raw.ok) {
-      return buildPassedResult(check.name, severity, durationMs, detail, fix, progress);
-    }
-    return buildFailedResult(check.name, severity, durationMs, detail, fix, null, progress);
+
+    const childResults = await collectChildResults(result, children, defaultSeverity, depth + 1);
+    return [result, ...childResults];
   } catch (error_: unknown) {
     const durationMs = performance.now() - start;
     const error = error_ instanceof Error ? error_ : new Error(String(error_));
-    return buildFailedResult(check.name, severity, durationMs, null, fix, error, null);
+    const result = buildFailedResult(check.name, severity, durationMs, null, fix, error, null, depth);
+    const childResults = skipAllDescendants(children, defaultSeverity, 'precondition', depth + 1);
+    return [result, ...childResults];
   }
 }
 
-/** Mark a check as skipped due to a failed precondition. */
-function skipCheck(check: PreflightCheck, defaultSeverity: Severity): PreflightResult {
+/**
+ * Collect results from child checks based on the parent's outcome.
+ *
+ * Passed parents: execute children concurrently, then iterate in declaration order
+ * to produce depth-first results. Failed/skipped parents: skip all descendants.
+ */
+async function collectChildResults(
+  parentResult: PreflightResult,
+  children: PreflightCheck[],
+  defaultSeverity: Severity,
+  childDepth: number,
+): Promise<PreflightResult[]> {
+  if (children.length === 0) return [];
+
+  if (parentResult.status === 'failed') {
+    return skipAllDescendants(children, defaultSeverity, 'precondition', childDepth);
+  }
+
+  if (parentResult.status === 'skipped') {
+    const reason = parentResult.skipReason === 'n/a' ? 'n/a' : 'precondition';
+    return skipAllDescendants(children, defaultSeverity, reason, childDepth);
+  }
+
+  return runSiblingChecks(children, defaultSeverity, childDepth);
+}
+
+/**
+ * Run sibling checks concurrently, then collect results in depth-first declaration order.
+ *
+ * All siblings execute concurrently via `Promise.all`, but the returned array
+ * preserves declaration order: each sibling's own result is followed by its
+ * subtree before the next sibling appears.
+ */
+async function runSiblingChecks(
+  checks: PreflightCheck[],
+  defaultSeverity: Severity,
+  depth: number,
+): Promise<PreflightResult[]> {
+  const siblingTrees = await Promise.all(checks.map((c) => executeCheck(c, defaultSeverity, depth)));
+  return siblingTrees.flat();
+}
+
+/** Recursively skip a check and all its descendants. */
+function skipAllDescendants(
+  checks: PreflightCheck[],
+  defaultSeverity: Severity,
+  skipReason: 'n/a' | 'precondition',
+  depth: number,
+): PreflightResult[] {
+  const results: PreflightResult[] = [];
+  for (const check of checks) {
+    results.push(skipCheck(check, defaultSeverity, skipReason, depth));
+    if (check.checks !== undefined && check.checks.length > 0) {
+      results.push(...skipAllDescendants(check.checks, defaultSeverity, skipReason, depth + 1));
+    }
+  }
+  return results;
+}
+
+/** Mark a check as skipped due to a failed precondition or N/A parent. */
+function skipCheck(
+  check: PreflightCheck,
+  defaultSeverity: Severity,
+  skipReason: 'n/a' | 'precondition' = 'precondition',
+  depth: number = 0,
+): PreflightResult {
   const severity = resolveSeverity(check, defaultSeverity);
-  return buildSkippedResult(check.name, severity, 'precondition', null, check.fix ?? null);
+  return buildSkippedResult(check.name, severity, skipReason, null, check.fix ?? null, depth);
 }
 
 /** Run preconditions concurrently. Return true if all passed. */
@@ -144,10 +230,12 @@ async function runPreconditions(
 ): Promise<boolean> {
   if (preconditions.length === 0) return true;
 
-  const preconditionResults = await Promise.all(preconditions.map((c) => executeCheck(c, defaultSeverity)));
-  results.push(...preconditionResults);
+  const trees = await Promise.all(preconditions.map((c) => executeCheck(c, defaultSeverity)));
+  const flat = trees.flat();
+  results.push(...flat);
 
-  return preconditionResults.every((r) => r.status === 'passed');
+  // Only top-level precondition results (depth 0) determine pass/fail.
+  return flat.filter((r) => (r.depth ?? 0) === 0).every((r) => r.status === 'passed');
 }
 
 /** Run a flat checklist: all checks concurrently. */
@@ -158,11 +246,11 @@ async function runFlatChecks(
   defaultSeverity: Severity,
 ): Promise<void> {
   if (!preconditionsPassed) {
-    results.push(...checklist.checks.map((c) => skipCheck(c, defaultSeverity)));
+    results.push(...skipAllDescendants(checklist.checks, defaultSeverity, 'precondition', 0));
     return;
   }
 
-  const checkResults = await Promise.all(checklist.checks.map((c) => executeCheck(c, defaultSeverity)));
+  const checkResults = await runSiblingChecks(checklist.checks, defaultSeverity, 0);
   results.push(...checkResults);
 }
 
@@ -176,7 +264,7 @@ async function runStagedChecks(
 ): Promise<void> {
   if (!preconditionsPassed) {
     for (const group of checklist.groups) {
-      results.push(...group.map((c) => skipCheck(c, defaultSeverity)));
+      results.push(...skipAllDescendants(group, defaultSeverity, 'precondition', 0));
     }
     return;
   }
@@ -184,11 +272,11 @@ async function runStagedChecks(
   let shouldSkipRemaining = false;
   for (const group of checklist.groups) {
     if (shouldSkipRemaining) {
-      results.push(...group.map((c) => skipCheck(c, defaultSeverity)));
+      results.push(...skipAllDescendants(group, defaultSeverity, 'precondition', 0));
       continue;
     }
 
-    const groupResults = await Promise.all(group.map((c) => executeCheck(c, defaultSeverity)));
+    const groupResults = await runSiblingChecks(group, defaultSeverity, 0);
     results.push(...groupResults);
 
     // Halt subsequent groups only when a failure meets the failure threshold.

--- a/packages/preflight/src/types.ts
+++ b/packages/preflight/src/types.ts
@@ -114,7 +114,7 @@ interface PreflightResultBase {
   durationMs: number;
 
   /** Nesting depth (0 for top-level checks). */
-  depth?: number;
+  depth: number;
 }
 
 /** Result for a check that ran and passed. */

--- a/packages/preflight/src/types.ts
+++ b/packages/preflight/src/types.ts
@@ -81,6 +81,9 @@ export interface PreflightCheck {
 
   /** Remediation message shown when the check fails. */
   fix?: string;
+
+  /** Dependent checks that run only if this check passes. */
+  checks?: PreflightCheck[];
 }
 
 // ---------------------------------------------------------------------------
@@ -109,6 +112,9 @@ interface PreflightResultBase {
 
   /** Wall-clock time to execute the check, in milliseconds. */
   durationMs: number;
+
+  /** Nesting depth (0 for top-level checks). */
+  depth?: number;
 }
 
 /** Result for a check that ran and passed. */
@@ -289,6 +295,7 @@ export interface JsonCheckEntry {
   error: string | null;
   progress: Progress | null;
   durationMs: number;
+  checks: JsonCheckEntry[];
 }
 
 /** Shape of a single checklist entry in `--json` output. */


### PR DESCRIPTION
Closes #157

## What

Makes `PreflightCheck` recursive by adding an optional `checks` field for dependent checks. The runner executes children when a parent passes, skips descendants when a parent fails or is N/A, and produces results in depth-first order with a `depth` field. The human-readable report indents nested checks, suppresses N/A descendants (showing the N/A parent with its skip reason), and prefixes fix messages with 💊. The JSON report reconstructs the tree from flat results, nesting child entries under their parent's `checks` array. Existing collections are restructured to use nesting where natural dependencies exist, and a new demo collection exercises every preflight feature.

## Why

The flat report gave no visibility into check dependencies. Readers couldn't tell which checks depended on which, or what the blast radius of a single failure was. Per-check nesting makes dependency relationships explicit in both the check definition and the output.

## Details

### Features

- `PreflightCheck` gains `checks?: PreflightCheck[]` for declaring dependent checks
- `PreflightResultBase` gains required `depth: number` (0 for top-level)
- `JsonCheckEntry` gains `checks: JsonCheckEntry[]` for nested tree structure in JSON output
- Human-readable report indents nested checks by `depth * 2` spaces
- N/A parents render as a single line (⚪ with skip reason); descendants are suppressed
- Fix messages prefixed with 💊 in both inline and collected "Fixes:" sections
- `commandExists` helper in demo collection checks for CLI tools on PATH
- Demo collection (`demo.ts`) exercises nested hierarchy, N/A suppression, staged halt-on-failure, preconditions, mixed severities, and external tool checks — all against real repo files

### Fixes

- Staged-group halt logic filtered to depth-0 results only, consistent with precondition handling — nested child failures no longer erroneously halt subsequent groups
- N/A suppression shows the parent (which carries the skip reason) and hides only descendants

### Refactoring

- Extracted `iterateWithNaSuppression` generator and `countResults` helper from `reportPreflight` to eliminate duplicated suppression logic and reduce cyclomatic complexity
- Made `depth` required on `PreflightResultBase`, removing defensive `?? 0` fallbacks
- Restructured default, nmr, and release-kit collections to nest checks where real parent-child dependencies exist

### Tests

- Nested check execution: children of passing, failed, and N/A-skipped parents
- Depth-first result ordering across multiple nesting levels
- Staged checklist with nested checks: halt only on depth-0 failures
- Precondition failure with nested grandchildren
- N/A parent visible, descendants suppressed in report output
- Summary counts exclude suppressed N/A descendants
- JSON tree reconstruction with nested `checks` arrays
- Fix message formatting with 💊 prefix
- Collection test helpers search nested checks recursively