### PR TITLE
#175 Skip compilation of unchanged collections and improve output

### DIFF
--- a/packages/preflight/__tests__/compileCommand.test.ts
+++ b/packages/preflight/__tests__/compileCommand.test.ts
@@ -51,18 +51,36 @@ describe(compileCommand, () => {
   });
 
   // Explicit input file tests
-  it('returns 0 and writes output path on success', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js' });
+  it('returns 0 and writes "Compiling collection:" header for single file', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: true });
 
     const exitCode = await compileCommand(['input.ts']);
 
     expect(exitCode).toBe(0);
     expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', undefined);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('/abs/out.js'));
+    expect(stdoutSpy).toHaveBeenCalledWith('Compiling collection:\n');
+  });
+
+  it('shows 📦 indicator for a changed single file', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: true });
+
+    await compileCommand(['input.ts']);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('📦'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('→'));
+  });
+
+  it('shows ⚪ indicator for an unchanged single file', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: false });
+
+    await compileCommand(['input.ts']);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('⚪'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('no changes'));
   });
 
   it('passes --output value to compileConfig', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js' });
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js', changed: true });
 
     const exitCode = await compileCommand(['input.ts', '--output', 'custom.js']);
 
@@ -71,7 +89,7 @@ describe(compileCommand, () => {
   });
 
   it('passes --output=value inline form to compileConfig', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js' });
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js', changed: true });
 
     const exitCode = await compileCommand(['input.ts', '--output=custom.js']);
 
@@ -80,7 +98,7 @@ describe(compileCommand, () => {
   });
 
   it('passes -o value short form to compileConfig', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js' });
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js', changed: true });
 
     const exitCode = await compileCommand(['input.ts', '-o', 'custom.js']);
 
@@ -118,20 +136,53 @@ describe(compileCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Too many arguments'));
   });
 
-  // No-args behavior (batch compile)
-  it('compiles all .ts files from config srcDir when no arguments given', async () => {
+  // Batch compile tests
+  it('prints "Compiling collections in" header when srcDir equals outDir', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['a.ts']);
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true });
+
+    await compileCommand([]);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Compiling collections in'));
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining(' to '));
+  });
+
+  it('prints "from ... to ..." header when srcDir differs from outDir', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.preflight/collections', outDir: '.preflight/dist', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['a.ts']);
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true });
+
+    await compileCommand([]);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('from'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('to'));
+  });
+
+  it('compiles all .ts files and shows per-file status lines', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.preflight/collections', outDir: '.preflight/collections', include: undefined },
     });
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['a.ts', 'b.ts', 'readme.md']);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js' });
+    mockCompileConfig
+      .mockResolvedValueOnce({ outputPath: '/abs/a.js', changed: true })
+      .mockResolvedValueOnce({ outputPath: '/abs/b.js', changed: false });
 
     const exitCode = await compileCommand([]);
 
     expect(exitCode).toBe(0);
     expect(mockCompileConfig).toHaveBeenCalledTimes(2);
-    expect(stdoutSpy).toHaveBeenCalledTimes(2);
+    // Header + 2 status lines
+    expect(stdoutSpy).toHaveBeenCalledTimes(3);
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('📦 a.ts → a.js'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('⚪ b.ts — no changes'));
   });
 
   it('returns 1 when --output is given without an input file', async () => {
@@ -156,7 +207,7 @@ describe(compileCommand, () => {
     mockReaddirSync.mockReturnValue(['shared/deploy.ts', 'shared/infra.ts', 'other.ts']);
     const matchFn = vi.fn((name: string) => name.startsWith('shared/'));
     mockPicomatch.mockReturnValue(matchFn);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js' });
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true });
 
     const exitCode = await compileCommand([]);
 
@@ -192,7 +243,7 @@ describe(compileCommand, () => {
 
   // Post-compile validation tests
   it('returns 1 when post-compile validation fails for explicit input', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js' });
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: true });
     mockValidateCompiledOutput.mockRejectedValue(new Error('Suite name(s) collide with checklist name(s): deploy'));
 
     const exitCode = await compileCommand(['input.ts']);
@@ -207,7 +258,7 @@ describe(compileCommand, () => {
     });
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['a.ts']);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js' });
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true });
     mockValidateCompiledOutput.mockRejectedValue(new Error('suite "ci" references unknown checklist "missing"'));
 
     const exitCode = await compileCommand([]);

--- a/packages/preflight/__tests__/compileConfig.test.ts
+++ b/packages/preflight/__tests__/compileConfig.test.ts
@@ -3,37 +3,59 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockBuild = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockMkdirSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
 
 vi.mock('esbuild', () => ({
   build: mockBuild,
 }));
 
