### PR TITLE
#207 Replace bare-command help with grouped check

### DIFF
--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -39,7 +39,7 @@ vi.mock('../src/sync.ts', async (importOriginal) => {
   };
 });
 
-import { auditCommand, generateCommand, reportCommand, syncCommand } from '../src/cli.ts';
+import { auditCommand, checkCommand, generateCommand, syncCommand } from '../src/cli.ts';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -271,81 +271,153 @@ describe(auditCommand, () => {
 });
 
 // ---------------------------------------------------------------------------
-// reportCommand
+// checkCommand
 // ---------------------------------------------------------------------------
 
-describe(reportCommand, () => {
+describe(checkCommand, () => {
   it('returns 1 when config loading fails', async () => {
     mocks.loadConfig.mockRejectedValue(new Error('Config not found'));
 
-    const exitCode = await reportCommand(makeOptions());
+    const exitCode = await checkCommand(makeOptions());
 
     expect(exitCode).toBe(1);
+    expect(stderrOutput).toContain('Config not found');
   });
 
-  it('deduplicates results across scopes', async () => {
+  it('returns 0 when no vulnerabilities are found', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig
-      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
-      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
 
-    const sharedResult = { id: 'GHSA-dup', path: 'lodash', url: 'https://example.com/GHSA-dup' };
-    mocks.runReport
-      .mockReturnValueOnce({ results: [sharedResult], stdout: '', stderr: '', warnings: [] })
-      .mockReturnValueOnce({ results: [sharedResult], stdout: '', stderr: '', warnings: [] });
+    const exitCode = await checkCommand(makeOptions({ scopes: ['prod'] }));
 
-    await reportCommand(makeOptions());
-
-    // Only one line for the deduplicated result
-    const lines = stdoutOutput.trim().split('\n');
-    expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('GHSA-dup');
+    expect(exitCode).toBe(0);
+    expect(stdoutOutput).toContain('(none)');
   });
 
-  it('returns 0 even when vulnerabilities exist', async () => {
+  it('returns 1 when unallowed vulnerabilities exist', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
-      results: [{ id: 'GHSA-1', path: 'pkg', url: 'https://example.com' }],
+      results: [{ id: 'GHSA-bad', path: 'bad-pkg', severity: 'high', url: 'https://example.com/bad' }],
       stdout: '',
       stderr: '',
       warnings: [],
     });
 
-    const exitCode = await reportCommand(makeOptions({ scopes: ['dev'] }));
+    const exitCode = await checkCommand(makeOptions({ scopes: ['prod'] }));
 
-    expect(exitCode).toBe(0);
+    expect(exitCode).toBe(1);
+    expect(stdoutOutput).toContain('GHSA-bad');
   });
 
-  it('prints "No vulnerabilities found." when results are empty', async () => {
-    setupLoadConfig();
+  it('classifies allowed vulnerabilities correctly', async () => {
+    const config = makeConfig({
+      dev: {
+        allowlist: [{ id: 'GHSA-ok', path: 'safe-pkg', url: 'https://example.com/ok' }],
+      },
+    });
+    setupLoadConfig(config);
     mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.runReport.mockReturnValue({
+      results: [{ id: 'GHSA-ok', path: 'safe-pkg', severity: 'moderate', url: 'https://example.com/ok' }],
+      stdout: '',
+      stderr: '',
+      warnings: [],
+    });
+
+    const exitCode = await checkCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(exitCode).toBe(0);
+    expect(stdoutOutput).toContain('allowed');
+  });
+
+  it('detects stale allowlist entries and returns 0', async () => {
+    const config = makeConfig({
+      prod: {
+        allowlist: [{ id: 'GHSA-stale', path: 'gone-pkg', url: 'https://example.com/stale' }],
+      },
+    });
+    setupLoadConfig(config);
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
 
-    await reportCommand(makeOptions({ scopes: ['dev'] }));
+    const exitCode = await checkCommand(makeOptions({ scopes: ['prod'] }));
 
-    expect(stdoutOutput).toContain('No vulnerabilities found.');
+    expect(exitCode).toBe(0);
+    expect(stdoutOutput).toContain('GHSA-stale');
+    expect(stdoutOutput).toContain('not needed');
   });
 
   it('outputs JSON when json option is true', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
-      results: [{ id: 'GHSA-1', path: 'pkg', url: 'https://example.com' }],
+      results: [{ id: 'GHSA-1', path: 'pkg', severity: 'high', url: 'https://example.com/1' }],
       stdout: '',
       stderr: '',
       warnings: [],
     });
 
-    await reportCommand(makeOptions({ json: true, scopes: ['dev'] }));
+    await checkCommand(makeOptions({ json: true, scopes: ['prod'] }));
 
     const parsed: unknown = JSON.parse(stdoutOutput);
-    expect(parsed).toEqual([{ id: 'GHSA-1', path: 'pkg', url: 'https://example.com' }]);
+    expect(parsed).toHaveProperty('prod');
+  });
+
+  it('checks both scopes when none are specified', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.json');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+
+    await checkCommand(makeOptions());
+
+    expect(mocks.runReport).toHaveBeenCalledTimes(2);
+    expect(stdoutOutput).toContain('prod');
+    expect(stdoutOutput).toContain('dev');
+  });
+
+  it('displays prod before dev even when scopes are passed in reverse order', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.json');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+
+    await checkCommand(makeOptions({ scopes: ['dev', 'prod'] }));
+
+    const prodIndex = stdoutOutput.indexOf('prod');
+    const devIndex = stdoutOutput.indexOf('dev');
+    expect(prodIndex).toBeGreaterThanOrEqual(0);
+    expect(devIndex).toBeGreaterThanOrEqual(0);
+    expect(prodIndex).toBeLessThan(devIndex);
+  });
+
+  it('wraps generateAuditCiConfig errors with scope context', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockRejectedValue(new Error('EACCES: permission denied'));
+
+    await expect(checkCommand(makeOptions({ scopes: ['prod'] }))).rejects.toThrow(
+      "Failed to generate config for scope 'prod': EACCES: permission denied",
+    );
+  });
+
+  it('forwards report stderr to process stderr', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
+    mocks.runReport.mockReturnValue({
+      results: [],
+      stdout: '',
+      stderr: 'audit-ci diagnostic output',
+      warnings: [],
+    });
+
+    await checkCommand(makeOptions({ scopes: ['prod'] }));
+
+    expect(stderrOutput).toContain('audit-ci diagnostic output');
   });
 
   it('forwards report warnings to stderr', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
       results: [],
       stdout: '',
@@ -353,7 +425,7 @@ describe(reportCommand, () => {
       warnings: ['Parse warning'],
     });
 
-    await reportCommand(makeOptions({ scopes: ['dev'] }));
+    await checkCommand(makeOptions({ scopes: ['prod'] }));
 
     expect(stderrOutput).toContain('warning: Parse warning');
   });

