### PR TITLE
#181 Create audit-deps wrapper to manage dependency audits

### DIFF
--- a/.agents/PROJECT.md
+++ b/.agents/PROJECT.md
@@ -8,6 +8,7 @@ A PNPM monorepo of CLI tools for Node.js monorepo development. Packages provide 
 
 Packages live under `packages/`:
 
+- **`@williamthorsen/audit-deps`** — Wraps audit-ci with a richer config model, typed JSON source of truth, and a sync workflow that automates allowlist management.
 - **`@williamthorsen/nmr`** — Context-aware script runner for PNPM monorepos. Detects root vs workspace context and resolves the appropriate script registry.
 - **`@williamthorsen/node-monorepo-core`** — Shared utilities consumed by `release-kit` and `preflight`.
 - **`@williamthorsen/preflight`** — Pre-deployment verification checks for environment and configuration.

--- a/.config/sync-labels.config.ts
+++ b/.config/sync-labels.config.ts
@@ -4,6 +4,7 @@ const config: SyncLabelsConfig = {
   presets: ['common'],
   labels: [
     { name: 'scope:root', color: '00ff96', description: 'Monorepo root configuration' },
+    { name: 'scope:audit', color: '00ff96', description: 'audit-deps package' },
     { name: 'scope:core', color: '00ff96', description: 'core package' },
     { name: 'scope:nmr', color: '00ff96', description: 'nmr package' },
     { name: 'scope:preflight', color: '00ff96', description: 'preflight package' },

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # PNPM Node monorepo
 
+## Packages
+
+| Package                                               | Description                                                 |
+| ----------------------------------------------------- | ----------------------------------------------------------- |
+| [`@williamthorsen/audit-deps`](packages/audit-deps)   | Wraps audit-ci with a richer config model and sync workflow |
+| [`@williamthorsen/nmr`](packages/nmr)                 | Context-aware script runner for PNPM monorepos              |
+| [`@williamthorsen/node-monorepo-core`](packages/core) | Shared utilities for monorepo tools                         |
+| [`@williamthorsen/preflight`](packages/preflight)     | Pre-deployment verification checks                          |
+| [`@williamthorsen/release-kit`](packages/release-kit) | Version-bumping and changelog generation                    |
+
 ## Getting started
 
 This project uses [pnpm](https://github.com/pnpm/pnpm) and NodeJS. The versions of each are set in `.tool-versions`.

--- a/packages/audit-deps/README.md
+++ b/packages/audit-deps/README.md
@@ -1,0 +1,88 @@
+# @williamthorsen/audit-deps
+
+Wraps [audit-ci](https://github.com/IBM/audit-ci) with a richer config model, typed JSON source of truth, and a sync workflow that automates allowlist management.
+
+## Installation
+
+```shell
+pnpm add -D @williamthorsen/audit-deps
+```
+
+## Quick start
+
+```shell
+# Scaffold a starter config
+npx audit-deps init
+
+# Run audit against all scopes
+npx audit-deps
+
+# Report vulnerabilities without failing
+npx audit-deps report
+
+# Sync allowlists with current findings
+npx audit-deps sync
+```
+
+## Configuration
+
+The source-of-truth config lives at `.config/audit-deps.config.json`:
+
+```json
+{
+  "outDir": "../tmp",
+  "dev": {
+    "moderate": true,
+    "allowlist": [
+      {
+        "id": "GHSA-1234-5678-abcd",
+        "path": "lodash",
+        "reason": "Accepted risk: no user input reaches this path",
+        "url": "https://github.com/advisories/GHSA-1234-5678-abcd"
+      }
+    ]
+  },
+  "prod": {
+    "high": true,
+    "allowlist": []
+  }
+}
+```
+
+### Fields
+
+- **`outDir`** (optional) — Directory for generated flat audit-ci config files, resolved relative to the config file's directory. Defaults to the config file's directory.
+- **`dev`** / **`prod`** — Scope-specific settings:
+  - **`critical`**, **`high`**, **`moderate`**, **`low`** — Severity thresholds (pass to audit-ci).
+  - **`allowlist`** — Typed advisory entries with `id`, `path`, `url`, and optional `reason`.
+
+## CLI reference
+
+```
+Usage: audit-deps [options]
+       audit-deps <command> [options]
+
+Commands:
+  (default)            Run audit-ci against configured scopes
+  report               Report vulnerabilities without failing
+  sync                 Synchronize allowlists with current audit findings
+  generate             Regenerate flat audit-ci config files
+  init                 Scaffold a starter config file
+
+Scope options:
+  --dev                Target dev dependencies only
+  --prod               Target production dependencies only
+
+Other options:
+  --config <path>      Path to config file (default: .config/audit-deps.config.json)
+  --json               Output results as JSON
+  --help, -h           Show this help message
+  --version, -V        Show version number
+```
+
+### Init options
+
+```
+  --dry-run, -n   Preview changes without writing files
+  --force, -f     Overwrite existing files
+```

--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -22,10 +22,14 @@ vi.mock('../src/generate.ts', () => ({
   generateAuditCiConfig: mocks.generateAuditCiConfig,
 }));
 
-vi.mock('../src/run-audit.ts', () => ({
-  runAudit: mocks.runAudit,
-  runReport: mocks.runReport,
-}));
+vi.mock('../src/run-audit.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/run-audit.ts')>();
+  return {
+    ...actual,
+    runAudit: mocks.runAudit,
+    runReport: mocks.runReport,
+  };
+});
 
 vi.mock('../src/sync.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/sync.ts')>();
@@ -158,20 +162,25 @@ describe(auditCommand, () => {
     expect(exitCode).toBe(0);
   });
 
-  it('writes stdout in JSON mode', async () => {
+  it('writes deduplicated JSON in JSON mode', async () => {
     setupLoadConfig();
     mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
     mocks.runAudit.mockReturnValue({
       exitCode: 0,
       staleEntries: [],
       stderr: '',
-      stdout: '{"advisories":{}}',
+      stdout: JSON.stringify({
+        advisories: {
+          'GHSA-1': { id: 'GHSA-1', module_name: 'pkg', url: 'https://example.com/1', findings: [{ paths: ['pkg'] }] },
+        },
+      }),
       warnings: [],
     });
 
     await auditCommand(makeOptions({ json: true, scopes: ['dev'] }));
 
-    expect(stdoutOutput).toBe('{"advisories":{}}');
+    const parsed: unknown = JSON.parse(stdoutOutput);
+    expect(parsed).toEqual([{ id: 'GHSA-1', path: 'pkg', url: 'https://example.com/1' }]);
   });
 
   it('writes stderr when stdout is empty and stderr has content', async () => {
@@ -188,6 +197,63 @@ describe(auditCommand, () => {
     await auditCommand(makeOptions({ scopes: ['dev'] }));
 
     expect(stderrOutput).toContain('audit-ci error output');
+  });
+
+  it('deduplicates advisory IDs across scopes in JSON mode', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig
+      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
+      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
+
+    const sharedAdvisory = {
+      id: 'GHSA-shared',
+      module_name: 'shared-pkg',
+      url: 'https://example.com/shared',
+      findings: [{ paths: ['shared-pkg'] }],
+    };
+    const devOnlyAdvisory = {
+      id: 'GHSA-dev-only',
+      module_name: 'dev-pkg',
+      url: 'https://example.com/dev',
+      findings: [{ paths: ['dev-pkg'] }],
+    };
+    const prodOnlyAdvisory = {
+      id: 'GHSA-prod-only',
+      module_name: 'prod-pkg',
+      url: 'https://example.com/prod',
+      findings: [{ paths: ['prod-pkg'] }],
+    };
+
+    mocks.runAudit
+      .mockReturnValueOnce({
+        exitCode: 1,
+        staleEntries: [],
+        stderr: '',
+        stdout: JSON.stringify({
+          advisories: { 'GHSA-shared': sharedAdvisory, 'GHSA-dev-only': devOnlyAdvisory },
+        }),
+        warnings: [],
+      })
+      .mockReturnValueOnce({
+        exitCode: 1,
+        staleEntries: [],
+        stderr: '',
+        stdout: JSON.stringify({
+          advisories: { 'GHSA-shared': sharedAdvisory, 'GHSA-prod-only': prodOnlyAdvisory },
+        }),
+        warnings: [],
+      });
+
+    await auditCommand(makeOptions({ json: true }));
+
+    const parsed = JSON.parse(stdoutOutput) as Array<{ id: string }>;
+    const ids = parsed.map((r) => r.id);
+    expect(ids).toHaveLength(3);
+    expect(ids).toContain('GHSA-shared');
+    expect(ids).toContain('GHSA-dev-only');
+    expect(ids).toContain('GHSA-prod-only');
+    // Verify no duplicates
+    expect(new Set(ids).size).toBe(ids.length);
   });
 
   it('audits both scopes when no scopes are specified', async () => {
@@ -365,6 +431,26 @@ describe(syncCommand, () => {
 
     await expect(syncCommand(makeOptions({ scopes: ['dev'] }))).rejects.toThrow(
       "Failed to generate config for scope 'dev': EACCES: permission denied",
+    );
+  });
+
+  it('throws when post-sync generateAuditCiConfig fails', async () => {
+    const config = makeConfig();
+    setupLoadConfig(config);
+
+    // First call (stripped config) succeeds
+    mocks.generateAuditCiConfig.mockResolvedValueOnce('/fake/out/audit-ci.dev.json');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+    mocks.syncAllowlist.mockResolvedValue({
+      syncResult: { added: [], kept: [], removed: [], scope: 'dev' },
+      updatedConfig: config,
+    });
+
+    // Second call (post-sync regeneration) fails
+    mocks.generateAuditCiConfig.mockRejectedValueOnce(new Error('Disk full'));
+
+    await expect(syncCommand(makeOptions({ scopes: ['dev'] }))).rejects.toThrow(
+      "Failed to generate config for scope 'dev'",
     );
   });
 });

--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -246,14 +246,15 @@ describe(auditCommand, () => {
 
     await auditCommand(makeOptions({ json: true }));
 
-    const parsed = JSON.parse(stdoutOutput) as Array<{ id: string }>;
-    const ids = parsed.map((r) => r.id);
-    expect(ids).toHaveLength(3);
-    expect(ids).toContain('GHSA-shared');
-    expect(ids).toContain('GHSA-dev-only');
-    expect(ids).toContain('GHSA-prod-only');
-    // Verify no duplicates
-    expect(new Set(ids).size).toBe(ids.length);
+    const parsed: unknown = JSON.parse(stdoutOutput);
+    expect(parsed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'GHSA-shared' }),
+        expect.objectContaining({ id: 'GHSA-dev-only' }),
+        expect.objectContaining({ id: 'GHSA-prod-only' }),
+      ]),
+    );
+    expect(parsed).toHaveLength(3);
   });
 
   it('audits both scopes when no scopes are specified', async () => {

--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -1,0 +1,407 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AuditDepsConfig, CommandOptions } from '../src/types.ts';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  generateAuditCiConfig: vi.fn<() => Promise<string>>(),
+  loadConfig: vi.fn<() => Promise<{ config: AuditDepsConfig; configDir: string; configFilePath: string }>>(),
+  runAudit: vi.fn(),
+  runReport: vi.fn(),
+  syncAllowlist: vi.fn(),
+}));
+
+vi.mock('../src/config.ts', () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock('../src/generate.ts', () => ({
+  generateAuditCiConfig: mocks.generateAuditCiConfig,
+}));
+
+vi.mock('../src/run-audit.ts', () => ({
+  runAudit: mocks.runAudit,
+  runReport: mocks.runReport,
+}));
+
+vi.mock('../src/sync.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/sync.ts')>();
+  return {
+    ...actual,
+    syncAllowlist: mocks.syncAllowlist,
+  };
+});
+
+import { auditCommand, generateCommand, reportCommand, syncCommand } from '../src/cli.ts';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides?: Partial<AuditDepsConfig>): AuditDepsConfig {
+  return {
+    dev: { allowlist: [] },
+    prod: { allowlist: [] },
+    ...overrides,
+  };
+}
+
+function makeOptions(overrides?: Partial<CommandOptions>): CommandOptions {
+  return { json: false, scopes: [], ...overrides };
+}
+
+function setupLoadConfig(config?: AuditDepsConfig): void {
+  mocks.loadConfig.mockResolvedValue({
+    config: config ?? makeConfig(),
+    configDir: '/fake/dir',
+    configFilePath: '/fake/dir/audit-deps.config.json',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Stderr / stdout capture helpers
+// ---------------------------------------------------------------------------
+
+let stderrOutput: string;
+let stdoutOutput: string;
+
+beforeEach(() => {
+  stderrOutput = '';
+  stdoutOutput = '';
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    stderrOutput += String(chunk);
+    return true;
+  });
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    stdoutOutput += String(chunk);
+    return true;
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// auditCommand
+// ---------------------------------------------------------------------------
+
+describe(auditCommand, () => {
+  it('returns 1 when config loading fails', async () => {
+    mocks.loadConfig.mockRejectedValue(new Error('Config not found'));
+
+    const exitCode = await auditCommand(makeOptions());
+
+    expect(exitCode).toBe(1);
+    expect(stderrOutput).toContain('Config not found');
+  });
+
+  it('forwards stale entry warnings to stderr', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runAudit.mockReturnValue({
+      exitCode: 0,
+      staleEntries: ['GHSA-1234', 'GHSA-5678'],
+      stderr: '',
+      stdout: '',
+      warnings: [],
+    });
+
+    await auditCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(stderrOutput).toContain('stale allowlist entries in dev: GHSA-1234, GHSA-5678');
+  });
+
+  it('forwards audit-ci warnings to stderr', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runAudit.mockReturnValue({
+      exitCode: 0,
+      staleEntries: [],
+      stderr: '',
+      stdout: '',
+      warnings: ['Some parse warning'],
+    });
+
+    await auditCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(stderrOutput).toContain('warning: Some parse warning');
+  });
+
+  it('returns non-zero exit code when any scope fails', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig
+      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
+      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
+    mocks.runAudit
+      .mockReturnValueOnce({ exitCode: 0, staleEntries: [], stderr: '', stdout: '', warnings: [] })
+      .mockReturnValueOnce({ exitCode: 1, staleEntries: [], stderr: '', stdout: '', warnings: [] });
+
+    const exitCode = await auditCommand(makeOptions());
+
+    expect(exitCode).toBe(1);
+  });
+
+  it('returns 0 when all scopes pass', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig
+      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
+      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
+    mocks.runAudit.mockReturnValue({ exitCode: 0, staleEntries: [], stderr: '', stdout: '', warnings: [] });
+
+    const exitCode = await auditCommand(makeOptions());
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('writes stdout in JSON mode', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runAudit.mockReturnValue({
+      exitCode: 0,
+      staleEntries: [],
+      stderr: '',
+      stdout: '{"advisories":{}}',
+      warnings: [],
+    });
+
+    await auditCommand(makeOptions({ json: true, scopes: ['dev'] }));
+
+    expect(stdoutOutput).toBe('{"advisories":{}}');
+  });
+
+  it('writes stderr when stdout is empty and stderr has content', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runAudit.mockReturnValue({
+      exitCode: 1,
+      staleEntries: [],
+      stderr: 'audit-ci error output',
+      stdout: '',
+      warnings: [],
+    });
+
+    await auditCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(stderrOutput).toContain('audit-ci error output');
+  });
+
+  it('audits both scopes when no scopes are specified', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig
+      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
+      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
+    mocks.runAudit.mockReturnValue({ exitCode: 0, staleEntries: [], stderr: '', stdout: '', warnings: [] });
+
+    await auditCommand(makeOptions());
+
+    expect(mocks.runAudit).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reportCommand
+// ---------------------------------------------------------------------------
+
+describe(reportCommand, () => {
+  it('returns 1 when config loading fails', async () => {
+    mocks.loadConfig.mockRejectedValue(new Error('Config not found'));
+
+    const exitCode = await reportCommand(makeOptions());
+
+    expect(exitCode).toBe(1);
+  });
+
+  it('deduplicates results across scopes', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig
+      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
+      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
+
+    const sharedResult = { id: 'GHSA-dup', path: 'lodash', url: 'https://example.com/GHSA-dup' };
+    mocks.runReport
+      .mockReturnValueOnce({ results: [sharedResult], stdout: '', stderr: '', warnings: [] })
+      .mockReturnValueOnce({ results: [sharedResult], stdout: '', stderr: '', warnings: [] });
+
+    await reportCommand(makeOptions());
+
+    // Only one line for the deduplicated result
+    const lines = stdoutOutput.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('GHSA-dup');
+  });
+
+  it('returns 0 even when vulnerabilities exist', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runReport.mockReturnValue({
+      results: [{ id: 'GHSA-1', path: 'pkg', url: 'https://example.com' }],
+      stdout: '',
+      stderr: '',
+      warnings: [],
+    });
+
+    const exitCode = await reportCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('prints "No vulnerabilities found." when results are empty', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+
+    await reportCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(stdoutOutput).toContain('No vulnerabilities found.');
+  });
+
+  it('outputs JSON when json option is true', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runReport.mockReturnValue({
+      results: [{ id: 'GHSA-1', path: 'pkg', url: 'https://example.com' }],
+      stdout: '',
+      stderr: '',
+      warnings: [],
+    });
+
+    await reportCommand(makeOptions({ json: true, scopes: ['dev'] }));
+
+    const parsed: unknown = JSON.parse(stdoutOutput);
+    expect(parsed).toEqual([{ id: 'GHSA-1', path: 'pkg', url: 'https://example.com' }]);
+  });
+
+  it('forwards report warnings to stderr', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runReport.mockReturnValue({
+      results: [],
+      stdout: '',
+      stderr: '',
+      warnings: ['Parse warning'],
+    });
+
+    await reportCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(stderrOutput).toContain('warning: Parse warning');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncCommand
+// ---------------------------------------------------------------------------
+
+describe(syncCommand, () => {
+  it('returns 1 when config loading fails', async () => {
+    mocks.loadConfig.mockRejectedValue(new Error('Config not found'));
+
+    const exitCode = await syncCommand(makeOptions());
+
+    expect(exitCode).toBe(1);
+  });
+
+  it('uses a stripped (empty) allowlist config when invoking runReport', async () => {
+    const config = makeConfig({
+      dev: { allowlist: [{ id: 'GHSA-existing', path: 'pkg', url: 'https://example.com' }] },
+    });
+    setupLoadConfig(config);
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+    mocks.syncAllowlist.mockResolvedValue({
+      syncResult: { added: [], kept: [], removed: [], scope: 'dev' },
+      updatedConfig: config,
+    });
+
+    await syncCommand(makeOptions({ scopes: ['dev'] }));
+
+    // The first generateAuditCiConfig call should receive a stripped scope with empty allowlist
+    expect(mocks.generateAuditCiConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ allowlist: [] }),
+      'dev',
+      '/fake/dir',
+      undefined,
+    );
+  });
+
+  it('prints text summary in non-JSON mode', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+    mocks.syncAllowlist.mockResolvedValue({
+      syncResult: { added: ['a'], kept: [], removed: ['b', 'c'], scope: 'dev' },
+      updatedConfig: makeConfig(),
+    });
+
+    await syncCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(stdoutOutput).toContain('--- dev ---');
+    expect(stdoutOutput).toContain('added: 1');
+    expect(stdoutOutput).toContain('removed: 2');
+  });
+
+  it('prints JSON in json mode', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+    mocks.syncAllowlist.mockResolvedValue({
+      syncResult: { added: [], kept: [], removed: [], scope: 'dev' },
+      updatedConfig: makeConfig(),
+    });
+
+    await syncCommand(makeOptions({ json: true, scopes: ['dev'] }));
+
+    const parsed: unknown = JSON.parse(stdoutOutput);
+    expect(parsed).toEqual(expect.objectContaining({ added: [], kept: [], removed: [] }));
+  });
+
+  it('wraps generateAuditCiConfig errors with scope context', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockRejectedValue(new Error('EACCES: permission denied'));
+
+    await expect(syncCommand(makeOptions({ scopes: ['dev'] }))).rejects.toThrow(
+      "Failed to generate config for scope 'dev': EACCES: permission denied",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateCommand
+// ---------------------------------------------------------------------------
+
+describe(generateCommand, () => {
+  it('returns 1 when config loading fails', async () => {
+    mocks.loadConfig.mockRejectedValue(new Error('Config not found'));
+
+    const exitCode = await generateCommand(makeOptions());
+
+    expect(exitCode).toBe(1);
+  });
+
+  it('prints generated paths', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig
+      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
+      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
+
+    await generateCommand(makeOptions());
+
+    expect(stdoutOutput).toContain('Generated: /fake/out/audit-ci.dev.json');
+    expect(stdoutOutput).toContain('Generated: /fake/out/audit-ci.prod.json');
+  });
+
+  it('generates only the requested scope', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
+
+    await generateCommand(makeOptions({ scopes: ['prod'] }));
+
+    expect(mocks.generateAuditCiConfig).toHaveBeenCalledTimes(1);
+    expect(stdoutOutput).toContain('Generated: /fake/out/audit-ci.prod.json');
+    expect(stdoutOutput).not.toContain('audit-ci.dev.json');
+  });
+});

--- a/packages/audit-deps/__tests__/config.test.ts
+++ b/packages/audit-deps/__tests__/config.test.ts
@@ -1,0 +1,86 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../src/config.ts';
+
+describe(loadConfig, () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = path.join(tmpdir(), `audit-deps-config-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('loads and validates a well-formed config', async () => {
+    const configDir = path.join(tempDir, '.config');
+    await mkdir(configDir, { recursive: true });
+
+    const config = {
+      outDir: '../tmp',
+      dev: { moderate: true, allowlist: [] },
+      prod: { high: true, allowlist: [{ id: 'GHSA-1234', path: 'lodash', url: 'https://example.com' }] },
+    };
+    await writeFile(path.join(configDir, 'audit-deps.config.json'), JSON.stringify(config), 'utf8');
+
+    const result = await loadConfig(undefined, tempDir);
+    expect(result.config.outDir).toBe('../tmp');
+    expect(result.config.dev.moderate).toBe(true);
+    expect(result.config.prod.allowlist).toHaveLength(1);
+    expect(result.configDir).toBe(configDir);
+  });
+
+  it('throws when the config file does not exist', async () => {
+    await expect(loadConfig(undefined, tempDir)).rejects.toThrow(/Config file not found/);
+  });
+
+  it('throws when the config file is not valid JSON', async () => {
+    const configDir = path.join(tempDir, '.config');
+    await mkdir(configDir, { recursive: true });
+    await writeFile(path.join(configDir, 'audit-deps.config.json'), 'not json', 'utf8');
+
+    await expect(loadConfig(undefined, tempDir)).rejects.toThrow(/not valid JSON/);
+  });
+
+  it('throws when the config fails schema validation', async () => {
+    const configDir = path.join(tempDir, '.config');
+    await mkdir(configDir, { recursive: true });
+    await writeFile(path.join(configDir, 'audit-deps.config.json'), JSON.stringify({ bad: true }), 'utf8');
+
+    await expect(loadConfig(undefined, tempDir)).rejects.toThrow(/Invalid config/);
+  });
+
+  it('accepts a custom config path', async () => {
+    const config = {
+      dev: { allowlist: [] },
+      prod: { allowlist: [] },
+    };
+    const customPath = path.join(tempDir, 'custom.json');
+    await writeFile(customPath, JSON.stringify(config), 'utf8');
+
+    const result = await loadConfig(customPath, tempDir);
+    expect(result.config.dev.allowlist).toEqual([]);
+    expect(result.configFilePath).toBe(customPath);
+  });
+
+  it('loads a config with empty allowlists', async () => {
+    const configDir = path.join(tempDir, '.config');
+    await mkdir(configDir, { recursive: true });
+
+    const config = {
+      dev: { allowlist: [] },
+      prod: { allowlist: [] },
+    };
+    await writeFile(path.join(configDir, 'audit-deps.config.json'), JSON.stringify(config), 'utf8');
+
+    const result = await loadConfig(undefined, tempDir);
+    expect(result.config.dev.allowlist).toEqual([]);
+    expect(result.config.prod.allowlist).toEqual([]);
+  });
+});

--- a/packages/audit-deps/__tests__/config.test.ts
+++ b/packages/audit-deps/__tests__/config.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
-import path from 'node:path';
 import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 

--- a/packages/audit-deps/__tests__/generate.test.ts
+++ b/packages/audit-deps/__tests__/generate.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, rm } from 'node:fs/promises';
-import path from 'node:path';
 import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -57,9 +57,9 @@ describe(generateAuditCiConfig, () => {
     const outputPath = await generateAuditCiConfig(scopeConfig, 'dev', tempDir);
 
     expect(outputPath).toBe(path.join(tempDir, 'audit-ci.dev.json'));
-    const content = JSON.parse(await readFile(outputPath, 'utf8'));
-    expect(content.allowlist).toEqual([]);
-    expect(content.moderate).toBe(true);
+    const content: unknown = JSON.parse(await readFile(outputPath, 'utf8'));
+    expect(content).toHaveProperty('allowlist', []);
+    expect(content).toHaveProperty('moderate', true);
   });
 
   it('resolves outDir relative to config directory', async () => {
@@ -69,8 +69,8 @@ describe(generateAuditCiConfig, () => {
     const expected = path.resolve(tempDir, '../tmp', 'audit-ci.prod.json');
     expect(outputPath).toBe(expected);
 
-    const content = JSON.parse(await readFile(outputPath, 'utf8'));
-    expect(content.high).toBe(true);
+    const content: unknown = JSON.parse(await readFile(outputPath, 'utf8'));
+    expect(content).toHaveProperty('high', true);
   });
 
   it('round-trips: load config values appear in generated JSON', async () => {
@@ -79,10 +79,10 @@ describe(generateAuditCiConfig, () => {
       critical: true,
     };
     const outputPath = await generateAuditCiConfig(scopeConfig, 'dev', tempDir);
-    const content = JSON.parse(await readFile(outputPath, 'utf8'));
+    const content: unknown = JSON.parse(await readFile(outputPath, 'utf8'));
 
-    expect(content.allowlist).toEqual(['GHSA-abcd']);
-    expect(content.critical).toBe(true);
-    expect(content['show-not-found']).toBe(true);
+    expect(content).toHaveProperty('allowlist', ['GHSA-abcd']);
+    expect(content).toHaveProperty('critical', true);
+    expect(content).toHaveProperty('show-not-found', true);
   });
 });

--- a/packages/audit-deps/__tests__/generate.test.ts
+++ b/packages/audit-deps/__tests__/generate.test.ts
@@ -1,0 +1,88 @@
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildFlatConfig, generateAuditCiConfig } from '../src/generate.ts';
+import type { ScopeConfig } from '../src/types.ts';
+
+describe(buildFlatConfig, () => {
+  it('flattens allowlist entries to an array of IDs', () => {
+    const scopeConfig: ScopeConfig = {
+      allowlist: [
+        { id: 'GHSA-1234', path: 'lodash', url: 'https://example.com/1' },
+        { id: 'GHSA-5678', path: 'express', url: 'https://example.com/2' },
+      ],
+      moderate: true,
+    };
+
+    const flat = buildFlatConfig(scopeConfig);
+    expect(flat.allowlist).toEqual(['GHSA-1234', 'GHSA-5678']);
+    expect(flat.moderate).toBe(true);
+    expect(flat['show-not-found']).toBe(true);
+  });
+
+  it('produces an empty allowlist when the source has no entries', () => {
+    const scopeConfig: ScopeConfig = { allowlist: [], high: true };
+    const flat = buildFlatConfig(scopeConfig);
+    expect(flat.allowlist).toEqual([]);
+    expect(flat.high).toBe(true);
+  });
+
+  it('omits severity fields that are not set', () => {
+    const scopeConfig: ScopeConfig = { allowlist: [] };
+    const flat = buildFlatConfig(scopeConfig);
+    expect(flat).not.toHaveProperty('moderate');
+    expect(flat).not.toHaveProperty('high');
+    expect(flat).not.toHaveProperty('critical');
+    expect(flat).not.toHaveProperty('low');
+  });
+});
+
+describe(generateAuditCiConfig, () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = path.join(tmpdir(), `audit-deps-generate-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes the flat config file to the config directory by default', async () => {
+    const scopeConfig: ScopeConfig = { allowlist: [], moderate: true };
+    const outputPath = await generateAuditCiConfig(scopeConfig, 'dev', tempDir);
+
+    expect(outputPath).toBe(path.join(tempDir, 'audit-ci.dev.json'));
+    const content = JSON.parse(await readFile(outputPath, 'utf8'));
+    expect(content.allowlist).toEqual([]);
+    expect(content.moderate).toBe(true);
+  });
+
+  it('resolves outDir relative to config directory', async () => {
+    const scopeConfig: ScopeConfig = { allowlist: [], high: true };
+    const outputPath = await generateAuditCiConfig(scopeConfig, 'prod', tempDir, '../tmp');
+
+    const expected = path.resolve(tempDir, '../tmp', 'audit-ci.prod.json');
+    expect(outputPath).toBe(expected);
+
+    const content = JSON.parse(await readFile(outputPath, 'utf8'));
+    expect(content.high).toBe(true);
+  });
+
+  it('round-trips: load config values appear in generated JSON', async () => {
+    const scopeConfig: ScopeConfig = {
+      allowlist: [{ id: 'GHSA-abcd', path: 'pkg', url: 'https://example.com' }],
+      critical: true,
+    };
+    const outputPath = await generateAuditCiConfig(scopeConfig, 'dev', tempDir);
+    const content = JSON.parse(await readFile(outputPath, 'utf8'));
+
+    expect(content.allowlist).toEqual(['GHSA-abcd']);
+    expect(content.critical).toBe(true);
+    expect(content['show-not-found']).toBe(true);
+  });
+});