+vi.mock(import('node:fs'), () => ({
+  existsSync: mockExistsSync,
+  mkdirSync: mockMkdirSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
 import { compileConfig } from '../src/compile/compileConfig.ts';
+
+/** Build a mock esbuild result with the given output text. */
+function buildResult(text: string) {
+  return { outputFiles: [{ contents: new TextEncoder().encode(text) }] };
+}
 
 describe(compileConfig, () => {
   afterEach(() => {
     mockBuild.mockReset();
+    mockExistsSync.mockReset();
+    mockMkdirSync.mockReset();
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
   });
 
-  it('invokes esbuild with the correct options', async () => {
-    mockBuild.mockResolvedValue(undefined);
+  it('invokes esbuild with write: false and no outfile', async () => {
+    mockBuild.mockResolvedValue(buildResult('compiled'));
+    mockExistsSync.mockReturnValue(false);
 
     await compileConfig('config/preflight.config.ts');
 
     expect(mockBuild).toHaveBeenCalledWith({
       entryPoints: [path.resolve('config/preflight.config.ts')],
-      outfile: path.resolve('config/preflight.config.js'),
       bundle: true,
       format: 'esm',
       platform: 'node',
       target: 'es2022',
       external: ['node:*'],
       banner: { js: expect.stringContaining('@generated') },
+      write: false,
     });
   });
 
   it('returns the resolved output path', async () => {
-    mockBuild.mockResolvedValue(undefined);
+    mockBuild.mockResolvedValue(buildResult('compiled'));
+    mockExistsSync.mockReturnValue(false);
 
     const result = await compileConfig('config/preflight.config.ts');
 
@@ -41,12 +63,12 @@ describe(compileConfig, () => {
   });
 
   it('uses a custom output path when provided', async () => {
-    mockBuild.mockResolvedValue(undefined);
+    mockBuild.mockResolvedValue(buildResult('compiled'));
+    mockExistsSync.mockReturnValue(false);
 
     const result = await compileConfig('config/preflight.config.ts', 'dist/bundle.js');
 
     expect(result.outputPath).toBe(path.resolve('dist/bundle.js'));
-    expect(mockBuild).toHaveBeenCalledWith(expect.objectContaining({ outfile: path.resolve('dist/bundle.js') }));
   });
 
   it.each([
@@ -55,11 +77,46 @@ describe(compileConfig, () => {
     ['input.cts', 'input.js'],
     ['input.js', 'input.js.js'],
   ])('derives the default output path for %s as %s', async (input, expectedSuffix) => {
-    mockBuild.mockResolvedValue(undefined);
+    mockBuild.mockResolvedValue(buildResult('compiled'));
+    mockExistsSync.mockReturnValue(false);
 
     const result = await compileConfig(input);
 
     expect(result.outputPath).toBe(path.resolve(expectedSuffix));
+  });
+
+  it('writes the output and returns changed: true when no existing file exists', async () => {
+    mockBuild.mockResolvedValue(buildResult('compiled'));
+    mockExistsSync.mockReturnValue(false);
+
+    const result = await compileConfig('input.ts');
+
+    expect(result.changed).toBe(true);
+    expect(mockMkdirSync).toHaveBeenCalledWith(path.dirname(path.resolve('input.js')), { recursive: true });
+    expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve('input.js'), expect.any(Buffer));
+  });
+
+  it('writes the output and returns changed: true when existing file differs', async () => {
+    mockBuild.mockResolvedValue(buildResult('new content'));
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(Buffer.from('old content'));
+
+    const result = await compileConfig('input.ts');
+
+    expect(result.changed).toBe(true);
+    expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+
+  it('skips writing and returns changed: false when existing file is identical', async () => {
+    const content = 'identical content';
+    mockBuild.mockResolvedValue(buildResult(content));
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(Buffer.from(content));
+
+    const result = await compileConfig('input.ts');
+
+    expect(result.changed).toBe(false);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
 
   it('propagates errors from esbuild.build', async () => {

--- a/packages/preflight/src/compile/compileCommand.ts
+++ b/packages/preflight/src/compile/compileCommand.ts
@@ -48,7 +48,10 @@ export async function compileCommand(args: string[]): Promise<number> {
     try {
       const result = await compileConfig(inputPath, outputPath);
       await validateCompiledOutput(result.outputPath);
-      process.stdout.write(`Compiled: ${result.outputPath}\n`);
+      const relInput = path.relative(process.cwd(), path.resolve(inputPath));
+      const relOutput = path.relative(process.cwd(), result.outputPath);
+      process.stdout.write('Compiling collection:\n');
+      process.stdout.write(formatResultLine(relInput, relOutput, result.changed));
       return 0;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
@@ -107,13 +110,22 @@ async function compileBatch(): Promise<number> {
     return 1;
   }
 
+  const relSrcDir = path.relative(process.cwd(), srcDir);
+  const relOutDir = path.relative(process.cwd(), outDir);
+  const header =
+    srcDir === outDir
+      ? `Compiling collections in ${relSrcDir}:\n`
+      : `Compiling collections from ${relSrcDir} to ${relOutDir}:\n`;
+  process.stdout.write(header);
+
   for (const fileName of tsFiles) {
     const srcFile = path.join(srcDir, fileName);
     const outFile = path.join(outDir, fileName.replace(/\.ts$/, '.js'));
     try {
       const result = await compileConfig(srcFile, outFile);
       await validateCompiledOutput(result.outputPath);
-      process.stdout.write(`Compiled: ${result.outputPath}\n`);
+      const outName = fileName.replace(/\.ts$/, '.js');
+      process.stdout.write(formatResultLine(fileName, outName, result.changed));
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       process.stderr.write(`Error compiling ${fileName}: ${message}\n`);
@@ -122,4 +134,9 @@ async function compileBatch(): Promise<number> {
   }
 
   return 0;
+}
+
+/** Format a single compile-result line with a change indicator. */
+function formatResultLine(srcName: string, outName: string, changed: boolean): string {
+  return changed ? `  📦 ${srcName} → ${outName}\n` : `  ⚪ ${srcName} — no changes\n`;
 }

--- a/packages/preflight/src/compile/compileConfig.ts
+++ b/packages/preflight/src/compile/compileConfig.ts
@@ -1,12 +1,18 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 /** Result of a successful compilation. */
 export interface CompileResult {
   outputPath: string;
+  changed: boolean;
 }
 
 /** Generated-file header prepended to compiled output. */
-const GENERATED_HEADER = '/** @noformat — @generated. Do not edit. Compiled by preflight. */\n/* eslint-disable */\n';
+const GENERATED_HEADER = [
+  '/** @noformat — @generated. Do not edit. Compiled by preflight. */',
+  '/* eslint-disable */',
+  '',
+].join('\n');
 
 /** Derive the default output path by replacing the `.ts` extension with `.js`. */
 function deriveOutputPath(inputPath: string): string {
@@ -37,16 +43,30 @@ export async function compileConfig(inputPath: string, outputPath?: string): Pro
     );
   }
 
-  await esbuild.build({
+  const result = await esbuild.build({
     entryPoints: [resolvedInput],
-    outfile: resolvedOutput,
     bundle: true,
     format: 'esm',
     platform: 'node',
     target: 'es2022',
     external: ['node:*'],
     banner: { js: GENERATED_HEADER },
+    write: false,
   });
 
-  return { outputPath: resolvedOutput };
+  const outputFile = result.outputFiles[0];
+  if (outputFile === undefined) {
+    throw new Error(`esbuild produced no output for ${resolvedInput}`);
+  }
+
+  const compiled = Buffer.from(outputFile.contents);
+  const existing = existsSync(resolvedOutput) ? readFileSync(resolvedOutput) : undefined;
+  const changed = existing === undefined || !compiled.equals(existing);
+
+  if (changed) {
+    mkdirSync(path.dirname(resolvedOutput), { recursive: true });
+    writeFileSync(resolvedOutput, compiled);
+  }
+
+  return { outputPath: resolvedOutput, changed };
 }


### PR DESCRIPTION
Closes #175 

## What

Add change detection to the `preflight compile` command by compiling in memory via esbuild's `write: false` option and byte-comparing against existing output files. Replace absolute `Compiled:` messages with structured output using cwd-relative paths, contextual headers, and `📦`/`⚪` indicators that distinguish changed from unchanged collections.

## Why

The compile command produced noisy, uninformative output — absolute paths and identical "Compiled:" messages regardless of whether anything changed. This made it hard to tell at a glance which collections were affected by a code change, especially in batch mode.

## Details

### Features

- `compileConfig` now compiles to an in-memory buffer and writes only when the output differs from the existing file, preserving mtime of unchanged collections.
- `CompileResult` includes a `changed: boolean` field.
- Batch mode prints a header: "Compiling collections in {dir}:" (same dir) or "Compiling collections from {src} to {out}:" (different dirs).
- Single-file mode prints a "Compiling collection:" header.
- Per-file lines show `📦 src → out` for changed files and `⚪ src — no changes` for unchanged.
- All displayed paths are relative to cwd.

### Tests

- `compileConfig.test.ts`: new tests for changed/unchanged/new-file detection; updated existing tests for `write: false` and the new `CompileResult` shape.
- `compileCommand.test.ts`: new tests for header variants (same-dir, different-dir), change indicators, and per-file status lines; updated existing mocks for the `changed` field.

## Test plan

- Run `npx preflight compile` and verify batch output with header and per-file indicators
- Run `npx preflight compile .preflight/collections/demo.ts` and verify single-file output
- Modify an output `.js` file and recompile to confirm `📦` appears for the changed collection