### PR TITLE
#185 Guard release-kit prepare against dirty working tree

### DIFF
--- a/packages/release-kit/src/__tests__/assertCleanWorkingTree.unit.test.ts
+++ b/packages/release-kit/src/__tests__/assertCleanWorkingTree.unit.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+import { assertCleanWorkingTree } from '../assertCleanWorkingTree.ts';
+
+describe(assertCleanWorkingTree, () => {
+  afterEach(() => {
+    mockExecFileSync.mockReset();
+  });
+
+  it('throws when the working tree has uncommitted changes', () => {
+    mockExecFileSync.mockReturnValue(' M packages/release-kit/package.json\n');
+
+    expect(() => assertCleanWorkingTree()).toThrow(/working tree has uncommitted changes/i);
+  });
+
+  it('includes --no-git-checks hint in the error message', () => {
+    mockExecFileSync.mockReturnValue(' M package.json\n');
+
+    expect(() => assertCleanWorkingTree()).toThrow(/--no-git-checks/);
+  });
+
+  it('does not throw when the working tree is clean', () => {
+    mockExecFileSync.mockReturnValue('');
+
+    expect(() => assertCleanWorkingTree()).not.toThrow();
+  });
+
+  it('does not throw when git status returns only whitespace', () => {
+    mockExecFileSync.mockReturnValue('  \n');
+
+    expect(() => assertCleanWorkingTree()).not.toThrow();
+  });
+
+  it('calls git status with --porcelain', () => {
+    mockExecFileSync.mockReturnValue('');
+
+    assertCleanWorkingTree();
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['status', '--porcelain'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  });
+});

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const mockAssertCleanWorkingTree = vi.hoisted(() => vi.fn());
 const mockBuildReleaseSummary = vi.hoisted(() => vi.fn());
 const mockDiscoverWorkspaces = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockReleasePrepareMono = vi.hoisted(() => vi.fn());
 const mockReleasePrepare = vi.hoisted(() => vi.fn());
 const mockWriteFileWithCheck = vi.hoisted(() => vi.fn());
+
+vi.mock('../assertCleanWorkingTree.ts', () => ({
+  assertCleanWorkingTree: mockAssertCleanWorkingTree,
+}));
 
 vi.mock('../buildReleaseSummary.ts', () => ({
   buildReleaseSummary: mockBuildReleaseSummary,
@@ -76,6 +81,7 @@ describe(prepareCommand, () => {
   });
 
   afterEach(() => {
+    mockAssertCleanWorkingTree.mockReset();
     mockBuildReleaseSummary.mockReset();
     mockDiscoverWorkspaces.mockReset();
     mockLoadConfig.mockReset();
@@ -330,6 +336,33 @@ describe(prepareCommand, () => {
 
     expect(process.stdout.write).toHaveBeenCalledWith(expect.any(String));
   });
+
+  it('exits with error when the working tree is dirty', async () => {
+    mockAssertCleanWorkingTree.mockImplementation(() => {
+      throw new Error('Working tree has uncommitted changes.');
+    });
+
+    await expect(prepareCommand([])).rejects.toThrow(ExitError);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('uncommitted changes'));
+  });
+
+  it('skips the clean-tree check when --no-git-checks is provided', async () => {
+    await prepareCommand(['--no-git-checks']);
+
+    expect(mockAssertCleanWorkingTree).not.toHaveBeenCalled();
+  });
+
+  it('skips the clean-tree check when -n is provided', async () => {
+    await prepareCommand(['-n']);
+
+    expect(mockAssertCleanWorkingTree).not.toHaveBeenCalled();
+  });
+
+  it('skips the clean-tree check during dry run', async () => {
+    await prepareCommand(['--dry-run']);
+
+    expect(mockAssertCleanWorkingTree).not.toHaveBeenCalled();
+  });
 });
 
 describe(parseArgs, () => {
@@ -364,6 +397,21 @@ describe(parseArgs, () => {
 
   it('throws when --only value is empty', () => {
     expect(() => parseArgs(['--only='])).toThrow('--only requires');
+  });
+
+  it('parses --no-git-checks flag', () => {
+    const result = parseArgs(['--no-git-checks']);
+    expect(result.noGitChecks).toBe(true);
+  });
+
+  it('parses -n as shorthand for --no-git-checks', () => {
+    const result = parseArgs(['-n']);
+    expect(result.noGitChecks).toBe(true);
+  });
+
+  it('defaults noGitChecks to false', () => {
+    const result = parseArgs([]);
+    expect(result.noGitChecks).toBe(false);
   });
 });
 

--- a/packages/release-kit/src/assertCleanWorkingTree.ts
+++ b/packages/release-kit/src/assertCleanWorkingTree.ts
@@ -1,0 +1,19 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Verify that the git working tree has no uncommitted changes.
+ *
+ * @throws If `git status --porcelain` reports any changes.
+ */
+export function assertCleanWorkingTree(): void {
+  const status = execFileSync('git', ['status', '--porcelain'], {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+
+  if (status.length > 0) {
+    throw new Error(
+      'Working tree has uncommitted changes. Commit or stash them before running prepare, or use --no-git-checks to bypass this check.',
+    );
+  }
+}

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -108,6 +108,7 @@ Run release preparation with automatic workspace discovery.
 Options:
   --dry-run             Run without modifying any files
   --bump=major|minor|patch  Override the bump type for all components
+  --no-git-checks, -n   Skip the clean-working-tree check
   --only=name1,name2    Only process the named components (comma-separated, monorepo only)
   --help, -h            Show this help message
 `);

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -8,6 +8,7 @@ import {
   writeFileWithCheck,
 } from '@williamthorsen/node-monorepo-core';
 
+import { assertCleanWorkingTree } from './assertCleanWorkingTree.ts';
 import { buildReleaseSummary } from './buildReleaseSummary.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
 import { dim } from './format.ts';
@@ -36,7 +37,7 @@ function isReleaseType(value: string): value is ReleaseType {
   return VALID_BUMP_TYPES.includes(value);
 }
 
-/** Display CLI usage information. */
+/** Displays CLI usage information. */
 function showHelp(): void {
   console.info(`
 Usage: npx @williamthorsen/release-kit prepare [options]
@@ -45,6 +46,7 @@ Options:
   --dry-run             Run without modifying any files
   --bump=major|minor|patch  Override the bump type for all components
   --force               Bypass the "no commits since last tag" check (monorepo only, requires --bump)
+  --no-git-checks, -n   Skip the clean-working-tree check
   --only=name1,name2    Only process the named components (comma-separated, monorepo only)
   --help                Show this help message
 `);
@@ -53,15 +55,21 @@ Options:
 const prepareFlagSchema = {
   dryRun: { long: '--dry-run', type: 'boolean' as const },
   force: { long: '--force', type: 'boolean' as const },
+  noGitChecks: {
+    long: '--no-git-checks',
+    type: 'boolean' as const,
+    short: '-n',
+  },
   bump: { long: '--bump', type: 'string' as const },
   only: { long: '--only', type: 'string' as const },
   help: { long: '--help', type: 'boolean' as const, short: '-h' },
 };
 
-/** Parse CLI arguments into structured options. Throws on invalid input. */
+/** Parses CLI arguments into structured options. Throws on invalid input. */
 export function parseArgs(argv: string[]): {
   dryRun: boolean;
   force: boolean;
+  noGitChecks: boolean;
   bumpOverride: ReleaseType | undefined;
   only: string[] | undefined;
 } {
@@ -96,11 +104,17 @@ export function parseArgs(argv: string[]): {
     throw new Error('--force requires --bump to specify the version bump type');
   }
 
-  return { dryRun: flags.dryRun, force: flags.force, bumpOverride, only };
+  return {
+    dryRun: flags.dryRun,
+    force: flags.force,
+    noGitChecks: flags.noGitChecks,
+    bumpOverride,
+    only,
+  };
 }
 
 /**
- * Write computed tags to the `.release-tags` file so the CI workflow can read them
+ * Writes computed tags to the `.release-tags` file so the CI workflow can read them
  * instead of deriving tag names independently.
  */
 export function writeReleaseTags(tags: string[], dryRun: boolean): WriteResult | undefined {
@@ -108,11 +122,14 @@ export function writeReleaseTags(tags: string[], dryRun: boolean): WriteResult |
     return undefined;
   }
 
-  return writeFileWithCheck(RELEASE_TAGS_FILE, tags.join('\n'), { dryRun, overwrite: true });
+  return writeFileWithCheck(RELEASE_TAGS_FILE, tags.join('\n'), {
+    dryRun,
+    overwrite: true,
+  });
 }
 
 /**
- * Orchestrate the CLI `prepare` command.
+ * Orchestrates the CLI `prepare` command.
  *
  * 1. Discovers workspaces from `pnpm-workspace.yaml`.
  * 2. Loads and validates `.config/release-kit.config.ts` (if present).
@@ -124,10 +141,11 @@ export function writeReleaseTags(tags: string[], dryRun: boolean): WriteResult |
 export async function prepareCommand(argv: string[]): Promise<void> {
   let dryRun: boolean;
   let force: boolean;
+  let noGitChecks: boolean;
   let bumpOverride: ReleaseType | undefined;
   let only: string[] | undefined;
   try {
-    ({ dryRun, force, bumpOverride, only } = parseArgs(argv));
+    ({ dryRun, force, noGitChecks, bumpOverride, only } = parseArgs(argv));
   } catch (error: unknown) {
     console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
@@ -142,28 +160,17 @@ export async function prepareCommand(argv: string[]): Promise<void> {
     console.info('\n🔍 DRY RUN — no files will be modified\n');
   }
 
-  // 1. Load config file
-  let rawConfig: unknown;
-  try {
-    rawConfig = await loadConfig();
-  } catch (error: unknown) {
-    console.error(`Error loading config: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(1);
-  }
-
-  // 2. Validate config
-  let userConfig: ReleaseKitConfig | undefined;
-  if (rawConfig !== undefined) {
-    const { config, errors } = validateConfig(rawConfig);
-    if (errors.length > 0) {
-      console.error('Invalid config:');
-      for (const err of errors) {
-        console.error(`  ❌ ${err}`);
-      }
+  // Guard against running on a dirty working tree (skip for dry runs and --no-git-checks).
+  if (!dryRun && !noGitChecks) {
+    try {
+      assertCleanWorkingTree();
+    } catch (error: unknown) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
-    userConfig = config;
   }
+
+  const userConfig = await loadAndValidateConfig();
 
   // 3. Discover workspaces
   let discoveredPaths: string[] | undefined;
@@ -206,7 +213,33 @@ export async function prepareCommand(argv: string[]): Promise<void> {
   }
 }
 
-/** Execute the prepare workflow, format the result, write to stdout, and handle errors. */
+/** Loads and validate the release-kit config file, exiting on errors. */
+async function loadAndValidateConfig(): Promise<ReleaseKitConfig | undefined> {
+  let rawConfig: unknown;
+  try {
+    rawConfig = await loadConfig();
+  } catch (error: unknown) {
+    console.error(`Error loading config: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  if (rawConfig === undefined) {
+    return undefined;
+  }
+
+  const { config, errors } = validateConfig(rawConfig);
+  if (errors.length > 0) {
+    console.error('Invalid config:');
+    for (const err of errors) {
+      console.error(`  ❌ ${err}`);
+    }
+    process.exit(1);
+  }
+
+  return config;
+}
+
+/** Executes the prepare workflow, format the result, write to stdout, and handle errors. */
 function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
   let result: PrepareResult;
   try {
@@ -234,10 +267,13 @@ function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
     }
   }
 
-  // Write the release summary file for the commit command.
+  // Writes the release summary file for the commit command.
   const summary = buildReleaseSummary(result);
   if (summary.length > 0) {
-    const summaryResult = writeFileWithCheck(RELEASE_SUMMARY_FILE, summary, { dryRun, overwrite: true });
+    const summaryResult = writeFileWithCheck(RELEASE_SUMMARY_FILE, summary, {
+      dryRun,
+      overwrite: true,
+    });
 
     if (summaryResult.outcome === 'failed') {
       console.error(`Error writing release summary: ${summaryResult.error ?? 'unknown error'}`);


### PR DESCRIPTION
## What

Adds a clean-working-tree guard to `release-kit prepare` that exits with an informative error when uncommitted changes are detected. The check can be bypassed with `--no-git-checks` (`-n`) and is automatically skipped during `--dry-run`.

## Why

Running `prepare` multiple times without committing between runs caused the version to be bumped repeatedly, because each run read the already-bumped version from `package.json`. Rather than changing where the version is derived from, the fix prevents the problematic scenario by refusing to run on a dirty tree.

## Details

### Features

- `assertCleanWorkingTree` utility runs `git status --porcelain` and throws a descriptive error when uncommitted changes exist, including a hint to use `--no-git-checks`.
- `--no-git-checks` / `-n` flag added to `prepare` to bypass the clean-tree check when the user intentionally wants to skip it.
- The guard is skipped during `--dry-run` since dry runs don't modify files.

### Refactoring

- Extracted `loadAndValidateConfig` from `prepareCommand` to keep the function under the ESLint complexity threshold after adding the new guard.

### Tests

- 5 unit tests for `assertCleanWorkingTree` (dirty tree, clean tree, whitespace-only, error message content, correct git arguments).
- 7 unit tests for `prepareCommand` (dirty tree exits, `--no-git-checks` bypasses, `-n` bypasses, `--dry-run` bypasses, `parseArgs` flag parsing).

## Test plan

- [ ] Run `release-kit prepare` on a repo with uncommitted changes — verify it exits with an error mentioning `--no-git-checks`
- [ ] Run `release-kit prepare --no-git-checks` on the same dirty tree — verify it proceeds
- [ ] Run `release-kit prepare -n` — verify short flag works
- [ ] Run `release-kit prepare --dry-run` on a dirty tree — verify it proceeds
- [ ] Run `release-kit prepare` on a clean tree — verify no regression

Closes #185