### PR TITLE
Generate release notes distinct from changelogs

### DIFF
--- a/.readyup/kits/release-kit.js
+++ b/.readyup/kits/release-kit.js
@@ -141,7 +141,8 @@ var package_default = {
     "@williamthorsen/node-monorepo-core": "workspace:*",
     glob: "13.0.6",
     jiti: "2.6.1",
-    "js-yaml": "4.1.1"
+    "js-yaml": "4.1.1",
+    "json-stringify-pretty-compact": "4.0.0"
   },
   devDependencies: {
     "@types/js-yaml": "4.0.9",
@@ -224,6 +225,13 @@ var release_kit_default = defineRdyKit({
           fix: "Remove 'tagPrefix' from .config/release-kit.config.ts \u2014 it is no longer supported; the default '{dir}-v' is used automatically"
         },
         {
+          name: "releaseNotes config is consistent with changelogJson",
+          severity: "warn",
+          skip: () => !fileExists(".config/release-kit.config.ts") ? "no release-kit config file" : false,
+          check: () => releaseNotesConfigIsConsistent(),
+          fix: "Either enable changelogJson.enabled or disable releaseNotes features (shouldCreateGithubRelease, shouldInjectIntoReadme)"
+        },
+        {
           name: "git-cliff not in devDependencies",
           severity: "recommend",
           check: () => !hasDevDependency("git-cliff"),
@@ -275,6 +283,15 @@ var release_kit_default = defineRdyKit({
     }
   ]
 });
+function releaseNotesConfigIsConsistent() {
+  const content = readFile(".config/release-kit.config.ts");
+  if (content === void 0) return true;
+  const changelogJsonDisabled = /changelogJson\s*:\s*\{[^}]*enabled\s*:\s*false/.test(content);
+  if (!changelogJsonDisabled) return true;
+  const hasGithubRelease = /shouldCreateGithubRelease\s*:\s*true/.test(content);
+  const hasReadmeInjection = /shouldInjectIntoReadme\s*:\s*true/.test(content);
+  return !hasGithubRelease && !hasReadmeInjection;
+}
 function labelsHaveCurrentPresetHash(presetName, expectedHash) {
   const content = readFile(".github/labels.yaml");
   if (content === void 0) return false;

--- a/.readyup/kits/release-kit.ts
+++ b/.readyup/kits/release-kit.ts
@@ -96,6 +96,13 @@ export default defineRdyKit({
           fix: "Remove 'tagPrefix' from .config/release-kit.config.ts — it is no longer supported; the default '{dir}-v' is used automatically",
         },
         {
+          name: 'releaseNotes config is consistent with changelogJson',
+          severity: 'warn',
+          skip: () => (!fileExists('.config/release-kit.config.ts') ? 'no release-kit config file' : false),
+          check: () => releaseNotesConfigIsConsistent(),
+          fix: 'Either enable changelogJson.enabled or disable releaseNotes features (shouldCreateGithubRelease, shouldInjectIntoReadme)',
+        },
+        {
           name: 'git-cliff not in devDependencies',
           severity: 'recommend',
           check: () => !hasDevDependency('git-cliff'),
@@ -149,6 +156,23 @@ export default defineRdyKit({
 });
 
 // -- Helpers ------------------------------------------------------------------
+
+/**
+ * Check that releaseNotes features are not enabled while changelogJson is disabled.
+ *
+ * Uses regex matching against the raw config file to avoid importing it.
+ */
+function releaseNotesConfigIsConsistent(): boolean {
+  const content = readFile('.config/release-kit.config.ts');
+  if (content === undefined) return true;
+
+  const changelogJsonDisabled = /changelogJson\s*:\s*\{[^}]*enabled\s*:\s*false/.test(content);
+  if (!changelogJsonDisabled) return true;
+
+  const hasGithubRelease = /shouldCreateGithubRelease\s*:\s*true/.test(content);
+  const hasReadmeInjection = /shouldInjectIntoReadme\s*:\s*true/.test(content);
+  return !hasGithubRelease && !hasReadmeInjection;
+}
 
 /** Check that `.github/labels.yaml` contains the expected hash for a named preset. */
 function labelsHaveCurrentPresetHash(presetName: string, expectedHash: string): boolean {

--- a/packages/release-kit/package.json
+++ b/packages/release-kit/package.json
@@ -42,7 +42,8 @@
     "@williamthorsen/node-monorepo-core": "workspace:*",
     "glob": "13.0.6",
     "jiti": "2.6.1",
-    "js-yaml": "4.1.1"
+    "js-yaml": "4.1.1",
+    "json-stringify-pretty-compact": "4.0.0"
   },
   "devDependencies": {
     "@types/js-yaml": "4.0.9",

--- a/packages/release-kit/src/__tests__/changelogJsonUtils.unit.test.ts
+++ b/packages/release-kit/src/__tests__/changelogJsonUtils.unit.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { extractVersion, isChangelogEntry, readChangelogEntries } from '../changelogJsonUtils.ts';
+import type { ChangelogEntry } from '../types.ts';
+
+describe(isChangelogEntry, () => {
+  it('returns true for a valid entry', () => {
+    expect(isChangelogEntry({ version: '1.0.0', date: '2024-01-01', sections: [] })).toBe(true);
+  });
+
+  it('returns false when version is missing', () => {
+    expect(isChangelogEntry({ date: '2024-01-01', sections: [] })).toBe(false);
+  });
+
+  it('returns false when sections is not an array', () => {
+    expect(isChangelogEntry({ version: '1.0.0', date: '2024-01-01', sections: 'not-array' })).toBe(false);
+  });
+
+  it('returns false for non-object values', () => {
+    expect(isChangelogEntry('string')).toBe(false);
+    expect(isChangelogEntry(null)).toBe(false);
+    expect(isChangelogEntry(42)).toBe(false);
+  });
+});
+
+describe(extractVersion, () => {
+  it('strips v prefix from a simple tag', () => {
+    expect(extractVersion('v1.2.3')).toBe('1.2.3');
+  });
+
+  it('strips scoped prefix from a monorepo tag', () => {
+    expect(extractVersion('release-kit-v1.0.0')).toBe('1.0.0');
+  });
+
+  it('returns the full tag when no version pattern is found', () => {
+    expect(extractVersion('not-a-version')).toBe('not-a-version');
+  });
+
+  it('preserves pre-release suffix', () => {
+    expect(extractVersion('v1.0.0-beta.1')).toBe('1.0.0-beta.1');
+  });
+});
+
+describe(readChangelogEntries, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `test-read-entries-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns undefined when file does not exist', () => {
+    expect(readChangelogEntries(join(tempDir, 'missing.json'))).toBeUndefined();
+  });
+
+  it('returns entries from a valid changelog JSON file', () => {
+    const entries: ChangelogEntry[] = [{ version: '1.0.0', date: '2024-01-01', sections: [] }];
+    writeFileSync(join(tempDir, 'changelog.json'), JSON.stringify(entries), 'utf8');
+
+    const result = readChangelogEntries(join(tempDir, 'changelog.json'));
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.version).toBe('1.0.0');
+  });
+
+  it('returns undefined when file contains non-array JSON', () => {
+    writeFileSync(join(tempDir, 'changelog.json'), '{"not": "array"}', 'utf8');
+
+    expect(readChangelogEntries(join(tempDir, 'changelog.json'))).toBeUndefined();
+  });
+
+  it('returns undefined when file contains malformed JSON', () => {
+    writeFileSync(join(tempDir, 'changelog.json'), '{bad json', 'utf8');
+
+    expect(readChangelogEntries(join(tempDir, 'changelog.json'))).toBeUndefined();
+  });
+
+  it('filters out invalid entries from the array', () => {
+    const mixed = [{ version: '1.0.0', date: '2024-01-01', sections: [] }, { invalid: true }, 'not-an-object'];
+    writeFileSync(join(tempDir, 'changelog.json'), JSON.stringify(mixed), 'utf8');
+
+    const result = readChangelogEntries(join(tempDir, 'changelog.json'));
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.version).toBe('1.0.0');
+  });
+});

--- a/packages/release-kit/src/__tests__/createGithubRelease.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubRelease.unit.test.ts
@@ -1,0 +1,144 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChangelogEntry } from '../types.ts';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+const { execFileSync } = await import('node:child_process');
+const { createGithubRelease } = await import('../createGithubRelease.ts');
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+describe(createGithubRelease, () => {
+  let tempDir: string;
+  let changelogJsonPath: string;
+
+  const sampleEntries: ChangelogEntry[] = [
+    {
+      version: '1.0.0',
+      date: '2024-11-15',
+      sections: [
+        { title: 'Features', audience: 'all', items: [{ description: 'Add widget' }] },
+        { title: 'CI', audience: 'dev', items: [{ description: 'Update pipeline' }] },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `test-gh-release-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    changelogJsonPath = join(tempDir, 'changelog.json');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('returns false and warns when changelog.json does not exist', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = createGithubRelease({
+      tag: 'v1.0.0',
+      changelogJsonPath: join(tempDir, 'nonexistent.json'),
+      dryRun: false,
+    });
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not found'));
+  });
+
+  it('returns false and warns when version is not in changelog.json', () => {
+    writeFileSync(changelogJsonPath, JSON.stringify(sampleEntries), 'utf8');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = createGithubRelease({
+      tag: 'v99.0.0',
+      changelogJsonPath,
+      dryRun: false,
+    });
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no changelog entry'));
+  });
+
+  it('logs the command in dry-run mode without executing', () => {
+    writeFileSync(changelogJsonPath, JSON.stringify(sampleEntries), 'utf8');
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const result = createGithubRelease({
+      tag: 'v1.0.0',
+      changelogJsonPath,
+      dryRun: true,
+    });
+    expect(result).toBe(true);
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('[dry-run]'));
+  });
+
+  it('calls gh CLI with correct arguments', () => {
+    writeFileSync(changelogJsonPath, JSON.stringify(sampleEntries), 'utf8');
+
+    createGithubRelease({
+      tag: 'v1.0.0',
+      changelogJsonPath,
+      dryRun: false,
+    });
+
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['release', 'create', 'v1.0.0']),
+      expect.objectContaining({ stdio: 'inherit' }),
+    );
+  });
+
+  it('passes only all-audience sections in the release notes', () => {
+    writeFileSync(changelogJsonPath, JSON.stringify(sampleEntries), 'utf8');
+
+    createGithubRelease({
+      tag: 'v1.0.0',
+      changelogJsonPath,
+      dryRun: false,
+    });
+
+    const callArgs = mockedExecFileSync.mock.calls[0];
+    const args = callArgs?.[1];
+    if (Array.isArray(args)) {
+      const notesIndex = args.indexOf('--notes');
+      const body = args[notesIndex + 1];
+      expect(body).toContain('Features');
+      expect(body).not.toContain('CI');
+    }
+  });
+
+  it('returns false and warns on gh CLI failure', () => {
+    writeFileSync(changelogJsonPath, JSON.stringify(sampleEntries), 'utf8');
+    mockedExecFileSync.mockImplementationOnce(() => {
+      throw new Error('gh failed');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = createGithubRelease({
+      tag: 'v1.0.0',
+      changelogJsonPath,
+      dryRun: false,
+    });
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('failed to create'));
+  });
+
+  it('extracts version from prefixed tags', () => {
+    writeFileSync(changelogJsonPath, JSON.stringify(sampleEntries), 'utf8');
+
+    createGithubRelease({
+      tag: 'release-kit-v1.0.0',
+      changelogJsonPath,
+      dryRun: false,
+    });
+
+    expect(mockedExecFileSync).toHaveBeenCalled();
+  });
+});

--- a/packages/release-kit/src/__tests__/createGithubRelease.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubRelease.unit.test.ts
@@ -130,7 +130,7 @@ describe(createGithubRelease, () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('failed to create'));
   });
 
-  it('extracts version from prefixed tags', () => {
+  it('extracts version from prefixed tags and matches correct entry', () => {
     writeFileSync(changelogJsonPath, JSON.stringify(sampleEntries), 'utf8');
 
     createGithubRelease({
@@ -139,6 +139,17 @@ describe(createGithubRelease, () => {
       dryRun: false,
     });
 
-    expect(mockedExecFileSync).toHaveBeenCalled();
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['release', 'create', 'release-kit-v1.0.0']),
+      expect.anything(),
+    );
+    const callArgs = mockedExecFileSync.mock.calls[0];
+    const args = callArgs?.[1];
+    if (Array.isArray(args)) {
+      const notesIndex = args.indexOf('--notes');
+      const body = args[notesIndex + 1];
+      expect(body).toContain('Add widget');
+    }
   });
 });