--- a/packages/audit-deps/__tests__/format-check.test.ts
+++ b/packages/audit-deps/__tests__/format-check.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CheckResult, ScopeCheckResult } from '../src/format-check.ts';
+import { formatCheckJson, formatCheckText, severityIndicator } from '../src/format-check.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emptyScopeResult(): ScopeCheckResult {
+  return { allowed: [], stale: [], unallowed: [] };
+}
+
+function makeCheckResult(overrides?: Partial<CheckResult>): CheckResult {
+  return {
+    dev: emptyScopeResult(),
+    prod: emptyScopeResult(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// severityIndicator
+// ---------------------------------------------------------------------------
+
+describe(severityIndicator, () => {
+  it.each([
+    ['critical', '\u{1F534}'],
+    ['high', '\u{1F534}'],
+    ['moderate', '\u{1F7E0}'],
+    ['low', '\u{1F7E1}'],
+    ['info', '\u{1F7E1}'],
+  ])('returns correct indicator for %s', (severity, expected) => {
+    expect(severityIndicator(severity)).toBe(expected);
+  });
+
+  it('returns empty string for undefined severity', () => {
+    expect(severityIndicator(undefined)).toBe('');
+  });
+
+  it('returns empty string for unknown severity', () => {
+    expect(severityIndicator('unknown')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCheckText
+// ---------------------------------------------------------------------------
+
+describe(formatCheckText, () => {
+  it('shows "(none)" when a scope has no findings', () => {
+    const result = makeCheckResult();
+    const output = formatCheckText(result, ['prod', 'dev']);
+
+    expect(output).toContain('-- \u{1F4E6} prod --');
+    expect(output).toContain('  (none)');
+    expect(output).toContain('-- \u{1F527} dev --');
+  });
+
+  it('separates scope sections with a blank line', () => {
+    const result = makeCheckResult();
+    const output = formatCheckText(result, ['prod', 'dev']);
+
+    // Verify a blank line separates the prod and dev sections.
+    const prodIndex = output.indexOf('prod');
+    const devIndex = output.indexOf('dev');
+    const between = output.slice(prodIndex, devIndex);
+    expect(between).toContain('\n\n');
+  });
+
+  it('lists unallowed vulnerabilities with severity indicators', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-1', path: 'lodash', severity: 'high', url: 'https://example.com/1' }],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod']);
+    expect(output).toContain('\u{1F534} GHSA-1: lodash (https://example.com/1)');
+    expect(output).not.toContain('allowed');
+  });
+
+  it('annotates allowed vulnerabilities', () => {
+    const result = makeCheckResult({
+      dev: {
+        allowed: [{ id: 'GHSA-2', path: 'express', severity: 'moderate', url: 'https://example.com/2' }],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['dev']);
+    expect(output).toContain('\u{1F7E0} GHSA-2: express (https://example.com/2) \u{1F6AB} allowed');
+  });
+
+  it('flags stale entries', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [{ id: 'GHSA-old' }],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod']);
+    expect(output).toContain('GHSA-old \u{1F5D1}\u{FE0F} not needed');
+  });
+
+  it('renders mixed findings in a single scope', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [{ id: 'GHSA-ok', path: 'safe-pkg', severity: 'low', url: 'https://example.com/ok' }],
+        stale: [{ id: 'GHSA-stale' }],
+        unallowed: [{ id: 'GHSA-bad', path: 'bad-pkg', severity: 'critical', url: 'https://example.com/bad' }],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod']);
+    expect(output).toContain('GHSA-bad');
+    expect(output).toContain('GHSA-ok');
+    expect(output).toContain('GHSA-stale');
+  });
+
+  it('renders only requested scopes', () => {
+    const result = makeCheckResult({
+      dev: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-dev', path: 'pkg', url: 'https://example.com/dev' }],
+      },
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-prod', path: 'pkg', url: 'https://example.com/prod' }],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod']);
+    expect(output).toContain('GHSA-prod');
+    expect(output).not.toContain('GHSA-dev');
+  });
+
+  it('omits severity prefix when severity is undefined', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-1', path: 'pkg', url: 'https://example.com/1' }],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod']);
+    expect(output).toContain('  GHSA-1: pkg (https://example.com/1)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCheckJson
+// ---------------------------------------------------------------------------
+
+describe(formatCheckJson, () => {
+  it('produces parseable JSON with requested scopes', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [{ id: 'GHSA-1', path: 'pkg', severity: 'high', url: 'https://example.com/1' }],
+        stale: [{ id: 'GHSA-old' }],
+        unallowed: [],
+      },
+    });
+
+    const parsed: unknown = JSON.parse(formatCheckJson(result, ['prod']));
+    expect(parsed).toEqual({
+      prod: {
+        allowed: [{ id: 'GHSA-1', path: 'pkg', severity: 'high', url: 'https://example.com/1' }],
+        stale: [{ id: 'GHSA-old' }],
+        unallowed: [],
+      },
+    });
+  });
+
+  it('includes only requested scopes', () => {
+    const result = makeCheckResult();
+    const parsed: unknown = JSON.parse(formatCheckJson(result, ['dev']));
+    expect(parsed).toHaveProperty('dev');
+    expect(parsed).not.toHaveProperty('prod');
+  });
+});

--- a/packages/audit-deps/__tests__/route.test.ts
+++ b/packages/audit-deps/__tests__/route.test.ts
@@ -2,8 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../src/cli.ts', () => ({
   auditCommand: vi.fn().mockResolvedValue(0),
+  checkCommand: vi.fn().mockResolvedValue(0),
   generateCommand: vi.fn().mockResolvedValue(0),
-  reportCommand: vi.fn().mockResolvedValue(0),
   syncCommand: vi.fn().mockResolvedValue(0),
 }));
 
@@ -12,7 +12,7 @@ vi.mock('../src/init/initCommand.ts', () => ({
 }));
 
 import { routeCommand } from '../src/bin/route.ts';
-import { auditCommand, generateCommand, reportCommand, syncCommand } from '../src/cli.ts';
+import { auditCommand, checkCommand, generateCommand, syncCommand } from '../src/cli.ts';
 import { initCommand } from '../src/init/initCommand.ts';
 
 describe(routeCommand, () => {
@@ -39,24 +39,29 @@ describe(routeCommand, () => {
     expect(exitCode).toBe(0);
   });
 
-  it('returns 0 when no args are given', async () => {
-    const exitCode = await routeCommand([]);
-    expect(exitCode).toBe(0);
+  it('dispatches to checkCommand when no args are given', async () => {
+    await routeCommand([]);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: [] }));
   });
 
-  it('dispatches "report" to reportCommand', async () => {
-    await routeCommand(['report']);
-    expect(reportCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: [] }));
+  it('dispatches --raw to auditCommand', async () => {
+    await routeCommand(['--raw']);
+    expect(auditCommand).toHaveBeenCalled();
   });
 
-  it('dispatches "report --dev" with scopes ["dev"]', async () => {
-    await routeCommand(['report', '--dev']);
-    expect(reportCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['dev'] }));
+  it('dispatches --raw --dev to auditCommand with scopes ["dev"]', async () => {
+    await routeCommand(['--raw', '--dev']);
+    expect(auditCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['dev'] }));
   });
 
-  it('dispatches "report --prod" with scopes ["prod"]', async () => {
-    await routeCommand(['report', '--prod']);
-    expect(reportCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['prod'] }));
+  it('dispatches --raw --prod to auditCommand with scopes ["prod"]', async () => {
+    await routeCommand(['--raw', '--prod']);
+    expect(auditCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['prod'] }));
+  });
+
+  it('returns 1 for "report" (removed subcommand)', async () => {
+    const exitCode = await routeCommand(['report']);
+    expect(exitCode).toBe(1);
   });
 
   it('dispatches "sync" to syncCommand', async () => {
@@ -79,13 +84,13 @@ describe(routeCommand, () => {
     expect(initCommand).toHaveBeenCalled();
   });
 
-  it('falls through to auditCommand for unknown flags', async () => {
+  it('dispatches flag-only args to checkCommand', async () => {
     await routeCommand(['--json']);
-    expect(auditCommand).toHaveBeenCalledWith(expect.objectContaining({ json: true }));
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ json: true }));
   });
 
   it('returns 1 for unknown command with typo match', async () => {
-    const exitCode = await routeCommand(['rep']);
+    const exitCode = await routeCommand(['syn']);
     expect(exitCode).toBe(1);
   });
 
@@ -97,13 +102,6 @@ describe(routeCommand, () => {
   it('returns 1 when --dev and --prod are both specified', async () => {
     const exitCode = await routeCommand(['--dev', '--prod']);
     expect(exitCode).toBe(1);
-  });
-
-  it('returns 0 for subcommand --help (e.g., report --help)', async () => {
-    const exitCode = await routeCommand(['report', '--help']);
-    expect(exitCode).toBe(0);
-    // reportCommand should not be called when showing help
-    expect(reportCommand).not.toHaveBeenCalled();
   });
 
   it('returns 0 for sync --help', async () => {
@@ -118,9 +116,9 @@ describe(routeCommand, () => {
     expect(initCommand).not.toHaveBeenCalled();
   });
 
-  it('forwards --config flag to reportCommand', async () => {
-    await routeCommand(['report', '--config', '/custom/audit.json']);
-    expect(reportCommand).toHaveBeenCalledWith(expect.objectContaining({ configPath: '/custom/audit.json' }));
+  it('forwards --config flag to checkCommand', async () => {
+    await routeCommand(['--config', '/custom/audit.json']);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ configPath: '/custom/audit.json' }));
   });
 
   it('forwards --dry-run flag to initCommand', async () => {

--- a/packages/audit-deps/__tests__/run-audit.test.ts
+++ b/packages/audit-deps/__tests__/run-audit.test.ts
@@ -92,6 +92,45 @@ describe(parseAuditCiOutput, () => {
     expect(results).toEqual([]);
   });
 
+  it('extracts severity from advisory when present', () => {
+    const json = JSON.stringify({
+      advisories: {
+        '1234': {
+          id: 1234,
+          module_name: 'lodash',
+          severity: 'high',
+          url: 'https://github.com/advisories/GHSA-1234',
+          findings: [{ paths: ['lodash>underscore'] }],
+        },
+      },
+    });
+
+    const { results } = parseAuditCiOutput(json);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      id: '1234',
+      path: 'lodash>underscore',
+      severity: 'high',
+      url: 'https://github.com/advisories/GHSA-1234',
+    });
+  });
+
+  it('omits severity when not present in advisory', () => {
+    const json = JSON.stringify({
+      advisories: {
+        '1234': {
+          id: 1234,
+          module_name: 'lodash',
+          url: 'https://github.com/advisories/GHSA-1234',
+          findings: [{ paths: ['lodash>underscore'] }],
+        },
+      },
+    });
+
+    const { results } = parseAuditCiOutput(json);
+    expect(results[0]).not.toHaveProperty('severity');
+  });
+
   it('uses module_name as fallback path when findings are empty', () => {
     const json = JSON.stringify({
       advisories: {

--- a/packages/audit-deps/src/bin/route.ts
+++ b/packages/audit-deps/src/bin/route.ts
@@ -2,12 +2,12 @@ import process from 'node:process';
 
 import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
-import { auditCommand, extractMessage, generateCommand, reportCommand, syncCommand } from '../cli.ts';
+import { auditCommand, checkCommand, extractMessage, generateCommand, syncCommand } from '../cli.ts';
 import { initCommand } from '../init/initCommand.ts';
 import type { AuditScope, CommandOptions } from '../types.ts';
 import { VERSION } from '../version.ts';
 
-const SUBCOMMANDS = ['generate', 'init', 'report', 'sync'];
+const SUBCOMMANDS = ['generate', 'init', 'sync'];
 const MIN_PREFIX_LENGTH = 3;
 
 function showHelp(): void {
@@ -16,8 +16,7 @@ Usage: audit-deps [options]
        audit-deps <command> [options]
 
 Commands:
-  (default)            Run audit-ci against configured scopes
-  report               Report vulnerabilities without failing
+  (default)            Grouped vulnerability check with severity indicators
   sync                 Synchronize allowlists with current audit findings
   generate             Regenerate flat audit-ci config files
   init                 Scaffold a starter config file
@@ -29,6 +28,7 @@ Scope options:
 Other options:
   --config <path>      Path to config file (default: .config/audit-deps.config.json)
   --json               Output results as JSON
+  --raw                Run raw audit-ci passthrough (CI mode)
   --help, -h           Show this help message
   --version, -V        Show version number
 `);
@@ -44,23 +44,6 @@ Options:
   --dry-run, -n   Preview changes without writing files
   --force, -f     Overwrite existing files
   --help, -h      Show this help message
-`);
-}
-
-function showReportHelp(): void {
-  console.info(`
-Usage: audit-deps report [options]
-
-Report vulnerabilities without failing.
-
-Scope options:
-  --dev              Target dev dependencies only
-  --prod             Target production dependencies only
-
-Other options:
-  --config <path>    Path to config file (default: .config/audit-deps.config.json)
-  --json             Output results as JSON
-  --help, -h         Show this help message
 `);
 }
 
@@ -144,7 +127,7 @@ function findTypoMatch(input: string): string | undefined {
 export async function routeCommand(args: string[]): Promise<number> {
   const command = args[0];
 
-  if (command === undefined || command === '--help' || command === '-h') {
+  if (command === '--help' || command === '-h') {
     showHelp();
     return 0;
   }
@@ -158,10 +141,6 @@ export async function routeCommand(args: string[]): Promise<number> {
     return handleInit(args.slice(1));
   }
 
-  if (command === 'report') {
-    return handleSubcommand(args.slice(1), reportCommand, showReportHelp);
-  }
-
   if (command === 'sync') {
     return handleSubcommand(args.slice(1), syncCommand, showSyncHelp);
   }
@@ -171,20 +150,24 @@ export async function routeCommand(args: string[]): Promise<number> {
   }
 
   // Check for typos before falling through to the default command
-  const typoMatch = findTypoMatch(command);
-  if (typoMatch !== undefined) {
-    process.stderr.write(`Error: Unknown command '${command}'. Did you mean 'audit-deps ${typoMatch}'?\n`);
-    return 1;
-  }
-
-  // Reject non-flag positional arguments that don't match a known subcommand
-  if (!command.startsWith('-')) {
+  if (command !== undefined && !command.startsWith('-')) {
+    const typoMatch = findTypoMatch(command);
+    if (typoMatch !== undefined) {
+      process.stderr.write(`Error: Unknown command '${command}'. Did you mean 'audit-deps ${typoMatch}'?\n`);
+      return 1;
+    }
     process.stderr.write(`Error: Unknown command '${command}'.\n`);
     return 1;
   }
 
-  // Default: treat all args as audit command options
-  return handleSubcommand(args, auditCommand);
+  // Handle --raw: strip it from args and route to auditCommand (raw passthrough).
+  if (args.includes('--raw')) {
+    const filteredArgs = args.filter((a) => a !== '--raw');
+    return handleSubcommand(filteredArgs, auditCommand);
+  }
+
+  // Default (no args or flag-only args): grouped check command.
+  return handleSubcommand(args, checkCommand);
 }
 
 /** Parse shared flags and dispatch to a subcommand handler. */

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -1,10 +1,12 @@
 import process from 'node:process';
 
 import { loadConfig } from './config.ts';
+import type { CheckResult, ScopeCheckResult } from './format-check.ts';
+import { formatCheckJson, formatCheckText } from './format-check.ts';
 import { generateAuditCiConfig } from './generate.ts';
 import { parseAuditCiOutput, runAudit, runReport } from './run-audit.ts';
 import { syncAllowlist } from './sync.ts';
-import type { AuditDepsConfig, AuditScope, CommandOptions } from './types.ts';
+import type { AuditDepsConfig, AuditScope, CommandOptions, ScopeConfig } from './types.ts';
 import { AUDIT_SCOPES } from './types.ts';
 
 /** Extract a displayable message from an unknown thrown value. */
@@ -72,46 +74,86 @@ export async function auditCommand(options: CommandOptions): Promise<number> {
   return exitCode;
 }
 
-/**
- * Run the `report` subcommand.
- *
- * Invokes audit-ci without allowlist filtering and prints vulnerability details.
- */
-export async function reportCommand(options: CommandOptions): Promise<number> {
-  const loaded = await loadAndGenerate(options);
-  if (loaded === undefined) return 1;
+/** Scopes in display order: prod first, then dev. */
+const CHECK_SCOPE_ORDER: readonly AuditScope[] = ['prod', 'dev'];
 
-  const { scopes, generatedPaths } = loaded;
-  const allResults: Array<{ id: string; path: string; url: string }> = [];
+/**
+ * Run the default grouped-check command.
+ *
+ * Audits each scope without allowlist filtering, cross-references results with
+ * the config allowlist, detects stale entries, and produces grouped output.
+ * Returns 1 when unallowed vulnerabilities exist.
+ */
+export async function checkCommand(options: CommandOptions): Promise<number> {
+  let config: AuditDepsConfig;
+  let configDir: string;
+
+  try {
+    ({ config, configDir } = await loadConfig(options.configPath));
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    return 1;
+  }
+
+  const requestedScopes = options.scopes.length > 0 ? options.scopes : [...CHECK_SCOPE_ORDER];
+  // Ensure display order: prod first, then dev.
+  const scopes = CHECK_SCOPE_ORDER.filter((s) => requestedScopes.includes(s));
+
+  const checkResult: CheckResult = {
+    dev: { allowed: [], stale: [], unallowed: [] },
+    prod: { allowed: [], stale: [], unallowed: [] },
+  };
 
   for (const scope of scopes) {
-    const configPath = generatedPaths.get(scope);
-    if (configPath === undefined) continue;
+    const scopeConfig = config[scope];
 
-    const report = runReport({ configPath });
+    // Generate a stripped config (empty allowlist) so audit-ci reports all vulnerabilities.
+    const strippedScope = { ...scopeConfig, allowlist: [] };
+    const strippedConfigPath = await generateScopeConfig(strippedScope, scope, configDir, config.outDir);
+
+    const report = runReport({ configPath: strippedConfigPath });
     for (const warning of report.warnings) {
       process.stderr.write(`warning: ${warning}\n`);
     }
+    if (report.stderr.length > 0) {
+      process.stderr.write(report.stderr);
+    }
+
+    const allowedIds = new Set(scopeConfig.allowlist.map((entry) => entry.id));
+    const foundIds = new Set(report.results.map((r) => r.id));
+    const scopeResult: ScopeCheckResult = { allowed: [], stale: [], unallowed: [] };
+
     for (const result of report.results) {
-      if (!allResults.some((r) => r.id === result.id)) {
-        allResults.push(result);
+      if (allowedIds.has(result.id)) {
+        scopeResult.allowed.push({
+          id: result.id,
+          path: result.path,
+          severity: result.severity,
+          url: result.url,
+        });
+      } else {
+        scopeResult.unallowed.push(result);
       }
     }
+
+    // Detect stale allowlist entries: IDs in the allowlist but not in audit results.
+    for (const entry of scopeConfig.allowlist) {
+      if (!foundIds.has(entry.id)) {
+        scopeResult.stale.push({ id: entry.id });
+      }
+    }
+
+    checkResult[scope] = scopeResult;
   }
 
   if (options.json) {
-    process.stdout.write(JSON.stringify(allResults, null, 2) + '\n');
+    process.stdout.write(formatCheckJson(checkResult, scopes));
   } else {
-    if (allResults.length === 0) {
-      process.stdout.write('No vulnerabilities found.\n');
-    } else {
-      for (const result of allResults) {
-        process.stdout.write(`${result.id}: ${result.path} (${result.url})\n`);
-      }
-    }
+    process.stdout.write(formatCheckText(checkResult, scopes));
   }
 
-  return 0;
+  const hasUnallowed = scopes.some((s) => checkResult[s].unallowed.length > 0);
+  return hasUnallowed ? 1 : 0;
 }
 
 /**
@@ -138,12 +180,7 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
   for (const scope of scopes) {
     // Generate a config without the allowlist so sync sees all vulnerabilities
     const strippedScope = { ...config[scope], allowlist: [] };
-    let strippedConfigPath: string;
-    try {
-      strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, configDir, config.outDir);
-    } catch (error: unknown) {
-      throw new Error(`Failed to generate config for scope '${scope}': ${extractMessage(error)}`);
-    }
+    const strippedConfigPath = await generateScopeConfig(strippedScope, scope, configDir, config.outDir);
 
     const report = runReport({ configPath: strippedConfigPath });
     for (const warning of report.warnings) {
@@ -164,11 +201,7 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
 
   // Regenerate flat configs after sync
   for (const scope of scopes) {
-    try {
-      await generateAuditCiConfig(config[scope], scope, configDir, config.outDir);
-    } catch (error: unknown) {
-      throw new Error(`Failed to generate config for scope '${scope}': ${extractMessage(error)}`);
-    }
+    await generateScopeConfig(config[scope], scope, configDir, config.outDir);
   }
 
   return 0;
@@ -193,6 +226,20 @@ export async function generateCommand(options: CommandOptions): Promise<number> 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Wrap `generateAuditCiConfig` with a scope-contextual error message. */
+async function generateScopeConfig(
+  scopeConfig: ScopeConfig,
+  scope: AuditScope,
+  configDir: string,
+  outDir: string | undefined,
+): Promise<string> {
+  try {
+    return await generateAuditCiConfig(scopeConfig, scope, configDir, outDir);
+  } catch (error: unknown) {
+    throw new Error(`Failed to generate config for scope '${scope}': ${extractMessage(error)}`);
+  }
+}
 
 interface LoadedState {
   config: AuditDepsConfig;
@@ -219,12 +266,7 @@ async function loadAndGenerate(options: CommandOptions): Promise<LoadedState | u
   const generatedPaths = new Map<AuditScope, string>();
 
   for (const scope of scopes) {
-    let outputPath: string;
-    try {
-      outputPath = await generateAuditCiConfig(config[scope], scope, configDir, config.outDir);
-    } catch (error: unknown) {
-      throw new Error(`Failed to generate config for scope '${scope}': ${extractMessage(error)}`);
-    }
+    const outputPath = await generateScopeConfig(config[scope], scope, configDir, config.outDir);
     generatedPaths.set(scope, outputPath);
   }
 

--- a/packages/audit-deps/src/format-check.ts
+++ b/packages/audit-deps/src/format-check.ts
@@ -1,0 +1,120 @@
+import type { AuditResult } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Classification of an allowlist entry relative to current audit findings. */
+export interface AllowedVuln {
+  id: string;
+  path: string;
+  severity?: string | undefined;
+  url: string;
+}
+
+/** An allowlist entry whose ID no longer appears in audit results. */
+export interface StaleEntry {
+  id: string;
+}
+
+/** Check results for a single scope. */
+export interface ScopeCheckResult {
+  allowed: AllowedVuln[];
+  stale: StaleEntry[];
+  unallowed: AuditResult[];
+}
+
+/** Aggregated check results across scopes. */
+export interface CheckResult {
+  dev: ScopeCheckResult;
+  prod: ScopeCheckResult;
+}
+
+// ---------------------------------------------------------------------------
+// Severity indicator
+// ---------------------------------------------------------------------------
+
+const SEVERITY_INDICATORS: Record<string, string> = {
+  critical: '\u{1F534}',
+  high: '\u{1F534}',
+  info: '\u{1F7E1}',
+  low: '\u{1F7E1}',
+  moderate: '\u{1F7E0}',
+};
+
+/** Map a severity string to a colored circle emoji. */
+export function severityIndicator(severity: string | undefined): string {
+  if (severity === undefined) return '';
+  return SEVERITY_INDICATORS[severity] ?? '';
+}
+
+// ---------------------------------------------------------------------------
+// Text formatter
+// ---------------------------------------------------------------------------
+
+/** Scope display metadata. */
+const SCOPE_HEADERS: Record<'dev' | 'prod', string> = {
+  prod: '-- \u{1F4E6} prod --',
+  dev: '-- \u{1F527} dev --',
+};
+
+/** Format a vulnerability line with optional severity indicator and suffix. */
+function formatVulnLine(
+  vuln: { id: string; path: string; severity?: string | undefined; url: string },
+  suffix?: string,
+): string {
+  const indicator = severityIndicator(vuln.severity);
+  const prefix = indicator.length > 0 ? `${indicator} ` : '';
+  const tail = suffix !== undefined ? ` ${suffix}` : '';
+  return `  ${prefix}${vuln.id}: ${vuln.path} (${vuln.url})${tail}`;
+}
+
+/** Format a single scope's check results as text lines. */
+function formatScopeText(scope: 'dev' | 'prod', result: ScopeCheckResult): string {
+  const lines: string[] = [SCOPE_HEADERS[scope]];
+
+  const hasFindings = result.unallowed.length > 0 || result.allowed.length > 0 || result.stale.length > 0;
+
+  if (!hasFindings) {
+    lines.push('  (none)');
+    return lines.join('\n');
+  }
+
+  for (const vuln of result.unallowed) {
+    lines.push(formatVulnLine(vuln));
+  }
+
+  for (const vuln of result.allowed) {
+    lines.push(formatVulnLine(vuln, '\u{1F6AB} allowed'));
+  }
+
+  for (const entry of result.stale) {
+    lines.push(`  ${entry.id} \u{1F5D1}\u{FE0F} not needed`);
+  }
+
+  return lines.join('\n');
+}
+
+/** Format check results as human-readable text output. */
+export function formatCheckText(result: CheckResult, scopes: Array<'dev' | 'prod'>): string {
+  const sections: string[] = [];
+
+  for (const scope of scopes) {
+    sections.push(formatScopeText(scope, result[scope]));
+  }
+
+  return sections.join('\n\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// JSON formatter
+// ---------------------------------------------------------------------------
+
+/** Format check results as a JSON string. */
+export function formatCheckJson(result: CheckResult, scopes: Array<'dev' | 'prod'>): string {
+  const output: Record<string, ScopeCheckResult> = {};
+  for (const scope of scopes) {
+    output[scope] = result[scope];
+  }
+  return JSON.stringify(output, null, 2) + '\n';
+}

--- a/packages/audit-deps/src/run-audit.ts
+++ b/packages/audit-deps/src/run-audit.ts
@@ -20,6 +20,7 @@ export function resolveAuditCiBin(): string {
 interface AuditCiAdvisory {
   id: number | string;
   module_name: string;
+  severity?: string;
   url: string;
   findings: Array<{ paths: string[] }>;
 }
@@ -59,11 +60,15 @@ export function parseAuditCiOutput(jsonString: string): ParseResult {
   const advisories = extractAdvisories(parsed);
   const results: AuditResult[] = [];
   for (const advisory of advisories) {
-    results.push({
+    const result: AuditResult = {
       id: String(advisory.id),
       path: extractPath(advisory),
       url: advisory.url,
-    });
+    };
+    if (typeof advisory.severity === 'string') {
+      result.severity = advisory.severity;
+    }
+    results.push(result);
   }
 
   return { results, warnings };

--- a/packages/audit-deps/src/types.ts
+++ b/packages/audit-deps/src/types.ts
@@ -79,6 +79,7 @@ export const auditDepsConfigSchema = z.object({
 export interface AuditResult {
   id: string;
   path: string;
+  severity?: string | undefined;
   url: string;
 }
 


### PR DESCRIPTION
## What

Turns `audit-deps` into a developer-friendly vulnerability check by default: running it with no arguments now prints a scannable per-scope summary (prod first) with severity markers, allowed-vulnerability annotations, and stale-allowlist flags, and exits non-zero only when an unallowed vulnerability is present. The previous raw audit-ci passthrough remains available behind `--raw` for CI pipelines and `pnpm audit`-compatible tooling.

## Why

The bare `audit-deps` command was a no-op: it printed help text and exited 0, burying the tool's primary action behind rarely-remembered incantations. For developers wanting a quick check before committing, the existing default output (a dense JSON blob with colored status) was unusable. Fixing the routing bug required rethinking the default output, so the two are addressed together while leaving a CI-friendly path intact.

## Details

### Features

- Bare `audit-deps` now runs a grouped vulnerability check across both scopes. Each scope header (`-- 📦 prod --`, `-- 🔧 dev --`) is followed by its unallowed vulnerabilities with severity indicators (🔴 critical/high, 🟠 moderate, 🟡 low/info), its allowed vulnerabilities tagged `🚫 allowed`, and any stale allowlist entries tagged `🗑️ not needed`. Empty scopes render as `(none)`. Exit code is 1 iff any unallowed vulnerability exists in any scope.
- `--raw` preserves the previous audit-ci passthrough (full JSON blob, colored status). `--dev`, `--prod`, `--config`, and `--json` compose with both the bare command and `--raw`.
- `--json` against the bare command produces a structured object keyed by scope, each containing `unallowed`, `allowed`, and `stale` arrays — suitable for programmatic consumption without screen-scraping the grouped text format.

### Fixes

- Bare `audit-deps` no longer shows help. The no-args case is routed to the new check command, separate from `--help`/`-h`.
- `runReport`'s stderr is now forwarded to `process.stderr` when non-empty, matching the existing `auditCommand` pattern. Previously, audit-ci diagnostics produced in report mode were silently dropped — a regression risk given the new default is report-mode-based.

### Refactoring

- Added optional `severity` field to `AuditResult`; `parseAuditCiOutput` extracts it from audit-ci advisory JSON when present.
- Extracted `generateScopeConfig` to consolidate the `generateAuditCiConfig` try/catch error-wrapping pattern shared by `checkCommand`, `syncCommand`, and `loadAndGenerate`.
- Added `formatCheckText`, `formatCheckJson`, and `severityIndicator` as pure functions in `format-check.ts`, separating presentation from command logic.
- Removed `reportCommand`, `showReportHelp`, and `report` from the `SUBCOMMANDS` typo-detection array. The richer verbose report is deferred to #208.
- Updated help text to document `--raw` and describe the new default behavior.

### Tests

- Severity field extraction, including the case where no severity is present.
- `formatCheckText` and `formatCheckJson` across empty scopes, unallowed-only, allowed-only, stale-only, mixed findings, and blank-line separators between scope sections.
- `checkCommand` classification (allowed vs unallowed vs stale), exit codes, `--json` output shape, stderr forwarding, `generateAuditCiConfig` failure wrapping, and prod-before-dev scope ordering when scopes are passed in reverse.
- Routing: bare command dispatches to the check, `--raw` and `--raw --dev`/`--prod` dispatch to `auditCommand` with the correct scope, and `report` is rejected as an unknown command.

Closes #207