--- a/packages/audit-deps/__tests__/init.test.ts
+++ b/packages/audit-deps/__tests__/init.test.ts
@@ -1,11 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import path from 'node:path';
 import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { scaffoldConfig } from '../src/init/scaffold.ts';
 import { initCommand } from '../src/init/initCommand.ts';
+import { scaffoldConfig } from '../src/init/scaffold.ts';
 
 describe(scaffoldConfig, () => {
   let originalCwd: string;
@@ -30,11 +30,9 @@ describe(scaffoldConfig, () => {
     const configPath = path.join(tempDir, '.config', 'audit-deps.config.json');
     expect(existsSync(configPath)).toBe(true);
 
-    const content = JSON.parse(readFileSync(configPath, 'utf8'));
-    expect(content).toHaveProperty('dev');
-    expect(content).toHaveProperty('prod');
-    expect(content.dev).toHaveProperty('allowlist');
-    expect(content.prod).toHaveProperty('allowlist');
+    const content: unknown = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(content).toHaveProperty('dev.allowlist');
+    expect(content).toHaveProperty('prod.allowlist');
   });
 
   it('skips without error when config already exists and force is false', () => {

--- a/packages/audit-deps/__tests__/init.test.ts
+++ b/packages/audit-deps/__tests__/init.test.ts
@@ -1,0 +1,115 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { scaffoldConfig } from '../src/init/scaffold.ts';
+import { initCommand } from '../src/init/initCommand.ts';
+
+describe(scaffoldConfig, () => {
+  let originalCwd: string;
+  let tempDir: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = path.join(tmpdir(), `audit-deps-init-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('creates config file with expected template content', () => {
+    const result = scaffoldConfig({ dryRun: false, force: false });
+
+    expect(result.configResult.outcome).toBe('created');
+    const configPath = path.join(tempDir, '.config', 'audit-deps.config.json');
+    expect(existsSync(configPath)).toBe(true);
+
+    const content = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(content).toHaveProperty('dev');
+    expect(content).toHaveProperty('prod');
+    expect(content.dev).toHaveProperty('allowlist');
+    expect(content.prod).toHaveProperty('allowlist');
+  });
+
+  it('skips without error when config already exists and force is false', () => {
+    const configPath = path.join(tempDir, '.config', 'audit-deps.config.json');
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(configPath, '{"existing": true}', 'utf8');
+
+    const result = scaffoldConfig({ dryRun: false, force: false });
+    expect(result.configResult.outcome).toBe('skipped');
+
+    // Existing file should be unchanged
+    const content = readFileSync(configPath, 'utf8');
+    expect(JSON.parse(content)).toEqual({ existing: true });
+  });
+
+  it('overwrites existing file when force is true', () => {
+    const configPath = path.join(tempDir, '.config', 'audit-deps.config.json');
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(configPath, '{"existing": true}', 'utf8');
+
+    const result = scaffoldConfig({ dryRun: false, force: true });
+    expect(result.configResult.outcome).toBe('overwritten');
+
+    const content = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(content).toHaveProperty('dev');
+    expect(content).toHaveProperty('prod');
+  });
+
+  it('returns created outcome without writing in dry-run mode', () => {
+    const result = scaffoldConfig({ dryRun: true, force: false });
+
+    expect(result.configResult.outcome).toBe('created');
+    const configPath = path.join(tempDir, '.config', 'audit-deps.config.json');
+    expect(existsSync(configPath)).toBe(false);
+  });
+});
+
+describe(initCommand, () => {
+  let originalCwd: string;
+  let tempDir: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = path.join(tmpdir(), `audit-deps-initcmd-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    process.chdir(tempDir);
+    // Suppress console output during tests
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('returns 0 on successful scaffold', () => {
+    const exitCode = initCommand({ dryRun: false, force: false });
+    expect(exitCode).toBe(0);
+  });
+
+  it('returns 0 in dry-run mode and does not write files', () => {
+    const exitCode = initCommand({ dryRun: true, force: false });
+    expect(exitCode).toBe(0);
+
+    const configPath = path.join(tempDir, '.config', 'audit-deps.config.json');
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  it('returns 0 when config already exists (skip, not error)', () => {
+    const configPath = path.join(tempDir, '.config', 'audit-deps.config.json');
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(configPath, '{"existing": true}', 'utf8');
+
+    const exitCode = initCommand({ dryRun: false, force: false });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/packages/audit-deps/__tests__/integration.test.ts
+++ b/packages/audit-deps/__tests__/integration.test.ts
@@ -1,0 +1,118 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../src/config.ts';
+import { generateAuditCiConfig } from '../src/generate.ts';
+import { computeSyncDiff, buildUpdatedConfig, serializeConfig } from '../src/sync.ts';
+import type { AuditDepsConfig, AuditResult } from '../src/types.ts';
+
+describe('integration: generate -> sync cycle', () => {
+  let tempDir: string;
+  let configDir: string;
+  let outDir: string;
+
+  beforeEach(async () => {
+    tempDir = path.join(tmpdir(), `audit-deps-integration-${Date.now()}`);
+    configDir = path.join(tempDir, '.config');
+    outDir = path.join(tempDir, 'tmp');
+    await mkdir(configDir, { recursive: true });
+    await mkdir(outDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('generates flat configs, then syncs allowlist based on audit results', async () => {
+    // Step 1: Write initial config
+    const initialConfig: AuditDepsConfig = {
+      outDir: '../tmp',
+      dev: { moderate: true, allowlist: [] },
+      prod: {
+        high: true,
+        allowlist: [{ id: 'GHSA-stale', path: 'old-pkg', reason: 'will be removed', url: 'https://example.com/stale' }],
+      },
+    };
+    const configFilePath = path.join(configDir, 'audit-deps.config.json');
+    await writeFile(configFilePath, JSON.stringify(initialConfig, null, 2), 'utf8');
+
+    // Step 2: Load and validate config
+    const loaded = await loadConfig(configFilePath, tempDir);
+    expect(loaded.config.prod.allowlist).toHaveLength(1);
+
+    // Step 3: Generate flat audit-ci configs
+    const devPath = await generateAuditCiConfig(loaded.config.dev, 'dev', configDir, loaded.config.outDir);
+    const prodPath = await generateAuditCiConfig(loaded.config.prod, 'prod', configDir, loaded.config.outDir);
+
+    expect(devPath).toBe(path.join(outDir, 'audit-ci.dev.json'));
+    expect(prodPath).toBe(path.join(outDir, 'audit-ci.prod.json'));
+
+    // Verify generated content
+    const devContent = JSON.parse(await readFile(devPath, 'utf8'));
+    expect(devContent.moderate).toBe(true);
+    expect(devContent.allowlist).toEqual([]);
+
+    const prodContent = JSON.parse(await readFile(prodPath, 'utf8'));
+    expect(prodContent.high).toBe(true);
+    expect(prodContent.allowlist).toEqual(['GHSA-stale']);
+
+    // Step 4: Simulate audit results (mocking audit-ci output)
+    const prodAuditResults: AuditResult[] = [{ id: 'GHSA-new1', path: 'new-pkg', url: 'https://example.com/new1' }];
+
+    // Step 5: Sync the prod allowlist
+    const fixedDate = new Date('2025-06-15T00:00:00Z');
+    const { added, kept, removed } = computeSyncDiff(loaded.config.prod.allowlist, prodAuditResults, fixedDate);
+
+    expect(added).toHaveLength(1);
+    expect(added[0]?.id).toBe('GHSA-new1');
+    expect(removed).toHaveLength(1);
+    expect(removed[0]?.id).toBe('GHSA-stale');
+    expect(kept).toHaveLength(0);
+
+    // Step 6: Build and write updated config
+    const updatedConfig = buildUpdatedConfig(loaded.config, 'prod', [...kept, ...added]);
+    await writeFile(configFilePath, serializeConfig(updatedConfig), 'utf8');
+
+    // Step 7: Verify persisted config
+    const reloaded = await loadConfig(configFilePath, tempDir);
+    expect(reloaded.config.prod.allowlist).toHaveLength(1);
+    expect(reloaded.config.prod.allowlist[0]?.id).toBe('GHSA-new1');
+    expect(reloaded.config.prod.allowlist[0]?.reason).toBe('Added by audit-deps sync on 2025-06-15');
+
+    // Step 8: Regenerate and verify updated flat config
+    const updatedProdPath = await generateAuditCiConfig(
+      reloaded.config.prod,
+      'prod',
+      path.dirname(configFilePath),
+      reloaded.config.outDir,
+    );
+    const updatedProdContent = JSON.parse(await readFile(updatedProdPath, 'utf8'));
+    expect(updatedProdContent.allowlist).toEqual(['GHSA-new1']);
+  });
+
+  it('works with a custom config path', async () => {
+    const customConfigPath = path.join(tempDir, 'custom', 'my-config.json');
+    const customConfigDir = path.dirname(customConfigPath);
+    await mkdir(customConfigDir, { recursive: true });
+
+    const config: AuditDepsConfig = {
+      outDir: './out',
+      dev: { allowlist: [] },
+      prod: { allowlist: [] },
+    };
+    await writeFile(customConfigPath, JSON.stringify(config), 'utf8');
+
+    const loaded = await loadConfig(customConfigPath, tempDir);
+    expect(loaded.configFilePath).toBe(customConfigPath);
+    expect(loaded.configDir).toBe(customConfigDir);
+
+    const devPath = await generateAuditCiConfig(loaded.config.dev, 'dev', customConfigDir, loaded.config.outDir);
+    expect(devPath).toBe(path.join(customConfigDir, 'out', 'audit-ci.dev.json'));
+
+    const content = JSON.parse(await readFile(devPath, 'utf8'));
+    expect(content.allowlist).toEqual([]);
+  });
+});

--- a/packages/audit-deps/__tests__/integration.test.ts
+++ b/packages/audit-deps/__tests__/integration.test.ts
@@ -1,9 +1,11 @@
+import { existsSync } from 'node:fs';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { routeCommand } from '../src/bin/route.ts';
 import { loadConfig } from '../src/config.ts';
 import { generateAuditCiConfig } from '../src/generate.ts';
 import { computeSyncDiff, buildUpdatedConfig, serializeConfig } from '../src/sync.ts';
@@ -114,5 +116,35 @@ describe('integration: generate -> sync cycle', () => {
 
     const content = JSON.parse(await readFile(devPath, 'utf8'));
     expect(content.allowlist).toEqual([]);
+  });
+});
+
+describe('integration: --config flag via routeCommand', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = path.join(tmpdir(), `audit-deps-config-flag-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('generates config files at the expected outDir when --config is passed', async () => {
+    const customConfigPath = path.join(tempDir, 'my-audit-deps.json');
+    const config: AuditDepsConfig = {
+      outDir: './generated',
+      dev: { allowlist: [] },
+      prod: { allowlist: [] },
+    };
+    await writeFile(customConfigPath, JSON.stringify(config, null, 2), 'utf8');
+
+    await routeCommand(['generate', '--config', customConfigPath]);
+
+    const expectedDevPath = path.join(tempDir, 'generated', 'audit-ci.dev.json');
+    const expectedProdPath = path.join(tempDir, 'generated', 'audit-ci.prod.json');
+    expect(existsSync(expectedDevPath)).toBe(true);
+    expect(existsSync(expectedProdPath)).toBe(true);
   });
 });

--- a/packages/audit-deps/__tests__/integration.test.ts
+++ b/packages/audit-deps/__tests__/integration.test.ts
@@ -1,14 +1,14 @@
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import path from 'node:path';
 import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { routeCommand } from '../src/bin/route.ts';
 import { loadConfig } from '../src/config.ts';
 import { generateAuditCiConfig } from '../src/generate.ts';
-import { computeSyncDiff, buildUpdatedConfig, serializeConfig } from '../src/sync.ts';
+import { buildUpdatedConfig, computeSyncDiff, serializeConfig } from '../src/sync.ts';
 import type { AuditDepsConfig, AuditResult } from '../src/types.ts';
 
 describe('integration: generate -> sync cycle', () => {
@@ -53,13 +53,13 @@ describe('integration: generate -> sync cycle', () => {
     expect(prodPath).toBe(path.join(outDir, 'audit-ci.prod.json'));
 
     // Verify generated content
-    const devContent = JSON.parse(await readFile(devPath, 'utf8'));
-    expect(devContent.moderate).toBe(true);
-    expect(devContent.allowlist).toEqual([]);
+    const devContent: unknown = JSON.parse(await readFile(devPath, 'utf8'));
+    expect(devContent).toHaveProperty('moderate', true);
+    expect(devContent).toHaveProperty('allowlist', []);
 
-    const prodContent = JSON.parse(await readFile(prodPath, 'utf8'));
-    expect(prodContent.high).toBe(true);
-    expect(prodContent.allowlist).toEqual(['GHSA-stale']);
+    const prodContent: unknown = JSON.parse(await readFile(prodPath, 'utf8'));
+    expect(prodContent).toHaveProperty('high', true);
+    expect(prodContent).toHaveProperty('allowlist', ['GHSA-stale']);
 
     // Step 4: Simulate audit results (mocking audit-ci output)
     const prodAuditResults: AuditResult[] = [{ id: 'GHSA-new1', path: 'new-pkg', url: 'https://example.com/new1' }];
@@ -91,8 +91,8 @@ describe('integration: generate -> sync cycle', () => {
       path.dirname(configFilePath),
       reloaded.config.outDir,
     );
-    const updatedProdContent = JSON.parse(await readFile(updatedProdPath, 'utf8'));
-    expect(updatedProdContent.allowlist).toEqual(['GHSA-new1']);
+    const updatedProdContent: unknown = JSON.parse(await readFile(updatedProdPath, 'utf8'));
+    expect(updatedProdContent).toHaveProperty('allowlist', ['GHSA-new1']);
   });
 
   it('works with a custom config path', async () => {
@@ -114,8 +114,8 @@ describe('integration: generate -> sync cycle', () => {
     const devPath = await generateAuditCiConfig(loaded.config.dev, 'dev', customConfigDir, loaded.config.outDir);
     expect(devPath).toBe(path.join(customConfigDir, 'out', 'audit-ci.dev.json'));
 
-    const content = JSON.parse(await readFile(devPath, 'utf8'));
-    expect(content.allowlist).toEqual([]);
+    const content: unknown = JSON.parse(await readFile(devPath, 'utf8'));
+    expect(content).toHaveProperty('allowlist', []);
   });
 });
 

--- a/packages/audit-deps/__tests__/route.test.ts
+++ b/packages/audit-deps/__tests__/route.test.ts
@@ -46,17 +46,32 @@ describe(routeCommand, () => {
 
   it('dispatches "report" to reportCommand', async () => {
     await routeCommand(['report']);
-    expect(reportCommand).toHaveBeenCalled();
+    expect(reportCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: [] }));
+  });
+
+  it('dispatches "report --dev" with scopes ["dev"]', async () => {
+    await routeCommand(['report', '--dev']);
+    expect(reportCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['dev'] }));
+  });
+
+  it('dispatches "report --prod" with scopes ["prod"]', async () => {
+    await routeCommand(['report', '--prod']);
+    expect(reportCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['prod'] }));
   });
 
   it('dispatches "sync" to syncCommand', async () => {
     await routeCommand(['sync']);
-    expect(syncCommand).toHaveBeenCalled();
+    expect(syncCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: [] }));
+  });
+
+  it('dispatches "sync --dev" with scopes ["dev"]', async () => {
+    await routeCommand(['sync', '--dev']);
+    expect(syncCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['dev'] }));
   });
 
   it('dispatches "generate" to generateCommand', async () => {
     await routeCommand(['generate']);
-    expect(generateCommand).toHaveBeenCalled();
+    expect(generateCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: [] }));
   });
 
   it('dispatches "init" to initCommand', async () => {
@@ -66,11 +81,16 @@ describe(routeCommand, () => {
 
   it('falls through to auditCommand for unknown flags', async () => {
     await routeCommand(['--json']);
-    expect(auditCommand).toHaveBeenCalled();
+    expect(auditCommand).toHaveBeenCalledWith(expect.objectContaining({ json: true }));
   });
 
   it('returns 1 for unknown command with typo match', async () => {
     const exitCode = await routeCommand(['rep']);
+    expect(exitCode).toBe(1);
+  });
+
+  it('returns 1 for unknown positional argument', async () => {
+    const exitCode = await routeCommand(['foo']);
     expect(exitCode).toBe(1);
   });
 

--- a/packages/audit-deps/__tests__/route.test.ts
+++ b/packages/audit-deps/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/cli.ts', () => ({
+  auditCommand: vi.fn().mockResolvedValue(0),
+  generateCommand: vi.fn().mockResolvedValue(0),
+  reportCommand: vi.fn().mockResolvedValue(0),
+  syncCommand: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('../src/init/initCommand.ts', () => ({
+  initCommand: vi.fn().mockReturnValue(0),
+}));
+
+import { auditCommand, generateCommand, reportCommand, syncCommand } from '../src/cli.ts';
+import { initCommand } from '../src/init/initCommand.ts';
+import { routeCommand } from '../src/bin/route.ts';
+
+describe(routeCommand, () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+  it('returns 0 for --version', async () => {
+    const exitCode = await routeCommand(['--version']);
+    expect(exitCode).toBe(0);
+  });
+
+  it('returns 0 for -V', async () => {
+    const exitCode = await routeCommand(['-V']);
+    expect(exitCode).toBe(0);
+  });
+
+  it('returns 0 for --help', async () => {
+    const exitCode = await routeCommand(['--help']);
+    expect(exitCode).toBe(0);
+  });
+
+  it('returns 0 for -h', async () => {
+    const exitCode = await routeCommand(['-h']);
+    expect(exitCode).toBe(0);
+  });
+
+  it('returns 0 when no args are given', async () => {
+    const exitCode = await routeCommand([]);
+    expect(exitCode).toBe(0);
+  });
+
+  it('dispatches "report" to reportCommand', async () => {
+    await routeCommand(['report']);
+    expect(reportCommand).toHaveBeenCalled();
+  });
+
+  it('dispatches "sync" to syncCommand', async () => {
+    await routeCommand(['sync']);
+    expect(syncCommand).toHaveBeenCalled();
+  });
+
+  it('dispatches "generate" to generateCommand', async () => {
+    await routeCommand(['generate']);
+    expect(generateCommand).toHaveBeenCalled();
+  });
+
+  it('dispatches "init" to initCommand', async () => {
+    await routeCommand(['init']);
+    expect(initCommand).toHaveBeenCalled();
+  });
+
+  it('falls through to auditCommand for unknown flags', async () => {
+    await routeCommand(['--json']);
+    expect(auditCommand).toHaveBeenCalled();
+  });
+
+  it('returns 1 for unknown command with typo match', async () => {
+    const exitCode = await routeCommand(['rep']);
+    expect(exitCode).toBe(1);
+  });
+
+  it('returns 1 when --dev and --prod are both specified', async () => {
+    const exitCode = await routeCommand(['--dev', '--prod']);
+    expect(exitCode).toBe(1);
+  });
+
+  it('returns 0 for subcommand --help (e.g., report --help)', async () => {
+    const exitCode = await routeCommand(['report', '--help']);
+    expect(exitCode).toBe(0);
+    // reportCommand should not be called when showing help
+    expect(reportCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 for sync --help', async () => {
+    const exitCode = await routeCommand(['sync', '--help']);
+    expect(exitCode).toBe(0);
+    expect(syncCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 for init --help', async () => {
+    const exitCode = await routeCommand(['init', '--help']);
+    expect(exitCode).toBe(0);
+    expect(initCommand).not.toHaveBeenCalled();
+  });
+});

--- a/packages/audit-deps/__tests__/route.test.ts
+++ b/packages/audit-deps/__tests__/route.test.ts
@@ -117,4 +117,19 @@ describe(routeCommand, () => {
     expect(exitCode).toBe(0);
     expect(initCommand).not.toHaveBeenCalled();
   });
+
+  it('forwards --config flag to reportCommand', async () => {
+    await routeCommand(['report', '--config', '/custom/audit.json']);
+    expect(reportCommand).toHaveBeenCalledWith(expect.objectContaining({ configPath: '/custom/audit.json' }));
+  });
+
+  it('forwards --dry-run flag to initCommand', async () => {
+    await routeCommand(['init', '--dry-run']);
+    expect(initCommand).toHaveBeenCalledWith({ dryRun: true, force: false });
+  });
+
+  it('forwards --force flag to initCommand', async () => {
+    await routeCommand(['init', '--force']);
+    expect(initCommand).toHaveBeenCalledWith({ dryRun: false, force: true });
+  });
 });

--- a/packages/audit-deps/__tests__/route.test.ts
+++ b/packages/audit-deps/__tests__/route.test.ts
@@ -11,9 +11,9 @@ vi.mock('../src/init/initCommand.ts', () => ({
   initCommand: vi.fn().mockReturnValue(0),
 }));
 
+import { routeCommand } from '../src/bin/route.ts';
 import { auditCommand, generateCommand, reportCommand, syncCommand } from '../src/cli.ts';
 import { initCommand } from '../src/init/initCommand.ts';
-import { routeCommand } from '../src/bin/route.ts';
 
 describe(routeCommand, () => {
   afterEach(() => {

--- a/packages/audit-deps/__tests__/run-audit.test.ts
+++ b/packages/audit-deps/__tests__/run-audit.test.ts
@@ -15,7 +15,7 @@ describe(parseAuditCiOutput, () => {
       },
     });
 
-    const results = parseAuditCiOutput(json);
+    const { results } = parseAuditCiOutput(json);
     expect(results).toHaveLength(1);
     expect(results[0]).toEqual({
       id: '1234',
@@ -38,17 +38,48 @@ describe(parseAuditCiOutput, () => {
       },
     ]);
 
-    const results = parseAuditCiOutput(json);
+    const { results } = parseAuditCiOutput(json);
     expect(results).toHaveLength(1);
     expect(results[0]?.id).toBe('5678');
   });
 
-  it('returns an empty array for invalid JSON', () => {
-    expect(parseAuditCiOutput('not json')).toEqual([]);
+  it('parses advisory with GHSA-format string ID', () => {
+    const json = JSON.stringify({
+      advisories: {
+        'GHSA-23c5-xmqv-rm74': {
+          id: 'GHSA-23c5-xmqv-rm74',
+          module_name: 'some-pkg',
+          url: 'https://github.com/advisories/GHSA-23c5-xmqv-rm74',
+          findings: [{ paths: ['some-pkg>dep'] }],
+        },
+      },
+    });
+
+    const { results } = parseAuditCiOutput(json);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      id: 'GHSA-23c5-xmqv-rm74',
+      path: 'some-pkg>dep',
+      url: 'https://github.com/advisories/GHSA-23c5-xmqv-rm74',
+    });
   });
 
-  it('returns an empty array for JSON with no advisories', () => {
-    expect(parseAuditCiOutput(JSON.stringify({}))).toEqual([]);
+  it('returns empty results and no warnings for invalid JSON when input is empty', () => {
+    const { results, warnings } = parseAuditCiOutput('');
+    expect(results).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns empty results with a warning for non-empty invalid JSON', () => {
+    const { results, warnings } = parseAuditCiOutput('not json');
+    expect(results).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/Failed to parse/);
+  });
+
+  it('returns empty results for JSON with no advisories', () => {
+    const { results } = parseAuditCiOutput(JSON.stringify({}));
+    expect(results).toEqual([]);
   });
 
   it('uses module_name as fallback path when findings are empty', () => {
@@ -63,7 +94,7 @@ describe(parseAuditCiOutput, () => {
       },
     });
 
-    const results = parseAuditCiOutput(json);
+    const { results } = parseAuditCiOutput(json);
     expect(results[0]?.path).toBe('some-pkg');
   });
 });
@@ -74,14 +105,23 @@ describe(extractStaleEntries, () => {
       allowlistedAdvisoriesNotFound: ['GHSA-old1', 'GHSA-old2'],
     });
 
-    expect(extractStaleEntries(json)).toEqual(['GHSA-old1', 'GHSA-old2']);
+    expect(extractStaleEntries(json).entries).toEqual(['GHSA-old1', 'GHSA-old2']);
   });
 
-  it('returns an empty array when no stale entries exist', () => {
-    expect(extractStaleEntries(JSON.stringify({}))).toEqual([]);
+  it('returns empty entries when no stale entries exist', () => {
+    expect(extractStaleEntries(JSON.stringify({})).entries).toEqual([]);
   });
 
-  it('returns an empty array for invalid JSON', () => {
-    expect(extractStaleEntries('not json')).toEqual([]);
+  it('returns empty entries and no warnings for empty input', () => {
+    const { entries, warnings } = extractStaleEntries('');
+    expect(entries).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns empty entries with a warning for non-empty invalid JSON', () => {
+    const { entries, warnings } = extractStaleEntries('not json');
+    expect(entries).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/Failed to parse/);
   });
 });

--- a/packages/audit-deps/__tests__/run-audit.test.ts
+++ b/packages/audit-deps/__tests__/run-audit.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractStaleEntries, parseAuditCiOutput } from '../src/run-audit.ts';
+
+describe(parseAuditCiOutput, () => {
+  it('parses advisories from a flat advisories object', () => {
+    const json = JSON.stringify({
+      advisories: {
+        '1234': {
+          id: 1234,
+          module_name: 'lodash',
+          url: 'https://github.com/advisories/GHSA-1234',
+          findings: [{ paths: ['lodash>underscore'] }],
+        },
+      },
+    });
+
+    const results = parseAuditCiOutput(json);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      id: '1234',
+      path: 'lodash>underscore',
+      url: 'https://github.com/advisories/GHSA-1234',
+    });
+  });
+
+  it('parses advisories from an array-of-objects shape', () => {
+    const json = JSON.stringify([
+      {
+        advisories: {
+          '5678': {
+            id: 5678,
+            module_name: 'express',
+            url: 'https://example.com/5678',
+            findings: [{ paths: ['express'] }],
+          },
+        },
+      },
+    ]);
+
+    const results = parseAuditCiOutput(json);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe('5678');
+  });
+
+  it('returns an empty array for invalid JSON', () => {
+    expect(parseAuditCiOutput('not json')).toEqual([]);
+  });
+
+  it('returns an empty array for JSON with no advisories', () => {
+    expect(parseAuditCiOutput(JSON.stringify({}))).toEqual([]);
+  });
+
+  it('uses module_name as fallback path when findings are empty', () => {
+    const json = JSON.stringify({
+      advisories: {
+        '9999': {
+          id: 9999,
+          module_name: 'some-pkg',
+          url: 'https://example.com/9999',
+          findings: [],
+        },
+      },
+    });
+
+    const results = parseAuditCiOutput(json);
+    expect(results[0]?.path).toBe('some-pkg');
+  });
+});
+
+describe(extractStaleEntries, () => {
+  it('extracts stale entries from allowlistedAdvisoriesNotFound', () => {
+    const json = JSON.stringify({
+      allowlistedAdvisoriesNotFound: ['GHSA-old1', 'GHSA-old2'],
+    });
+
+    expect(extractStaleEntries(json)).toEqual(['GHSA-old1', 'GHSA-old2']);
+  });
+
+  it('returns an empty array when no stale entries exist', () => {
+    expect(extractStaleEntries(JSON.stringify({}))).toEqual([]);
+  });
+
+  it('returns an empty array for invalid JSON', () => {
+    expect(extractStaleEntries('not json')).toEqual([]);
+  });
+});

--- a/packages/audit-deps/__tests__/run-audit.test.ts
+++ b/packages/audit-deps/__tests__/run-audit.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { extractStaleEntries, parseAuditCiOutput } from '../src/run-audit.ts';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks for runAudit / runReport tests
+// ---------------------------------------------------------------------------
+
+const mockSpawnSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  spawnSync: mockSpawnSync,
+}));
 
 describe(parseAuditCiOutput, () => {
   it('parses advisories from a flat advisories object', () => {
@@ -123,5 +133,93 @@ describe(extractStaleEntries, () => {
     expect(entries).toEqual([]);
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatch(/Failed to parse/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runAudit / runReport (with mocked spawnSync)
+// ---------------------------------------------------------------------------
+
+// Import after vi.mock so the mock is active
+const { resolveAuditCiBin, runAudit, runReport } = await import('../src/run-audit.ts');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe(runAudit, () => {
+  it('passes --config and --output-format json when json is true', () => {
+    mockSpawnSync.mockReturnValue({ status: 0, stdout: '{}', stderr: '', error: null });
+
+    runAudit({ configPath: '/path/to/config.json', json: true });
+
+    const args: string[] = mockSpawnSync.mock.calls[0][1];
+    expect(args).toContain('--config');
+    expect(args).toContain('/path/to/config.json');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('json');
+  });
+
+  it('passes --output-format text when json is false', () => {
+    mockSpawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '', error: null });
+
+    runAudit({ configPath: '/path/to/config.json', json: false });
+
+    const args: string[] = mockSpawnSync.mock.calls[0][1];
+    expect(args).toContain('--output-format');
+    expect(args).toContain('text');
+  });
+
+  it('returns the exit code from spawnSync', () => {
+    mockSpawnSync.mockReturnValue({ status: 7, stdout: '', stderr: '', error: null });
+
+    const result = runAudit({ configPath: '/cfg.json' });
+
+    expect(result.exitCode).toBe(7);
+  });
+
+  it('throws on spawn failure', () => {
+    mockSpawnSync.mockReturnValue({ status: null, stdout: '', stderr: '', error: new Error('ENOENT') });
+
+    expect(() => runAudit({ configPath: '/cfg.json' })).toThrow('Failed to launch audit-ci');
+  });
+});
+
+describe(runReport, () => {
+  it('returns parsed results regardless of exit code', () => {
+    const advisoryOutput = JSON.stringify({
+      advisories: {
+        'GHSA-abc': {
+          id: 'GHSA-abc',
+          module_name: 'pkg-a',
+          url: 'https://example.com/abc',
+          findings: [{ paths: ['pkg-a'] }],
+        },
+      },
+    });
+
+    mockSpawnSync.mockReturnValue({ status: 1, stdout: advisoryOutput, stderr: '', error: null });
+
+    const report = runReport({ configPath: '/cfg.json' });
+
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0]?.id).toBe('GHSA-abc');
+  });
+
+  it('throws on spawn failure', () => {
+    mockSpawnSync.mockReturnValue({ status: null, stdout: '', stderr: '', error: new Error('ENOENT') });
+
+    expect(() => runReport({ configPath: '/cfg.json' })).toThrow('Failed to launch audit-ci');
+  });
+});
+
+describe(resolveAuditCiBin, () => {
+  it('returns fallback "audit-ci" when import.meta.resolve fails', () => {
+    // import.meta.resolve for audit-ci may or may not work in the test env;
+    // if it fails, the function returns 'audit-ci' as fallback
+    const result = resolveAuditCiBin();
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
   });
 });

--- a/packages/audit-deps/__tests__/sync.test.ts
+++ b/packages/audit-deps/__tests__/sync.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, rm } from 'node:fs/promises';
-import path from 'node:path';
 import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -116,9 +116,10 @@ describe(serializeConfig, () => {
     };
 
     const json = serializeConfig(config);
-    const parsed = JSON.parse(json);
-    const keys = Object.keys(parsed.dev.allowlist[0]);
-    expect(keys).toEqual(['id', 'path', 'reason', 'url']);
+    // Re-parse through the typed loader to verify key order in raw JSON
+    const devMatch = json.match(/"allowlist":\s*\[\s*\{([^}]+)\}/);
+    const keyOrder = devMatch?.[1]?.match(/"(\w+)":/g)?.map((k) => k.replace(/"/g, '').replace(':', ''));
+    expect(keyOrder).toEqual(['id', 'path', 'reason', 'url']);
   });
 
   it('omits reason key when entry has no reason', () => {
@@ -130,9 +131,10 @@ describe(serializeConfig, () => {
     };
 
     const json = serializeConfig(config);
-    const parsed = JSON.parse(json);
-    expect(Object.keys(parsed.dev.allowlist[0])).toEqual(['id', 'path', 'url']);
-    expect(parsed.dev.allowlist[0]).not.toHaveProperty('reason');
+    const devMatch = json.match(/"allowlist":\s*\[\s*\{([^}]+)\}/);
+    const keyOrder = devMatch?.[1]?.match(/"(\w+)":/g)?.map((k) => k.replace(/"/g, '').replace(':', ''));
+    expect(keyOrder).toEqual(['id', 'path', 'url']);
+    expect(json).not.toContain('"reason"');
   });
 });
 
@@ -163,8 +165,8 @@ describe(syncAllowlist, () => {
     expect(syncResult.scope).toBe('dev');
     expect(updatedConfig.dev.allowlist).toHaveLength(1);
 
-    const written = JSON.parse(await readFile(configPath, 'utf8'));
-    expect(written.dev.allowlist).toHaveLength(1);
-    expect(written.dev.allowlist[0].id).toBe('1001');
+    const written: unknown = JSON.parse(await readFile(configPath, 'utf8'));
+    expect(written).toHaveProperty('dev.allowlist.length', 1);
+    expect(written).toHaveProperty('dev.allowlist[0].id', '1001');
   });
 });

--- a/packages/audit-deps/__tests__/sync.test.ts
+++ b/packages/audit-deps/__tests__/sync.test.ts
@@ -1,0 +1,146 @@
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildUpdatedConfig, computeSyncDiff, serializeConfig, syncAllowlist } from '../src/sync.ts';
+import type { AllowlistEntry, AuditDepsConfig, AuditResult } from '../src/types.ts';
+
+const fixedDate = new Date('2025-06-15T00:00:00Z');
+
+describe(computeSyncDiff, () => {
+  it('adds new advisories not in the current allowlist', () => {
+    const current: AllowlistEntry[] = [];
+    const audit: AuditResult[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
+
+    const { added, kept, removed } = computeSyncDiff(current, audit, fixedDate);
+
+    expect(added).toHaveLength(1);
+    expect(added[0]?.reason).toBe('Added by audit-deps sync on 2025-06-15');
+    expect(kept).toHaveLength(0);
+    expect(removed).toHaveLength(0);
+  });
+
+  it('removes advisories no longer in audit output', () => {
+    const current: AllowlistEntry[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
+    const audit: AuditResult[] = [];
+
+    const { added, kept, removed } = computeSyncDiff(current, audit, fixedDate);
+
+    expect(added).toHaveLength(0);
+    expect(kept).toHaveLength(0);
+    expect(removed).toHaveLength(1);
+    expect(removed[0]?.id).toBe('1001');
+  });
+
+  it('preserves existing entries with manual reasons', () => {
+    const current: AllowlistEntry[] = [
+      { id: '1001', path: 'lodash', reason: 'accepted risk', url: 'https://example.com/1001' },
+    ];
+    const audit: AuditResult[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
+
+    const { added, kept, removed } = computeSyncDiff(current, audit, fixedDate);
+
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.reason).toBe('accepted risk');
+    expect(added).toHaveLength(0);
+    expect(removed).toHaveLength(0);
+  });
+
+  it('computes a mixed diff with additions and removals', () => {
+    const current: AllowlistEntry[] = [
+      { id: '1001', path: 'lodash', url: 'https://example.com/1001' },
+      { id: '1002', path: 'express', reason: 'manual reason', url: 'https://example.com/1002' },
+    ];
+    const audit: AuditResult[] = [
+      { id: '1002', path: 'express', url: 'https://example.com/1002' },
+      { id: '1003', path: 'axios', url: 'https://example.com/1003' },
+    ];
+
+    const { added, kept, removed } = computeSyncDiff(current, audit, fixedDate);
+
+    expect(added).toHaveLength(1);
+    expect(added[0]?.id).toBe('1003');
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.id).toBe('1002');
+    expect(kept[0]?.reason).toBe('manual reason');
+    expect(removed).toHaveLength(1);
+    expect(removed[0]?.id).toBe('1001');
+  });
+
+  it('returns empty arrays when both lists are empty', () => {
+    const { added, kept, removed } = computeSyncDiff([], [], fixedDate);
+    expect(added).toEqual([]);
+    expect(kept).toEqual([]);
+    expect(removed).toEqual([]);
+  });
+});
+
+describe(buildUpdatedConfig, () => {
+  it('replaces the allowlist for the given scope, sorted by ID', () => {
+    const config: AuditDepsConfig = {
+      dev: { allowlist: [], moderate: true },
+      prod: { allowlist: [], high: true },
+    };
+
+    const entries: AllowlistEntry[] = [
+      { id: 'z-entry', path: 'z', url: 'https://z' },
+      { id: 'a-entry', path: 'a', url: 'https://a' },
+    ];
+
+    const updated = buildUpdatedConfig(config, 'dev', entries);
+    expect(updated.dev.allowlist[0]?.id).toBe('a-entry');
+    expect(updated.dev.allowlist[1]?.id).toBe('z-entry');
+    expect(updated.prod.allowlist).toEqual([]);
+  });
+});
+
+describe(serializeConfig, () => {
+  it('produces JSON with alphabetically ordered allowlist entry keys', () => {
+    const config: AuditDepsConfig = {
+      dev: {
+        allowlist: [{ id: '1001', path: 'lodash', reason: 'test', url: 'https://example.com' }],
+      },
+      prod: { allowlist: [] },
+    };
+
+    const json = serializeConfig(config);
+    const parsed = JSON.parse(json);
+    const keys = Object.keys(parsed.dev.allowlist[0]);
+    expect(keys).toEqual(['id', 'path', 'reason', 'url']);
+  });
+});
+
+describe(syncAllowlist, () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = path.join(tmpdir(), `audit-deps-sync-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes updated config to disk after sync', async () => {
+    const config: AuditDepsConfig = {
+      dev: { allowlist: [], moderate: true },
+      prod: { allowlist: [] },
+    };
+    const configPath = path.join(tempDir, 'config.json');
+
+    const auditResults: AuditResult[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
+
+    const { syncResult, updatedConfig } = await syncAllowlist(config, 'dev', auditResults, configPath, fixedDate);
+
+    expect(syncResult.added).toHaveLength(1);
+    expect(syncResult.scope).toBe('dev');
+    expect(updatedConfig.dev.allowlist).toHaveLength(1);
+
+    const written = JSON.parse(await readFile(configPath, 'utf8'));
+    expect(written.dev.allowlist).toHaveLength(1);
+    expect(written.dev.allowlist[0].id).toBe('1001');
+  });
+});

--- a/packages/audit-deps/__tests__/sync.test.ts
+++ b/packages/audit-deps/__tests__/sync.test.ts
@@ -48,6 +48,16 @@ describe(computeSyncDiff, () => {
     expect(removed).toHaveLength(0);
   });
 
+  it('keeps entry without reason when ID is still in audit output', () => {
+    const current: AllowlistEntry[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
+    const audit: AuditResult[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
+
+    const { kept } = computeSyncDiff(current, audit, fixedDate);
+
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.reason).toBeUndefined();
+  });
+
   it('computes a mixed diff with additions and removals', () => {
     const current: AllowlistEntry[] = [
       { id: '1001', path: 'lodash', url: 'https://example.com/1001' },
@@ -109,6 +119,20 @@ describe(serializeConfig, () => {
     const parsed = JSON.parse(json);
     const keys = Object.keys(parsed.dev.allowlist[0]);
     expect(keys).toEqual(['id', 'path', 'reason', 'url']);
+  });
+
+  it('omits reason key when entry has no reason', () => {
+    const config: AuditDepsConfig = {
+      dev: {
+        allowlist: [{ id: '1001', path: 'lodash', url: 'https://example.com' }],
+      },
+      prod: { allowlist: [] },
+    };
+
+    const json = serializeConfig(config);
+    const parsed = JSON.parse(json);
+    expect(Object.keys(parsed.dev.allowlist[0])).toEqual(['id', 'path', 'url']);
+    expect(parsed.dev.allowlist[0]).not.toHaveProperty('reason');
   });
 });
 

--- a/packages/audit-deps/bin/audit-deps.js
+++ b/packages/audit-deps/bin/audit-deps.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+try {
+  await import('../dist/esm/bin/audit-deps.js');
+} catch (error) {
+  if (error.code === 'ERR_MODULE_NOT_FOUND') {
+    process.stderr.write('audit-deps: build output not found — run `pnpm run build` first\n');
+  } else {
+    process.stderr.write(`audit-deps: failed to load: ${error.message}\n`);
+  }
+  process.exit(1);
+}

--- a/packages/audit-deps/package.json
+++ b/packages/audit-deps/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@williamthorsen/audit-deps",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Wrap audit-ci with a richer config model, typed JSON source of truth, and sync workflow",
+  "keywords": [
+    "audit",
+    "audit-ci",
+    "dependencies",
+    "security",
+    "vulnerabilities"
+  ],
+  "homepage": "https://github.com/williamthorsen/node-monorepo-tools/tree/main/packages/audit-deps#readme",
+  "bugs": {
+    "url": "https://github.com/williamthorsen/node-monorepo-tools/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/williamthorsen/node-monorepo-tools.git",
+    "directory": "packages/audit-deps"
+  },
+  "license": "MIT",
+  "author": "William Thorsen <william@thorsen.dev> (https://github.com/williamthorsen)",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "types": "./dist/esm/index.d.ts"
+    }
+  },
+  "bin": {
+    "audit-deps": "bin/audit-deps.js"
+  },
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "scripts": {
+    "prepare": "tsx ../../config/generateVersion.ts && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json"
+  },
+  "dependencies": {
+    "@williamthorsen/node-monorepo-core": "workspace:*",
+    "audit-ci": "7.1.0",
+    "zod": "4.3.6"
+  },
+  "engines": {
+    "node": ">=18.17.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/audit-deps/src/bin/audit-deps.ts
+++ b/packages/audit-deps/src/bin/audit-deps.ts
@@ -1,0 +1,16 @@
+/* eslint n/hashbang: off, n/no-process-exit: off */
+/* eslint unicorn/no-process-exit: off */
+
+import process from 'node:process';
+
+import { routeCommand } from './route.ts';
+
+let exitCode: number;
+try {
+  exitCode = await routeCommand(process.argv.slice(2));
+} catch (error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`audit-deps: unexpected error: ${message}\n`);
+  exitCode = 1;
+}
+process.exit(exitCode);

--- a/packages/audit-deps/src/bin/route.ts
+++ b/packages/audit-deps/src/bin/route.ts
@@ -182,6 +182,12 @@ export async function routeCommand(args: string[]): Promise<number> {
     return 1;
   }
 
+  // Reject non-flag positional arguments that don't match a known subcommand
+  if (!command.startsWith('-')) {
+    process.stderr.write(`Error: Unknown command '${command}'.\n`);
+    return 1;
+  }
+
   // Default: treat all args as audit command options
   return handleSubcommand(args, auditCommand);
 }

--- a/packages/audit-deps/src/bin/route.ts
+++ b/packages/audit-deps/src/bin/route.ts
@@ -52,6 +52,56 @@ Options:
 `);
 }
 
+function showReportHelp(): void {
+  console.info(`
+Usage: audit-deps report [options]
+
+Report vulnerabilities without failing.
+
+Scope options:
+  --dev              Target dev dependencies only
+  --prod             Target production dependencies only
+
+Other options:
+  --config <path>    Path to config file (default: .config/audit-deps.config.json)
+  --json             Output results as JSON
+  --help, -h         Show this help message
+`);
+}
+
+function showSyncHelp(): void {
+  console.info(`
+Usage: audit-deps sync [options]
+
+Synchronize allowlists with current audit findings.
+
+Scope options:
+  --dev              Target dev dependencies only
+  --prod             Target production dependencies only
+
+Other options:
+  --config <path>    Path to config file (default: .config/audit-deps.config.json)
+  --json             Output results as JSON
+  --help, -h         Show this help message
+`);
+}
+
+function showGenerateHelp(): void {
+  console.info(`
+Usage: audit-deps generate [options]
+
+Regenerate flat audit-ci config files.
+
+Scope options:
+  --dev              Target dev dependencies only
+  --prod             Target production dependencies only
+
+Other options:
+  --config <path>    Path to config file (default: .config/audit-deps.config.json)
+  --help, -h         Show this help message
+`);
+}
+
 /** Parse the shared flags (--dev, --prod, --config, --json) from argv. */
 function parseSharedFlags(flags: string[]): CommandOptions {
   const flagSchema = {
@@ -114,15 +164,15 @@ export async function routeCommand(args: string[]): Promise<number> {
   }
 
   if (command === 'report') {
-    return handleSubcommand(args.slice(1), reportCommand);
+    return handleSubcommand(args.slice(1), reportCommand, showReportHelp);
   }
 
   if (command === 'sync') {
-    return handleSubcommand(args.slice(1), syncCommand);
+    return handleSubcommand(args.slice(1), syncCommand, showSyncHelp);
   }
 
   if (command === 'generate') {
-    return handleSubcommand(args.slice(1), generateCommand);
+    return handleSubcommand(args.slice(1), generateCommand, showGenerateHelp);
   }
 
   // Check for typos before falling through to the default command
@@ -140,9 +190,10 @@ export async function routeCommand(args: string[]): Promise<number> {
 async function handleSubcommand(
   flags: string[],
   handler: (options: CommandOptions) => Promise<number>,
+  helpFn: () => void = showHelp,
 ): Promise<number> {
   if (flags.some((f) => f === '--help' || f === '-h')) {
-    showHelp();
+    helpFn();
     return 0;
   }
 

--- a/packages/audit-deps/src/bin/route.ts
+++ b/packages/audit-deps/src/bin/route.ts
@@ -1,0 +1,186 @@
+import process from 'node:process';
+
+import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
+
+import { auditCommand, generateCommand, reportCommand, syncCommand } from '../cli.ts';
+import { initCommand } from '../init/initCommand.ts';
+import type { AuditScope, CommandOptions } from '../types.ts';
+import { VERSION } from '../version.ts';
+
+const SUBCOMMANDS = ['generate', 'init', 'report', 'sync'];
+const MIN_PREFIX_LENGTH = 3;
+
+/** Extract a displayable message from an unknown thrown value. */
+function extractMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function showHelp(): void {
+  console.info(`
+Usage: audit-deps [options]
+       audit-deps <command> [options]
+
+Commands:
+  (default)            Run audit-ci against configured scopes
+  report               Report vulnerabilities without failing
+  sync                 Synchronize allowlists with current audit findings
+  generate             Regenerate flat audit-ci config files
+  init                 Scaffold a starter config file
+
+Scope options:
+  --dev                Target dev dependencies only
+  --prod               Target production dependencies only
+
+Other options:
+  --config <path>      Path to config file (default: .config/audit-deps.config.json)
+  --json               Output results as JSON
+  --help, -h           Show this help message
+  --version, -V        Show version number
+`);
+}
+
+function showInitHelp(): void {
+  console.info(`
+Usage: audit-deps init [options]
+
+Scaffold a starter config file.
+
+Options:
+  --dry-run, -n   Preview changes without writing files
+  --force, -f     Overwrite existing files
+  --help, -h      Show this help message
+`);
+}
+
+/** Parse the shared flags (--dev, --prod, --config, --json) from argv. */
+function parseSharedFlags(flags: string[]): CommandOptions {
+  const flagSchema = {
+    config: { long: '--config', type: 'string' as const },
+    dev: { long: '--dev', type: 'boolean' as const },
+    json: { long: '--json', type: 'boolean' as const, short: '-j' },
+    prod: { long: '--prod', type: 'boolean' as const },
+  };
+
+  const { flags: parsed } = parseArgs(flags, flagSchema);
+
+  if (parsed.dev && parsed.prod) {
+    throw new Error('Cannot specify both --dev and --prod');
+  }
+
+  const scopes: AuditScope[] = [];
+  if (parsed.dev) scopes.push('dev');
+  if (parsed.prod) scopes.push('prod');
+
+  return {
+    configPath: parsed.config,
+    json: parsed.json,
+    scopes,
+  };
+}
+
+/** Check whether a positional arg is a close prefix of a known subcommand. */
+function findTypoMatch(input: string): string | undefined {
+  if (input.length < MIN_PREFIX_LENGTH || input.startsWith('-')) {
+    return undefined;
+  }
+  for (const cmd of SUBCOMMANDS) {
+    if (cmd !== input && cmd.startsWith(input)) {
+      return cmd;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Route CLI arguments to the appropriate subcommand.
+ *
+ * Returns a numeric exit code: 0 for success, 1 for errors.
+ */
+export async function routeCommand(args: string[]): Promise<number> {
+  const command = args[0];
+
+  if (command === undefined || command === '--help' || command === '-h') {
+    showHelp();
+    return 0;
+  }
+
+  if (command === '--version' || command === '-V') {
+    console.info(VERSION);
+    return 0;
+  }
+
+  if (command === 'init') {
+    return handleInit(args.slice(1));
+  }
+
+  if (command === 'report') {
+    return handleSubcommand(args.slice(1), reportCommand);
+  }
+
+  if (command === 'sync') {
+    return handleSubcommand(args.slice(1), syncCommand);
+  }
+
+  if (command === 'generate') {
+    return handleSubcommand(args.slice(1), generateCommand);
+  }
+
+  // Check for typos before falling through to the default command
+  const typoMatch = findTypoMatch(command);
+  if (typoMatch !== undefined) {
+    process.stderr.write(`Error: Unknown command '${command}'. Did you mean 'audit-deps ${typoMatch}'?\n`);
+    return 1;
+  }
+
+  // Default: treat all args as audit command options
+  return handleSubcommand(args, auditCommand);
+}
+
+/** Parse shared flags and dispatch to a subcommand handler. */
+async function handleSubcommand(
+  flags: string[],
+  handler: (options: CommandOptions) => Promise<number>,
+): Promise<number> {
+  if (flags.some((f) => f === '--help' || f === '-h')) {
+    showHelp();
+    return 0;
+  }
+
+  let options: CommandOptions;
+  try {
+    options = parseSharedFlags(flags);
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${translateParseError(error)}\n`);
+    return 1;
+  }
+
+  try {
+    return await handler(options);
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    return 1;
+  }
+}
+
+/** Handle the `init` subcommand with its own flag set. */
+function handleInit(flags: string[]): number {
+  if (flags.some((f) => f === '--help' || f === '-h')) {
+    showInitHelp();
+    return 0;
+  }
+
+  const initFlagSchema = {
+    dryRun: { long: '--dry-run', type: 'boolean' as const, short: '-n' },
+    force: { long: '--force', type: 'boolean' as const, short: '-f' },
+  };
+
+  let parsed;
+  try {
+    parsed = parseArgs(flags, initFlagSchema);
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${translateParseError(error)}\n`);
+    return 1;
+  }
+
+  return initCommand({ dryRun: parsed.flags.dryRun, force: parsed.flags.force });
+}

--- a/packages/audit-deps/src/bin/route.ts
+++ b/packages/audit-deps/src/bin/route.ts
@@ -2,18 +2,13 @@ import process from 'node:process';
 
 import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
-import { auditCommand, generateCommand, reportCommand, syncCommand } from '../cli.ts';
+import { auditCommand, extractMessage, generateCommand, reportCommand, syncCommand } from '../cli.ts';
 import { initCommand } from '../init/initCommand.ts';
 import type { AuditScope, CommandOptions } from '../types.ts';
 import { VERSION } from '../version.ts';
 
 const SUBCOMMANDS = ['generate', 'init', 'report', 'sync'];
 const MIN_PREFIX_LENGTH = 3;
-
-/** Extract a displayable message from an unknown thrown value. */
-function extractMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 function showHelp(): void {
   console.info(`

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -1,0 +1,172 @@
+import process from 'node:process';
+
+import type { AuditDepsConfig, AuditScope, CommandOptions } from './types.ts';
+import { AUDIT_SCOPES } from './types.ts';
+import { loadConfig } from './config.ts';
+import { generateAuditCiConfig } from './generate.ts';
+import { runAudit, runReport } from './run-audit.ts';
+import { syncAllowlist } from './sync.ts';
+
+/**
+ * Run the default audit command (CI mode).
+ *
+ * Generates config, invokes audit-ci for each scope, and returns a combined exit code.
+ */
+export async function auditCommand(options: CommandOptions): Promise<number> {
+  const loaded = await loadAndGenerate(options);
+  if (loaded === undefined) return 1;
+
+  const { scopes, generatedPaths } = loaded;
+  let exitCode = 0;
+
+  for (const scope of scopes) {
+    const configPath = generatedPaths.get(scope);
+    if (configPath === undefined) continue;
+
+    const result = runAudit({ configPath, json: options.json });
+
+    if (result.staleEntries.length > 0) {
+      process.stderr.write(`warning: stale allowlist entries in ${scope}: ${result.staleEntries.join(', ')}\n`);
+    }
+
+    if (options.json) {
+      process.stdout.write(result.stdout);
+    } else if (result.stderr.length > 0) {
+      process.stderr.write(result.stderr);
+    }
+
+    if (result.exitCode !== 0) {
+      exitCode = result.exitCode;
+    }
+  }
+
+  return exitCode;
+}
+
+/**
+ * Run the `report` subcommand.
+ *
+ * Invokes audit-ci without allowlist filtering and prints vulnerability details.
+ */
+export async function reportCommand(options: CommandOptions): Promise<number> {
+  const loaded = await loadAndGenerate(options);
+  if (loaded === undefined) return 1;
+
+  const { scopes, generatedPaths } = loaded;
+  const allResults: Array<{ id: string; path: string; url: string }> = [];
+
+  for (const scope of scopes) {
+    const configPath = generatedPaths.get(scope);
+    if (configPath === undefined) continue;
+
+    const report = runReport({ configPath });
+    for (const result of report.results) {
+      if (!allResults.some((r) => r.id === result.id)) {
+        allResults.push(result);
+      }
+    }
+  }
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(allResults, null, 2) + '\n');
+  } else {
+    if (allResults.length === 0) {
+      process.stdout.write('No vulnerabilities found.\n');
+    } else {
+      for (const result of allResults) {
+        process.stdout.write(`${result.id}: ${result.path} (${result.url})\n`);
+      }
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Run the `sync` subcommand.
+ *
+ * Audits each scope in report mode, then updates the allowlist to match current findings.
+ */
+export async function syncCommand(options: CommandOptions): Promise<number> {
+  const loaded = await loadAndGenerate(options);
+  if (loaded === undefined) return 1;
+
+  let { config, configDir, configFilePath, scopes, generatedPaths } = loaded;
+
+  for (const scope of scopes) {
+    const configPath = generatedPaths.get(scope);
+    if (configPath === undefined) continue;
+
+    const report = runReport({ configPath });
+    const { syncResult, updatedConfig } = await syncAllowlist(config, scope, report.results, configFilePath);
+    config = updatedConfig;
+
+    if (options.json) {
+      process.stdout.write(JSON.stringify(syncResult, null, 2) + '\n');
+    } else {
+      process.stdout.write(`\n--- ${scope} ---\n`);
+      process.stdout.write(`  added: ${syncResult.added.length}\n`);
+      process.stdout.write(`  kept: ${syncResult.kept.length}\n`);
+      process.stdout.write(`  removed: ${syncResult.removed.length}\n`);
+    }
+  }
+
+  // Regenerate flat configs after sync
+  for (const scope of scopes) {
+    await generateAuditCiConfig(config[scope], scope, configDir, config.outDir);
+  }
+
+  return 0;
+}
+
+/**
+ * Run the `generate` subcommand.
+ *
+ * Regenerates the flat audit-ci JSON config files for each scope.
+ */
+export async function generateCommand(options: CommandOptions): Promise<number> {
+  const loaded = await loadAndGenerate(options);
+  if (loaded === undefined) return 1;
+
+  for (const [_scope, outputPath] of loaded.generatedPaths) {
+    process.stdout.write(`Generated: ${outputPath}\n`);
+  }
+
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface LoadedState {
+  config: AuditDepsConfig;
+  configDir: string;
+  configFilePath: string;
+  generatedPaths: Map<AuditScope, string>;
+  scopes: AuditScope[];
+}
+
+/** Load config and generate flat audit-ci configs for the requested scopes. */
+async function loadAndGenerate(options: CommandOptions): Promise<LoadedState | undefined> {
+  let config: AuditDepsConfig;
+  let configDir: string;
+  let configFilePath: string;
+
+  try {
+    ({ config, configDir, configFilePath } = await loadConfig(options.configPath));
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+    return undefined;
+  }
+
+  const scopes = options.scopes.length > 0 ? options.scopes : [...AUDIT_SCOPES];
+  const generatedPaths = new Map<AuditScope, string>();
+
+  for (const scope of scopes) {
+    const outputPath = await generateAuditCiConfig(config[scope], scope, configDir, config.outDir);
+    generatedPaths.set(scope, outputPath);
+  }
+
+  return { config, configDir, configFilePath, generatedPaths, scopes };
+}

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -25,11 +25,17 @@ export async function auditCommand(options: CommandOptions): Promise<number> {
 
     const result = runAudit({ configPath, json: options.json });
 
+    for (const warning of result.warnings) {
+      process.stderr.write(`warning: ${warning}\n`);
+    }
+
     if (result.staleEntries.length > 0) {
       process.stderr.write(`warning: stale allowlist entries in ${scope}: ${result.staleEntries.join(', ')}\n`);
     }
 
     if (options.json) {
+      process.stdout.write(result.stdout);
+    } else if (result.stdout.length > 0) {
       process.stdout.write(result.stdout);
     } else if (result.stderr.length > 0) {
       process.stderr.write(result.stderr);
@@ -60,6 +66,9 @@ export async function reportCommand(options: CommandOptions): Promise<number> {
     if (configPath === undefined) continue;
 
     const report = runReport({ configPath });
+    for (const warning of report.warnings) {
+      process.stderr.write(`warning: ${warning}\n`);
+    }
     for (const result of report.results) {
       if (!allResults.some((r) => r.id === result.id)) {
         allResults.push(result);
@@ -85,19 +94,26 @@ export async function reportCommand(options: CommandOptions): Promise<number> {
 /**
  * Run the `sync` subcommand.
  *
- * Audits each scope in report mode, then updates the allowlist to match current findings.
+ * Audits each scope in report mode without allowlist filtering, then updates
+ * the allowlist to match current findings. Uses a stripped config so audit-ci
+ * reports ALL current vulnerabilities, not just un-allowlisted ones.
  */
 export async function syncCommand(options: CommandOptions): Promise<number> {
   const loaded = await loadAndGenerate(options);
   if (loaded === undefined) return 1;
 
-  let { config, configDir, configFilePath, scopes, generatedPaths } = loaded;
+  const { configDir, configFilePath, scopes } = loaded;
+  let { config } = loaded;
 
   for (const scope of scopes) {
-    const configPath = generatedPaths.get(scope);
-    if (configPath === undefined) continue;
+    // Generate a config without the allowlist so sync sees all vulnerabilities
+    const strippedScope = { ...config[scope], allowlist: [] };
+    const strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, configDir, config.outDir);
 
-    const report = runReport({ configPath });
+    const report = runReport({ configPath: strippedConfigPath });
+    for (const warning of report.warnings) {
+      process.stderr.write(`warning: ${warning}\n`);
+    }
     const { syncResult, updatedConfig } = await syncAllowlist(config, scope, report.results, configFilePath);
     config = updatedConfig;
 
@@ -164,7 +180,13 @@ async function loadAndGenerate(options: CommandOptions): Promise<LoadedState | u
   const generatedPaths = new Map<AuditScope, string>();
 
   for (const scope of scopes) {
-    const outputPath = await generateAuditCiConfig(config[scope], scope, configDir, config.outDir);
+    let outputPath: string;
+    try {
+      outputPath = await generateAuditCiConfig(config[scope], scope, configDir, config.outDir);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to generate config for scope '${scope}': ${message}`);
+    }
     generatedPaths.set(scope, outputPath);
   }
 

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -7,6 +7,11 @@ import { syncAllowlist } from './sync.ts';
 import type { AuditDepsConfig, AuditScope, CommandOptions } from './types.ts';
 import { AUDIT_SCOPES } from './types.ts';
 
+/** Extract a displayable message from an unknown thrown value. */
+export function extractMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Run the default audit command (CI mode).
  *
@@ -45,11 +50,14 @@ export async function auditCommand(options: CommandOptions): Promise<number> {
           allResults.push(r);
         }
       }
-    } else if (result.stdout.length > 0) {
-      // Text mode: output raw stdout per scope (dedup not possible without structure)
-      process.stdout.write(result.stdout);
-    } else if (result.stderr.length > 0) {
-      process.stderr.write(result.stderr);
+    } else {
+      // Text mode: forward both stdout and stderr independently
+      if (result.stdout.length > 0) {
+        process.stdout.write(result.stdout);
+      }
+      if (result.stderr.length > 0) {
+        process.stderr.write(result.stderr);
+      }
     }
 
     if (result.exitCode !== 0) {
@@ -114,11 +122,18 @@ export async function reportCommand(options: CommandOptions): Promise<number> {
  * reports ALL current vulnerabilities, not just un-allowlisted ones.
  */
 export async function syncCommand(options: CommandOptions): Promise<number> {
-  const loaded = await loadAndGenerate(options);
-  if (loaded === undefined) return 1;
+  let config: AuditDepsConfig;
+  let configDir: string;
+  let configFilePath: string;
 
-  const { configDir, configFilePath, scopes } = loaded;
-  let { config } = loaded;
+  try {
+    ({ config, configDir, configFilePath } = await loadConfig(options.configPath));
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    return 1;
+  }
+
+  const scopes = options.scopes.length > 0 ? options.scopes : [...AUDIT_SCOPES];
 
   for (const scope of scopes) {
     // Generate a config without the allowlist so sync sees all vulnerabilities
@@ -127,8 +142,7 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
     try {
       strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, configDir, config.outDir);
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to generate config for scope '${scope}': ${message}`);
+      throw new Error(`Failed to generate config for scope '${scope}': ${extractMessage(error)}`);
     }
 
     const report = runReport({ configPath: strippedConfigPath });
@@ -153,8 +167,7 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
     try {
       await generateAuditCiConfig(config[scope], scope, configDir, config.outDir);
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to generate config for scope '${scope}': ${message}`);
+      throw new Error(`Failed to generate config for scope '${scope}': ${extractMessage(error)}`);
     }
   }
 
@@ -198,7 +211,7 @@ async function loadAndGenerate(options: CommandOptions): Promise<LoadedState | u
   try {
     ({ config, configDir, configFilePath } = await loadConfig(options.configPath));
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
     return undefined;
   }
 
@@ -210,8 +223,7 @@ async function loadAndGenerate(options: CommandOptions): Promise<LoadedState | u
     try {
       outputPath = await generateAuditCiConfig(config[scope], scope, configDir, config.outDir);
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to generate config for scope '${scope}': ${message}`);
+      throw new Error(`Failed to generate config for scope '${scope}': ${extractMessage(error)}`);
     }
     generatedPaths.set(scope, outputPath);
   }

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -108,7 +108,13 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
   for (const scope of scopes) {
     // Generate a config without the allowlist so sync sees all vulnerabilities
     const strippedScope = { ...config[scope], allowlist: [] };
-    const strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, configDir, config.outDir);
+    let strippedConfigPath: string;
+    try {
+      strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, configDir, config.outDir);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to generate config for scope '${scope}': ${message}`);
+    }
 
     const report = runReport({ configPath: strippedConfigPath });
     for (const warning of report.warnings) {
@@ -129,7 +135,12 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
 
   // Regenerate flat configs after sync
   for (const scope of scopes) {
-    await generateAuditCiConfig(config[scope], scope, configDir, config.outDir);
+    try {
+      await generateAuditCiConfig(config[scope], scope, configDir, config.outDir);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to generate config for scope '${scope}': ${message}`);
+    }
   }
 
   return 0;

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -1,11 +1,11 @@
 import process from 'node:process';
 
-import type { AuditDepsConfig, AuditScope, CommandOptions } from './types.ts';
-import { AUDIT_SCOPES } from './types.ts';
 import { loadConfig } from './config.ts';
 import { generateAuditCiConfig } from './generate.ts';
 import { parseAuditCiOutput, runAudit, runReport } from './run-audit.ts';
 import { syncAllowlist } from './sync.ts';
+import type { AuditDepsConfig, AuditScope, CommandOptions } from './types.ts';
+import { AUDIT_SCOPES } from './types.ts';
 
 /**
  * Run the default audit command (CI mode).

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -4,7 +4,7 @@ import type { AuditDepsConfig, AuditScope, CommandOptions } from './types.ts';
 import { AUDIT_SCOPES } from './types.ts';
 import { loadConfig } from './config.ts';
 import { generateAuditCiConfig } from './generate.ts';
-import { runAudit, runReport } from './run-audit.ts';
+import { parseAuditCiOutput, runAudit, runReport } from './run-audit.ts';
 import { syncAllowlist } from './sync.ts';
 
 /**
@@ -18,6 +18,7 @@ export async function auditCommand(options: CommandOptions): Promise<number> {
 
   const { scopes, generatedPaths } = loaded;
   let exitCode = 0;
+  const allResults: Array<{ id: string; path: string; url: string }> = [];
 
   for (const scope of scopes) {
     const configPath = generatedPaths.get(scope);
@@ -34,8 +35,18 @@ export async function auditCommand(options: CommandOptions): Promise<number> {
     }
 
     if (options.json) {
-      process.stdout.write(result.stdout);
+      // Collect parsed results for cross-scope deduplication
+      const parsed = parseAuditCiOutput(result.stdout);
+      for (const warning of parsed.warnings) {
+        process.stderr.write(`warning: ${warning}\n`);
+      }
+      for (const r of parsed.results) {
+        if (!allResults.some((existing) => existing.id === r.id)) {
+          allResults.push(r);
+        }
+      }
     } else if (result.stdout.length > 0) {
+      // Text mode: output raw stdout per scope (dedup not possible without structure)
       process.stdout.write(result.stdout);
     } else if (result.stderr.length > 0) {
       process.stderr.write(result.stderr);
@@ -44,6 +55,10 @@ export async function auditCommand(options: CommandOptions): Promise<number> {
     if (result.exitCode !== 0) {
       exitCode = result.exitCode;
     }
+  }
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(allResults, null, 2) + '\n');
   }
 
   return exitCode;

--- a/packages/audit-deps/src/config.ts
+++ b/packages/audit-deps/src/config.ts
@@ -1,0 +1,48 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { AuditDepsConfig } from './types.ts';
+import { auditDepsConfigSchema } from './types.ts';
+
+/** Default config file path, relative to the working directory. */
+export const DEFAULT_CONFIG_PATH = '.config/audit-deps.config.json';
+
+/**
+ * Load and validate the audit-deps config from disk.
+ *
+ * Resolves the config path against `cwd`. Throws on missing file or validation failure.
+ */
+export async function loadConfig(
+  configPath?: string,
+  cwd?: string,
+): Promise<{
+  config: AuditDepsConfig;
+  configDir: string;
+  configFilePath: string;
+}> {
+  const resolvedCwd = cwd ?? process.cwd();
+  const filePath = path.resolve(resolvedCwd, configPath ?? DEFAULT_CONFIG_PATH);
+  const configDir = path.dirname(filePath);
+
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf8');
+  } catch {
+    throw new Error(`Config file not found: ${filePath}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Config file is not valid JSON: ${filePath}`);
+  }
+
+  const result = auditDepsConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues.map((issue) => `  - ${issue.path.join('.')}: ${issue.message}`).join('\n');
+    throw new Error(`Invalid config in ${filePath}:\n${issues}`);
+  }
+
+  return { config: result.data, configDir, configFilePath: filePath };
+}

--- a/packages/audit-deps/src/generate.ts
+++ b/packages/audit-deps/src/generate.ts
@@ -1,0 +1,58 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { AuditScope, ScopeConfig } from './types.ts';
+
+/** Flat JSON shape that audit-ci expects as its config file. */
+interface AuditCiFlatConfig {
+  allowlist: string[];
+  'show-not-found'?: boolean;
+  [key: string]: boolean | string | string[] | undefined;
+}
+
+/** Map severity booleans from our config to audit-ci field names. */
+const SEVERITY_FIELDS = ['critical', 'high', 'low', 'moderate'] as const;
+
+/**
+ * Transform a scope config into the flat JSON structure audit-ci expects.
+ *
+ * Extracts severity thresholds and flattens the typed allowlist to an array of ID strings.
+ */
+export function buildFlatConfig(scopeConfig: ScopeConfig): AuditCiFlatConfig {
+  const flat: AuditCiFlatConfig = {
+    allowlist: scopeConfig.allowlist.map((entry) => entry.id),
+    'show-not-found': true,
+  };
+
+  for (const field of SEVERITY_FIELDS) {
+    const value = scopeConfig[field];
+    if (value !== undefined) {
+      flat[field] = value;
+    }
+  }
+
+  return flat;
+}
+
+/**
+ * Generate the audit-ci config file for a scope and write it to disk.
+ *
+ * The output path is `{outDir}/audit-ci.{scope}.json`, where `outDir` is resolved
+ * relative to `configDir`.
+ */
+export async function generateAuditCiConfig(
+  scopeConfig: ScopeConfig,
+  scope: AuditScope,
+  configDir: string,
+  outDir?: string,
+): Promise<string> {
+  const resolvedOutDir = outDir !== undefined ? path.resolve(configDir, outDir) : configDir;
+  const outputPath = path.join(resolvedOutDir, `audit-ci.${scope}.json`);
+  const flat = buildFlatConfig(scopeConfig);
+  const content = JSON.stringify(flat, null, 2) + '\n';
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, content, 'utf8');
+
+  return outputPath;
+}

--- a/packages/audit-deps/src/index.ts
+++ b/packages/audit-deps/src/index.ts
@@ -1,0 +1,14 @@
+// Types
+export type { AllowlistEntry, AuditDepsConfig, AuditResult, AuditScope, CommandOptions, ScopeConfig } from './types.ts';
+
+// Schemas
+export { allowlistEntrySchema, AUDIT_SCOPES, auditDepsConfigSchema, scopeConfigSchema } from './types.ts';
+
+// Config
+export { loadConfig } from './config.ts';
+
+// Generation
+export { generateAuditCiConfig } from './generate.ts';
+
+// Sync
+export { syncAllowlist } from './sync.ts';

--- a/packages/audit-deps/src/init/initCommand.ts
+++ b/packages/audit-deps/src/init/initCommand.ts
@@ -1,5 +1,6 @@
 import { printError, printStep, reportWriteResult } from '@williamthorsen/node-monorepo-core';
 
+import { extractMessage } from '../cli.ts';
 import { scaffoldConfig } from './scaffold.ts';
 
 interface InitOptions {
@@ -23,7 +24,7 @@ export function initCommand({ dryRun, force }: InitOptions): number {
   try {
     result = scaffoldConfig({ dryRun, force });
   } catch (error: unknown) {
-    printError(`Failed to scaffold config: ${error instanceof Error ? error.message : String(error)}`);
+    printError(`Failed to scaffold config: ${extractMessage(error)}`);
     return 1;
   }
 

--- a/packages/audit-deps/src/init/initCommand.ts
+++ b/packages/audit-deps/src/init/initCommand.ts
@@ -1,0 +1,47 @@
+import { printError, printStep, reportWriteResult } from '@williamthorsen/node-monorepo-core';
+
+import { scaffoldConfig } from './scaffold.ts';
+
+interface InitOptions {
+  dryRun: boolean;
+  force: boolean;
+}
+
+/**
+ * Run the `audit-deps init` command.
+ *
+ * Scaffolds a starter config file, then prints next steps.
+ * Returns the process exit code (0 for success, 1 for failure).
+ */
+export function initCommand({ dryRun, force }: InitOptions): number {
+  if (dryRun) {
+    console.info('[dry-run mode]');
+  }
+
+  printStep('Scaffolding config');
+  let result: ReturnType<typeof scaffoldConfig>;
+  try {
+    result = scaffoldConfig({ dryRun, force });
+  } catch (error: unknown) {
+    printError(`Failed to scaffold config: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+
+  reportWriteResult(result.configResult, dryRun);
+
+  if (result.configResult.outcome === 'failed') {
+    return 1;
+  }
+
+  if (!dryRun) {
+    printStep('Next steps');
+    console.info(`
+  1. Customize .config/audit-deps.config.json with your severity thresholds.
+  2. Run: npx @williamthorsen/audit-deps generate
+  3. Run: npx @williamthorsen/audit-deps
+  4. Commit the config file.
+`);
+  }
+
+  return 0;
+}

--- a/packages/audit-deps/src/init/scaffold.ts
+++ b/packages/audit-deps/src/init/scaffold.ts
@@ -1,0 +1,21 @@
+import type { WriteResult } from '@williamthorsen/node-monorepo-core';
+import { writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
+
+import { auditDepsConfigTemplate } from './templates.ts';
+
+const CONFIG_PATH = '.config/audit-deps.config.json';
+
+interface ScaffoldOptions {
+  dryRun: boolean;
+  force: boolean;
+}
+
+interface ScaffoldResult {
+  configResult: WriteResult;
+}
+
+/** Scaffold the audit-deps config file with sensible defaults. */
+export function scaffoldConfig({ dryRun, force }: ScaffoldOptions): ScaffoldResult {
+  const configResult = writeFileWithCheck(CONFIG_PATH, auditDepsConfigTemplate, { dryRun, overwrite: force });
+  return { configResult };
+}

--- a/packages/audit-deps/src/init/templates.ts
+++ b/packages/audit-deps/src/init/templates.ts
@@ -1,0 +1,17 @@
+/** Default audit-deps config file content. */
+export const auditDepsConfigTemplate =
+  JSON.stringify(
+    {
+      outDir: '../tmp',
+      dev: {
+        moderate: true,
+        allowlist: [],
+      },
+      prod: {
+        high: true,
+        allowlist: [],
+      },
+    },
+    null,
+    2,
+  ) + '\n';

--- a/packages/audit-deps/src/run-audit.ts
+++ b/packages/audit-deps/src/run-audit.ts
@@ -9,9 +9,9 @@ function resolveAuditCiBin(): string {
     const resolved = import.meta.resolve('audit-ci');
     // Strip the file:// protocol and navigate to the bin entry
     const modulePath = new URL(resolved).pathname;
-    // audit-ci's bin is at the package root's bin/audit-ci.js
+    // audit-ci v7 ships its CLI at dist/bin.js
     const pkgDir = modulePath.replace(/\/dist\/.*$/, '');
-    return `${pkgDir}/lib/audit-ci.js`;
+    return `${pkgDir}/dist/bin.js`;
   } catch {
     return 'audit-ci';
   }
@@ -24,29 +24,40 @@ interface AuditCiAdvisory {
   findings: Array<{ paths: string[] }>;
 }
 
+/** Result of parsing audit-ci output, including any warnings. */
+export interface ParseResult {
+  results: AuditResult[];
+  warnings: string[];
+}
+
 /**
  * Parse audit-ci JSON output into typed audit results.
  *
  * Extracts advisories from the JSON, mapping each to an `AuditResult` with
- * the first discovered dependency path.
+ * the first discovered dependency path. Returns warnings when input is
+ * non-empty but not parseable.
  */
-export function parseAuditCiOutput(jsonString: string): AuditResult[] {
-  const results: AuditResult[] = [];
+export function parseAuditCiOutput(jsonString: string): ParseResult {
+  const warnings: string[] = [];
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonString);
   } catch {
-    return results;
+    if (jsonString.trim().length > 0) {
+      warnings.push(`Failed to parse audit-ci output as JSON (${jsonString.length} bytes)`);
+    }
+    return { results: [], warnings };
   }
 
   if (typeof parsed !== 'object' || parsed === null) {
-    return results;
+    return { results: [], warnings };
   }
 
   // audit-ci outputs an array of action objects; advisories live inside them.
   // Try multiple known output shapes.
   const advisories = extractAdvisories(parsed);
+  const results: AuditResult[] = [];
   for (const advisory of advisories) {
     results.push({
       id: String(advisory.id),
@@ -55,7 +66,7 @@ export function parseAuditCiOutput(jsonString: string): AuditResult[] {
     });
   }
 
-  return results;
+  return { results, warnings };
 }
 
 /** Extract advisory objects from various audit-ci output shapes. */
@@ -92,24 +103,35 @@ function extractPath(advisory: AuditCiAdvisory): string {
   return firstPath ?? advisory.module_name ?? 'unknown';
 }
 
+/** Result of extracting stale entries, including any warnings. */
+export interface StaleEntriesResult {
+  entries: string[];
+  warnings: string[];
+}
+
 /** Extract stale allowlist entries from audit-ci JSON output. */
-export function extractStaleEntries(jsonString: string): string[] {
+export function extractStaleEntries(jsonString: string): StaleEntriesResult {
+  const warnings: string[] = [];
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonString);
   } catch {
-    return [];
+    if (jsonString.trim().length > 0) {
+      warnings.push(`Failed to parse audit-ci output as JSON for stale entry detection (${jsonString.length} bytes)`);
+    }
+    return { entries: [], warnings };
   }
 
-  if (typeof parsed !== 'object' || parsed === null) return [];
+  if (typeof parsed !== 'object' || parsed === null) return { entries: [], warnings };
 
   const record = parsed as Record<string, unknown>;
   const notFound = record['allowlistedAdvisoriesNotFound'];
   if (Array.isArray(notFound)) {
-    return notFound.filter((item): item is string => typeof item === 'string');
+    return { entries: notFound.filter((item): item is string => typeof item === 'string'), warnings };
   }
 
-  return [];
+  return { entries: [], warnings };
 }
 
 /** Options for running audit-ci. */
@@ -125,6 +147,7 @@ export interface AuditRunResult {
   staleEntries: string[];
   stdout: string;
   stderr: string;
+  warnings: string[];
 }
 
 /**
@@ -136,7 +159,8 @@ export interface AuditRunResult {
  */
 export function runAudit({ configPath, cwd, json }: RunAuditOptions): AuditRunResult {
   const bin = resolveAuditCiBin();
-  const args = ['--config', configPath, '--output-format', 'json'];
+  const outputFormat = json ? 'json' : 'text';
+  const args = ['--config', configPath, '--output-format', outputFormat];
 
   const result = spawnSync(process.execPath, [bin, ...args], {
     cwd: cwd ?? process.cwd(),
@@ -144,15 +168,21 @@ export function runAudit({ configPath, cwd, json }: RunAuditOptions): AuditRunRe
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 
-  const stdout = result.stdout ?? '';
-  const stderr = result.stderr ?? '';
-  const staleEntries = extractStaleEntries(stdout);
-
-  if (json) {
-    return { exitCode: result.status ?? 1, staleEntries, stdout, stderr };
+  if (result.error) {
+    throw new Error(`Failed to launch audit-ci: ${result.error.message}`);
   }
 
-  return { exitCode: result.status ?? 1, staleEntries, stdout, stderr };
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+  const staleResult = json ? extractStaleEntries(stdout) : { entries: [], warnings: [] };
+
+  return {
+    exitCode: result.status ?? 1,
+    staleEntries: staleResult.entries,
+    stdout,
+    stderr,
+    warnings: staleResult.warnings,
+  };
 }
 
 /** Result from a report-mode audit run. */
@@ -160,6 +190,7 @@ export interface ReportResult {
   results: AuditResult[];
   stdout: string;
   stderr: string;
+  warnings: string[];
 }
 
 /**
@@ -177,9 +208,13 @@ export function runReport({ configPath, cwd }: Omit<RunAuditOptions, 'json'>): R
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 
+  if (result.error) {
+    throw new Error(`Failed to launch audit-ci: ${result.error.message}`);
+  }
+
   const stdout = result.stdout ?? '';
   const stderr = result.stderr ?? '';
-  const results = parseAuditCiOutput(stdout);
+  const parseResult = parseAuditCiOutput(stdout);
 
-  return { results, stdout, stderr };
+  return { results: parseResult.results, stdout, stderr, warnings: parseResult.warnings };
 }

--- a/packages/audit-deps/src/run-audit.ts
+++ b/packages/audit-deps/src/run-audit.ts
@@ -1,0 +1,185 @@
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+import type { AuditResult } from './types.ts';
+
+/** Resolve the audit-ci binary path from node_modules. */
+function resolveAuditCiBin(): string {
+  try {
+    const resolved = import.meta.resolve('audit-ci');
+    // Strip the file:// protocol and navigate to the bin entry
+    const modulePath = new URL(resolved).pathname;
+    // audit-ci's bin is at the package root's bin/audit-ci.js
+    const pkgDir = modulePath.replace(/\/dist\/.*$/, '');
+    return `${pkgDir}/lib/audit-ci.js`;
+  } catch {
+    return 'audit-ci';
+  }
+}
+
+interface AuditCiAdvisory {
+  id: number;
+  module_name: string;
+  url: string;
+  findings: Array<{ paths: string[] }>;
+}
+
+/**
+ * Parse audit-ci JSON output into typed audit results.
+ *
+ * Extracts advisories from the JSON, mapping each to an `AuditResult` with
+ * the first discovered dependency path.
+ */
+export function parseAuditCiOutput(jsonString: string): AuditResult[] {
+  const results: AuditResult[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonString);
+  } catch {
+    return results;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return results;
+  }
+
+  // audit-ci outputs an array of action objects; advisories live inside them.
+  // Try multiple known output shapes.
+  const advisories = extractAdvisories(parsed);
+  for (const advisory of advisories) {
+    results.push({
+      id: String(advisory.id),
+      path: extractPath(advisory),
+      url: advisory.url ?? `https://github.com/advisories/GHSA-${advisory.id}`,
+    });
+  }
+
+  return results;
+}
+
+/** Extract advisory objects from various audit-ci output shapes. */
+function extractAdvisories(parsed: unknown): AuditCiAdvisory[] {
+  if (typeof parsed !== 'object' || parsed === null) return [];
+
+  // Shape: { advisories: { [id]: advisory } }
+  const record = parsed as Record<string, unknown>;
+  if (record['advisories'] !== undefined && typeof record['advisories'] === 'object' && record['advisories'] !== null) {
+    return Object.values(record['advisories'] as Record<string, AuditCiAdvisory>);
+  }
+
+  // Shape: array of objects with an advisories field
+  if (Array.isArray(parsed)) {
+    const advisories: AuditCiAdvisory[] = [];
+    for (const item of parsed) {
+      if (typeof item === 'object' && item !== null) {
+        const obj = item as Record<string, unknown>;
+        if (obj['advisories'] !== undefined && typeof obj['advisories'] === 'object' && obj['advisories'] !== null) {
+          advisories.push(...Object.values(obj['advisories'] as Record<string, AuditCiAdvisory>));
+        }
+      }
+    }
+    return advisories;
+  }
+
+  return [];
+}
+
+/** Extract the first dependency path from an advisory's findings. */
+function extractPath(advisory: AuditCiAdvisory): string {
+  const firstFinding = advisory.findings?.[0];
+  const firstPath = firstFinding?.paths?.[0];
+  return firstPath ?? advisory.module_name ?? 'unknown';
+}
+
+/** Extract stale allowlist entries from audit-ci JSON output. */
+export function extractStaleEntries(jsonString: string): string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonString);
+  } catch {
+    return [];
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return [];
+
+  const record = parsed as Record<string, unknown>;
+  const notFound = record['allowlistedAdvisoriesNotFound'];
+  if (Array.isArray(notFound)) {
+    return notFound.filter((item): item is string => typeof item === 'string');
+  }
+
+  return [];
+}
+
+/** Options for running audit-ci. */
+interface RunAuditOptions {
+  configPath: string;
+  cwd?: string;
+  json?: boolean;
+}
+
+/** Result from a normal audit run. */
+export interface AuditRunResult {
+  exitCode: number;
+  staleEntries: string[];
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Invoke audit-ci with the given config file in normal (CI) mode.
+ *
+ * Returns the exit code faithfully. When `json` is true, output is JSON;
+ * otherwise audit-ci uses its default text format. Stale overrides are
+ * detected from JSON output and returned.
+ */
+export function runAudit({ configPath, cwd, json }: RunAuditOptions): AuditRunResult {
+  const bin = resolveAuditCiBin();
+  const args = ['--config', configPath, '--output-format', 'json'];
+
+  const result = spawnSync(process.execPath, [bin, ...args], {
+    cwd: cwd ?? process.cwd(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+  const staleEntries = extractStaleEntries(stdout);
+
+  if (json) {
+    return { exitCode: result.status ?? 1, staleEntries, stdout, stderr };
+  }
+
+  return { exitCode: result.status ?? 1, staleEntries, stdout, stderr };
+}
+
+/** Result from a report-mode audit run. */
+export interface ReportResult {
+  results: AuditResult[];
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Invoke audit-ci in report mode (no allowlist filtering, swallows exit code).
+ *
+ * Always returns exit code 0. Parses JSON output into typed `AuditResult` objects.
+ */
+export function runReport({ configPath, cwd }: Omit<RunAuditOptions, 'json'>): ReportResult {
+  const bin = resolveAuditCiBin();
+  const args = ['--config', configPath, '--output-format', 'json'];
+
+  const result = spawnSync(process.execPath, [bin, ...args], {
+    cwd: cwd ?? process.cwd(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+  const results = parseAuditCiOutput(stdout);
+
+  return { results, stdout, stderr };
+}

--- a/packages/audit-deps/src/run-audit.ts
+++ b/packages/audit-deps/src/run-audit.ts
@@ -4,7 +4,7 @@ import process from 'node:process';
 import type { AuditResult } from './types.ts';
 
 /** Resolve the audit-ci binary path from node_modules. */
-function resolveAuditCiBin(): string {
+export function resolveAuditCiBin(): string {
   try {
     const resolved = import.meta.resolve('audit-ci');
     // Strip the file:// protocol and navigate to the bin entry
@@ -18,7 +18,7 @@ function resolveAuditCiBin(): string {
 }
 
 interface AuditCiAdvisory {
-  id: number;
+  id: number | string;
   module_name: string;
   url: string;
   findings: Array<{ paths: string[] }>;

--- a/packages/audit-deps/src/run-audit.ts
+++ b/packages/audit-deps/src/run-audit.ts
@@ -62,11 +62,30 @@ export function parseAuditCiOutput(jsonString: string): ParseResult {
     results.push({
       id: String(advisory.id),
       path: extractPath(advisory),
-      url: advisory.url ?? `https://github.com/advisories/GHSA-${advisory.id}`,
+      url: advisory.url,
     });
   }
 
   return { results, warnings };
+}
+
+/** Narrow an unknown value to a non-null object. */
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}
+
+/** Check whether a value has the shape of an AuditCiAdvisory. */
+function isAuditCiAdvisory(value: unknown): value is AuditCiAdvisory {
+  if (!isObject(value)) return false;
+  return 'id' in value && 'url' in value && 'findings' in value;
+}
+
+/** Extract advisories from an object that has an `advisories` record. */
+function collectAdvisories(obj: object): AuditCiAdvisory[] {
+  if (!('advisories' in obj) || typeof obj.advisories !== 'object' || obj.advisories === null) {
+    return [];
+  }
+  return Object.values(obj.advisories).filter(isAuditCiAdvisory);
 }
 
 /** Extract advisory objects from various audit-ci output shapes. */
@@ -74,20 +93,16 @@ function extractAdvisories(parsed: unknown): AuditCiAdvisory[] {
   if (typeof parsed !== 'object' || parsed === null) return [];
 
   // Shape: { advisories: { [id]: advisory } }
-  const record = parsed as Record<string, unknown>;
-  if (record['advisories'] !== undefined && typeof record['advisories'] === 'object' && record['advisories'] !== null) {
-    return Object.values(record['advisories'] as Record<string, AuditCiAdvisory>);
+  if ('advisories' in parsed) {
+    return collectAdvisories(parsed);
   }
 
   // Shape: array of objects with an advisories field
   if (Array.isArray(parsed)) {
     const advisories: AuditCiAdvisory[] = [];
     for (const item of parsed) {
-      if (typeof item === 'object' && item !== null) {
-        const obj = item as Record<string, unknown>;
-        if (obj['advisories'] !== undefined && typeof obj['advisories'] === 'object' && obj['advisories'] !== null) {
-          advisories.push(...Object.values(obj['advisories'] as Record<string, AuditCiAdvisory>));
-        }
+      if (isObject(item)) {
+        advisories.push(...collectAdvisories(item));
       }
     }
     return advisories;
@@ -98,9 +113,9 @@ function extractAdvisories(parsed: unknown): AuditCiAdvisory[] {
 
 /** Extract the first dependency path from an advisory's findings. */
 function extractPath(advisory: AuditCiAdvisory): string {
-  const firstFinding = advisory.findings?.[0];
-  const firstPath = firstFinding?.paths?.[0];
-  return firstPath ?? advisory.module_name ?? 'unknown';
+  const firstFinding = advisory.findings[0];
+  const firstPath = firstFinding?.paths[0];
+  return firstPath ?? advisory.module_name;
 }
 
 /** Result of extracting stale entries, including any warnings. */
@@ -124,9 +139,9 @@ export function extractStaleEntries(jsonString: string): StaleEntriesResult {
   }
 
   if (typeof parsed !== 'object' || parsed === null) return { entries: [], warnings };
+  if (!('allowlistedAdvisoriesNotFound' in parsed)) return { entries: [], warnings };
 
-  const record = parsed as Record<string, unknown>;
-  const notFound = record['allowlistedAdvisoriesNotFound'];
+  const notFound = parsed.allowlistedAdvisoriesNotFound;
   if (Array.isArray(notFound)) {
     return { entries: notFound.filter((item): item is string => typeof item === 'string'), warnings };
   }
@@ -172,8 +187,8 @@ export function runAudit({ configPath, cwd, json }: RunAuditOptions): AuditRunRe
     throw new Error(`Failed to launch audit-ci: ${result.error.message}`);
   }
 
-  const stdout = result.stdout ?? '';
-  const stderr = result.stderr ?? '';
+  const stdout = result.stdout;
+  const stderr = result.stderr;
   const staleResult = json ? extractStaleEntries(stdout) : { entries: [], warnings: [] };
 
   return {
@@ -212,8 +227,8 @@ export function runReport({ configPath, cwd }: Omit<RunAuditOptions, 'json'>): R
     throw new Error(`Failed to launch audit-ci: ${result.error.message}`);
   }
 
-  const stdout = result.stdout ?? '';
-  const stderr = result.stderr ?? '';
+  const stdout = result.stdout;
+  const stderr = result.stderr;
   const parseResult = parseAuditCiOutput(stdout);
 
   return { results: parseResult.results, stdout, stderr, warnings: parseResult.warnings };

--- a/packages/audit-deps/src/sync.ts
+++ b/packages/audit-deps/src/sync.ts
@@ -12,11 +12,11 @@ function formatUtcDate(date: Date): string {
  *
  * Produces consistent, reviewable JSON diffs regardless of insertion order.
  */
-function serializeEntry(entry: AllowlistEntry): Record<string, string | undefined> {
+function serializeEntry(entry: AllowlistEntry): Record<string, string> {
   return {
     id: entry.id,
     path: entry.path,
-    reason: entry.reason,
+    ...(entry.reason !== undefined && { reason: entry.reason }),
     url: entry.url,
   };
 }
@@ -128,7 +128,12 @@ export async function syncAllowlist(
   const { added, kept, removed } = computeSyncDiff(config[scope].allowlist, auditResults, date);
   const updatedConfig = buildUpdatedConfig(config, scope, [...kept, ...added]);
 
-  await writeFile(configFilePath, serializeConfig(updatedConfig), 'utf8');
+  try {
+    await writeFile(configFilePath, serializeConfig(updatedConfig), 'utf8');
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to write config file '${configFilePath}': ${message}`);
+  }
 
   return {
     syncResult: { added, kept, removed, scope },

--- a/packages/audit-deps/src/sync.ts
+++ b/packages/audit-deps/src/sync.ts
@@ -83,6 +83,7 @@ export function buildUpdatedConfig(
   scope: AuditScope,
   newAllowlist: AllowlistEntry[],
 ): AuditDepsConfig {
+  // eslint-disable-next-line unicorn/no-array-sort -- toSorted requires Node 20+; engine target is >=18.17.0
   const sorted = [...newAllowlist].sort((a, b) => a.id.localeCompare(b.id));
   return {
     ...config,

--- a/packages/audit-deps/src/sync.ts
+++ b/packages/audit-deps/src/sync.ts
@@ -1,0 +1,137 @@
+import { writeFile } from 'node:fs/promises';
+
+import type { AllowlistEntry, AuditDepsConfig, AuditResult, AuditScope } from './types.ts';
+
+/** Produce a UTC date string in YYYY-MM-DD format. */
+function formatUtcDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Serialize an allowlist entry with keys in alphabetical order.
+ *
+ * Produces consistent, reviewable JSON diffs regardless of insertion order.
+ */
+function serializeEntry(entry: AllowlistEntry): Record<string, string | undefined> {
+  return {
+    id: entry.id,
+    path: entry.path,
+    reason: entry.reason,
+    url: entry.url,
+  };
+}
+
+/** Result of a sync operation for a single scope. */
+export interface SyncResult {
+  added: AllowlistEntry[];
+  kept: AllowlistEntry[];
+  removed: AllowlistEntry[];
+  scope: AuditScope;
+}
+
+/**
+ * Compute the updated allowlist by diffing audit results against the current entries.
+ *
+ * New advisories are added with an auto-populated reason. Resolved advisories are removed.
+ * Existing entries with a non-empty reason are preserved.
+ */
+export function computeSyncDiff(
+  currentAllowlist: AllowlistEntry[],
+  auditResults: AuditResult[],
+  date?: Date,
+): { added: AllowlistEntry[]; kept: AllowlistEntry[]; removed: AllowlistEntry[] } {
+  const now = date ?? new Date();
+  const currentById = new Map(currentAllowlist.map((entry) => [entry.id, entry]));
+  const auditById = new Map(auditResults.map((result) => [result.id, result]));
+
+  const added: AllowlistEntry[] = [];
+  const kept: AllowlistEntry[] = [];
+  const removed: AllowlistEntry[] = [];
+
+  // Identify new and kept entries
+  for (const [id, result] of auditById) {
+    const existing = currentById.get(id);
+    if (existing !== undefined) {
+      kept.push(existing);
+    } else {
+      added.push({
+        id: result.id,
+        path: result.path,
+        reason: `Added by audit-deps sync on ${formatUtcDate(now)}`,
+        url: result.url,
+      });
+    }
+  }
+
+  // Identify removed entries
+  for (const [id, entry] of currentById) {
+    if (!auditById.has(id)) {
+      removed.push(entry);
+    }
+  }
+
+  return { added, kept, removed };
+}
+
+/**
+ * Build the updated config by replacing the allowlist for the given scope.
+ *
+ * Returns a new config object; does not mutate the input.
+ */
+export function buildUpdatedConfig(
+  config: AuditDepsConfig,
+  scope: AuditScope,
+  newAllowlist: AllowlistEntry[],
+): AuditDepsConfig {
+  const sorted = [...newAllowlist].sort((a, b) => a.id.localeCompare(b.id));
+  return {
+    ...config,
+    [scope]: {
+      ...config[scope],
+      allowlist: sorted,
+    },
+  };
+}
+
+/**
+ * Serialize the config to JSON with alphabetically ordered allowlist entry keys.
+ *
+ * Uses a custom replacer to guarantee key order within allowlist entries.
+ */
+export function serializeConfig(config: AuditDepsConfig): string {
+  const serializable = {
+    ...config,
+    dev: {
+      ...config.dev,
+      allowlist: config.dev.allowlist.map(serializeEntry),
+    },
+    prod: {
+      ...config.prod,
+      allowlist: config.prod.allowlist.map(serializeEntry),
+    },
+  };
+  return JSON.stringify(serializable, null, 2) + '\n';
+}
+
+/**
+ * Synchronize the allowlist for a scope by diffing audit results against the current config.
+ *
+ * Returns the sync diff and the updated config. Writes the updated config to disk.
+ */
+export async function syncAllowlist(
+  config: AuditDepsConfig,
+  scope: AuditScope,
+  auditResults: AuditResult[],
+  configFilePath: string,
+  date?: Date,
+): Promise<{ syncResult: SyncResult; updatedConfig: AuditDepsConfig }> {
+  const { added, kept, removed } = computeSyncDiff(config[scope].allowlist, auditResults, date);
+  const updatedConfig = buildUpdatedConfig(config, scope, [...kept, ...added]);
+
+  await writeFile(configFilePath, serializeConfig(updatedConfig), 'utf8');
+
+  return {
+    syncResult: { added, kept, removed, scope },
+    updatedConfig,
+  };
+}

--- a/packages/audit-deps/src/types.ts
+++ b/packages/audit-deps/src/types.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Audit scope
+// ---------------------------------------------------------------------------
+
+/** The dependency scope to audit: development or production. */
+export type AuditScope = 'dev' | 'prod';
+
+/** All valid scope values. */
+export const AUDIT_SCOPES: readonly AuditScope[] = ['dev', 'prod'];
+
+// ---------------------------------------------------------------------------
+// Allowlist entry
+// ---------------------------------------------------------------------------
+
+/** A single allowlisted advisory with metadata for traceability. */
+export interface AllowlistEntry {
+  id: string;
+  path: string;
+  reason?: string | undefined;
+  url: string;
+}
+
+/** Zod schema for an allowlist entry. */
+export const allowlistEntrySchema = z.object({
+  id: z.string(),
+  path: z.string(),
+  reason: z.string().optional(),
+  url: z.string(),
+});
+
+// ---------------------------------------------------------------------------
+// Scope config
+// ---------------------------------------------------------------------------
+
+/** Configuration for a single audit scope (dev or prod). */
+export interface ScopeConfig {
+  allowlist: AllowlistEntry[];
+  /** Fail on advisories at or above this severity. */
+  critical?: boolean | undefined;
+  high?: boolean | undefined;
+  low?: boolean | undefined;
+  moderate?: boolean | undefined;
+}
+
+/** Zod schema for a scope configuration block. */
+export const scopeConfigSchema = z.object({
+  allowlist: z.array(allowlistEntrySchema),
+  critical: z.boolean().optional(),
+  high: z.boolean().optional(),
+  low: z.boolean().optional(),
+  moderate: z.boolean().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Top-level config
+// ---------------------------------------------------------------------------
+
+/** Source-of-truth configuration for audit-deps. */
+export interface AuditDepsConfig {
+  dev: ScopeConfig;
+  outDir?: string | undefined;
+  prod: ScopeConfig;
+}
+
+/** Zod schema for the full audit-deps configuration file. */
+export const auditDepsConfigSchema = z.object({
+  dev: scopeConfigSchema,
+  outDir: z.string().optional(),
+  prod: scopeConfigSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Audit result
+// ---------------------------------------------------------------------------
+
+/** A single vulnerability found by audit-ci. */
+export interface AuditResult {
+  id: string;
+  path: string;
+  url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Command options
+// ---------------------------------------------------------------------------
+
+/** Parsed CLI options shared across subcommands. */
+export interface CommandOptions {
+  configPath?: string | undefined;
+  json: boolean;
+  scopes: AuditScope[];
+}

--- a/packages/audit-deps/tsconfig.eslint.json
+++ b/packages/audit-deps/tsconfig.eslint.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+  },
+  "exclude": [],
+  "include": [
+    "__tests__/",
+    "config/",
+    "configs/",
+    "src/",
+    "eslint.config.js",
+    "*.cjs",
+    "*.json",
+    "*.mjs",
+    "*.mts",
+    "*.ts",
+  ],
+}

--- a/packages/audit-deps/tsconfig.generate-typings.json
+++ b/packages/audit-deps/tsconfig.generate-typings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "./dist/esm",
+    "rootDir": "./src",
+    "sourceMap": false,
+    "tsBuildInfoFile": "./dist/tsconfig.generate-typings.tsbuildinfo",
+  },
+  "exclude": ["**/__tests__"],
+  "include": ["src"],
+}

--- a/packages/audit-deps/tsconfig.json
+++ b/packages/audit-deps/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2022"],
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "*.ts"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,18 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
 
+  packages/audit-deps:
+    dependencies:
+      '@williamthorsen/node-monorepo-core':
+        specifier: workspace:*
+        version: link:../core
+      audit-ci:
+        specifier: 7.1.0
+        version: 7.1.0
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+
   packages/core: {}
 
   packages/nmr:
@@ -1182,6 +1194,10 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1219,6 +1235,11 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  audit-ci@7.1.0:
+    resolution: {integrity: sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1295,6 +1316,10 @@ packages:
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1398,8 +1423,14 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
@@ -1635,6 +1666,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-stream@4.0.1:
+    resolution: {integrity: sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1680,6 +1714,9 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  from@0.1.7:
+    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1694,6 +1731,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1813,6 +1854,9 @@ packages:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -1860,6 +1904,10 @@ packages:
   is-finalizationregistry@1.1.1:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-generator-function@1.1.0:
     resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
@@ -1946,6 +1994,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -1983,6 +2034,15 @@ packages:
   jsonc-eslint-parser@3.1.0:
     resolution: {integrity: sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
+
+  jsonstream-next@3.0.0:
+    resolution: {integrity: sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2140,6 +2200,9 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  map-stream@0.0.7:
+    resolution: {integrity: sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2247,6 +2310,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pause-stream@0.0.11:
+    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2279,6 +2345,14 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readline-transform@1.0.0:
+    resolution: {integrity: sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==}
+    engines: {node: '>=6'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -2294,6 +2368,10 @@ packages:
   regjsparser@0.13.0:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -2319,6 +2397,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -2415,6 +2496,9 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
+  split@1.0.1:
+    resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2424,6 +2508,13 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  stream-combiner@0.2.2:
+    resolution: {integrity: sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   string.prototype.trim@1.2.10:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
@@ -2436,6 +2527,13 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2472,6 +2570,12 @@ packages:
     resolution: {integrity: sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  through2@4.0.2:
+    resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2589,6 +2693,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -2721,12 +2828,20 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yaml-eslint-parser@2.0.0:
     resolution: {integrity: sha512-h0uDm97wvT2bokfwwTmY6kJ1hp6YDFL0nRHwNKz8s/VD1FH/vvZjAKoMUE+un0eaYBSG7/c6h+lJTP+31tjgTw==}
@@ -2736,6 +2851,14 @@ packages:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3584,6 +3707,8 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -3647,6 +3772,18 @@ snapshots:
       js-tokens: 10.0.0
 
   async-function@1.0.0: {}
+
+  audit-ci@7.1.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      escape-string-regexp: 4.0.0
+      event-stream: 4.0.1
+      jju: 1.4.0
+      jsonstream-next: 3.0.0
+      readline-transform: 1.0.0
+      semver: 7.7.4
+      tslib: 2.8.1
+      yargs: 17.7.2
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -3720,6 +3857,12 @@ snapshots:
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   color-convert@2.0.1:
     dependencies:
@@ -3827,7 +3970,11 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexer@0.1.2: {}
+
   electron-to-chromium@1.5.302: {}
+
+  emoji-regex@8.0.0: {}
 
   enhanced-resolve@5.20.0:
     dependencies:
@@ -4257,6 +4404,16 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-stream@4.0.1:
+    dependencies:
+      duplexer: 0.1.2
+      from: 0.1.7
+      map-stream: 0.0.7
+      pause-stream: 0.0.11
+      split: 1.0.1
+      stream-combiner: 0.2.2
+      through: 2.3.8
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -4291,6 +4448,8 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  from@0.1.7: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -4306,6 +4465,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4426,6 +4587,8 @@ snapshots:
 
   indent-string@5.0.0: {}
 
+  inherits@2.0.4: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -4481,6 +4644,8 @@ snapshots:
   is-finalizationregistry@1.1.1:
     dependencies:
       call-bound: 1.0.4
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-generator-function@1.1.0:
     dependencies:
@@ -4565,6 +4730,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jju@1.4.0: {}
+
   js-tokens@10.0.0: {}
 
   js-yaml@4.1.1:
@@ -4616,6 +4783,13 @@ snapshots:
       acorn: 8.16.0
       eslint-visitor-keys: 5.0.1
       semver: 7.7.4
+
+  jsonparse@1.3.1: {}
+
+  jsonstream-next@3.0.0:
+    dependencies:
+      jsonparse: 1.3.1
+      through2: 4.0.2
 
   keyv@4.5.4:
     dependencies:
@@ -4740,6 +4914,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  map-stream@0.0.7: {}
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.27.1:
@@ -4851,6 +5027,10 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pause-stream@0.0.11:
+    dependencies:
+      through: 2.3.8
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -4870,6 +5050,14 @@ snapshots:
   prettier@3.8.1: {}
 
   punycode@2.3.1: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readline-transform@1.0.0: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -4896,6 +5084,8 @@ snapshots:
   regjsparser@0.13.0:
     dependencies:
       jsesc: 3.1.0
+
+  require-directory@2.1.1: {}
 
   require-from-string@2.0.2:
     optional: true
@@ -4938,6 +5128,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -5056,6 +5248,10 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
+  split@1.0.1:
+    dependencies:
+      through: 2.3.8
+
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
@@ -5064,6 +5260,17 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-combiner@0.2.2:
+    dependencies:
+      duplexer: 0.1.2
+      through: 2.3.8
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
   string.prototype.trim@1.2.10:
     dependencies:
@@ -5087,6 +5294,14 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
 
@@ -5116,6 +5331,12 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
     optional: true
+
+  through2@4.0.2:
+    dependencies:
+      readable-stream: 3.6.2
+
+  through@2.3.8: {}
 
   tinybench@2.9.0: {}
 
@@ -5166,8 +5387,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -5258,6 +5478,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -5382,11 +5604,19 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   xml-name-validator@5.0.0:
     optional: true
 
   xmlchars@2.2.0:
     optional: true
+
+  y18n@5.0.8: {}
 
   yaml-eslint-parser@2.0.0:
     dependencies:
@@ -5394,6 +5624,18 @@ snapshots:
       yaml: 2.8.3
 
   yaml@2.8.3: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Closes #181 

## What

Adds a new `@williamthorsen/audit-deps` package that wraps `audit-ci` with a typed JSON config model, per-scope (dev/prod) severity thresholds, and a sync workflow that automates allowlist management. The package provides a CLI with five commands: default audit (CI pass/fail), `report` (all vulnerabilities), `sync` (diff-based allowlist updates), `generate` (flat config regeneration), and `init` (config scaffolding).

## Why

Managing audit-ci allowlists across repos is tedious — manually copying advisory IDs, formatting config entries, and checking for stale entries. This package replaces that with a single `audit-deps sync` command that adds new vulnerabilities, removes resolved ones, and preserves manual reasons, all backed by a Zod-validated source-of-truth config.

## Details

### Features

- Zod-validated config schema (`AuditDepsConfig`, `AllowlistEntry`, `ScopeConfig`) loaded from `.config/audit-deps.config.json`
- Flat JSON generation for audit-ci consumption (`audit-ci.dev.json`, `audit-ci.prod.json`) written to configurable `outDir`
- Child process wrapper invoking audit-ci in normal (CI) and report modes with `spawnSync` error checking and stale override detection
- Set-based sync diffing that adds new vulnerabilities with auto-populated UTC-dated reasons, removes resolved entries, and preserves manual reasons
- Serialized allowlist entries with alphabetically-ordered keys for clean diffs
- CLI with subcommand routing (`report`, `sync`, `generate`, `init`), `--dev`/`--prod` scope targeting, `--json` output, `--config` path override, `--help`/`--version`, typo detection, and unknown positional rejection
- Cross-scope advisory deduplication by ID in JSON mode for both audit and report commands
- `init` scaffolding with `--dry-run` and `--force` flags following the preflight pattern

### Fixes

- Binary resolution corrected from `lib/audit-ci.js` to `dist/bin.js` matching audit-ci v7's actual CLI entry
- `runReport` uses stripped config (empty allowlist) so sync discovers all current vulnerabilities
- `spawnSync` error checking prevents silent empty results on binary launch failure
- stderr forwarded independently of stdout in text mode to avoid dropping audit-ci diagnostics

### Refactoring

- All `as` type assertions replaced with runtime narrowing via type guard functions (`isObject`, `isAuditCiAdvisory`) and `in` operator checks
- `extractMessage` consolidated as a shared export, replacing 6 inline `error instanceof Error` patterns
- `syncCommand` calls `loadConfig` directly instead of `loadAndGenerate` to skip a wasted generation round

### Tests

- 96 tests across 8 files: cli, config, generate, init, integration, route, run-audit, sync
- CLI command orchestration tests with mocked dependencies covering exit code merging, deduplication, stale entry warnings, and scope forwarding
- Route dispatch tests verifying `--dev`/`--prod`/`--config` flag forwarding to command handlers
- Integration tests exercising the full generate → sync cycle and `--config` flag via `routeCommand`

### Dependencies

- `audit-ci` v7.1.0 added as a regular dependency
- `zod` for config schema validation (consistent with the preflight package)