--- a/packages/release-kit/src/__tests__/devOnlySections.drift.test.ts
+++ b/packages/release-kit/src/__tests__/devOnlySections.drift.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parse } from 'smol-toml';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_CHANGELOG_JSON_CONFIG } from '../defaults.ts';
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const templatePath = resolve(thisDir, '..', '..', 'cliff.toml.template');
+const templateContent = readFileSync(templatePath, 'utf8');
+
+/** Groups in cliff.toml.template that are intended for all audiences (not dev-only). */
+const ALL_AUDIENCE_GROUPS = new Set([
+  'Bug fixes',
+  'Deprecated',
+  'Documentation',
+  'Features',
+  'Performance',
+  'Refactoring',
+  'Security',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Extract all unique group values from cliff.toml.template commit_parsers. */
+function getTemplateGroups(): Set<string> {
+  const config = parse(templateContent);
+  const git = config.git;
+  if (!isRecord(git)) {
+    throw new Error('cliff.toml.template is missing [git] section');
+  }
+
+  const parsers = git.commit_parsers;
+  if (!Array.isArray(parsers)) {
+    throw new TypeError('cliff.toml.template is missing git.commit_parsers array');
+  }
+
+  const groups = new Set<string>();
+  for (const entry of parsers) {
+    if (isRecord(entry) && typeof entry.group === 'string') {
+      groups.add(entry.group);
+    }
+  }
+  return groups;
+}
+
+describe('devOnlySections drift detection', () => {
+  const templateGroups = getTemplateGroups();
+  const devOnlySections = new Set(DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections);
+
+  it('every devOnlySections default exists as a group in cliff.toml.template', () => {
+    for (const section of devOnlySections) {
+      expect(templateGroups, `devOnlySections entry "${section}" not found in cliff.toml.template groups`).toContain(
+        section,
+      );
+    }
+  });
+
+  it('every cliff.toml.template group is classified as either dev-only or all-audience', () => {
+    for (const group of templateGroups) {
+      const isClassified = devOnlySections.has(group) || ALL_AUDIENCE_GROUPS.has(group);
+      expect(
+        isClassified,
+        `Group "${group}" in cliff.toml.template is not classified — add it to devOnlySections defaults or ALL_AUDIENCE_GROUPS`,
+      ).toBe(true);
+    }
+  });
+
+  it('no group appears in both devOnlySections and ALL_AUDIENCE_GROUPS', () => {
+    for (const group of devOnlySections) {
+      expect(
+        ALL_AUDIENCE_GROUPS.has(group),
+        `Group "${group}" appears in both devOnlySections and ALL_AUDIENCE_GROUPS`,
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
@@ -218,6 +218,8 @@ describe(generateChangelogs, () => {
       changelogPaths: ['packages/arrays', 'packages/strings'],
       workTypes: {},
       cliffConfigPath: 'cliff.toml',
+      changelogJson: { enabled: false, outputPath: '.meta/changelog.json', devOnlySections: [] },
+      releaseNotes: { shouldInjectIntoReadme: false, shouldCreateGithubRelease: false },
     } satisfies ReleaseConfig;
 
     const result = generateChangelogs(config, 'v1.0.0', false);
@@ -234,6 +236,8 @@ describe(generateChangelogs, () => {
       changelogPaths: ['packages/release-kit'],
       workTypes: {},
       cliffConfigPath: 'cliff.toml',
+      changelogJson: { enabled: false, outputPath: '.meta/changelog.json', devOnlySections: [] },
+      releaseNotes: { shouldInjectIntoReadme: false, shouldCreateGithubRelease: false },
     } satisfies ReleaseConfig;
 
     generateChangelogs(config, 'release-kit-v2.3.0', false);

--- a/packages/release-kit/src/__tests__/generateChangelogJson.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelogJson.unit.test.ts
@@ -1,0 +1,211 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChangelogEntry, ChangelogJsonConfig, ReleaseConfig } from '../types.ts';
+
+// Mock execFileSync to avoid actually running git-cliff.
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+// Mock resolveCliffConfigPath to return a dummy path.
+vi.mock('../resolveCliffConfigPath.ts', () => ({
+  resolveCliffConfigPath: () => '/fake/cliff.toml',
+}));
+
+const { execFileSync } = await import('node:child_process');
+const { generateChangelogJson, generateSyntheticChangelogJson } = await import('../generateChangelogJson.ts');
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+const defaultChangelogJsonConfig: ChangelogJsonConfig = {
+  enabled: true,
+  outputPath: '.meta/changelog.json',
+  devOnlySections: ['CI', 'Dependencies', 'Formatting', 'Internal', 'Tests', 'Tooling'],
+};
+
+function makeConfig(
+  overrides?: Partial<ChangelogJsonConfig>,
+): Pick<ReleaseConfig, 'cliffConfigPath' | 'changelogJson'> {
+  return {
+    changelogJson: { ...defaultChangelogJsonConfig, ...overrides },
+  };
+}
+
+describe(generateChangelogJson, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `test-changelog-json-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('returns output path without writing in dry-run mode', () => {
+    const result = generateChangelogJson(makeConfig(), tempDir, 'v1.0.0', true);
+    expect(result).toStrictEqual([`${tempDir}/.meta/changelog.json`]);
+  });
+
+  it('transforms git-cliff context into ChangelogEntry array', () => {
+    const cliffContext = [
+      {
+        version: 'v1.0.0',
+        timestamp: 1700000000,
+        commits: [
+          { message: '#1 feat: Add new feature', group: 'Features' },
+          { message: '#2 fix: Fix a bug', group: 'Bug fixes' },
+          { message: '#3 ci: Update pipeline', group: 'CI' },
+        ],
+      },
+    ];
+
+    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+
+    generateChangelogJson(makeConfig(), tempDir, 'v1.0.0', false);
+
+    const outputPath = join(tempDir, '.meta', 'changelog.json');
+    const content = readFileSync(outputPath, 'utf8');
+    const entries: ChangelogEntry[] = JSON.parse(content);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.version).toBe('1.0.0');
+    expect(entries[0]?.sections).toHaveLength(3);
+
+    const features = entries[0]?.sections.find((s) => s.title === 'Features');
+    expect(features?.audience).toBe('all');
+    expect(features?.items[0]?.description).toBe('Add new feature');
+
+    const ci = entries[0]?.sections.find((s) => s.title === 'CI');
+    expect(ci?.audience).toBe('dev');
+  });
+
+  it('omits releases without version', () => {
+    const cliffContext = [
+      { commits: [{ message: '#1 feat: Unreleased', group: 'Features' }] },
+      {
+        version: 'v1.0.0',
+        timestamp: 1700000000,
+        commits: [{ message: '#2 feat: Released', group: 'Features' }],
+      },
+    ];
+
+    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+
+    generateChangelogJson(makeConfig(), tempDir, 'v1.0.0', false);
+
+    const outputPath = join(tempDir, '.meta', 'changelog.json');
+    const entries: ChangelogEntry[] = JSON.parse(readFileSync(outputPath, 'utf8'));
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.version).toBe('1.0.0');
+  });
+
+  it('tags sections with correct audience based on devOnlySections', () => {
+    const cliffContext = [
+      {
+        version: 'v2.0.0',
+        timestamp: 1700000000,
+        commits: [
+          { message: '#1 feat: Feature', group: 'Features' },
+          { message: '#2 deps: Bump deps', group: 'Dependencies' },
+          { message: '#3 tests: Add test', group: 'Tests' },
+          { message: '#4 fix: Bug fix', group: 'Bug fixes' },
+        ],
+      },
+    ];
+
+    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+
+    generateChangelogJson(makeConfig(), tempDir, 'v2.0.0', false);
+
+    const entries: ChangelogEntry[] = JSON.parse(readFileSync(join(tempDir, '.meta', 'changelog.json'), 'utf8'));
+
+    const audiences = Object.fromEntries(entries[0]?.sections.map((s) => [s.title, s.audience]) ?? []);
+    expect(audiences).toStrictEqual({
+      Features: 'all',
+      Dependencies: 'dev',
+      Tests: 'dev',
+      'Bug fixes': 'all',
+    });
+  });
+
+  it('merges new entries with existing entries and sorts newest-first', () => {
+    const outputPath = join(tempDir, '.meta', 'changelog.json');
+    mkdirSync(join(tempDir, '.meta'), { recursive: true });
+
+    const existing: ChangelogEntry[] = [
+      {
+        version: '0.9.0',
+        date: '2024-01-01',
+        sections: [{ title: 'Features', audience: 'all', items: [{ description: 'Old feature' }] }],
+      },
+    ];
+    writeFileSync(outputPath, JSON.stringify(existing), 'utf8');
+
+    const cliffContext = [
+      {
+        version: 'v1.0.0',
+        timestamp: 1700000000,
+        commits: [{ message: '#1 feat: New feature', group: 'Features' }],
+      },
+    ];
+
+    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+
+    generateChangelogJson(makeConfig(), tempDir, 'v1.0.0', false);
+
+    const entries: ChangelogEntry[] = JSON.parse(readFileSync(outputPath, 'utf8'));
+    expect(entries).toHaveLength(2);
+    expect(entries[0]?.version).toBe('1.0.0');
+    expect(entries[1]?.version).toBe('0.9.0');
+  });
+});
+
+describe(generateSyntheticChangelogJson, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `test-synthetic-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns output path without writing in dry-run mode', () => {
+    const config = makeConfig();
+    const result = generateSyntheticChangelogJson(config, tempDir, '1.0.1', '2024-01-15', [], true);
+    expect(result).toStrictEqual([`${tempDir}/.meta/changelog.json`]);
+  });
+
+  it('produces a ChangelogEntry with Dependency updates section', () => {
+    const config = makeConfig();
+    generateSyntheticChangelogJson(
+      config,
+      tempDir,
+      '1.0.1',
+      '2024-01-15',
+      [{ packageName: '@scope/dep', newVersion: '2.0.0' }],
+      false,
+    );
+
+    const outputPath = join(tempDir, '.meta', 'changelog.json');
+    const entries: ChangelogEntry[] = JSON.parse(readFileSync(outputPath, 'utf8'));
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.version).toBe('1.0.1');
+    expect(entries[0]?.date).toBe('2024-01-15');
+    expect(entries[0]?.sections).toHaveLength(1);
+    expect(entries[0]?.sections[0]?.title).toBe('Dependency updates');
+    expect(entries[0]?.sections[0]?.audience).toBe('dev');
+    expect(entries[0]?.sections[0]?.items[0]?.description).toBe('Bumped `@scope/dep` to 2.0.0');
+  });
+});

--- a/packages/release-kit/src/__tests__/generateChangelogJson.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelogJson.unit.test.ts
@@ -57,7 +57,7 @@ describe(generateChangelogJson, () => {
     const cliffContext = [
       {
         version: 'v1.0.0',
-        timestamp: 1700000000,
+        timestamp: 1_700_000_000,
         commits: [
           { message: '#1 feat: Add new feature', group: 'Features' },
           { message: '#2 fix: Fix a bug', group: 'Bug fixes' },
@@ -91,7 +91,7 @@ describe(generateChangelogJson, () => {
       { commits: [{ message: '#1 feat: Unreleased', group: 'Features' }] },
       {
         version: 'v1.0.0',
-        timestamp: 1700000000,
+        timestamp: 1_700_000_000,
         commits: [{ message: '#2 feat: Released', group: 'Features' }],
       },
     ];
@@ -111,7 +111,7 @@ describe(generateChangelogJson, () => {
     const cliffContext = [
       {
         version: 'v2.0.0',
-        timestamp: 1700000000,
+        timestamp: 1_700_000_000,
         commits: [
           { message: '#1 feat: Feature', group: 'Features' },
           { message: '#2 deps: Bump deps', group: 'Dependencies' },
@@ -140,7 +140,7 @@ describe(generateChangelogJson, () => {
     const cliffContext = [
       {
         version: 'v1.0.0',
-        timestamp: 1700000000,
+        timestamp: 1_700_000_000,
         commits: [{ message: 'Initial commit', group: 'Other' }],
       },
     ];
@@ -165,7 +165,7 @@ describe(generateChangelogJson, () => {
     const cliffContext = [
       {
         version: 'v1.0.0',
-        timestamp: 1700000000,
+        timestamp: 1_700_000_000,
         commits: [{ message: '#1 feat: New feature', group: 'Features' }],
       },
     ];
@@ -196,7 +196,7 @@ describe(generateChangelogJson, () => {
     const cliffContext = [
       {
         version: 'v1.0.0',
-        timestamp: 1700000000,
+        timestamp: 1_700_000_000,
         commits: [{ message: '#1 feat: New feature', group: 'Features' }],
       },
     ];

--- a/packages/release-kit/src/__tests__/generateChangelogJson.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelogJson.unit.test.ts
@@ -136,6 +136,50 @@ describe(generateChangelogJson, () => {
     });
   });
 
+  it('preserves full first line when commit message has no colon separator', () => {
+    const cliffContext = [
+      {
+        version: 'v1.0.0',
+        timestamp: 1700000000,
+        commits: [{ message: 'Initial commit', group: 'Other' }],
+      },
+    ];
+
+    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+
+    generateChangelogJson(makeConfig(), tempDir, 'v1.0.0', false);
+
+    const outputPath = join(tempDir, '.meta', 'changelog.json');
+    const entries: ChangelogEntry[] = JSON.parse(readFileSync(outputPath, 'utf8'));
+
+    expect(entries[0]?.sections[0]?.items[0]?.description).toBe('Initial commit');
+  });
+
+  it('recovers gracefully when existing changelog JSON is malformed', () => {
+    const outputPath = join(tempDir, '.meta', 'changelog.json');
+    mkdirSync(join(tempDir, '.meta'), { recursive: true });
+    writeFileSync(outputPath, '{invalid json', 'utf8');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const cliffContext = [
+      {
+        version: 'v1.0.0',
+        timestamp: 1700000000,
+        commits: [{ message: '#1 feat: New feature', group: 'Features' }],
+      },
+    ];
+
+    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+
+    generateChangelogJson(makeConfig(), tempDir, 'v1.0.0', false);
+
+    const entries: ChangelogEntry[] = JSON.parse(readFileSync(outputPath, 'utf8'));
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.version).toBe('1.0.0');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('could not parse existing'));
+  });
+
   it('merges new entries with existing entries and sorts newest-first', () => {
     const outputPath = join(tempDir, '.meta', 'changelog.json');
     mkdirSync(join(tempDir, '.meta'), { recursive: true });

--- a/packages/release-kit/src/__tests__/injectSection.unit.test.ts
+++ b/packages/release-kit/src/__tests__/injectSection.unit.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { injectSection } from '../injectSection.ts';
+
+describe(injectSection, () => {
+  it('replaces content between existing markers', () => {
+    const content = [
+      '<!-- section:release-notes -->',
+      'old content',
+      '<!-- /section:release-notes -->',
+      '',
+      '# README',
+    ].join('\n');
+
+    const result = injectSection(content, 'release-notes', 'new content');
+    expect(result).toBe(
+      ['<!-- section:release-notes -->', 'new content', '<!-- /section:release-notes -->', '', '# README'].join('\n'),
+    );
+  });
+
+  it('prepends section with markers when none exist', () => {
+    const content = '# README\n\nSome text.';
+    const result = injectSection(content, 'release-notes', 'injected');
+    expect(result).toBe(
+      [
+        '<!-- section:release-notes -->',
+        'injected',
+        '<!-- /section:release-notes -->',
+        '',
+        '# README',
+        '',
+        'Some text.',
+      ].join('\n'),
+    );
+  });
+
+  it('inserts into empty content', () => {
+    const result = injectSection('', 'release-notes', 'injected');
+    expect(result).toBe(
+      ['<!-- section:release-notes -->', 'injected', '<!-- /section:release-notes -->', ''].join('\n'),
+    );
+  });
+
+  it('handles multiple sections with different keys independently', () => {
+    let content = '# README';
+    content = injectSection(content, 'notes', 'Notes content');
+    content = injectSection(content, 'changelog', 'Changelog content');
+
+    expect(content).toContain('<!-- section:notes -->');
+    expect(content).toContain('Notes content');
+    expect(content).toContain('<!-- section:changelog -->');
+    expect(content).toContain('Changelog content');
+    expect(content).toContain('# README');
+  });
+
+  it('replaces only the targeted section when multiple sections exist', () => {
+    const content = [
+      '<!-- section:a -->',
+      'old A',
+      '<!-- /section:a -->',
+      '',
+      '<!-- section:b -->',
+      'old B',
+      '<!-- /section:b -->',
+    ].join('\n');
+
+    const result = injectSection(content, 'a', 'new A');
+    expect(result).toContain('new A');
+    expect(result).toContain('old B');
+    expect(result).not.toContain('old A');
+  });
+
+  it('handles empty injection content', () => {
+    const content = ['<!-- section:release-notes -->', 'old content', '<!-- /section:release-notes -->'].join('\n');
+
+    const result = injectSection(content, 'release-notes', '');
+    expect(result).toBe(['<!-- section:release-notes -->', '', '<!-- /section:release-notes -->'].join('\n'));
+  });
+});

--- a/packages/release-kit/src/__tests__/publish.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publish.unit.test.ts
@@ -6,6 +6,8 @@ const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
 const mockExtractVersion = vi.hoisted(() => vi.fn());
 const mockReadChangelogEntries = vi.hoisted(() => vi.fn());
+const mockMatchesAudience = vi.hoisted(() => vi.fn());
+const mockRenderReleaseNotesSingle = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,
@@ -20,6 +22,11 @@ vi.mock('node:fs', () => ({
 vi.mock('../changelogJsonUtils.ts', () => ({
   extractVersion: mockExtractVersion,
   readChangelogEntries: mockReadChangelogEntries,
+}));
+
+vi.mock('../renderReleaseNotes.ts', () => ({
+  matchesAudience: mockMatchesAudience,
+  renderReleaseNotesSingle: mockRenderReleaseNotesSingle,
 }));
 
 import { publish } from '../publish.ts';
@@ -40,6 +47,8 @@ describe(publish, () => {
     mockWriteFileSync.mockReset();
     mockExtractVersion.mockReset();
     mockReadChangelogEntries.mockReset();
+    mockMatchesAudience.mockReset();
+    mockRenderReleaseNotesSingle.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -269,6 +278,8 @@ describe(publish, () => {
           sections: [{ title: 'Features', audience: 'all', items: [{ description: 'Add widget' }] }],
         },
       ]);
+      mockMatchesAudience.mockReturnValue(() => true);
+      mockRenderReleaseNotesSingle.mockReturnValue('### Features\n\n- Add widget\n');
     }
 
     it('injects release notes into README before publish when enabled', () => {
@@ -317,6 +328,30 @@ describe(publish, () => {
 
       expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('not found; skipping README injection'));
       // Only the publish happens, no README write
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('warns and skips injection when changelog.json is malformed', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('# README\n');
+      mockExtractVersion.mockReturnValue('1.0.0');
+      mockReadChangelogEntries.mockReturnValue(undefined);
+
+      publish(tag, 'npm', injectionOptions);
+
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('could not parse'));
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('skipping README injection'));
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('warns and skips injection when all sections are dev-only', () => {
+      setupInjectionMocks();
+      mockRenderReleaseNotesSingle.mockReturnValue('');
+
+      publish(tag, 'npm', injectionOptions);
+
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no user-facing release notes'));
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('skipping README injection'));
       expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
 

--- a/packages/release-kit/src/__tests__/publish.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publish.unit.test.ts
@@ -1,9 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockExecFileSync = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockExtractVersion = vi.hoisted(() => vi.fn());
+const mockReadChangelogEntries = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+vi.mock('../changelogJsonUtils.ts', () => ({
+  extractVersion: mockExtractVersion,
+  readChangelogEntries: mockReadChangelogEntries,
 }));
 
 import { publish } from '../publish.ts';
@@ -13,10 +29,17 @@ describe(publish, () => {
   beforeEach(() => {
     vi.spyOn(console, 'info').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Default: no README exists (non-injection tests)
+    mockExistsSync.mockReturnValue(false);
   });
 
   afterEach(() => {
     mockExecFileSync.mockReset();
+    mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
+    mockExtractVersion.mockReset();
+    mockReadChangelogEntries.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -217,5 +240,96 @@ describe(publish, () => {
 
     expect(console.warn).toHaveBeenCalledWith('Packages published before failure:');
     expect(console.warn).toHaveBeenCalledWith('  core-v1.3.0');
+  });
+
+  describe('README injection', () => {
+    const tag: ResolvedTag[] = [{ tag: 'v1.0.0', dir: '.', workspacePath: '/pkg' }];
+    const injectionOptions = {
+      dryRun: false,
+      noGitChecks: false,
+      provenance: false,
+      releaseNotes: { shouldInjectIntoReadme: true, shouldCreateGithubRelease: false },
+      changelogJsonOutputPath: '.meta/changelog.json',
+    };
+
+    function setupInjectionMocks(): void {
+      // README.md exists, changelog.json exists
+      mockExistsSync.mockImplementation((p: string) => {
+        if (typeof p === 'string' && (p.endsWith('README.md') || p.endsWith('changelog.json'))) {
+          return true;
+        }
+        return false;
+      });
+      mockReadFileSync.mockReturnValue('# Original README\n');
+      mockExtractVersion.mockReturnValue('1.0.0');
+      mockReadChangelogEntries.mockReturnValue([
+        {
+          version: '1.0.0',
+          date: '2024-01-01',
+          sections: [{ title: 'Features', audience: 'all', items: [{ description: 'Add widget' }] }],
+        },
+      ]);
+    }
+
+    it('injects release notes into README before publish when enabled', () => {
+      setupInjectionMocks();
+
+      publish(tag, 'npm', injectionOptions);
+
+      // writeFileSync called twice: once for injection, once for restoration
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
+      // First call: injected content
+      const injectedContent = mockWriteFileSync.mock.calls[0]?.[1];
+      expect(typeof injectedContent === 'string' && injectedContent).toContain('Features');
+    });
+
+    it('restores original README after successful publish', () => {
+      setupInjectionMocks();
+
+      publish(tag, 'npm', injectionOptions);
+
+      // Second writeFileSync call restores original
+      const restoredContent = mockWriteFileSync.mock.calls[1]?.[1];
+      expect(restoredContent).toBe('# Original README\n');
+    });
+
+    it('restores original README when publish throws', () => {
+      setupInjectionMocks();
+      mockExecFileSync.mockImplementation(() => {
+        throw new Error('publish failed');
+      });
+
+      expect(() => publish(tag, 'npm', injectionOptions)).toThrow('publish failed');
+
+      // Restoration still happens via finally block
+      const lastCall = mockWriteFileSync.mock.calls.at(-1);
+      expect(lastCall?.[1]).toBe('# Original README\n');
+    });
+
+    it('skips injection when changelog.json is missing', () => {
+      mockExistsSync.mockImplementation((p: string) => {
+        if (typeof p === 'string' && p.endsWith('README.md')) return true;
+        return false;
+      });
+      mockReadFileSync.mockReturnValue('# README\n');
+
+      publish(tag, 'npm', injectionOptions);
+
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('not found; skipping README injection'));
+      // Only the publish happens, no README write
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('skips injection when no entry matches the tag version', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('# README\n');
+      mockExtractVersion.mockReturnValue('99.0.0');
+      mockReadChangelogEntries.mockReturnValue([{ version: '1.0.0', date: '2024-01-01', sections: [] }]);
+
+      publish(tag, 'npm', injectionOptions);
+
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no changelog entry for version 99.0.0'));
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
@@ -5,6 +5,7 @@ const mockResolveReleaseTags = vi.hoisted(() => vi.fn());
 const mockDetectPackageManager = vi.hoisted(() => vi.fn());
 const mockPublish = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
+const mockValidateConfig = vi.hoisted(() => vi.fn());
 const mockCreateGithubReleases = vi.hoisted(() => vi.fn());
 
 vi.mock('../discoverWorkspaces.ts', () => ({
@@ -27,6 +28,10 @@ vi.mock('../loadConfig.ts', () => ({
   loadConfig: mockLoadConfig,
 }));
 
+vi.mock('../validateConfig.ts', () => ({
+  validateConfig: mockValidateConfig,
+}));
+
 vi.mock('../createGithubRelease.ts', () => ({
   createGithubReleases: mockCreateGithubReleases,
 }));
@@ -46,6 +51,7 @@ describe(publishCommand, () => {
     mockResolveReleaseTags.mockReturnValue([{ tag: 'v1.0.0', dir: '.', workspacePath: '.' }]);
     mockDetectPackageManager.mockReturnValue('npm');
     mockLoadConfig.mockResolvedValue(undefined);
+    mockValidateConfig.mockReturnValue({ config: {}, errors: [], warnings: [] });
     vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
@@ -59,6 +65,7 @@ describe(publishCommand, () => {
     mockDetectPackageManager.mockReset();
     mockPublish.mockReset();
     mockLoadConfig.mockReset();
+    mockValidateConfig.mockReset();
     mockCreateGithubReleases.mockReset();
     vi.restoreAllMocks();
   });
@@ -218,9 +225,14 @@ describe(publishCommand, () => {
 
   describe('config loading', () => {
     it('passes releaseNotes and changelogJsonOutputPath from loaded config', async () => {
-      mockLoadConfig.mockResolvedValue({
-        releaseNotes: { shouldCreateGithubRelease: true, shouldInjectIntoReadme: true },
-        changelogJson: { outputPath: 'custom/changelog.json' },
+      mockLoadConfig.mockResolvedValue({ releaseNotes: {}, changelogJson: {} });
+      mockValidateConfig.mockReturnValue({
+        config: {
+          releaseNotes: { shouldCreateGithubRelease: true, shouldInjectIntoReadme: true },
+          changelogJson: { outputPath: 'custom/changelog.json' },
+        },
+        errors: [],
+        warnings: [],
       });
 
       await publishCommand([]);
@@ -264,16 +276,41 @@ describe(publishCommand, () => {
     });
 
     it('prints validation warnings from config', async () => {
-      // Config with releaseNotes enabled but changelogJson disabled triggers a warning
-      mockLoadConfig.mockResolvedValue({
-        changelogJson: { enabled: false },
-        releaseNotes: { shouldCreateGithubRelease: true },
+      mockLoadConfig.mockResolvedValue({ releaseNotes: {} });
+      mockValidateConfig.mockReturnValue({
+        config: { releaseNotes: { shouldCreateGithubRelease: true } },
+        errors: [],
+        warnings: ['releaseNotes.shouldCreateGithubRelease is enabled but changelogJson.enabled is false'],
       });
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       await publishCommand([]);
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('shouldCreateGithubRelease'));
+    });
+
+    it('exits with code 1 when config has validation errors', async () => {
+      mockLoadConfig.mockResolvedValue({ bogus: 123 });
+      mockValidateConfig.mockReturnValue({
+        config: {},
+        errors: ["Unknown field: 'bogus'"],
+        warnings: [],
+      });
+
+      let thrown: ExitError | undefined;
+      try {
+        await publishCommand([]);
+      } catch (error: unknown) {
+        if (error instanceof ExitError) {
+          thrown = error;
+        }
+      }
+
+      expect(thrown).toBeInstanceOf(ExitError);
+      expect(thrown?.code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith('Invalid config:');
+      expect(console.error).toHaveBeenCalledWith("  ❌ Unknown field: 'bogus'");
+      expect(mockPublish).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
@@ -215,4 +215,65 @@ describe(publishCommand, () => {
 
     expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'pnpm', expect.anything());
   });
+
+  describe('config loading', () => {
+    it('passes releaseNotes and changelogJsonOutputPath from loaded config', async () => {
+      mockLoadConfig.mockResolvedValue({
+        releaseNotes: { shouldCreateGithubRelease: true, shouldInjectIntoReadme: true },
+        changelogJson: { outputPath: 'custom/changelog.json' },
+      });
+
+      await publishCommand([]);
+
+      expect(mockPublish).toHaveBeenCalledWith(
+        expect.anything(),
+        'npm',
+        expect.objectContaining({
+          releaseNotes: expect.objectContaining({
+            shouldCreateGithubRelease: true,
+            shouldInjectIntoReadme: true,
+          }),
+          changelogJsonOutputPath: 'custom/changelog.json',
+        }),
+      );
+      expect(mockCreateGithubReleases).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ shouldCreateGithubRelease: true }),
+        'custom/changelog.json',
+        false,
+      );
+    });
+
+    it('uses defaults when loadConfig throws', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockLoadConfig.mockRejectedValue(new Error('config read failure'));
+
+      await publishCommand([]);
+
+      expect(mockPublish).toHaveBeenCalledWith(
+        expect.anything(),
+        'npm',
+        expect.objectContaining({
+          releaseNotes: expect.objectContaining({
+            shouldCreateGithubRelease: false,
+            shouldInjectIntoReadme: false,
+          }),
+        }),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('failed to load config'));
+    });
+
+    it('prints validation warnings from config', async () => {
+      // Config with releaseNotes enabled but changelogJson disabled triggers a warning
+      mockLoadConfig.mockResolvedValue({
+        changelogJson: { enabled: false },
+        releaseNotes: { shouldCreateGithubRelease: true },
+      });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await publishCommand([]);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('shouldCreateGithubRelease'));
+    });
+  });
 });

--- a/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
@@ -4,6 +4,8 @@ const mockDiscoverWorkspaces = vi.hoisted(() => vi.fn());
 const mockResolveReleaseTags = vi.hoisted(() => vi.fn());
 const mockDetectPackageManager = vi.hoisted(() => vi.fn());
 const mockPublish = vi.hoisted(() => vi.fn());
+const mockLoadConfig = vi.hoisted(() => vi.fn());
+const mockCreateGithubReleases = vi.hoisted(() => vi.fn());
 
 vi.mock('../discoverWorkspaces.ts', () => ({
   discoverWorkspaces: mockDiscoverWorkspaces,
@@ -21,6 +23,14 @@ vi.mock('../publish.ts', () => ({
   publish: mockPublish,
 }));
 
+vi.mock('../loadConfig.ts', () => ({
+  loadConfig: mockLoadConfig,
+}));
+
+vi.mock('../createGithubRelease.ts', () => ({
+  createGithubReleases: mockCreateGithubReleases,
+}));
+
 import { publishCommand } from '../publishCommand.ts';
 
 /** Sentinel error thrown by the mocked process.exit. */
@@ -35,6 +45,7 @@ describe(publishCommand, () => {
     mockDiscoverWorkspaces.mockResolvedValue(undefined);
     mockResolveReleaseTags.mockReturnValue([{ tag: 'v1.0.0', dir: '.', workspacePath: '.' }]);
     mockDetectPackageManager.mockReturnValue('npm');
+    mockLoadConfig.mockResolvedValue(undefined);
     vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
@@ -47,47 +58,49 @@ describe(publishCommand, () => {
     mockResolveReleaseTags.mockReset();
     mockDetectPackageManager.mockReset();
     mockPublish.mockReset();
+    mockLoadConfig.mockReset();
+    mockCreateGithubReleases.mockReset();
     vi.restoreAllMocks();
   });
 
   it('delegates to publish with default options', async () => {
     await publishCommand([]);
 
-    expect(mockPublish).toHaveBeenCalledWith([{ tag: 'v1.0.0', dir: '.', workspacePath: '.' }], 'npm', {
-      dryRun: false,
-      noGitChecks: false,
-      provenance: false,
-    });
+    expect(mockPublish).toHaveBeenCalledWith(
+      [{ tag: 'v1.0.0', dir: '.', workspacePath: '.' }],
+      'npm',
+      expect.objectContaining({ dryRun: false, noGitChecks: false, provenance: false }),
+    );
   });
 
   it('passes dryRun when --dry-run is provided', async () => {
     await publishCommand(['--dry-run']);
 
-    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'npm', {
-      dryRun: true,
-      noGitChecks: false,
-      provenance: false,
-    });
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.anything(),
+      'npm',
+      expect.objectContaining({ dryRun: true, noGitChecks: false, provenance: false }),
+    );
   });
 
   it('passes noGitChecks when --no-git-checks is provided', async () => {
     await publishCommand(['--no-git-checks']);
 
-    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'npm', {
-      dryRun: false,
-      noGitChecks: true,
-      provenance: false,
-    });
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.anything(),
+      'npm',
+      expect.objectContaining({ dryRun: false, noGitChecks: true, provenance: false }),
+    );
   });
 
   it('passes provenance when --provenance is provided', async () => {
     await publishCommand(['--provenance']);
 
-    expect(mockPublish).toHaveBeenCalledWith(expect.anything(), 'npm', {
-      dryRun: false,
-      noGitChecks: false,
-      provenance: true,
-    });
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.anything(),
+      'npm',
+      expect.objectContaining({ dryRun: false, noGitChecks: false, provenance: true }),
+    );
   });
 
   it('exits with code 1 on unknown flags', async () => {
@@ -154,7 +167,7 @@ describe(publishCommand, () => {
     expect(mockPublish).toHaveBeenCalledWith(
       [{ tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' }],
       'npm',
-      { dryRun: false, noGitChecks: false, provenance: false },
+      expect.objectContaining({ dryRun: false, noGitChecks: false, provenance: false }),
     );
   });
 

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -24,6 +24,7 @@ vi.mock('../hasPrettierConfig.ts', () => ({
   hasPrettierConfig: mockHasPrettierConfig,
 }));
 
+import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG } from '../defaults.ts';
 import { releasePrepare } from '../releasePrepare.ts';
 import type { ReleaseConfig, WorkTypeConfig } from '../types.ts';
 
@@ -38,6 +39,8 @@ function makeConfig(overrides?: Partial<ReleaseConfig>): ReleaseConfig {
     packageFiles: ['package.json'],
     changelogPaths: ['.'],
     workTypes,
+    changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: false },
+    releaseNotes: { ...DEFAULT_RELEASE_NOTES_CONFIG },
     ...overrides,
   };
 }

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -26,6 +26,7 @@ vi.mock('../hasPrettierConfig.ts', () => ({
   hasPrettierConfig: mockHasPrettierConfig,
 }));
 
+import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG } from '../defaults.ts';
 import { releasePrepareMono } from '../releasePrepareMono.ts';
 import type { MonorepoReleaseConfig, WorkTypeConfig } from '../types.ts';
 
@@ -38,6 +39,8 @@ function makeConfig(overrides?: Partial<MonorepoReleaseConfig>): MonorepoRelease
   return {
     components: [],
     workTypes,
+    changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: false },
+    releaseNotes: { ...DEFAULT_RELEASE_NOTES_CONFIG },
     ...overrides,
   };
 }

--- a/packages/release-kit/src/__tests__/renderReleaseNotes.unit.test.ts
+++ b/packages/release-kit/src/__tests__/renderReleaseNotes.unit.test.ts
@@ -42,6 +42,11 @@ describe(renderReleaseNotesSingle, () => {
     expect(result).toContain('### Features');
   });
 
+  it('does not produce a leading newline when includeHeading is false', () => {
+    const result = renderReleaseNotesSingle(sampleEntry, { includeHeading: false });
+    expect(result.startsWith('###')).toBe(true);
+  });
+
   it('filters sections using a predicate', () => {
     const result = renderReleaseNotesSingle(sampleEntry, { filter: matchesAudience('all') });
     expect(result).toContain('### Features');

--- a/packages/release-kit/src/__tests__/renderReleaseNotes.unit.test.ts
+++ b/packages/release-kit/src/__tests__/renderReleaseNotes.unit.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchesAudience, renderReleaseNotesMulti, renderReleaseNotesSingle } from '../renderReleaseNotes.ts';
+import type { ChangelogEntry } from '../types.ts';
+
+const sampleEntry: ChangelogEntry = {
+  version: '2.0.0',
+  date: '2024-11-15',
+  sections: [
+    { title: 'Features', audience: 'all', items: [{ description: 'Add widget API' }] },
+    { title: 'Bug fixes', audience: 'all', items: [{ description: 'Fix crash on startup' }] },
+    { title: 'CI', audience: 'dev', items: [{ description: 'Update pipeline config' }] },
+  ],
+};
+
+describe(renderReleaseNotesSingle, () => {
+  it('renders all sections with heading by default', () => {
+    const result = renderReleaseNotesSingle(sampleEntry);
+    expect(result).toBe(
+      [
+        '## 2.0.0 — 2024-11-15',
+        '',
+        '### Features',
+        '',
+        '- Add widget API',
+        '',
+        '### Bug fixes',
+        '',
+        '- Fix crash on startup',
+        '',
+        '### CI',
+        '',
+        '- Update pipeline config',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('omits version heading when includeHeading is false', () => {
+    const result = renderReleaseNotesSingle(sampleEntry, { includeHeading: false });
+    expect(result).not.toContain('## 2.0.0');
+    expect(result).toContain('### Features');
+  });
+
+  it('filters sections using a predicate', () => {
+    const result = renderReleaseNotesSingle(sampleEntry, { filter: matchesAudience('all') });
+    expect(result).toContain('### Features');
+    expect(result).toContain('### Bug fixes');
+    expect(result).not.toContain('### CI');
+  });
+
+  it('returns empty string when all sections are filtered out', () => {
+    const entry: ChangelogEntry = {
+      version: '1.0.0',
+      date: '2024-01-01',
+      sections: [{ title: 'CI', audience: 'dev', items: [{ description: 'Pipeline update' }] }],
+    };
+    const result = renderReleaseNotesSingle(entry, { filter: matchesAudience('all') });
+    expect(result).toBe('');
+  });
+
+  it('renders multiple items in a section', () => {
+    const entry: ChangelogEntry = {
+      version: '1.0.0',
+      date: '2024-01-01',
+      sections: [
+        {
+          title: 'Features',
+          audience: 'all',
+          items: [{ description: 'First feature' }, { description: 'Second feature' }],
+        },
+      ],
+    };
+    const result = renderReleaseNotesSingle(entry);
+    expect(result).toContain('- First feature\n- Second feature');
+  });
+});
+
+describe(matchesAudience, () => {
+  it('"all" matches only all-audience sections', () => {
+    const predicate = matchesAudience('all');
+    expect(predicate({ title: 'Features', audience: 'all', items: [] })).toBe(true);
+    expect(predicate({ title: 'CI', audience: 'dev', items: [] })).toBe(false);
+  });
+
+  it('"dev" matches all sections', () => {
+    const predicate = matchesAudience('dev');
+    expect(predicate({ title: 'Features', audience: 'all', items: [] })).toBe(true);
+    expect(predicate({ title: 'CI', audience: 'dev', items: [] })).toBe(true);
+  });
+});
+
+describe(renderReleaseNotesMulti, () => {
+  it('concatenates multiple entries', () => {
+    const entries: ChangelogEntry[] = [
+      {
+        version: '2.0.0',
+        date: '2024-11-15',
+        sections: [{ title: 'Features', audience: 'all', items: [{ description: 'New feature' }] }],
+      },
+      {
+        version: '1.0.0',
+        date: '2024-01-01',
+        sections: [{ title: 'Bug fixes', audience: 'all', items: [{ description: 'Bug fix' }] }],
+      },
+    ];
+
+    const result = renderReleaseNotesMulti(entries);
+    expect(result).toContain('## 2.0.0');
+    expect(result).toContain('## 1.0.0');
+    expect(result.indexOf('## 2.0.0')).toBeLessThan(result.indexOf('## 1.0.0'));
+  });
+
+  it('skips entries that produce empty output after filtering', () => {
+    const entries: ChangelogEntry[] = [
+      {
+        version: '2.0.0',
+        date: '2024-11-15',
+        sections: [{ title: 'Features', audience: 'all', items: [{ description: 'Public feature' }] }],
+      },
+      {
+        version: '1.0.0',
+        date: '2024-01-01',
+        sections: [{ title: 'CI', audience: 'dev', items: [{ description: 'Dev-only' }] }],
+      },
+    ];
+
+    const result = renderReleaseNotesMulti(entries, { filter: matchesAudience('all') });
+    expect(result).toContain('## 2.0.0');
+    expect(result).not.toContain('## 1.0.0');
+  });
+
+  it('returns empty string when all entries produce empty output', () => {
+    const result = renderReleaseNotesMulti([]);
+    expect(result).toBe('');
+  });
+});

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -160,4 +160,117 @@ describe(validateConfig, () => {
       expect(errors).toContain('scopeAliases.api: value must be a string');
     });
   });
+
+  describe('changelogJson', () => {
+    it('validates a complete changelogJson object', () => {
+      const { config, errors } = validateConfig({
+        changelogJson: { enabled: true, outputPath: '.meta/changelog.json', devOnlySections: ['CI'] },
+      });
+      expect(errors).toStrictEqual([]);
+      expect(config.changelogJson).toStrictEqual({
+        enabled: true,
+        outputPath: '.meta/changelog.json',
+        devOnlySections: ['CI'],
+      });
+    });
+
+    it('validates a partial changelogJson object', () => {
+      const { config, errors } = validateConfig({ changelogJson: { enabled: false } });
+      expect(errors).toStrictEqual([]);
+      expect(config.changelogJson).toStrictEqual({ enabled: false });
+    });
+
+    it('returns an error when changelogJson is not an object', () => {
+      const { errors } = validateConfig({ changelogJson: 'invalid' });
+      expect(errors).toContain("'changelogJson' must be an object");
+    });
+
+    it('returns an error when enabled is not a boolean', () => {
+      const { errors } = validateConfig({ changelogJson: { enabled: 'yes' } });
+      expect(errors).toContain('changelogJson.enabled: must be a boolean');
+    });
+
+    it('returns an error when outputPath is not a string', () => {
+      const { errors } = validateConfig({ changelogJson: { outputPath: 123 } });
+      expect(errors).toContain('changelogJson.outputPath: must be a string');
+    });
+
+    it('returns an error when devOnlySections is not a string array', () => {
+      const { errors } = validateConfig({ changelogJson: { devOnlySections: [1, 2] } });
+      expect(errors).toContain('changelogJson.devOnlySections: must be a string array');
+    });
+
+    it('returns an error for unknown changelogJson fields', () => {
+      const { errors } = validateConfig({ changelogJson: { bogus: true } });
+      expect(errors).toContain("changelogJson: unknown field 'bogus'");
+    });
+  });
+
+  describe('releaseNotes', () => {
+    it('validates a complete releaseNotes object', () => {
+      const { config, errors } = validateConfig({
+        releaseNotes: { shouldInjectIntoReadme: true, shouldCreateGithubRelease: false },
+      });
+      expect(errors).toStrictEqual([]);
+      expect(config.releaseNotes).toStrictEqual({
+        shouldInjectIntoReadme: true,
+        shouldCreateGithubRelease: false,
+      });
+    });
+
+    it('returns an error when releaseNotes is not an object', () => {
+      const { errors } = validateConfig({ releaseNotes: 'invalid' });
+      expect(errors).toContain("'releaseNotes' must be an object");
+    });
+
+    it('returns an error when shouldInjectIntoReadme is not a boolean', () => {
+      const { errors } = validateConfig({ releaseNotes: { shouldInjectIntoReadme: 'yes' } });
+      expect(errors).toContain('releaseNotes.shouldInjectIntoReadme: must be a boolean');
+    });
+
+    it('returns an error when shouldCreateGithubRelease is not a boolean', () => {
+      const { errors } = validateConfig({ releaseNotes: { shouldCreateGithubRelease: 42 } });
+      expect(errors).toContain('releaseNotes.shouldCreateGithubRelease: must be a boolean');
+    });
+
+    it('returns an error for unknown releaseNotes fields', () => {
+      const { errors } = validateConfig({ releaseNotes: { unknownField: true } });
+      expect(errors).toContain("releaseNotes: unknown field 'unknownField'");
+    });
+  });
+
+  describe('cross-field warnings', () => {
+    it('warns when shouldCreateGithubRelease is true but changelogJson is disabled', () => {
+      const { warnings } = validateConfig({
+        changelogJson: { enabled: false },
+        releaseNotes: { shouldCreateGithubRelease: true },
+      });
+      expect(warnings).toContain(
+        'releaseNotes.shouldCreateGithubRelease is enabled but changelogJson.enabled is false; GitHub Releases will be skipped at runtime',
+      );
+    });
+
+    it('warns when shouldInjectIntoReadme is true but changelogJson is disabled', () => {
+      const { warnings } = validateConfig({
+        changelogJson: { enabled: false },
+        releaseNotes: { shouldInjectIntoReadme: true },
+      });
+      expect(warnings).toContain(
+        'releaseNotes.shouldInjectIntoReadme is enabled but changelogJson.enabled is false; README injection will be skipped at runtime',
+      );
+    });
+
+    it('returns no warnings when config is consistent', () => {
+      const { warnings } = validateConfig({
+        changelogJson: { enabled: true },
+        releaseNotes: { shouldCreateGithubRelease: true },
+      });
+      expect(warnings).toStrictEqual([]);
+    });
+
+    it('returns no warnings for empty config', () => {
+      const { warnings } = validateConfig({});
+      expect(warnings).toStrictEqual([]);
+    });
+  });
 });

--- a/packages/release-kit/src/changelogJsonUtils.ts
+++ b/packages/release-kit/src/changelogJsonUtils.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+import { isRecord, isUnknownArray } from './typeGuards.ts';
+import type { ChangelogEntry } from './types.ts';
+
+/** Type guard for `ChangelogEntry` values parsed from JSON. */
+export function isChangelogEntry(value: unknown): value is ChangelogEntry {
+  return (
+    isRecord(value) &&
+    typeof value.version === 'string' &&
+    typeof value.date === 'string' &&
+    isUnknownArray(value.sections)
+  );
+}
+
+/** Extract the version from a tag by stripping the prefix up to the first digit. */
+export function extractVersion(tag: string): string {
+  const match = /(\d+\.\d+\.\d+.*)$/.exec(tag);
+  return match?.[1] ?? tag;
+}
+
+/**
+ * Read and parse a changelog JSON file, returning validated entries.
+ *
+ * Returns `undefined` if the file cannot be read or does not contain a valid array.
+ */
+export function readChangelogEntries(filePath: string): ChangelogEntry[] | undefined {
+  if (!existsSync(filePath)) {
+    return undefined;
+  }
+  try {
+    const content = readFileSync(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+    if (!isUnknownArray(parsed)) {
+      return undefined;
+    }
+    return parsed.filter(isChangelogEntry);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/release-kit/src/createGithubRelease.ts
+++ b/packages/release-kit/src/createGithubRelease.ts
@@ -1,0 +1,116 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { matchesAudience, renderReleaseNotesSingle } from './renderReleaseNotes.ts';
+import { isRecord, isUnknownArray } from './typeGuards.ts';
+import type { ChangelogEntry, ReleaseNotesConfig } from './types.ts';
+
+/** Options for creating a GitHub Release. */
+export interface CreateGithubReleaseOptions {
+  tag: string;
+  changelogJsonPath: string;
+  dryRun: boolean;
+}
+
+/**
+ * Create a GitHub Release from changelog.json using the `gh` CLI.
+ *
+ * Reads the changelog JSON, finds the entry matching the tag's version, renders all-audience
+ * release notes, and creates the release. Failures produce warnings rather than errors.
+ */
+export function createGithubRelease(options: CreateGithubReleaseOptions): boolean {
+  const { tag, changelogJsonPath, dryRun } = options;
+
+  if (!existsSync(changelogJsonPath)) {
+    console.warn(`Warning: ${changelogJsonPath} not found; skipping GitHub Release creation`);
+    return false;
+  }
+
+  const version = extractVersion(tag);
+  const entries = readChangelogJson(changelogJsonPath);
+
+  if (entries === undefined) {
+    console.warn(`Warning: could not parse ${changelogJsonPath}; skipping GitHub Release creation`);
+    return false;
+  }
+
+  const entry = entries.find((e) => e.version === version);
+  if (entry === undefined) {
+    console.warn(`Warning: no changelog entry for version ${version}; skipping GitHub Release creation`);
+    return false;
+  }
+
+  const body = renderReleaseNotesSingle(entry, {
+    filter: matchesAudience('all'),
+    includeHeading: false,
+  });
+
+  const args = ['release', 'create', tag, '--title', tag, '--notes', body];
+
+  if (dryRun) {
+    console.info(`[dry-run] Would run: gh ${args.join(' ')}`);
+    return true;
+  }
+
+  try {
+    execFileSync('gh', args, { stdio: 'inherit' });
+    return true;
+  } catch (error: unknown) {
+    console.warn(
+      `Warning: failed to create GitHub Release for ${tag}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Create GitHub Releases for all resolved tags.
+ *
+ * Called from the publish command when `shouldCreateGithubRelease` is enabled.
+ */
+export function createGithubReleases(
+  tags: Array<{ tag: string; workspacePath: string }>,
+  releaseNotes: ReleaseNotesConfig,
+  changelogJsonOutputPath: string,
+  dryRun: boolean,
+): void {
+  if (!releaseNotes.shouldCreateGithubRelease) {
+    return;
+  }
+
+  for (const { tag, workspacePath } of tags) {
+    const changelogJsonPath = join(workspacePath, changelogJsonOutputPath);
+    createGithubRelease({ tag, changelogJsonPath, dryRun });
+  }
+}
+
+/** Extract the version from a tag by stripping the prefix up to the first digit. */
+function extractVersion(tag: string): string {
+  const match = /(\d+\.\d+\.\d+.*)$/.exec(tag);
+  return match?.[1] ?? tag;
+}
+
+/** Read and parse a changelog JSON file. */
+function readChangelogJson(filePath: string): ChangelogEntry[] | undefined {
+  try {
+    const content = readFileSync(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+    if (!isUnknownArray(parsed)) {
+      return undefined;
+    }
+    return parsed.filter(isChangelogEntry);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Type guard for `ChangelogEntry` values parsed from JSON. */
+function isChangelogEntry(value: unknown): value is ChangelogEntry {
+  return (
+    isRecord(value) &&
+    typeof value.version === 'string' &&
+    typeof value.date === 'string' &&
+    isUnknownArray(value.sections)
+  );
+}

--- a/packages/release-kit/src/createGithubRelease.ts
+++ b/packages/release-kit/src/createGithubRelease.ts
@@ -1,10 +1,10 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { extractVersion, readChangelogEntries } from './changelogJsonUtils.ts';
 import { matchesAudience, renderReleaseNotesSingle } from './renderReleaseNotes.ts';
-import { isRecord, isUnknownArray } from './typeGuards.ts';
-import type { ChangelogEntry, ReleaseNotesConfig } from './types.ts';
+import type { ReleaseNotesConfig } from './types.ts';
 
 /** Options for creating a GitHub Release. */
 export interface CreateGithubReleaseOptions {
@@ -28,7 +28,7 @@ export function createGithubRelease(options: CreateGithubReleaseOptions): boolea
   }
 
   const version = extractVersion(tag);
-  const entries = readChangelogJson(changelogJsonPath);
+  const entries = readChangelogEntries(changelogJsonPath);
 
   if (entries === undefined) {
     console.warn(`Warning: could not parse ${changelogJsonPath}; skipping GitHub Release creation`);
@@ -83,34 +83,4 @@ export function createGithubReleases(
     const changelogJsonPath = join(workspacePath, changelogJsonOutputPath);
     createGithubRelease({ tag, changelogJsonPath, dryRun });
   }
-}
-
-/** Extract the version from a tag by stripping the prefix up to the first digit. */
-function extractVersion(tag: string): string {
-  const match = /(\d+\.\d+\.\d+.*)$/.exec(tag);
-  return match?.[1] ?? tag;
-}
-
-/** Read and parse a changelog JSON file. */
-function readChangelogJson(filePath: string): ChangelogEntry[] | undefined {
-  try {
-    const content = readFileSync(filePath, 'utf8');
-    const parsed: unknown = JSON.parse(content);
-    if (!isUnknownArray(parsed)) {
-      return undefined;
-    }
-    return parsed.filter(isChangelogEntry);
-  } catch {
-    return undefined;
-  }
-}
-
-/** Type guard for `ChangelogEntry` values parsed from JSON. */
-function isChangelogEntry(value: unknown): value is ChangelogEntry {
-  return (
-    isRecord(value) &&
-    typeof value.version === 'string' &&
-    typeof value.date === 'string' &&
-    isUnknownArray(value.sections)
-  );
 }

--- a/packages/release-kit/src/defaults.ts
+++ b/packages/release-kit/src/defaults.ts
@@ -1,4 +1,4 @@
-import type { VersionPatterns, WorkTypeConfig } from './types.ts';
+import type { ChangelogJsonConfig, ReleaseNotesConfig, VersionPatterns, WorkTypeConfig } from './types.ts';
 
 /** Default work types ordered by priority, matching the skypilot-site convention. */
 export const DEFAULT_WORK_TYPES: Record<string, WorkTypeConfig> = {
@@ -21,4 +21,17 @@ export const DEFAULT_WORK_TYPES: Record<string, WorkTypeConfig> = {
 export const DEFAULT_VERSION_PATTERNS: VersionPatterns = {
   major: ['!'],
   minor: ['feat'],
+};
+
+/** Default configuration for structured changelog JSON generation. */
+export const DEFAULT_CHANGELOG_JSON_CONFIG: ChangelogJsonConfig = {
+  enabled: true,
+  outputPath: '.meta/changelog.json',
+  devOnlySections: ['CI', 'Dependencies', 'Formatting', 'Internal', 'Tests', 'Tooling'],
+};
+
+/** Default configuration for release notes consumption. */
+export const DEFAULT_RELEASE_NOTES_CONFIG: ReleaseNotesConfig = {
+  shouldInjectIntoReadme: false,
+  shouldCreateGithubRelease: false,
 };

--- a/packages/release-kit/src/generateChangelogJson.ts
+++ b/packages/release-kit/src/generateChangelogJson.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 
 import stringify from 'json-stringify-pretty-compact';
 
+import { isChangelogEntry } from './changelogJsonUtils.ts';
 import type { GenerateChangelogOptions } from './generateChangelogs.ts';
 import { resolveCliffConfigPath } from './resolveCliffConfigPath.ts';
 import { isRecord, isUnknownArray } from './typeGuards.ts';
@@ -37,7 +38,7 @@ export function generateChangelogJson(
   dryRun: boolean,
   options?: GenerateChangelogOptions,
 ): string[] {
-  const outputFile = `${changelogPath}/${config.changelogJson.outputPath}`;
+  const outputFile = join(changelogPath, config.changelogJson.outputPath);
 
   if (dryRun) {
     return [outputFile];
@@ -104,7 +105,7 @@ export function generateSyntheticChangelogJson(
   propagatedFrom: Array<{ packageName: string; newVersion: string }>,
   dryRun: boolean,
 ): string[] {
-  const outputFile = `${changelogPath}/${config.changelogJson.outputPath}`;
+  const outputFile = join(changelogPath, config.changelogJson.outputPath);
 
   if (dryRun) {
     return [outputFile];
@@ -233,22 +234,19 @@ function readExistingEntries(filePath: string): ChangelogEntry[] {
   if (!existsSync(filePath)) {
     return [];
   }
-  const content = readFileSync(filePath, 'utf8');
-  const parsed: unknown = JSON.parse(content);
-  if (!isUnknownArray(parsed)) {
+  try {
+    const content = readFileSync(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+    if (!isUnknownArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(isChangelogEntry);
+  } catch (error: unknown) {
+    console.warn(
+      `Warning: could not parse existing ${filePath}: ${error instanceof Error ? error.message : String(error)}; treating as empty`,
+    );
     return [];
   }
-  return parsed.filter(isChangelogEntry);
-}
-
-/** Type guard for `ChangelogEntry` values parsed from JSON. */
-function isChangelogEntry(value: unknown): value is ChangelogEntry {
-  return (
-    isRecord(value) &&
-    typeof value.version === 'string' &&
-    typeof value.date === 'string' &&
-    isUnknownArray(value.sections)
-  );
 }
 
 /** Merge new entries with existing ones, replacing entries with matching versions. */
@@ -264,8 +262,14 @@ function mergeEntries(newEntries: ChangelogEntry[], existingEntries: ChangelogEn
 
   // eslint-disable-next-line unicorn/no-array-sort -- spread already creates a fresh copy; toSorted requires Node >=20
   return [...versionMap.values()].sort((a, b) => {
-    const partsA = a.version.split('.').map(Number);
-    const partsB = b.version.split('.').map(Number);
+    const partsA = a.version.split('.').map((s) => {
+      const n = Number(s);
+      return Number.isNaN(n) ? 0 : n;
+    });
+    const partsB = b.version.split('.').map((s) => {
+      const n = Number(s);
+      return Number.isNaN(n) ? 0 : n;
+    });
     for (let i = 0; i < 3; i++) {
       const diff = (partsB[i] ?? 0) - (partsA[i] ?? 0);
       if (diff !== 0) return diff;

--- a/packages/release-kit/src/generateChangelogJson.ts
+++ b/packages/release-kit/src/generateChangelogJson.ts
@@ -1,0 +1,275 @@
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import stringify from 'json-stringify-pretty-compact';
+
+import type { GenerateChangelogOptions } from './generateChangelogs.ts';
+import { resolveCliffConfigPath } from './resolveCliffConfigPath.ts';
+import { isRecord, isUnknownArray } from './typeGuards.ts';
+import type { ChangelogEntry, ChangelogItem, ChangelogSection, ReleaseConfig } from './types.ts';
+
+/** Shape of a single commit in git-cliff's `--context` JSON output. */
+interface CliffContextCommit {
+  message: string;
+  group?: string;
+}
+
+/** Shape of a single release in git-cliff's `--context` JSON output. */
+interface CliffContextRelease {
+  version?: string;
+  timestamp?: number;
+  commits?: CliffContextCommit[];
+}
+
+/**
+ * Generate structured changelog JSON from git history using git-cliff `--context`.
+ *
+ * Transforms git-cliff's context output into `ChangelogEntry[]`, tags each section with an
+ * audience based on `devOnlySections`, and writes the result to the configured output path.
+ * Returns the output file path as a single-element array for consistency with `generateChangelog`.
+ */
+export function generateChangelogJson(
+  config: Pick<ReleaseConfig, 'cliffConfigPath' | 'changelogJson'>,
+  changelogPath: string,
+  tag: string,
+  dryRun: boolean,
+  options?: GenerateChangelogOptions,
+): string[] {
+  const outputFile = `${changelogPath}/${config.changelogJson.outputPath}`;
+
+  if (dryRun) {
+    return [outputFile];
+  }
+
+  const resolvedConfigPath = resolveCliffConfigPath(config.cliffConfigPath, import.meta.url);
+
+  let cliffConfigPath = resolvedConfigPath;
+  let tempDir: string | undefined;
+  if (resolvedConfigPath.endsWith('.template')) {
+    tempDir = mkdtempSync(join(tmpdir(), 'cliff-'));
+    cliffConfigPath = join(tempDir, 'cliff.toml');
+    copyFileSync(resolvedConfigPath, cliffConfigPath);
+  }
+
+  const args = ['--config', cliffConfigPath, '--context', '--tag', tag];
+
+  if (options?.tagPattern !== undefined) {
+    args.push('--tag-pattern', options.tagPattern);
+  }
+
+  for (const includePath of options?.includePaths ?? []) {
+    args.push('--include-path', includePath);
+  }
+
+  try {
+    const contextJson = execFileSync('npx', ['--yes', 'git-cliff', ...args], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'inherit'],
+    });
+
+    const releases = parseCliffContext(contextJson);
+    const devOnlySections = new Set(config.changelogJson.devOnlySections);
+    const entries = transformReleases(releases, devOnlySections);
+
+    const existingEntries = readExistingEntries(outputFile);
+    const merged = mergeEntries(entries, existingEntries);
+
+    mkdirSync(dirname(outputFile), { recursive: true });
+    writeFileSync(outputFile, stringify(merged, { maxLength: 100 }) + '\n', 'utf8');
+
+    return [outputFile];
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to generate changelog JSON for ${outputFile}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  } finally {
+    if (tempDir !== undefined) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * Generate a synthetic changelog JSON entry for propagation-only bumps.
+ *
+ * Mirrors `writeSyntheticChangelog` but produces structured JSON instead of markdown.
+ */
+export function generateSyntheticChangelogJson(
+  config: Pick<ReleaseConfig, 'changelogJson'>,
+  changelogPath: string,
+  newVersion: string,
+  date: string,
+  propagatedFrom: Array<{ packageName: string; newVersion: string }>,
+  dryRun: boolean,
+): string[] {
+  const outputFile = `${changelogPath}/${config.changelogJson.outputPath}`;
+
+  if (dryRun) {
+    return [outputFile];
+  }
+
+  const items: ChangelogItem[] = propagatedFrom.map((dep) => ({
+    description: `Bumped \`${dep.packageName}\` to ${dep.newVersion}`,
+  }));
+
+  const entry: ChangelogEntry = {
+    version: newVersion,
+    date,
+    sections: [{ title: 'Dependency updates', audience: 'dev', items }],
+  };
+
+  const existingEntries = readExistingEntries(outputFile);
+  const merged = mergeEntries([entry], existingEntries);
+
+  mkdirSync(dirname(outputFile), { recursive: true });
+  writeFileSync(outputFile, stringify(merged, { maxLength: 100 }) + '\n', 'utf8');
+
+  return [outputFile];
+}
+
+/** Parse the JSON output from `git-cliff --context`. */
+function parseCliffContext(json: string): CliffContextRelease[] {
+  const parsed: unknown = JSON.parse(json);
+  if (!isUnknownArray(parsed)) {
+    throw new TypeError('Expected git-cliff --context output to be an array');
+  }
+  return parsed.map(toCliffContextRelease);
+}
+
+/** Narrow an unknown value to a `CliffContextRelease`, treating non-object entries as empty releases. */
+function toCliffContextRelease(value: unknown): CliffContextRelease {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const release: CliffContextRelease = {};
+  if (typeof value.version === 'string') {
+    release.version = value.version;
+  }
+  if (typeof value.timestamp === 'number') {
+    release.timestamp = value.timestamp;
+  }
+  if (isUnknownArray(value.commits)) {
+    release.commits = value.commits.map(toCliffContextCommit);
+  }
+  return release;
+}
+
+/** Narrow an unknown value to a `CliffContextCommit`. */
+function toCliffContextCommit(value: unknown): CliffContextCommit {
+  if (!isRecord(value)) {
+    return { message: '' };
+  }
+  const commit: CliffContextCommit = {
+    message: typeof value.message === 'string' ? value.message : '',
+  };
+  if (typeof value.group === 'string') {
+    commit.group = value.group;
+  }
+  return commit;
+}
+
+/** Transform git-cliff context releases into `ChangelogEntry[]`. */
+function transformReleases(releases: CliffContextRelease[], devOnlySections: Set<string>): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = [];
+
+  for (const release of releases) {
+    if (release.version === undefined) {
+      continue;
+    }
+
+    const version = release.version.replace(/^v/, '');
+    const date =
+      release.timestamp !== undefined ? new Date(release.timestamp * 1000).toISOString().slice(0, 10) : 'unreleased';
+
+    const sectionMap = new Map<string, ChangelogItem[]>();
+
+    for (const commit of release.commits ?? []) {
+      const group = commit.group ?? 'Other';
+      const description = extractDescription(commit.message);
+
+      if (!sectionMap.has(group)) {
+        sectionMap.set(group, []);
+      }
+      const items = sectionMap.get(group);
+      if (items !== undefined) {
+        items.push({ description });
+      }
+    }
+
+    const sections: ChangelogSection[] = [];
+    for (const [title, items] of sectionMap) {
+      if (items.length === 0) {
+        continue;
+      }
+      sections.push({
+        title,
+        audience: devOnlySections.has(title) ? 'dev' : 'all',
+        items,
+      });
+    }
+
+    if (sections.length > 0) {
+      entries.push({ version, date, sections });
+    }
+  }
+
+  return entries;
+}
+
+/** Extract the description from a commit message, stripping ticket ID and type prefix. */
+function extractDescription(message: string): string {
+  const firstLine = message.split('\n')[0] ?? message;
+  const afterColon = firstLine.split(': ').slice(1).join(': ');
+  if (afterColon.length > 0) {
+    return afterColon.charAt(0).toUpperCase() + afterColon.slice(1);
+  }
+  return firstLine;
+}
+
+/** Read existing changelog entries from a JSON file, if it exists. */
+function readExistingEntries(filePath: string): ChangelogEntry[] {
+  if (!existsSync(filePath)) {
+    return [];
+  }
+  const content = readFileSync(filePath, 'utf8');
+  const parsed: unknown = JSON.parse(content);
+  if (!isUnknownArray(parsed)) {
+    return [];
+  }
+  return parsed.filter(isChangelogEntry);
+}
+
+/** Type guard for `ChangelogEntry` values parsed from JSON. */
+function isChangelogEntry(value: unknown): value is ChangelogEntry {
+  return (
+    isRecord(value) &&
+    typeof value.version === 'string' &&
+    typeof value.date === 'string' &&
+    isUnknownArray(value.sections)
+  );
+}
+
+/** Merge new entries with existing ones, replacing entries with matching versions. */
+function mergeEntries(newEntries: ChangelogEntry[], existingEntries: ChangelogEntry[]): ChangelogEntry[] {
+  const versionMap = new Map<string, ChangelogEntry>();
+
+  for (const entry of existingEntries) {
+    versionMap.set(entry.version, entry);
+  }
+  for (const entry of newEntries) {
+    versionMap.set(entry.version, entry);
+  }
+
+  // eslint-disable-next-line unicorn/no-array-sort -- spread already creates a fresh copy; toSorted requires Node >=20
+  return [...versionMap.values()].sort((a, b) => {
+    const partsA = a.version.split('.').map(Number);
+    const partsB = b.version.split('.').map(Number);
+    for (let i = 0; i < 3; i++) {
+      const diff = (partsB[i] ?? 0) - (partsA[i] ?? 0);
+      if (diff !== 0) return diff;
+    }
+    return 0;
+  });
+}

--- a/packages/release-kit/src/generateChangelogJson.ts
+++ b/packages/release-kit/src/generateChangelogJson.ts
@@ -190,13 +190,12 @@ function transformReleases(releases: CliffContextRelease[], devOnlySections: Set
       const group = commit.group ?? 'Other';
       const description = extractDescription(commit.message);
 
-      if (!sectionMap.has(group)) {
-        sectionMap.set(group, []);
+      let items = sectionMap.get(group);
+      if (items === undefined) {
+        items = [];
+        sectionMap.set(group, items);
       }
-      const items = sectionMap.get(group);
-      if (items !== undefined) {
-        items.push({ description });
-      }
+      items.push({ description });
     }
 
     const sections: ChangelogSection[] = [];
@@ -261,19 +260,24 @@ function mergeEntries(newEntries: ChangelogEntry[], existingEntries: ChangelogEn
   }
 
   // eslint-disable-next-line unicorn/no-array-sort -- spread already creates a fresh copy; toSorted requires Node >=20
-  return [...versionMap.values()].sort((a, b) => {
-    const partsA = a.version.split('.').map((s) => {
-      const n = Number(s);
-      return Number.isNaN(n) ? 0 : n;
-    });
-    const partsB = b.version.split('.').map((s) => {
-      const n = Number(s);
-      return Number.isNaN(n) ? 0 : n;
-    });
-    for (let i = 0; i < 3; i++) {
-      const diff = (partsB[i] ?? 0) - (partsA[i] ?? 0);
-      if (diff !== 0) return diff;
-    }
-    return 0;
+  return [...versionMap.values()].sort((a, b) => compareVersionsDescending(a.version, b.version));
+}
+
+/** Parse a version string into numeric parts for comparison. */
+function parseVersionParts(version: string): number[] {
+  return version.split('.').map((s) => {
+    const n = Number(s);
+    return Number.isNaN(n) ? 0 : n;
   });
+}
+
+/** Compare two version strings in descending order (newest first). */
+function compareVersionsDescending(a: string, b: string): number {
+  const partsA = parseVersionParts(a);
+  const partsB = parseVersionParts(b);
+  for (let i = 0; i < 3; i++) {
+    const diff = (partsB[i] ?? 0) - (partsA[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
 }

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -8,6 +8,11 @@ export type { ResolvedTag } from './resolveReleaseTags.ts';
 export type { LabelDefinition, SyncLabelsConfig } from './sync-labels/types.ts';
 export type {
   BumpResult,
+  ChangelogAudience,
+  ChangelogEntry,
+  ChangelogItem,
+  ChangelogJsonConfig,
+  ChangelogSection,
   Commit,
   ComponentConfig,
   ComponentOverride,
@@ -17,13 +22,19 @@ export type {
   PrepareResult,
   ReleaseConfig,
   ReleaseKitConfig,
+  ReleaseNotesConfig,
   ReleaseType,
   VersionPatterns,
   WorkTypeConfig,
 } from './types.ts';
 
 // Defaults
-export { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
+export {
+  DEFAULT_CHANGELOG_JSON_CONFIG,
+  DEFAULT_RELEASE_NOTES_CONFIG,
+  DEFAULT_VERSION_PATTERNS,
+  DEFAULT_WORK_TYPES,
+} from './defaults.ts';
 
 // Functions
 export { buildReleaseSummary } from './buildReleaseSummary.ts';
@@ -31,18 +42,24 @@ export { bumpAllVersions } from './bumpAllVersions.ts';
 export { bumpVersion } from './bumpVersion.ts';
 export { commitCommand } from './commitCommand.ts';
 export { component } from './component.ts';
+export type { CreateGithubReleaseOptions } from './createGithubRelease.ts';
+export { createGithubRelease, createGithubReleases } from './createGithubRelease.ts';
 export { createTags } from './createTags.ts';
 export { deleteFileIfExists } from './deleteFileIfExists.ts';
 export { detectPackageManager } from './detectPackageManager.ts';
 export { determineBumpType } from './determineBumpType.ts';
 export { discoverWorkspaces } from './discoverWorkspaces.ts';
+export { generateChangelogJson, generateSyntheticChangelogJson } from './generateChangelogJson.ts';
 export { generateChangelog, generateChangelogs } from './generateChangelogs.ts';
 export { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
+export { injectSection } from './injectSection.ts';
 export { COMMIT_PREPROCESSOR_PATTERNS, parseCommitMessage } from './parseCommitMessage.ts';
 export { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE, writeReleaseTags } from './prepareCommand.ts';
 export { publish } from './publish.ts';
 export { releasePrepare } from './releasePrepare.ts';
 export { releasePrepareMono } from './releasePrepareMono.ts';
+export type { RenderOptions } from './renderReleaseNotes.ts';
+export { matchesAudience, renderReleaseNotesMulti, renderReleaseNotesSingle } from './renderReleaseNotes.ts';
 export { reportPrepare } from './reportPrepare.ts';
 export { resolveReleaseTags } from './resolveReleaseTags.ts';
 export { stripScope } from './stripScope.ts';

--- a/packages/release-kit/src/injectSection.ts
+++ b/packages/release-kit/src/injectSection.ts
@@ -1,0 +1,35 @@
+/** Marker format for section delimiters in markdown files. */
+function openMarker(key: string): string {
+  return `<!-- section:${key} -->`;
+}
+
+/** Closing marker for a section delimiter. */
+function closeMarker(key: string): string {
+  return `<!-- /section:${key} -->`;
+}
+
+/**
+ * Replace or insert a delimited section in file content.
+ *
+ * When markers exist, replaces the content between them. When absent, prepends the section
+ * (with markers) at the top of the content. The function is pure — no file I/O.
+ */
+export function injectSection(content: string, key: string, injection: string): string {
+  const open = openMarker(key);
+  const close = closeMarker(key);
+
+  const openIndex = content.indexOf(open);
+  const closeIndex = content.indexOf(close);
+
+  if (openIndex !== -1 && closeIndex !== -1 && closeIndex > openIndex) {
+    const before = content.slice(0, openIndex + open.length);
+    const after = content.slice(closeIndex);
+    return `${before}\n${injection}\n${after}`;
+  }
+
+  const section = `${open}\n${injection}\n${close}`;
+  if (content.length === 0) {
+    return `${section}\n`;
+  }
+  return `${section}\n\n${content}`;
+}

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -2,9 +2,21 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import { component } from './component.ts';
-import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
+import {
+  DEFAULT_CHANGELOG_JSON_CONFIG,
+  DEFAULT_RELEASE_NOTES_CONFIG,
+  DEFAULT_VERSION_PATTERNS,
+  DEFAULT_WORK_TYPES,
+} from './defaults.ts';
 import { isRecord } from './typeGuards.ts';
-import type { ComponentConfig, MonorepoReleaseConfig, ReleaseConfig, ReleaseKitConfig } from './types.ts';
+import type {
+  ChangelogJsonConfig,
+  ComponentConfig,
+  MonorepoReleaseConfig,
+  ReleaseConfig,
+  ReleaseKitConfig,
+  ReleaseNotesConfig,
+} from './types.ts';
 
 /** The path where the consumer-facing config file is expected. */
 export const CONFIG_FILE_PATH = '.config/release-kit.config.ts';
@@ -78,10 +90,15 @@ export function mergeMonorepoConfig(
   const versionPatterns =
     userConfig?.versionPatterns === undefined ? { ...DEFAULT_VERSION_PATTERNS } : { ...userConfig.versionPatterns };
 
+  const changelogJson = mergeChangelogJsonConfig(userConfig?.changelogJson);
+  const releaseNotes = mergeReleaseNotesConfig(userConfig?.releaseNotes);
+
   const result: MonorepoReleaseConfig = {
     components,
     workTypes,
     versionPatterns,
+    changelogJson,
+    releaseNotes,
   };
 
   const formatCommand = userConfig?.formatCommand;
@@ -114,12 +131,17 @@ export function mergeSinglePackageConfig(userConfig: ReleaseKitConfig | undefine
   const versionPatterns =
     userConfig?.versionPatterns === undefined ? { ...DEFAULT_VERSION_PATTERNS } : { ...userConfig.versionPatterns };
 
+  const changelogJson = mergeChangelogJsonConfig(userConfig?.changelogJson);
+  const releaseNotes = mergeReleaseNotesConfig(userConfig?.releaseNotes);
+
   const result: ReleaseConfig = {
     tagPrefix: 'v',
     packageFiles: ['package.json'],
     changelogPaths: ['.'],
     workTypes,
     versionPatterns,
+    changelogJson,
+    releaseNotes,
   };
 
   const formatCommand = userConfig?.formatCommand;
@@ -138,4 +160,28 @@ export function mergeSinglePackageConfig(userConfig: ReleaseKitConfig | undefine
   }
 
   return result;
+}
+
+/** Merge user-provided changelog JSON config with defaults. */
+function mergeChangelogJsonConfig(partial: Partial<ChangelogJsonConfig> | undefined): ChangelogJsonConfig {
+  if (partial === undefined) {
+    return { ...DEFAULT_CHANGELOG_JSON_CONFIG };
+  }
+  return {
+    enabled: partial.enabled ?? DEFAULT_CHANGELOG_JSON_CONFIG.enabled,
+    outputPath: partial.outputPath ?? DEFAULT_CHANGELOG_JSON_CONFIG.outputPath,
+    devOnlySections: partial.devOnlySections ?? [...DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections],
+  };
+}
+
+/** Merge user-provided release notes config with defaults. */
+function mergeReleaseNotesConfig(partial: Partial<ReleaseNotesConfig> | undefined): ReleaseNotesConfig {
+  if (partial === undefined) {
+    return { ...DEFAULT_RELEASE_NOTES_CONFIG };
+  }
+  return {
+    shouldInjectIntoReadme: partial.shouldInjectIntoReadme ?? DEFAULT_RELEASE_NOTES_CONFIG.shouldInjectIntoReadme,
+    shouldCreateGithubRelease:
+      partial.shouldCreateGithubRelease ?? DEFAULT_RELEASE_NOTES_CONFIG.shouldCreateGithubRelease,
+  };
 }

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -227,13 +227,17 @@ async function loadAndValidateConfig(): Promise<ReleaseKitConfig | undefined> {
     return undefined;
   }
 
-  const { config, errors } = validateConfig(rawConfig);
+  const { config, errors, warnings } = validateConfig(rawConfig);
   if (errors.length > 0) {
     console.error('Invalid config:');
     for (const err of errors) {
       console.error(`  ❌ ${err}`);
     }
     process.exit(1);
+  }
+
+  for (const warning of warnings) {
+    console.warn(`  ⚠️  ${warning}`);
   }
 
   return config;

--- a/packages/release-kit/src/publish.ts
+++ b/packages/release-kit/src/publish.ts
@@ -2,12 +2,12 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { extractVersion, readChangelogEntries } from './changelogJsonUtils.ts';
 import type { PackageManager } from './detectPackageManager.ts';
 import { injectSection } from './injectSection.ts';
 import { matchesAudience, renderReleaseNotesSingle } from './renderReleaseNotes.ts';
 import type { ResolvedTag } from './resolveReleaseTags.ts';
-import { isRecord, isUnknownArray } from './typeGuards.ts';
-import type { ChangelogEntry, ReleaseNotesConfig } from './types.ts';
+import type { ReleaseNotesConfig } from './types.ts';
 
 export interface PublishOptions {
   dryRun: boolean;
@@ -104,7 +104,7 @@ function injectReleaseNotesIntoReadme(readmePath: string, changelogJsonPath: str
   const originalReadme = readFileSync(readmePath, 'utf8');
 
   const version = extractVersion(tag);
-  const entries = readChangelogJsonFile(changelogJsonPath);
+  const entries = readChangelogEntries(changelogJsonPath);
   if (entries === undefined) {
     return undefined;
   }
@@ -124,36 +124,6 @@ function injectReleaseNotesIntoReadme(readmePath: string, changelogJsonPath: str
   writeFileSync(readmePath, injected, 'utf8');
 
   return originalReadme;
-}
-
-/** Extract the version from a tag by stripping the prefix up to the first digit. */
-function extractVersion(tag: string): string {
-  const match = /(\d+\.\d+\.\d+.*)$/.exec(tag);
-  return match?.[1] ?? tag;
-}
-
-/** Read and parse a changelog JSON file. */
-function readChangelogJsonFile(filePath: string): ChangelogEntry[] | undefined {
-  try {
-    const content = readFileSync(filePath, 'utf8');
-    const parsed: unknown = JSON.parse(content);
-    if (!isUnknownArray(parsed)) {
-      return undefined;
-    }
-    return parsed.filter(isChangelogEntry);
-  } catch {
-    return undefined;
-  }
-}
-
-/** Type guard for `ChangelogEntry` values parsed from JSON. */
-function isChangelogEntry(value: unknown): value is ChangelogEntry {
-  return (
-    isRecord(value) &&
-    typeof value.version === 'string' &&
-    typeof value.date === 'string' &&
-    isUnknownArray(value.sections)
-  );
 }
 
 /** Build the argument list for the publish command. */

--- a/packages/release-kit/src/publish.ts
+++ b/packages/release-kit/src/publish.ts
@@ -1,12 +1,20 @@
 import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import type { PackageManager } from './detectPackageManager.ts';
+import { injectSection } from './injectSection.ts';
+import { matchesAudience, renderReleaseNotesSingle } from './renderReleaseNotes.ts';
 import type { ResolvedTag } from './resolveReleaseTags.ts';
+import { isRecord, isUnknownArray } from './typeGuards.ts';
+import type { ChangelogEntry, ReleaseNotesConfig } from './types.ts';
 
 export interface PublishOptions {
   dryRun: boolean;
   noGitChecks: boolean;
   provenance: boolean;
+  releaseNotes?: ReleaseNotesConfig;
+  changelogJsonOutputPath?: string;
 }
 
 /**
@@ -31,7 +39,20 @@ export function publish(resolvedTags: ResolvedTag[], packageManager: PackageMana
   const executable = resolveExecutable(packageManager);
   const args = buildPublishArgs(packageManager, { dryRun, noGitChecks, provenance });
 
+  const shouldInject = options.releaseNotes?.shouldInjectIntoReadme === true;
+  const changelogJsonOutputPath = options.changelogJsonOutputPath ?? '.meta/changelog.json';
+
   for (const { tag, workspacePath } of resolvedTags) {
+    let readmePath: string | undefined;
+    let originalReadme: string | undefined;
+
+    if (shouldInject) {
+      readmePath = resolveReadmePath(workspacePath);
+      if (readmePath !== undefined) {
+        originalReadme = injectReleaseNotesIntoReadme(readmePath, join(workspacePath, changelogJsonOutputPath), tag);
+      }
+    }
+
     try {
       console.info(`\n${dryRun ? '[dry-run] ' : ''}Running: ${executable} ${args.join(' ')} (cwd: ${workspacePath})`);
       execFileSync(executable, args, { cwd: workspacePath, stdio: 'inherit' });
@@ -44,6 +65,10 @@ export function publish(resolvedTags: ResolvedTag[], packageManager: PackageMana
         }
       }
       throw error;
+    } finally {
+      if (readmePath !== undefined && originalReadme !== undefined) {
+        writeFileSync(readmePath, originalReadme, 'utf8');
+      }
     }
   }
 }
@@ -54,6 +79,81 @@ function resolveExecutable(packageManager: PackageManager): string {
     return 'yarn';
   }
   return packageManager;
+}
+
+/** Find the README file in a workspace directory. */
+function resolveReadmePath(workspacePath: string): string | undefined {
+  const readmePath = join(workspacePath, 'README.md');
+  if (existsSync(readmePath)) {
+    return readmePath;
+  }
+  return undefined;
+}
+
+/**
+ * Inject release notes into a README and return the original content for restoration.
+ *
+ * Returns the original README content, or `undefined` if injection was skipped.
+ */
+function injectReleaseNotesIntoReadme(readmePath: string, changelogJsonPath: string, tag: string): string | undefined {
+  if (!existsSync(changelogJsonPath)) {
+    console.warn(`Warning: ${changelogJsonPath} not found; skipping README injection`);
+    return undefined;
+  }
+
+  const originalReadme = readFileSync(readmePath, 'utf8');
+
+  const version = extractVersion(tag);
+  const entries = readChangelogJsonFile(changelogJsonPath);
+  if (entries === undefined) {
+    return undefined;
+  }
+
+  const entry = entries.find((e) => e.version === version);
+  if (entry === undefined) {
+    console.warn(`Warning: no changelog entry for version ${version}; skipping README injection`);
+    return undefined;
+  }
+
+  const releaseNotesMarkdown = renderReleaseNotesSingle(entry, {
+    filter: matchesAudience('all'),
+    includeHeading: false,
+  });
+
+  const injected = injectSection(originalReadme, 'release-notes', releaseNotesMarkdown.trimEnd());
+  writeFileSync(readmePath, injected, 'utf8');
+
+  return originalReadme;
+}
+
+/** Extract the version from a tag by stripping the prefix up to the first digit. */
+function extractVersion(tag: string): string {
+  const match = /(\d+\.\d+\.\d+.*)$/.exec(tag);
+  return match?.[1] ?? tag;
+}
+
+/** Read and parse a changelog JSON file. */
+function readChangelogJsonFile(filePath: string): ChangelogEntry[] | undefined {
+  try {
+    const content = readFileSync(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+    if (!isUnknownArray(parsed)) {
+      return undefined;
+    }
+    return parsed.filter(isChangelogEntry);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Type guard for `ChangelogEntry` values parsed from JSON. */
+function isChangelogEntry(value: unknown): value is ChangelogEntry {
+  return (
+    isRecord(value) &&
+    typeof value.version === 'string' &&
+    typeof value.date === 'string' &&
+    isUnknownArray(value.sections)
+  );
 }
 
 /** Build the argument list for the publish command. */

--- a/packages/release-kit/src/publish.ts
+++ b/packages/release-kit/src/publish.ts
@@ -106,6 +106,7 @@ function injectReleaseNotesIntoReadme(readmePath: string, changelogJsonPath: str
   const version = extractVersion(tag);
   const entries = readChangelogEntries(changelogJsonPath);
   if (entries === undefined) {
+    console.warn(`Warning: could not parse ${changelogJsonPath}; skipping README injection`);
     return undefined;
   }
 
@@ -119,6 +120,11 @@ function injectReleaseNotesIntoReadme(readmePath: string, changelogJsonPath: str
     filter: matchesAudience('all'),
     includeHeading: false,
   });
+
+  if (releaseNotesMarkdown.trimEnd().length === 0) {
+    console.warn(`Warning: no user-facing release notes for version ${version}; skipping README injection`);
+    return undefined;
+  }
 
   const injected = injectSection(originalReadme, 'release-notes', releaseNotesMarkdown.trimEnd());
   writeFileSync(readmePath, injected, 'utf8');

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -21,6 +21,47 @@ const publishFlagSchema = {
   only: { long: '--only', type: 'string' as const },
 };
 
+interface ResolvedPublishConfig {
+  releaseNotes: typeof DEFAULT_RELEASE_NOTES_CONFIG;
+  changelogJsonOutputPath: string;
+}
+
+/** Load and validate the release-kit config, falling back to defaults on load failure. */
+async function resolvePublishConfig(): Promise<ResolvedPublishConfig> {
+  let rawConfig: unknown;
+  try {
+    rawConfig = await loadConfig();
+  } catch (error: unknown) {
+    console.warn(
+      `Warning: failed to load config; using defaults: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (rawConfig === undefined) {
+    return {
+      releaseNotes: { ...DEFAULT_RELEASE_NOTES_CONFIG },
+      changelogJsonOutputPath: DEFAULT_CHANGELOG_JSON_CONFIG.outputPath,
+    };
+  }
+
+  const { config, errors, warnings } = validateConfig(rawConfig);
+  if (errors.length > 0) {
+    console.error('Invalid config:');
+    for (const err of errors) {
+      console.error(`  ❌ ${err}`);
+    }
+    process.exit(1);
+  }
+  for (const warning of warnings) {
+    console.warn(`  ⚠️  ${warning}`);
+  }
+
+  return {
+    releaseNotes: { ...DEFAULT_RELEASE_NOTES_CONFIG, ...config.releaseNotes },
+    changelogJsonOutputPath: config.changelogJson?.outputPath ?? DEFAULT_CHANGELOG_JSON_CONFIG.outputPath,
+  };
+}
+
 /**
  * Orchestrate the CLI `publish` command: parse flags, discover workspaces, resolve tags from HEAD,
  * detect the package manager, validate `--only`, and delegate to `publish`.
@@ -37,7 +78,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
   const { dryRun, noGitChecks, provenance } = parsed.flags;
   const only = parsed.flags.only?.split(',');
 
-  // Discover workspaces to determine single-package vs monorepo mode
+  // Discover workspaces to determine single-package vs monorepo mode.
   let discoveredPaths: string[] | undefined;
   try {
     discoveredPaths = await discoverWorkspaces();
@@ -51,11 +92,11 @@ export async function publishCommand(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Build workspace map: dir (basename) -> workspace path
+  // Build workspace map: dir (basename) -> workspace path.
   const workspaceMap =
     discoveredPaths === undefined ? undefined : new Map(discoveredPaths.map((p) => [basename(p), p]));
 
-  // Resolve tags from HEAD
+  // Resolve tags from HEAD.
   let resolvedTags = resolveReleaseTags(workspaceMap);
 
   if (resolvedTags.length === 0) {
@@ -63,7 +104,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Validate --only against resolved tags
+  // Validate --only against resolved tags.
   if (only !== undefined) {
     const availableNames = resolvedTags.map((t) => t.dir);
     for (const name of only) {
@@ -76,37 +117,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
   }
 
   const packageManager = detectPackageManager();
-
-  // Load config for releaseNotes and changelogJson settings.
-  let releaseNotes = { ...DEFAULT_RELEASE_NOTES_CONFIG };
-  let changelogJsonOutputPath = DEFAULT_CHANGELOG_JSON_CONFIG.outputPath;
-  let rawConfig: unknown;
-  try {
-    rawConfig = await loadConfig();
-  } catch (error: unknown) {
-    console.warn(
-      `Warning: failed to load config; using defaults: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
-  if (rawConfig !== undefined) {
-    const { config, errors, warnings } = validateConfig(rawConfig);
-    if (errors.length > 0) {
-      console.error('Invalid config:');
-      for (const err of errors) {
-        console.error(`  ❌ ${err}`);
-      }
-      process.exit(1);
-    }
-    for (const warning of warnings) {
-      console.warn(`  ⚠️  ${warning}`);
-    }
-    releaseNotes = {
-      ...DEFAULT_RELEASE_NOTES_CONFIG,
-      ...config.releaseNotes,
-    };
-    changelogJsonOutputPath = config.changelogJson?.outputPath ?? DEFAULT_CHANGELOG_JSON_CONFIG.outputPath;
-  }
+  const { releaseNotes, changelogJsonOutputPath } = await resolvePublishConfig();
 
   try {
     publish(resolvedTags, packageManager, {

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -83,15 +83,20 @@ export async function publishCommand(argv: string[]): Promise<void> {
   try {
     const rawConfig = await loadConfig();
     if (rawConfig !== undefined) {
-      const { config } = validateConfig(rawConfig);
+      const { config, warnings } = validateConfig(rawConfig);
+      for (const warning of warnings) {
+        console.warn(`  ⚠️  ${warning}`);
+      }
       releaseNotes = {
         ...DEFAULT_RELEASE_NOTES_CONFIG,
         ...config.releaseNotes,
       };
       changelogJsonOutputPath = config.changelogJson?.outputPath ?? DEFAULT_CHANGELOG_JSON_CONFIG.outputPath;
     }
-  } catch {
-    // Config loading failure is non-fatal for publish; use defaults.
+  } catch (error: unknown) {
+    console.warn(
+      `Warning: failed to load config; using defaults: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 
   try {

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -5,10 +5,14 @@ import { basename } from 'node:path';
 
 import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
+import { createGithubReleases } from './createGithubRelease.ts';
+import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG } from './defaults.ts';
 import { detectPackageManager } from './detectPackageManager.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
+import { loadConfig } from './loadConfig.ts';
 import { publish } from './publish.ts';
 import { resolveReleaseTags } from './resolveReleaseTags.ts';
+import { validateConfig } from './validateConfig.ts';
 
 const publishFlagSchema = {
   dryRun: { long: '--dry-run', type: 'boolean' as const },
@@ -73,10 +77,36 @@ export async function publishCommand(argv: string[]): Promise<void> {
 
   const packageManager = detectPackageManager();
 
+  // Load config for releaseNotes and changelogJson settings.
+  let releaseNotes = { ...DEFAULT_RELEASE_NOTES_CONFIG };
+  let changelogJsonOutputPath = DEFAULT_CHANGELOG_JSON_CONFIG.outputPath;
   try {
-    publish(resolvedTags, packageManager, { dryRun, noGitChecks, provenance });
+    const rawConfig = await loadConfig();
+    if (rawConfig !== undefined) {
+      const { config } = validateConfig(rawConfig);
+      releaseNotes = {
+        ...DEFAULT_RELEASE_NOTES_CONFIG,
+        ...config.releaseNotes,
+      };
+      changelogJsonOutputPath = config.changelogJson?.outputPath ?? DEFAULT_CHANGELOG_JSON_CONFIG.outputPath;
+    }
+  } catch {
+    // Config loading failure is non-fatal for publish; use defaults.
+  }
+
+  try {
+    publish(resolvedTags, packageManager, {
+      dryRun,
+      noGitChecks,
+      provenance,
+      releaseNotes,
+      changelogJsonOutputPath,
+    });
   } catch (error: unknown) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
+
+  // Create GitHub Releases after successful publish.
+  createGithubReleases(resolvedTags, releaseNotes, changelogJsonOutputPath, dryRun);
 }

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -80,23 +80,32 @@ export async function publishCommand(argv: string[]): Promise<void> {
   // Load config for releaseNotes and changelogJson settings.
   let releaseNotes = { ...DEFAULT_RELEASE_NOTES_CONFIG };
   let changelogJsonOutputPath = DEFAULT_CHANGELOG_JSON_CONFIG.outputPath;
+  let rawConfig: unknown;
   try {
-    const rawConfig = await loadConfig();
-    if (rawConfig !== undefined) {
-      const { config, warnings } = validateConfig(rawConfig);
-      for (const warning of warnings) {
-        console.warn(`  ⚠️  ${warning}`);
-      }
-      releaseNotes = {
-        ...DEFAULT_RELEASE_NOTES_CONFIG,
-        ...config.releaseNotes,
-      };
-      changelogJsonOutputPath = config.changelogJson?.outputPath ?? DEFAULT_CHANGELOG_JSON_CONFIG.outputPath;
-    }
+    rawConfig = await loadConfig();
   } catch (error: unknown) {
     console.warn(
       `Warning: failed to load config; using defaults: ${error instanceof Error ? error.message : String(error)}`,
     );
+  }
+
+  if (rawConfig !== undefined) {
+    const { config, errors, warnings } = validateConfig(rawConfig);
+    if (errors.length > 0) {
+      console.error('Invalid config:');
+      for (const err of errors) {
+        console.error(`  ❌ ${err}`);
+      }
+      process.exit(1);
+    }
+    for (const warning of warnings) {
+      console.warn(`  ⚠️  ${warning}`);
+    }
+    releaseNotes = {
+      ...DEFAULT_RELEASE_NOTES_CONFIG,
+      ...config.releaseNotes,
+    };
+    changelogJsonOutputPath = config.changelogJson?.outputPath ?? DEFAULT_CHANGELOG_JSON_CONFIG.outputPath;
   }
 
   try {

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process';
 import { bumpAllVersions } from './bumpAllVersions.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpFromCommits } from './determineBumpFromCommits.ts';
+import { generateChangelogJson } from './generateChangelogJson.ts';
 import { generateChangelogs } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
@@ -77,12 +78,24 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   // 4. Generate changelogs
   const changelogFiles = generateChangelogs(config, newTag, dryRun);
 
+  // 4b. Generate changelog JSON if enabled
+  const changelogJsonFiles: string[] = [];
+  if (config.changelogJson.enabled) {
+    for (const changelogPath of config.changelogPaths) {
+      changelogJsonFiles.push(...generateChangelogJson(config, changelogPath, newTag, dryRun));
+    }
+  }
+
   // 5. Run format command, appending modified file paths
   const formatCommandStr = config.formatCommand ?? (hasPrettierConfig() ? 'npx prettier --write' : undefined);
   let formatCommand: PrepareResult['formatCommand'];
 
   if (formatCommandStr !== undefined) {
-    const modifiedFiles = [...config.packageFiles, ...config.changelogPaths.map((p) => `${p}/CHANGELOG.md`)];
+    const modifiedFiles = [
+      ...config.packageFiles,
+      ...config.changelogPaths.map((p) => `${p}/CHANGELOG.md`),
+      ...changelogJsonFiles,
+    ];
     const fullCommand = `${formatCommandStr} ${modifiedFiles.join(' ')}`;
 
     if (dryRun) {

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -6,6 +6,7 @@ import { buildDependencyGraph } from './buildDependencyGraph.ts';
 import { bumpAllVersions } from './bumpAllVersions.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpFromCommits } from './determineBumpFromCommits.ts';
+import { generateChangelogJson, generateSyntheticChangelogJson } from './generateChangelogJson.ts';
 import { buildTagPattern, generateChangelog } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
@@ -270,6 +271,21 @@ function executeReleaseSet(
           }),
         );
       }
+
+      // Generate synthetic changelog JSON for propagation-only bumps.
+      if (config.changelogJson.enabled) {
+        for (const changelogPath of component.changelogPaths) {
+          const jsonFiles = generateSyntheticChangelogJson(
+            config,
+            changelogPath,
+            bump.newVersion,
+            today,
+            releaseEntry.propagatedFrom,
+            dryRun,
+          );
+          modifiedFiles.push(...jsonFiles);
+        }
+      }
     } else {
       for (const changelogPath of component.changelogPaths) {
         changelogFiles.push(
@@ -278,6 +294,17 @@ function executeReleaseSet(
             includePaths: component.paths,
           }),
         );
+      }
+
+      // Generate changelog JSON for direct bumps.
+      if (config.changelogJson.enabled) {
+        for (const changelogPath of component.changelogPaths) {
+          const jsonFiles = generateChangelogJson(config, changelogPath, newTag, dryRun, {
+            tagPattern: buildTagPattern(component.tagPrefix),
+            includePaths: component.paths,
+          });
+          modifiedFiles.push(...jsonFiles);
+        }
       }
     }
 

--- a/packages/release-kit/src/renderReleaseNotes.ts
+++ b/packages/release-kit/src/renderReleaseNotes.ts
@@ -1,0 +1,64 @@
+import type { ChangelogAudience, ChangelogEntry, ChangelogSection } from './types.ts';
+
+/** Options for rendering a single changelog entry to markdown. */
+export interface RenderOptions {
+  /** Predicate to filter sections. When absent, all sections are included. */
+  filter?: (section: ChangelogSection) => boolean;
+  /** Whether to include the version/date heading. Defaults to `true`. */
+  includeHeading?: boolean;
+}
+
+/**
+ * Create a predicate that matches sections visible to the given audience.
+ *
+ * `"all"` matches only sections with `audience: "all"` (public-facing).
+ * `"dev"` matches all sections (developers see everything).
+ */
+export function matchesAudience(audience: ChangelogAudience): (section: ChangelogSection) => boolean {
+  if (audience === 'dev') {
+    return () => true;
+  }
+  return (section) => section.audience === 'all';
+}
+
+/**
+ * Render a single `ChangelogEntry` to markdown.
+ *
+ * Output format mirrors the existing CHANGELOG.md style: an H2 version heading followed by
+ * H3 section headings with bulleted items.
+ */
+export function renderReleaseNotesSingle(entry: ChangelogEntry, options?: RenderOptions): string {
+  const filter = options?.filter;
+  const includeHeading = options?.includeHeading ?? true;
+
+  const sections = filter !== undefined ? entry.sections.filter(filter) : entry.sections;
+
+  if (sections.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [];
+
+  if (includeHeading) {
+    lines.push(`## ${entry.version} — ${entry.date}`);
+  }
+
+  for (const section of sections) {
+    lines.push('', `### ${section.title}`, '');
+    for (const item of section.items) {
+      lines.push(`- ${item.description}`);
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Render multiple `ChangelogEntry` values to a single markdown document.
+ *
+ * Entries are rendered in the order provided; the caller is responsible for sorting.
+ */
+export function renderReleaseNotesMulti(entries: ChangelogEntry[], options?: RenderOptions): string {
+  const parts = entries.map((entry) => renderReleaseNotesSingle(entry, options)).filter((part) => part.length > 0);
+  return parts.join('\n');
+}

--- a/packages/release-kit/src/renderReleaseNotes.ts
+++ b/packages/release-kit/src/renderReleaseNotes.ts
@@ -8,6 +8,14 @@ export interface RenderOptions {
   includeHeading?: boolean;
 }
 
+function allSections() {
+  return true;
+}
+
+function publicSections(section: ChangelogSection) {
+  return section.audience === 'all';
+}
+
 /**
  * Create a predicate that matches sections visible to the given audience.
  *
@@ -15,10 +23,7 @@ export interface RenderOptions {
  * `"dev"` matches all sections (developers see everything).
  */
 export function matchesAudience(audience: ChangelogAudience): (section: ChangelogSection) => boolean {
-  if (audience === 'dev') {
-    return () => true;
-  }
-  return (section) => section.audience === 'all';
+  return audience === 'dev' ? allSections : publicSections;
 }
 
 /**

--- a/packages/release-kit/src/renderReleaseNotes.ts
+++ b/packages/release-kit/src/renderReleaseNotes.ts
@@ -44,7 +44,10 @@ export function renderReleaseNotesSingle(entry: ChangelogEntry, options?: Render
   }
 
   for (const section of sections) {
-    lines.push('', `### ${section.title}`, '');
+    if (lines.length > 0) {
+      lines.push('');
+    }
+    lines.push(`### ${section.title}`, '');
     for (const item of section.items) {
       lines.push(`- ${item.description}`);
     }

--- a/packages/release-kit/src/typeGuards.ts
+++ b/packages/release-kit/src/typeGuards.ts
@@ -2,3 +2,8 @@
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
+
+/** Narrow an `unknown` value to `unknown[]` via `Array.isArray`, avoiding `any[]`. */
+export function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -1,6 +1,41 @@
 /** Semver release type for version bumping. */
 export type ReleaseType = 'major' | 'minor' | 'patch';
 
+/** Target audience for a changelog section. */
+export type ChangelogAudience = 'all' | 'dev';
+
+/** A single item in a changelog section (typically one commit). */
+export interface ChangelogItem {
+  description: string;
+}
+
+/** A grouped section within a changelog entry (e.g., "Features", "Bug fixes"). */
+export interface ChangelogSection {
+  title: string;
+  audience: ChangelogAudience;
+  items: ChangelogItem[];
+}
+
+/** A single version's changelog data. */
+export interface ChangelogEntry {
+  version: string;
+  date: string;
+  sections: ChangelogSection[];
+}
+
+/** Configuration for structured changelog JSON generation. */
+export interface ChangelogJsonConfig {
+  enabled: boolean;
+  outputPath: string;
+  devOnlySections: string[];
+}
+
+/** Configuration for release notes consumption (GitHub Releases, README injection). */
+export interface ReleaseNotesConfig {
+  shouldInjectIntoReadme: boolean;
+  shouldCreateGithubRelease: boolean;
+}
+
 /** Identifies a dependency whose version bump triggered a propagated release. */
 export interface PropagationSource {
   packageName: string;
@@ -101,6 +136,10 @@ export interface ReleaseKitConfig {
    * the shorthand is resolved to the canonical scope name before the parsed commit is returned.
    */
   scopeAliases?: Record<string, string>;
+  /** Controls structured changelog JSON generation. */
+  changelogJson?: Partial<ChangelogJsonConfig>;
+  /** Controls release notes consumption (GitHub Releases, README injection). */
+  releaseNotes?: Partial<ReleaseNotesConfig>;
 }
 
 /** Override for a single component in the config file. */
@@ -171,6 +210,10 @@ export interface MonorepoReleaseConfig {
    * the shorthand is resolved to the canonical scope name before the parsed commit is returned.
    */
   scopeAliases?: Record<string, string>;
+  /** Controls structured changelog JSON generation. */
+  changelogJson: ChangelogJsonConfig;
+  /** Controls release notes consumption (GitHub Releases, README injection). */
+  releaseNotes: ReleaseNotesConfig;
 }
 
 /** Configuration for the release workflow. */
@@ -199,4 +242,8 @@ export interface ReleaseConfig {
    * the shorthand is resolved to the canonical scope name before the parsed commit is returned.
    */
   scopeAliases?: Record<string, string>;
+  /** Controls structured changelog JSON generation. */
+  changelogJson: ChangelogJsonConfig;
+  /** Controls release notes consumption (GitHub Releases, README injection). */
+  releaseNotes: ReleaseNotesConfig;
 }

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -7,23 +7,25 @@ import type { ReleaseKitConfig } from './types.ts';
  * Returns an array of validation error messages. An empty array means the config is valid.
  * Uses hand-coded type guards rather than a schema library.
  */
-export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors: string[] } {
+export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors: string[]; warnings: string[] } {
   const errors: string[] = [];
 
   if (!isRecord(raw)) {
-    return { config: {}, errors: ['Config must be an object'] };
+    return { config: {}, errors: ['Config must be an object'], warnings: [] };
   }
 
   const config: ReleaseKitConfig = {};
 
   // Detect unknown fields
   const knownFields = new Set([
+    'changelogJson',
+    'cliffConfigPath',
     'components',
+    'formatCommand',
+    'releaseNotes',
+    'scopeAliases',
     'versionPatterns',
     'workTypes',
-    'formatCommand',
-    'cliffConfigPath',
-    'scopeAliases',
   ]);
 
   for (const key of Object.keys(raw)) {
@@ -32,14 +34,112 @@ export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors
     }
   }
 
+  validateChangelogJson(raw.changelogJson, config, errors);
   validateComponents(raw.components, config, errors);
+  validateReleaseNotes(raw.releaseNotes, config, errors);
   validateVersionPatterns(raw.versionPatterns, config, errors);
   validateWorkTypes(raw.workTypes, config, errors);
   validateStringField('formatCommand', raw.formatCommand, config, errors);
   validateStringField('cliffConfigPath', raw.cliffConfigPath, config, errors);
   validateScopeAliases(raw.scopeAliases, config, errors);
 
-  return { config, errors };
+  // Cross-field warnings: releaseNotes features require changelogJson to be enabled.
+  const warnings: string[] = [];
+  const changelogJsonEnabled = config.changelogJson?.enabled ?? true;
+  if (!changelogJsonEnabled) {
+    if (config.releaseNotes?.shouldCreateGithubRelease) {
+      warnings.push(
+        'releaseNotes.shouldCreateGithubRelease is enabled but changelogJson.enabled is false; GitHub Releases will be skipped at runtime',
+      );
+    }
+    if (config.releaseNotes?.shouldInjectIntoReadme) {
+      warnings.push(
+        'releaseNotes.shouldInjectIntoReadme is enabled but changelogJson.enabled is false; README injection will be skipped at runtime',
+      );
+    }
+  }
+
+  return { config, errors, warnings };
+}
+
+function validateChangelogJson(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
+  if (value === undefined) return;
+
+  if (!isRecord(value)) {
+    errors.push("'changelogJson' must be an object");
+    return;
+  }
+
+  const knownChangelogJsonFields = new Set(['enabled', 'outputPath', 'devOnlySections']);
+  for (const key of Object.keys(value)) {
+    if (!knownChangelogJsonFields.has(key)) {
+      errors.push(`changelogJson: unknown field '${key}'`);
+    }
+  }
+
+  const result: NonNullable<ReleaseKitConfig['changelogJson']> = {};
+
+  if (value.enabled !== undefined) {
+    if (typeof value.enabled === 'boolean') {
+      result.enabled = value.enabled;
+    } else {
+      errors.push('changelogJson.enabled: must be a boolean');
+    }
+  }
+
+  if (value.outputPath !== undefined) {
+    if (typeof value.outputPath === 'string') {
+      result.outputPath = value.outputPath;
+    } else {
+      errors.push('changelogJson.outputPath: must be a string');
+    }
+  }
+
+  if (value.devOnlySections !== undefined) {
+    if (isStringArray(value.devOnlySections)) {
+      result.devOnlySections = value.devOnlySections;
+    } else {
+      errors.push('changelogJson.devOnlySections: must be a string array');
+    }
+  }
+
+  config.changelogJson = result;
+}
+
+function validateReleaseNotes(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
+  if (value === undefined) return;
+
+  if (!isRecord(value)) {
+    errors.push("'releaseNotes' must be an object");
+    return;
+  }
+
+  const knownReleaseNotesFields = new Set(['shouldInjectIntoReadme', 'shouldCreateGithubRelease']);
+  for (const key of Object.keys(value)) {
+    if (!knownReleaseNotesFields.has(key)) {
+      errors.push(`releaseNotes: unknown field '${key}'`);
+    }
+  }
+
+  const result: NonNullable<ReleaseKitConfig['releaseNotes']> = {};
+
+  if (value.shouldInjectIntoReadme !== undefined) {
+    if (typeof value.shouldInjectIntoReadme === 'boolean') {
+      result.shouldInjectIntoReadme = value.shouldInjectIntoReadme;
+    } else {
+      errors.push('releaseNotes.shouldInjectIntoReadme: must be a boolean');
+    }
+  }
+
+  if (value.shouldCreateGithubRelease !== undefined) {
+    if (typeof value.shouldCreateGithubRelease === 'boolean') {
+      result.shouldCreateGithubRelease = value.shouldCreateGithubRelease;
+    } else {
+      errors.push('releaseNotes.shouldCreateGithubRelease: must be a boolean');
+    }
+  }
+
+  config.releaseNotes = result;
 }
 
 function isStringArray(value: unknown): value is string[] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
+      json-stringify-pretty-compact:
+        specifier: 4.0.0
+        version: 4.0.0
     devDependencies:
       '@types/js-yaml':
         specifier: 4.0.9
@@ -1880,6 +1883,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -4587,6 +4593,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-pretty-compact@4.0.0: {}
 
   json5@1.0.2:
     dependencies:


### PR DESCRIPTION
## What

Adds structured changelog generation with audience tagging to the `release-kit` package, enabling GitHub Release creation and npm README injection with user-facing release notes filtered from developer-only sections. The existing CHANGELOG.md pipeline is unchanged; a new `.meta/changelog.json` artifact is generated in parallel during `release-kit prepare`, and consumed during `release-kit publish` to create GitHub Releases and inject release notes into the published package's README.

## Why

The changelog serves both end users and developers, but sections like CI, Tooling, Dependencies, and Internals are noise for end users reading release notes. There was no structured data artifact for downstream tools to consume, and no mechanism to surface release notes on GitHub Releases or the npm registry.

## Details

### Features

- **Structured changelog JSON** — `generateChangelogJson` runs `git-cliff --context` and transforms the output into `ChangelogEntry[]` with each section tagged `"all"` (user-facing) or `"dev"` (internal) based on a configurable `devOnlySections` list. Output is written to `.meta/changelog.json` using `json-stringify-pretty-compact` for readable formatting.
- **Markdown renderers** — `renderReleaseNotesSingle` and `renderReleaseNotesMulti` convert changelog entries to markdown with predicate-based audience filtering via `matchesAudience`. The single-version renderer supports an `includeHeading` flag for contexts where the heading is provided externally.
- **README section injector** — `injectSection` is a general-purpose pure function for managing `<!-- section:{key} -->` delimited sections in markdown files. Replaces content between markers or prepends when markers are absent.
- **GitHub Release creation** — `createGithubRelease` reads changelog.json, renders release notes for the current version filtered to `audience: "all"`, and creates a GitHub Release via `gh release create`. Failures warn without failing publish.
- **npm README injection** — Before `npm publish`, injects the current version's release notes into a working copy of README.md using the section injector, then restores the original in a `finally` block. Guards against empty release notes (all dev-only sections) and missing/malformed changelog.json.
- **Configuration** — Two new config sections: `changelogJson` (controls structured data generation: `enabled`, `outputPath`, `devOnlySections`) and `releaseNotes` (controls downstream consumption: `shouldCreateGithubRelease`, `shouldInjectIntoReadme`). Both threaded through `ReleaseKitConfig`, `ReleaseConfig`, and `MonorepoReleaseConfig` via the existing merge functions. Validation warns when `releaseNotes` features are enabled with `changelogJson.enabled: false`.
- **Pipeline integration** — `releasePrepare` and `releasePrepareMono` call `generateChangelogJson` after `generateChangelogs` when enabled. Monorepo mode produces per-component changelog.json files. Propagation-only bumps produce synthetic entries.
- **Readyup kit check** — Advisory warning when `releaseNotes` features are enabled alongside `changelogJson.enabled: false`.
- **Drift detection** — `devOnlySections.drift.test.ts` validates the default `devOnlySections` list against `cliff.toml.template` groups, catching configuration drift in both directions.

### Refactoring

- Extracted shared helpers (`isChangelogEntry`, `extractVersion`, `readChangelogEntries`) into `changelogJsonUtils.ts` to eliminate duplication across `generateChangelogJson.ts`, `createGithubRelease.ts`, and `publish.ts`.
- Extracted `resolvePublishConfig` from `publishCommand` to reduce cyclomatic complexity.
- Hoisted audience-filtering predicates to module-scope function declarations in `renderReleaseNotes.ts`.

### Tests

- 11 new test files with 748 total tests passing.
- Coverage includes: type guards, version extraction, file I/O edge cases, audience filtering, dry-run behavior, error recovery, README injection and restore flow, config validation, drift detection, and all skip/warning paths.

### Dependencies

- Added `json-stringify-pretty-compact` as a runtime dependency for readable JSON output formatting.

## Test plan

- [ ] Run `release-kit prepare` in a test fixture and verify both CHANGELOG.md and `.meta/changelog.json` are produced with consistent content
- [ ] Verify changelog.json sections are correctly tagged with audience based on `devOnlySections`
- [ ] Test `release-kit publish --dry-run` with `shouldCreateGithubRelease: true` — verify `gh release create` command is logged
- [ ] Test `release-kit publish --dry-run` with `shouldInjectIntoReadme: true` — verify README injection and restore
- [ ] Verify monorepo mode produces per-component `.meta/changelog.json` files

Closes #195