### PR TITLE
#208 Verbose check output for audit-deps

### DIFF
--- a/packages/audit-deps/README.md
+++ b/packages/audit-deps/README.md
@@ -35,6 +35,7 @@ The source-of-truth config lives at `.config/audit-deps.config.json`:
     "moderate": true,
     "allowlist": [
       {
+        "addedAt": "2026-04-15",
         "id": "GHSA-1234-5678-abcd",
         "path": "lodash",
         "reason": "Accepted risk: no user input reaches this path",
@@ -54,7 +55,7 @@ The source-of-truth config lives at `.config/audit-deps.config.json`:
 - **`outDir`** (optional) — Directory for generated flat audit-ci config files, resolved relative to the config file's directory. Defaults to the config file's directory.
 - **`dev`** / **`prod`** — Scope-specific settings:
   - **`critical`**, **`high`**, **`moderate`**, **`low`** — Severity thresholds (pass to audit-ci).
-  - **`allowlist`** — Typed advisory entries with `id`, `path`, `url`, and optional `reason`.
+  - **`allowlist`** — Typed advisory entries with `id`, `path`, `url`, and optional `reason` and `addedAt`. `addedAt` is an ISO date (UTC, `YYYY-MM-DD`) populated automatically by `audit-deps sync` on new entries; existing entries retain whatever value they had.
 
 ## CLI reference
 
@@ -76,6 +77,7 @@ Other options:
   --config <path>      Path to config file (default: .config/audit-deps.config.json)
   --json               Output results as JSON
   --raw                Run raw audit-ci passthrough
+  --verbose, -v        Show detailed per-vulnerability output
   --help, -h           Show this help message
   --version, -V        Show version number
 ```

--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -54,7 +54,7 @@ function makeConfig(overrides?: Partial<AuditDepsConfig>): AuditDepsConfig {
 }
 
 function makeOptions(overrides?: Partial<CommandOptions>): CommandOptions {
-  return { json: false, scopes: [], ...overrides };
+  return { json: false, scopes: [], verbose: false, ...overrides };
 }
 
 function setupLoadConfig(config?: AuditDepsConfig): void {
@@ -180,7 +180,7 @@ describe(auditCommand, () => {
     await auditCommand(makeOptions({ json: true, scopes: ['dev'] }));
 
     const parsed: unknown = JSON.parse(stdoutOutput);
-    expect(parsed).toEqual([{ id: 'GHSA-1', path: 'pkg', url: 'https://example.com/1' }]);
+    expect(parsed).toEqual([{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }]);
   });
 
   it('writes stderr when stdout is empty and stderr has content', async () => {
@@ -299,7 +299,9 @@ describe(checkCommand, () => {
     setupLoadConfig();
     mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
-      results: [{ id: 'GHSA-bad', path: 'bad-pkg', severity: 'high', url: 'https://example.com/bad' }],
+      results: [
+        { id: 'GHSA-bad', path: 'bad-pkg', paths: ['bad-pkg'], severity: 'high', url: 'https://example.com/bad' },
+      ],
       stdout: '',
       stderr: '',
       warnings: [],
@@ -320,7 +322,9 @@ describe(checkCommand, () => {
     setupLoadConfig(config);
     mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
     mocks.runReport.mockReturnValue({
-      results: [{ id: 'GHSA-ok', path: 'safe-pkg', severity: 'moderate', url: 'https://example.com/ok' }],
+      results: [
+        { id: 'GHSA-ok', path: 'safe-pkg', paths: ['safe-pkg'], severity: 'moderate', url: 'https://example.com/ok' },
+      ],
       stdout: '',
       stderr: '',
       warnings: [],
@@ -330,6 +334,63 @@ describe(checkCommand, () => {
 
     expect(exitCode).toBe(0);
     expect(stdoutOutput).toContain('allowed');
+  });
+
+  it('populates allowed entries with advisory fields from the audit result and metadata from the allowlist entry', async () => {
+    const config = makeConfig({
+      prod: {
+        allowlist: [
+          {
+            addedAt: '2026-04-01',
+            id: 'GHSA-enriched',
+            path: 'pkg',
+            reason: 'Accepted risk',
+            url: 'https://example.com/enriched',
+          },
+        ],
+      },
+    });
+    setupLoadConfig(config);
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
+    mocks.runReport.mockReturnValue({
+      results: [
+        {
+          cvss: { score: 7.5 },
+          description: 'Detailed description',
+          id: 'GHSA-enriched',
+          path: 'pkg',
+          paths: ['pkg', 'root>pkg'],
+          severity: 'high',
+          title: 'Prototype pollution',
+          url: 'https://example.com/enriched',
+        },
+      ],
+      stdout: '',
+      stderr: '',
+      warnings: [],
+    });
+
+    await checkCommand(makeOptions({ json: true, scopes: ['prod'] }));
+
+    const parsed: unknown = JSON.parse(stdoutOutput);
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        prod: expect.objectContaining({
+          allowed: [
+            expect.objectContaining({
+              addedAt: '2026-04-01',
+              cvss: { score: 7.5 },
+              description: 'Detailed description',
+              id: 'GHSA-enriched',
+              paths: ['pkg', 'root>pkg'],
+              reason: 'Accepted risk',
+              severity: 'high',
+              title: 'Prototype pollution',
+            }),
+          ],
+        }),
+      }),
+    );
   });
 
   it('detects stale allowlist entries and returns 0', async () => {
@@ -353,7 +414,7 @@ describe(checkCommand, () => {
     setupLoadConfig();
     mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
-      results: [{ id: 'GHSA-1', path: 'pkg', severity: 'high', url: 'https://example.com/1' }],
+      results: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/1' }],
       stdout: '',
       stderr: '',
       warnings: [],
@@ -428,6 +489,113 @@ describe(checkCommand, () => {
     await checkCommand(makeOptions({ scopes: ['prod'] }));
 
     expect(stderrOutput).toContain('warning: Parse warning');
+  });
+
+  it('invokes runReport with reportType "full" when verbose is true', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+
+    await checkCommand(makeOptions({ scopes: ['prod'], verbose: true }));
+
+    expect(mocks.runReport).toHaveBeenCalledWith(expect.objectContaining({ reportType: 'full' }));
+  });
+
+  it('omits reportType when verbose is false', async () => {
+    setupLoadConfig();
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+
+    await checkCommand(makeOptions({ scopes: ['prod'] }));
+
+    const call = mocks.runReport.mock.calls[0]?.[0];
+    expect(call).not.toHaveProperty('reportType');
+  });
+
+  it('renders verbose text output when verbose is true and json is false', async () => {
+    const config = makeConfig({
+      prod: {
+        allowlist: [
+          {
+            addedAt: '2026-04-01',
+            id: 'GHSA-allowed',
+            path: 'pkg',
+            reason: 'Accepted',
+            url: 'https://example.com/allowed',
+          },
+        ],
+      },
+    });
+    setupLoadConfig(config);
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
+    mocks.runReport.mockReturnValue({
+      results: [
+        {
+          description: 'Detailed description',
+          id: 'GHSA-allowed',
+          path: 'pkg',
+          paths: ['pkg'],
+          severity: 'moderate',
+          title: 'Example title',
+          url: 'https://example.com/allowed',
+        },
+      ],
+      stdout: '',
+      stderr: '',
+      warnings: [],
+    });
+
+    await checkCommand(makeOptions({ scopes: ['prod'], verbose: true }));
+
+    expect(stdoutOutput).toContain('\u{26A0}\u{FE0F} GHSA-allowed');
+    expect(stdoutOutput).toContain('Example title');
+    expect(stdoutOutput).toContain('reason: Accepted');
+  });
+
+  it('renders verbose JSON output when both verbose and json are true', async () => {
+    const config = makeConfig({
+      prod: {
+        allowlist: [{ addedAt: '2026-04-01', id: 'GHSA-1', path: 'pkg', reason: 'r', url: 'https://example.com/1' }],
+      },
+    });
+    setupLoadConfig(config);
+    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
+    mocks.runReport.mockReturnValue({
+      results: [
+        {
+          cvss: { score: 7.5 },
+          description: 'desc',
+          id: 'GHSA-1',
+          path: 'pkg',
+          paths: ['pkg'],
+          severity: 'high',
+          title: 'title',
+          url: 'https://example.com/1',
+        },
+      ],
+      stdout: '',
+      stderr: '',
+      warnings: [],
+    });
+
+    await checkCommand(makeOptions({ json: true, scopes: ['prod'], verbose: true }));
+
+    const parsed: unknown = JSON.parse(stdoutOutput);
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        prod: expect.objectContaining({
+          allowed: [
+            expect.objectContaining({
+              addedAt: '2026-04-01',
+              cvss: { score: 7.5 },
+              description: 'desc',
+              reason: 'r',
+              title: 'title',
+            }),
+          ],
+        }),
+      }),
+    );
   });
 });
 

--- a/packages/audit-deps/__tests__/format-actions.test.ts
+++ b/packages/audit-deps/__tests__/format-actions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatActionHints } from '../src/format-actions.ts';
+import type { CheckResult, ScopeCheckResult } from '../src/format-check.ts';
+
+function emptyScopeResult(): ScopeCheckResult {
+  return { allowed: [], stale: [], unallowed: [] };
+}
+
+function makeCheckResult(overrides?: Partial<CheckResult>): CheckResult {
+  return {
+    dev: emptyScopeResult(),
+    prod: emptyScopeResult(),
+    ...overrides,
+  };
+}
+
+describe(formatActionHints, () => {
+  it('returns empty string when no unallowed or stale entries exist', () => {
+    const result = makeCheckResult();
+    expect(formatActionHints(result, ['prod', 'dev'])).toBe('');
+  });
+
+  it('returns the add-only hint when only unallowed vulnerabilities exist', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
+      },
+    });
+
+    const output = formatActionHints(result, ['prod']);
+    expect(output).toBe('\nActions:\n  Run `audit-deps sync` to add vulnerabilities to the allowlist.\n');
+  });
+
+  it('returns the remove-only hint when only stale entries exist', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale' }],
+        unallowed: [],
+      },
+    });
+
+    const output = formatActionHints(result, ['prod']);
+    expect(output).toBe('\nActions:\n  Run `audit-deps sync` to remove stale allowlist entries.\n');
+  });
+
+  it('returns the combined hint when both unallowed and stale entries exist', () => {
+    const result = makeCheckResult({
+      dev: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale' }],
+        unallowed: [],
+      },
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
+      },
+    });
+
+    const output = formatActionHints(result, ['prod', 'dev']);
+    expect(output).toBe(
+      '\nActions:\n  Run `audit-deps sync` to add vulnerabilities to the allowlist and remove stale entries.\n',
+    );
+  });
+
+  it('only considers scopes included in the scopes array', () => {
+    const result = makeCheckResult({
+      dev: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-dev', path: 'pkg', paths: ['pkg'], url: 'https://example.com/dev' }],
+      },
+    });
+
+    // Only 'prod' is passed; dev's unallowed should be ignored.
+    expect(formatActionHints(result, ['prod'])).toBe('');
+  });
+});

--- a/packages/audit-deps/__tests__/format-check.test.ts
+++ b/packages/audit-deps/__tests__/format-check.test.ts
@@ -73,7 +73,9 @@ describe(formatCheckText, () => {
       prod: {
         allowed: [],
         stale: [],
-        unallowed: [{ id: 'GHSA-1', path: 'lodash', severity: 'high', url: 'https://example.com/1' }],
+        unallowed: [
+          { id: 'GHSA-1', path: 'lodash', paths: ['lodash'], severity: 'high', url: 'https://example.com/1' },
+        ],
       },
     });
 
@@ -85,7 +87,9 @@ describe(formatCheckText, () => {
   it('annotates allowed vulnerabilities', () => {
     const result = makeCheckResult({
       dev: {
-        allowed: [{ id: 'GHSA-2', path: 'express', severity: 'moderate', url: 'https://example.com/2' }],
+        allowed: [
+          { id: 'GHSA-2', path: 'express', paths: ['express'], severity: 'moderate', url: 'https://example.com/2' },
+        ],
         stale: [],
         unallowed: [],
       },
@@ -95,7 +99,7 @@ describe(formatCheckText, () => {
     expect(output).toContain('\u{1F7E0} GHSA-2: express (https://example.com/2) \u{1F6AB} allowed');
   });
 
-  it('flags stale entries', () => {
+  it('flags stale entries with emoji-first ordering', () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
@@ -105,15 +109,19 @@ describe(formatCheckText, () => {
     });
 
     const output = formatCheckText(result, ['prod']);
-    expect(output).toContain('GHSA-old \u{1F5D1}\u{FE0F} not needed');
+    expect(output).toContain('  \u{1F5D1}\u{FE0F} GHSA-old  not needed');
   });
 
   it('renders mixed findings in a single scope', () => {
     const result = makeCheckResult({
       prod: {
-        allowed: [{ id: 'GHSA-ok', path: 'safe-pkg', severity: 'low', url: 'https://example.com/ok' }],
+        allowed: [
+          { id: 'GHSA-ok', path: 'safe-pkg', paths: ['safe-pkg'], severity: 'low', url: 'https://example.com/ok' },
+        ],
         stale: [{ id: 'GHSA-stale' }],
-        unallowed: [{ id: 'GHSA-bad', path: 'bad-pkg', severity: 'critical', url: 'https://example.com/bad' }],
+        unallowed: [
+          { id: 'GHSA-bad', path: 'bad-pkg', paths: ['bad-pkg'], severity: 'critical', url: 'https://example.com/bad' },
+        ],
       },
     });
 
@@ -128,12 +136,12 @@ describe(formatCheckText, () => {
       dev: {
         allowed: [],
         stale: [],
-        unallowed: [{ id: 'GHSA-dev', path: 'pkg', url: 'https://example.com/dev' }],
+        unallowed: [{ id: 'GHSA-dev', path: 'pkg', paths: ['pkg'], url: 'https://example.com/dev' }],
       },
       prod: {
         allowed: [],
         stale: [],
-        unallowed: [{ id: 'GHSA-prod', path: 'pkg', url: 'https://example.com/prod' }],
+        unallowed: [{ id: 'GHSA-prod', path: 'pkg', paths: ['pkg'], url: 'https://example.com/prod' }],
       },
     });
 
@@ -147,12 +155,61 @@ describe(formatCheckText, () => {
       prod: {
         allowed: [],
         stale: [],
-        unallowed: [{ id: 'GHSA-1', path: 'pkg', url: 'https://example.com/1' }],
+        unallowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
       },
     });
 
     const output = formatCheckText(result, ['prod']);
     expect(output).toContain('  GHSA-1: pkg (https://example.com/1)');
+  });
+
+  it('appends an Actions footer with the add-only hint when only unallowed vulnerabilities exist', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-bad', path: 'pkg', paths: ['pkg'], url: 'https://example.com/bad' }],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod']);
+    expect(output).toContain('Actions:');
+    expect(output).toContain('Run `audit-deps sync` to add vulnerabilities to the allowlist.');
+    expect(output).not.toContain('and remove stale entries');
+  });
+
+  it('appends an Actions footer with the remove-only hint when only stale entries exist', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale' }],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod']);
+    expect(output).toContain('Actions:');
+    expect(output).toContain('Run `audit-deps sync` to remove stale allowlist entries.');
+  });
+
+  it('appends an Actions footer combining both hints when unallowed and stale both exist', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale' }],
+        unallowed: [{ id: 'GHSA-bad', path: 'pkg', paths: ['pkg'], url: 'https://example.com/bad' }],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod']);
+    expect(output).toContain('Actions:');
+    expect(output).toContain('add vulnerabilities to the allowlist and remove stale entries');
+  });
+
+  it('omits the Actions footer when the allowlist is fully current', () => {
+    const result = makeCheckResult();
+    const output = formatCheckText(result, ['prod', 'dev']);
+    expect(output).not.toContain('Actions:');
   });
 });
 
@@ -164,7 +221,7 @@ describe(formatCheckJson, () => {
   it('produces parseable JSON with requested scopes', () => {
     const result = makeCheckResult({
       prod: {
-        allowed: [{ id: 'GHSA-1', path: 'pkg', severity: 'high', url: 'https://example.com/1' }],
+        allowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/1' }],
         stale: [{ id: 'GHSA-old' }],
         unallowed: [],
       },
@@ -173,11 +230,52 @@ describe(formatCheckJson, () => {
     const parsed: unknown = JSON.parse(formatCheckJson(result, ['prod']));
     expect(parsed).toEqual({
       prod: {
-        allowed: [{ id: 'GHSA-1', path: 'pkg', severity: 'high', url: 'https://example.com/1' }],
+        allowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/1' }],
         stale: [{ id: 'GHSA-old' }],
         unallowed: [],
       },
     });
+  });
+
+  it('includes new advisory fields and allowlist fields on allowed entries in JSON', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [
+          {
+            addedAt: '2026-04-01',
+            cvss: { score: 7.5 },
+            description: 'Detailed description',
+            id: 'GHSA-allowed',
+            path: 'pkg',
+            paths: ['pkg', 'other-pkg>pkg'],
+            reason: 'Accepted risk',
+            severity: 'high',
+            title: 'Prototype pollution',
+            url: 'https://example.com/allowed',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const parsed: unknown = JSON.parse(formatCheckJson(result, ['prod']));
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        prod: expect.objectContaining({
+          allowed: [
+            expect.objectContaining({
+              addedAt: '2026-04-01',
+              cvss: { score: 7.5 },
+              description: 'Detailed description',
+              paths: ['pkg', 'other-pkg>pkg'],
+              reason: 'Accepted risk',
+              title: 'Prototype pollution',
+            }),
+          ],
+        }),
+      }),
+    );
   });
 
   it('includes only requested scopes', () => {

--- a/packages/audit-deps/__tests__/format-verbose.test.ts
+++ b/packages/audit-deps/__tests__/format-verbose.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CheckResult, ScopeCheckResult } from '../src/format-check.ts';
+import { formatCheckVerboseJson, formatCheckVerboseText, formatRelativeTime } from '../src/format-verbose.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emptyScopeResult(): ScopeCheckResult {
+  return { allowed: [], stale: [], unallowed: [] };
+}
+
+function makeCheckResult(overrides?: Partial<CheckResult>): CheckResult {
+  return {
+    dev: emptyScopeResult(),
+    prod: emptyScopeResult(),
+    ...overrides,
+  };
+}
+
+const FIXED_NOW = new Date('2026-04-15T00:00:00Z');
+
+// ---------------------------------------------------------------------------
+// formatCheckVerboseText: unallowed entries
+// ---------------------------------------------------------------------------
+
+describe(formatCheckVerboseText, () => {
+  it('renders "(none)" for an empty scope', () => {
+    const result = makeCheckResult();
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('-- \u{1F4E6} prod --');
+    expect(output).toContain('  (none)');
+  });
+
+  it('renders an unallowed vulnerability with 🚨 marker, title, path, and link', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            id: 'GHSA-unallowed',
+            path: 'lodash',
+            paths: ['my-app>lodash'],
+            severity: 'high',
+            title: 'Prototype pollution in lodash',
+            url: 'https://github.com/advisories/GHSA-unallowed',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('\u{1F6A8} GHSA-unallowed');
+    expect(output).toContain('\u{1F534} high');
+    expect(output).toContain('Prototype pollution in lodash');
+    expect(output).toContain('path: my-app>lodash');
+    expect(output).toContain('link: https://github.com/advisories/GHSA-unallowed');
+  });
+
+  it('renders multi-path vulnerabilities with a plural "paths:" list', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            id: 'GHSA-multi',
+            path: 'lodash',
+            paths: ['app>some-lib>lodash', 'app>other-lib>lodash'],
+            severity: 'high',
+            url: 'https://github.com/advisories/GHSA-multi',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('paths:');
+    expect(output).toContain('- app>some-lib>lodash');
+    expect(output).toContain('- app>other-lib>lodash');
+    expect(output).not.toMatch(/\bpath: /);
+  });
+
+  it('renders single-path vulnerabilities with a singular "path:" line', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            id: 'GHSA-single',
+            path: 'pkg',
+            paths: ['pkg'],
+            url: 'https://example.com/single',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('path: pkg');
+    expect(output).not.toMatch(/paths:\s*\n/);
+  });
+
+  it('word-wraps description indented to the detail column', () => {
+    const longDescription =
+      'Merging user-controlled objects into a plain object can lead to prototype pollution, enabling attackers to modify Object.prototype.';
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            description: longDescription,
+            id: 'GHSA-wrap',
+            path: 'pkg',
+            paths: ['pkg'],
+            url: 'https://example.com/wrap',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('     Merging');
+    // No single line should contain the whole description.
+    const lines = output.split('\n');
+    const veryLongLine = lines.find((line) => line.length > 90);
+    expect(veryLongLine).toBeUndefined();
+  });
+
+  it('preserves paragraph breaks in description', () => {
+    const description = 'First paragraph.\n\nSecond paragraph.';
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            description,
+            id: 'GHSA-paras',
+            path: 'pkg',
+            paths: ['pkg'],
+            url: 'https://example.com/paras',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('First paragraph.');
+    expect(output).toContain('Second paragraph.');
+    // Expect a blank line between the two paragraphs.
+    const firstIdx = output.indexOf('First paragraph.');
+    const secondIdx = output.indexOf('Second paragraph.');
+    const between = output.slice(firstIdx, secondIdx);
+    expect(between).toContain('\n\n');
+  });
+
+  it('omits description block when description is absent', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            id: 'GHSA-nodesc',
+            path: 'pkg',
+            paths: ['pkg'],
+            url: 'https://example.com/nodesc',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    // Link is the last content line, followed by scope newline, not a description.
+    expect(output).toContain('link: https://example.com/nodesc');
+  });
+
+  // --------------------
+  // Allowed entries
+  // --------------------
+
+  it('renders an allowed entry with ⚠️ marker and "allowed X ago (YYYY-MM-DD)"', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [
+          {
+            addedAt: '2026-04-01',
+            id: 'GHSA-allowed',
+            path: 'pkg',
+            paths: ['pkg'],
+            reason: 'Accepted risk: no user input reaches this path',
+            severity: 'moderate',
+            title: 'Regex denial of service',
+            url: 'https://example.com/allowed',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('\u{26A0}\u{FE0F} GHSA-allowed');
+    expect(output).toContain('allowed 2 weeks ago (2026-04-01)');
+    expect(output).toContain('reason: Accepted risk: no user input reaches this path');
+    expect(output).toContain('Regex denial of service');
+    expect(output).toContain('\u{1F7E0} moderate');
+  });
+
+  it('omits "allowed X ago" line when addedAt is absent', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [
+          {
+            id: 'GHSA-noAddedAt',
+            path: 'pkg',
+            paths: ['pkg'],
+            reason: 'legacy',
+            url: 'https://example.com/noAddedAt',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('GHSA-noAddedAt');
+    expect(output).not.toContain('allowed ');
+  });
+
+  it('omits "reason:" line when reason is absent', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [
+          {
+            addedAt: '2026-04-01',
+            id: 'GHSA-noReason',
+            path: 'pkg',
+            paths: ['pkg'],
+            url: 'https://example.com/noReason',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).not.toContain('reason:');
+  });
+
+  // --------------------
+  // Stale entries
+  // --------------------
+
+  it('renders stale entries as a single "🗑️ <id>  not needed" line', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale-entry-0000' }],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('  \u{1F5D1}\u{FE0F} GHSA-stale-entry-0000  not needed');
+  });
+
+  it('appends an Actions footer when unallowed or stale entries exist', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale' }],
+        unallowed: [
+          {
+            id: 'GHSA-bad',
+            path: 'pkg',
+            paths: ['pkg'],
+            url: 'https://example.com/bad',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('Actions:');
+    expect(output).toContain('add vulnerabilities to the allowlist and remove stale entries');
+  });
+
+  it('omits the Actions footer when the allowlist is fully current', () => {
+    const output = formatCheckVerboseText(makeCheckResult(), ['prod', 'dev'], FIXED_NOW);
+    expect(output).not.toContain('Actions:');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatRelativeTime
+// ---------------------------------------------------------------------------
+
+describe(formatRelativeTime, () => {
+  const nowDate = new Date('2026-04-15T12:00:00Z');
+
+  it('returns "just now" when the interval is under a minute', () => {
+    const thirtySecondsAgo = new Date('2026-04-15T11:59:30Z');
+    expect(formatRelativeTime(thirtySecondsAgo.toISOString(), nowDate)).toBe('just now');
+  });
+
+  it('returns "N minutes ago" for sub-hour intervals', () => {
+    const tenMinutesAgo = new Date('2026-04-15T11:50:00Z');
+    expect(formatRelativeTime(tenMinutesAgo.toISOString(), nowDate)).toBe('10 minutes ago');
+  });
+
+  it('uses "1 minute ago" singular', () => {
+    const oneMinuteAgo = new Date('2026-04-15T11:59:00Z');
+    expect(formatRelativeTime(oneMinuteAgo.toISOString(), nowDate)).toBe('1 minute ago');
+  });
+
+  it('returns "N hours ago" for sub-day intervals', () => {
+    const fiveHoursAgo = new Date('2026-04-15T07:00:00Z');
+    expect(formatRelativeTime(fiveHoursAgo.toISOString(), nowDate)).toBe('5 hours ago');
+  });
+
+  it('returns "yesterday" for exactly one day ago', () => {
+    const yesterday = new Date('2026-04-14T12:00:00Z');
+    expect(formatRelativeTime(yesterday.toISOString(), nowDate)).toBe('yesterday');
+  });
+
+  it('returns "N days ago" for intervals between 2 and 6 days', () => {
+    const threeDaysAgo = new Date('2026-04-12T12:00:00Z');
+    expect(formatRelativeTime(threeDaysAgo.toISOString(), nowDate)).toBe('3 days ago');
+  });
+
+  it('returns "N weeks ago" for intervals of 1 to 4 weeks', () => {
+    expect(formatRelativeTime('2026-04-01', nowDate)).toBe('2 weeks ago');
+  });
+
+  it('returns "N months ago" for intervals spanning several months', () => {
+    expect(formatRelativeTime('2026-01-15', nowDate)).toBe('3 months ago');
+  });
+
+  it('returns "N years ago" for intervals of a year or more', () => {
+    expect(formatRelativeTime('2024-04-15', nowDate)).toBe('2 years ago');
+  });
+
+  it('handles month-boundary edge cases (earlier day-of-month in the source)', () => {
+    // From Mar 20 to Apr 15 is 26 days → under a month (under 5 weeks renders as 3 weeks ago).
+    expect(formatRelativeTime('2026-03-20', nowDate)).toBe('3 weeks ago');
+  });
+
+  it('returns empty string for an unparseable date', () => {
+    expect(formatRelativeTime('not-a-date', nowDate)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCheckVerboseJson
+// ---------------------------------------------------------------------------
+
+describe(formatCheckVerboseJson, () => {
+  it('emits all richer fields (title, description, cvss, paths) for unallowed entries', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            cvss: { score: 7.5, vectorString: 'CVSS:3.1' },
+            description: 'Detailed description',
+            id: 'GHSA-1',
+            path: 'pkg',
+            paths: ['pkg', 'app>pkg'],
+            severity: 'high',
+            title: 'Prototype pollution',
+            url: 'https://example.com/1',
+          },
+        ],
+      },
+    });
+
+    const parsed: unknown = JSON.parse(formatCheckVerboseJson(result, ['prod']));
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        prod: expect.objectContaining({
+          unallowed: [
+            expect.objectContaining({
+              cvss: { score: 7.5, vectorString: 'CVSS:3.1' },
+              description: 'Detailed description',
+              id: 'GHSA-1',
+              paths: ['pkg', 'app>pkg'],
+              title: 'Prototype pollution',
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
+  it('emits reason and addedAt for allowed entries when present', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [
+          {
+            addedAt: '2026-04-01',
+            id: 'GHSA-allowed',
+            path: 'pkg',
+            paths: ['pkg'],
+            reason: 'Accepted',
+            url: 'https://example.com/allowed',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const parsed: unknown = JSON.parse(formatCheckVerboseJson(result, ['prod']));
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        prod: expect.objectContaining({
+          allowed: [
+            expect.objectContaining({
+              addedAt: '2026-04-01',
+              reason: 'Accepted',
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
+  it('includes only id for stale entries', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale' }],
+        unallowed: [],
+      },
+    });
+
+    const parsed: unknown = JSON.parse(formatCheckVerboseJson(result, ['prod']));
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        prod: expect.objectContaining({
+          stale: [{ id: 'GHSA-stale' }],
+        }),
+      }),
+    );
+  });
+});

--- a/packages/audit-deps/__tests__/format-verbose.test.ts
+++ b/packages/audit-deps/__tests__/format-verbose.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { CheckResult, ScopeCheckResult } from '../src/format-check.ts';
-import { formatCheckVerboseJson, formatCheckVerboseText, formatRelativeTime } from '../src/format-verbose.ts';
+import { formatCheckVerboseText, formatRelativeTime } from '../src/format-verbose.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -234,6 +234,28 @@ describe(formatCheckVerboseText, () => {
     expect(output).not.toContain('allowed ');
   });
 
+  it('omits the relative-time portion when addedAt is unparseable', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [
+          {
+            addedAt: 'not-a-date',
+            id: 'GHSA-badDate',
+            path: 'pkg',
+            paths: ['pkg'],
+            url: 'https://example.com/badDate',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('allowed (not-a-date)');
+    expect(output).not.toContain('allowed  (not-a-date)');
+  });
+
   it('omits "reason:" line when reason is absent', () => {
     const result = makeCheckResult({
       prod: {
@@ -326,6 +348,11 @@ describe(formatRelativeTime, () => {
     expect(formatRelativeTime(fiveHoursAgo.toISOString(), nowDate)).toBe('5 hours ago');
   });
 
+  it('uses "1 hour ago" singular', () => {
+    const oneHourAgo = new Date('2026-04-15T11:00:00Z');
+    expect(formatRelativeTime(oneHourAgo.toISOString(), nowDate)).toBe('1 hour ago');
+  });
+
   it('returns "yesterday" for exactly one day ago', () => {
     const yesterday = new Date('2026-04-14T12:00:00Z');
     expect(formatRelativeTime(yesterday.toISOString(), nowDate)).toBe('yesterday');
@@ -348,6 +375,10 @@ describe(formatRelativeTime, () => {
     expect(formatRelativeTime('2024-04-15', nowDate)).toBe('2 years ago');
   });
 
+  it('uses "1 year ago" singular at exactly 12 months on the same calendar day', () => {
+    expect(formatRelativeTime('2025-04-15', nowDate)).toBe('1 year ago');
+  });
+
   it('handles month-boundary edge cases (earlier day-of-month in the source)', () => {
     // From Mar 20 to Apr 15 is 26 days → under a month (under 5 weeks renders as 3 weeks ago).
     expect(formatRelativeTime('2026-03-20', nowDate)).toBe('3 weeks ago');
@@ -355,101 +386,5 @@ describe(formatRelativeTime, () => {
 
   it('returns empty string for an unparseable date', () => {
     expect(formatRelativeTime('not-a-date', nowDate)).toBe('');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// formatCheckVerboseJson
-// ---------------------------------------------------------------------------
-
-describe(formatCheckVerboseJson, () => {
-  it('emits all richer fields (title, description, cvss, paths) for unallowed entries', () => {
-    const result = makeCheckResult({
-      prod: {
-        allowed: [],
-        stale: [],
-        unallowed: [
-          {
-            cvss: { score: 7.5, vectorString: 'CVSS:3.1' },
-            description: 'Detailed description',
-            id: 'GHSA-1',
-            path: 'pkg',
-            paths: ['pkg', 'app>pkg'],
-            severity: 'high',
-            title: 'Prototype pollution',
-            url: 'https://example.com/1',
-          },
-        ],
-      },
-    });
-
-    const parsed: unknown = JSON.parse(formatCheckVerboseJson(result, ['prod']));
-    expect(parsed).toEqual(
-      expect.objectContaining({
-        prod: expect.objectContaining({
-          unallowed: [
-            expect.objectContaining({
-              cvss: { score: 7.5, vectorString: 'CVSS:3.1' },
-              description: 'Detailed description',
-              id: 'GHSA-1',
-              paths: ['pkg', 'app>pkg'],
-              title: 'Prototype pollution',
-            }),
-          ],
-        }),
-      }),
-    );
-  });
-
-  it('emits reason and addedAt for allowed entries when present', () => {
-    const result = makeCheckResult({
-      prod: {
-        allowed: [
-          {
-            addedAt: '2026-04-01',
-            id: 'GHSA-allowed',
-            path: 'pkg',
-            paths: ['pkg'],
-            reason: 'Accepted',
-            url: 'https://example.com/allowed',
-          },
-        ],
-        stale: [],
-        unallowed: [],
-      },
-    });
-
-    const parsed: unknown = JSON.parse(formatCheckVerboseJson(result, ['prod']));
-    expect(parsed).toEqual(
-      expect.objectContaining({
-        prod: expect.objectContaining({
-          allowed: [
-            expect.objectContaining({
-              addedAt: '2026-04-01',
-              reason: 'Accepted',
-            }),
-          ],
-        }),
-      }),
-    );
-  });
-
-  it('includes only id for stale entries', () => {
-    const result = makeCheckResult({
-      prod: {
-        allowed: [],
-        stale: [{ id: 'GHSA-stale' }],
-        unallowed: [],
-      },
-    });
-
-    const parsed: unknown = JSON.parse(formatCheckVerboseJson(result, ['prod']));
-    expect(parsed).toEqual(
-      expect.objectContaining({
-        prod: expect.objectContaining({
-          stale: [{ id: 'GHSA-stale' }],
-        }),
-      }),
-    );
   });
 });

--- a/packages/audit-deps/__tests__/format-verbose.test.ts
+++ b/packages/audit-deps/__tests__/format-verbose.test.ts
@@ -384,6 +384,12 @@ describe(formatRelativeTime, () => {
     expect(formatRelativeTime('2026-03-20', nowDate)).toBe('3 weeks ago');
   });
 
+  it('crosses the 5-week boundary into months at exactly 35 days', () => {
+    // From Mar 11 to Apr 15 is 35 days → 5 weeks, which the formatter reports as 1 month ago
+    // (>= 5 weeks switches to UTC calendar-month math, which yields 1 for this pair).
+    expect(formatRelativeTime('2026-03-11', nowDate)).toBe('1 month ago');
+  });
+
   it('returns empty string for an unparseable date', () => {
     expect(formatRelativeTime('not-a-date', nowDate)).toBe('');
   });

--- a/packages/audit-deps/__tests__/route.test.ts
+++ b/packages/audit-deps/__tests__/route.test.ts
@@ -146,6 +146,18 @@ describe(routeCommand, () => {
     expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['dev'], verbose: true }));
   });
 
+  it('composes --verbose with --prod', async () => {
+    await routeCommand(['--verbose', '--prod']);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['prod'], verbose: true }));
+  });
+
+  it('composes --verbose with --config', async () => {
+    await routeCommand(['--verbose', '--config', '/custom/audit.json']);
+    expect(checkCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ configPath: '/custom/audit.json', verbose: true }),
+    );
+  });
+
   it('forwards --dry-run flag to initCommand', async () => {
     await routeCommand(['init', '--dry-run']);
     expect(initCommand).toHaveBeenCalledWith({ dryRun: true, force: false });

--- a/packages/audit-deps/__tests__/route.test.ts
+++ b/packages/audit-deps/__tests__/route.test.ts
@@ -121,6 +121,31 @@ describe(routeCommand, () => {
     expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ configPath: '/custom/audit.json' }));
   });
 
+  it('forwards --verbose flag to checkCommand', async () => {
+    await routeCommand(['--verbose']);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ verbose: true }));
+  });
+
+  it('forwards -v short flag to checkCommand', async () => {
+    await routeCommand(['-v']);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ verbose: true }));
+  });
+
+  it('defaults verbose to false when the flag is not provided', async () => {
+    await routeCommand([]);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ verbose: false }));
+  });
+
+  it('composes --verbose with --json', async () => {
+    await routeCommand(['--verbose', '--json']);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ json: true, verbose: true }));
+  });
+
+  it('composes --verbose with --dev', async () => {
+    await routeCommand(['--verbose', '--dev']);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['dev'], verbose: true }));
+  });
+
   it('forwards --dry-run flag to initCommand', async () => {
     await routeCommand(['init', '--dry-run']);
     expect(initCommand).toHaveBeenCalledWith({ dryRun: true, force: false });

--- a/packages/audit-deps/__tests__/run-audit.test.ts
+++ b/packages/audit-deps/__tests__/run-audit.test.ts
@@ -30,6 +30,7 @@ describe(parseAuditCiOutput, () => {
     expect(results[0]).toEqual({
       id: '1234',
       path: 'lodash>underscore',
+      paths: ['lodash>underscore'],
       url: 'https://github.com/advisories/GHSA-1234',
     });
   });
@@ -70,6 +71,7 @@ describe(parseAuditCiOutput, () => {
     expect(results[0]).toEqual({
       id: 'GHSA-23c5-xmqv-rm74',
       path: 'some-pkg>dep',
+      paths: ['some-pkg>dep'],
       url: 'https://github.com/advisories/GHSA-23c5-xmqv-rm74',
     });
   });
@@ -110,6 +112,7 @@ describe(parseAuditCiOutput, () => {
     expect(results[0]).toEqual({
       id: '1234',
       path: 'lodash>underscore',
+      paths: ['lodash>underscore'],
       severity: 'high',
       url: 'https://github.com/advisories/GHSA-1234',
     });
@@ -145,6 +148,63 @@ describe(parseAuditCiOutput, () => {
 
     const { results } = parseAuditCiOutput(json);
     expect(results[0]?.path).toBe('some-pkg');
+    expect(results[0]?.paths).toEqual([]);
+  });
+
+  it('collects all paths from multiple findings, deduplicated in insertion order', () => {
+    const json = JSON.stringify({
+      advisories: {
+        '1234': {
+          id: 1234,
+          module_name: 'lodash',
+          url: 'https://github.com/advisories/GHSA-1234',
+          findings: [{ paths: ['a>b>lodash', 'c>lodash'] }, { paths: ['c>lodash', 'd>lodash'] }],
+        },
+      },
+    });
+
+    const { results } = parseAuditCiOutput(json);
+    expect(results[0]?.paths).toEqual(['a>b>lodash', 'c>lodash', 'd>lodash']);
+    expect(results[0]?.path).toBe('a>b>lodash');
+  });
+
+  it('surfaces title, overview as description, and cvss when present in advisory', () => {
+    const json = JSON.stringify({
+      advisories: {
+        '1234': {
+          id: 1234,
+          module_name: 'lodash',
+          title: 'Prototype pollution in lodash',
+          overview: 'Detailed description of the vulnerability.',
+          cvss: { score: 7.5, vectorString: 'CVSS:3.1/AV:N' },
+          url: 'https://github.com/advisories/GHSA-1234',
+          findings: [{ paths: ['lodash'] }],
+        },
+      },
+    });
+
+    const { results } = parseAuditCiOutput(json);
+    expect(results[0]?.title).toBe('Prototype pollution in lodash');
+    expect(results[0]?.description).toBe('Detailed description of the vulnerability.');
+    expect(results[0]?.cvss).toEqual({ score: 7.5, vectorString: 'CVSS:3.1/AV:N' });
+  });
+
+  it('omits title, description, and cvss when advisory does not include them', () => {
+    const json = JSON.stringify({
+      advisories: {
+        '1234': {
+          id: 1234,
+          module_name: 'lodash',
+          url: 'https://github.com/advisories/GHSA-1234',
+          findings: [{ paths: ['lodash'] }],
+        },
+      },
+    });
+
+    const { results } = parseAuditCiOutput(json);
+    expect(results[0]).not.toHaveProperty('title');
+    expect(results[0]).not.toHaveProperty('description');
+    expect(results[0]).not.toHaveProperty('cvss');
   });
 });
 
@@ -250,6 +310,26 @@ describe(runReport, () => {
     mockSpawnSync.mockReturnValue({ status: null, stdout: '', stderr: '', error: new Error('ENOENT') });
 
     expect(() => runReport({ configPath: '/cfg.json' })).toThrow('Failed to launch audit-ci');
+  });
+
+  it('appends --report-type full when reportType is "full"', () => {
+    mockSpawnSync.mockReturnValue({ status: 0, stdout: '{}', stderr: '', error: null });
+
+    runReport({ configPath: '/cfg.json', reportType: 'full' });
+
+    const args: string[] = mockSpawnSync.mock.calls[0][1];
+    expect(args).toEqual(
+      expect.arrayContaining(['--config', '/cfg.json', '--output-format', 'json', '--report-type', 'full']),
+    );
+  });
+
+  it('omits --report-type when reportType is not specified', () => {
+    mockSpawnSync.mockReturnValue({ status: 0, stdout: '{}', stderr: '', error: null });
+
+    runReport({ configPath: '/cfg.json' });
+
+    const args: string[] = mockSpawnSync.mock.calls[0][1];
+    expect(args).not.toContain('--report-type');
   });
 });
 

--- a/packages/audit-deps/__tests__/sync.test.ts
+++ b/packages/audit-deps/__tests__/sync.test.ts
@@ -4,22 +4,49 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { buildUpdatedConfig, computeSyncDiff, serializeConfig, syncAllowlist } from '../src/sync.ts';
+import { buildUpdatedConfig, computeSyncDiff, formatUtcDate, serializeConfig, syncAllowlist } from '../src/sync.ts';
 import type { AllowlistEntry, AuditDepsConfig, AuditResult } from '../src/types.ts';
+
+function makeAuditResult(overrides: Partial<AuditResult> & Pick<AuditResult, 'id' | 'path' | 'url'>): AuditResult {
+  return { paths: [overrides.path], ...overrides };
+}
 
 const fixedDate = new Date('2025-06-15T00:00:00Z');
 
 describe(computeSyncDiff, () => {
   it('adds new advisories not in the current allowlist', () => {
     const current: AllowlistEntry[] = [];
-    const audit: AuditResult[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
+    const audit: AuditResult[] = [makeAuditResult({ id: '1001', path: 'lodash', url: 'https://example.com/1001' })];
 
     const { added, kept, removed } = computeSyncDiff(current, audit, fixedDate);
 
     expect(added).toHaveLength(1);
     expect(added[0]?.reason).toBe('Added by audit-deps sync on 2025-06-15');
+    expect(added[0]?.addedAt).toBe('2025-06-15');
     expect(kept).toHaveLength(0);
     expect(removed).toHaveLength(0);
+  });
+
+  it('preserves addedAt on kept entries when present', () => {
+    const current: AllowlistEntry[] = [
+      { addedAt: '2025-01-01', id: '1001', path: 'lodash', url: 'https://example.com/1001' },
+    ];
+    const audit: AuditResult[] = [makeAuditResult({ id: '1001', path: 'lodash', url: 'https://example.com/1001' })];
+
+    const { kept } = computeSyncDiff(current, audit, fixedDate);
+
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.addedAt).toBe('2025-01-01');
+  });
+
+  it('leaves addedAt absent on kept entries that did not have it', () => {
+    const current: AllowlistEntry[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
+    const audit: AuditResult[] = [makeAuditResult({ id: '1001', path: 'lodash', url: 'https://example.com/1001' })];
+
+    const { kept } = computeSyncDiff(current, audit, fixedDate);
+
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.addedAt).toBeUndefined();
   });
 
   it('removes advisories no longer in audit output', () => {
@@ -38,7 +65,7 @@ describe(computeSyncDiff, () => {
     const current: AllowlistEntry[] = [
       { id: '1001', path: 'lodash', reason: 'accepted risk', url: 'https://example.com/1001' },
     ];
-    const audit: AuditResult[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
+    const audit: AuditResult[] = [makeAuditResult({ id: '1001', path: 'lodash', url: 'https://example.com/1001' })];
 
     const { added, kept, removed } = computeSyncDiff(current, audit, fixedDate);
 
@@ -50,7 +77,7 @@ describe(computeSyncDiff, () => {
 
   it('keeps entry without reason when ID is still in audit output', () => {
     const current: AllowlistEntry[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
-    const audit: AuditResult[] = [{ id: '1001', path: 'lodash', url: 'https://example.com/1001' }];
+    const audit: AuditResult[] = [makeAuditResult({ id: '1001', path: 'lodash', url: 'https://example.com/1001' })];
 
     const { kept } = computeSyncDiff(current, audit, fixedDate);
 
@@ -64,8 +91,8 @@ describe(computeSyncDiff, () => {
       { id: '1002', path: 'express', reason: 'manual reason', url: 'https://example.com/1002' },
     ];
     const audit: AuditResult[] = [
-      { id: '1002', path: 'express', url: 'https://example.com/1002' },
-      { id: '1003', path: 'axios', url: 'https://example.com/1003' },
+      makeAuditResult({ id: '1002', path: 'express', url: 'https://example.com/1002' }),
+      makeAuditResult({ id: '1003', path: 'axios', url: 'https://example.com/1003' }),
     ];
 
     const { added, kept, removed } = computeSyncDiff(current, audit, fixedDate);
@@ -107,10 +134,10 @@ describe(buildUpdatedConfig, () => {
 });
 
 describe(serializeConfig, () => {
-  it('produces JSON with alphabetically ordered allowlist entry keys', () => {
+  it('produces JSON with alphabetically ordered allowlist entry keys including addedAt', () => {
     const config: AuditDepsConfig = {
       dev: {
-        allowlist: [{ id: '1001', path: 'lodash', reason: 'test', url: 'https://example.com' }],
+        allowlist: [{ addedAt: '2026-04-01', id: '1001', path: 'lodash', reason: 'test', url: 'https://example.com' }],
       },
       prod: { allowlist: [] },
     };
@@ -119,7 +146,22 @@ describe(serializeConfig, () => {
     // Re-parse through the typed loader to verify key order in raw JSON
     const devMatch = json.match(/"allowlist":\s*\[\s*\{([^}]+)\}/);
     const keyOrder = devMatch?.[1]?.match(/"(\w+)":/g)?.map((k) => k.replace(/"/g, '').replace(':', ''));
+    expect(keyOrder).toEqual(['addedAt', 'id', 'path', 'reason', 'url']);
+  });
+
+  it('omits addedAt when entry has no addedAt', () => {
+    const config: AuditDepsConfig = {
+      dev: {
+        allowlist: [{ id: '1001', path: 'lodash', reason: 'test', url: 'https://example.com' }],
+      },
+      prod: { allowlist: [] },
+    };
+
+    const json = serializeConfig(config);
+    const devMatch = json.match(/"allowlist":\s*\[\s*\{([^}]+)\}/);
+    const keyOrder = devMatch?.[1]?.match(/"(\w+)":/g)?.map((k) => k.replace(/"/g, '').replace(':', ''));
     expect(keyOrder).toEqual(['id', 'path', 'reason', 'url']);
+    expect(json).not.toContain('"addedAt"');
   });
 
   it('omits reason key when entry has no reason', () => {
@@ -135,6 +177,17 @@ describe(serializeConfig, () => {
     const keyOrder = devMatch?.[1]?.match(/"(\w+)":/g)?.map((k) => k.replace(/"/g, '').replace(':', ''));
     expect(keyOrder).toEqual(['id', 'path', 'url']);
     expect(json).not.toContain('"reason"');
+  });
+});
+
+describe(formatUtcDate, () => {
+  it('returns a YYYY-MM-DD date string in UTC', () => {
+    expect(formatUtcDate(new Date('2026-04-15T12:34:56Z'))).toBe('2026-04-15');
+  });
+
+  it('returns the UTC date regardless of the local timezone portion of the ISO string', () => {
+    // This date in PST is 2026-04-14, but UTC is 2026-04-15.
+    expect(formatUtcDate(new Date('2026-04-15T03:00:00Z'))).toBe('2026-04-15');
   });
 });
 

--- a/packages/audit-deps/src/bin/route.ts
+++ b/packages/audit-deps/src/bin/route.ts
@@ -29,6 +29,7 @@ Other options:
   --config <path>      Path to config file (default: .config/audit-deps.config.json)
   --json               Output results as JSON
   --raw                Run raw audit-ci passthrough
+  --verbose, -v        Show detailed per-vulnerability output
   --help, -h           Show this help message
   --version, -V        Show version number
 `);
@@ -80,13 +81,14 @@ Other options:
 `);
 }
 
-/** Parse the shared flags (--dev, --prod, --config, --json) from argv. */
+/** Parse the shared flags (--dev, --prod, --config, --json, --verbose) from argv. */
 function parseSharedFlags(flags: string[]): CommandOptions {
   const flagSchema = {
     config: { long: '--config', type: 'string' as const },
     dev: { long: '--dev', type: 'boolean' as const },
     json: { long: '--json', type: 'boolean' as const, short: '-j' },
     prod: { long: '--prod', type: 'boolean' as const },
+    verbose: { long: '--verbose', type: 'boolean' as const, short: '-v' },
   };
 
   const { flags: parsed } = parseArgs(flags, flagSchema);
@@ -103,6 +105,7 @@ function parseSharedFlags(flags: string[]): CommandOptions {
     configPath: parsed.config,
     json: parsed.json,
     scopes,
+    verbose: parsed.verbose,
   };
 }
 

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -3,7 +3,7 @@ import process from 'node:process';
 import { loadConfig } from './config.ts';
 import type { AllowedVuln, CheckResult, ScopeCheckResult } from './format-check.ts';
 import { formatCheckJson, formatCheckText } from './format-check.ts';
-import { formatCheckVerboseJson, formatCheckVerboseText } from './format-verbose.ts';
+import { formatCheckVerboseText } from './format-verbose.ts';
 import { generateAuditCiConfig } from './generate.ts';
 import { parseAuditCiOutput, runAudit, runReport } from './run-audit.ts';
 import { syncAllowlist } from './sync.ts';
@@ -26,7 +26,7 @@ export async function auditCommand(options: CommandOptions): Promise<number> {
 
   const { scopes, generatedPaths } = loaded;
   let exitCode = 0;
-  const allResults: Array<{ id: string; path: string; url: string }> = [];
+  const allResults: AuditResult[] = [];
 
   for (const scope of scopes) {
     const configPath = generatedPaths.get(scope);
@@ -148,9 +148,7 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
     checkResult[scope] = scopeResult;
   }
 
-  if (options.verbose && options.json) {
-    process.stdout.write(formatCheckVerboseJson(checkResult, scopes));
-  } else if (options.verbose) {
+  if (options.verbose && !options.json) {
     process.stdout.write(formatCheckVerboseText(checkResult, scopes));
   } else if (options.json) {
     process.stdout.write(formatCheckJson(checkResult, scopes));

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -1,12 +1,13 @@
 import process from 'node:process';
 
 import { loadConfig } from './config.ts';
-import type { CheckResult, ScopeCheckResult } from './format-check.ts';
+import type { AllowedVuln, CheckResult, ScopeCheckResult } from './format-check.ts';
 import { formatCheckJson, formatCheckText } from './format-check.ts';
+import { formatCheckVerboseJson, formatCheckVerboseText } from './format-verbose.ts';
 import { generateAuditCiConfig } from './generate.ts';
 import { parseAuditCiOutput, runAudit, runReport } from './run-audit.ts';
 import { syncAllowlist } from './sync.ts';
-import type { AuditDepsConfig, AuditScope, CommandOptions, ScopeConfig } from './types.ts';
+import type { AllowlistEntry, AuditDepsConfig, AuditResult, AuditScope, CommandOptions, ScopeConfig } from './types.ts';
 import { AUDIT_SCOPES } from './types.ts';
 
 /** Extract a displayable message from an unknown thrown value. */
@@ -111,7 +112,11 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
     const strippedScope = { ...scopeConfig, allowlist: [] };
     const strippedConfigPath = await generateScopeConfig(strippedScope, scope, configDir, config.outDir);
 
-    const report = runReport({ configPath: strippedConfigPath });
+    const reportOptions: { configPath: string; reportType?: 'full' } = { configPath: strippedConfigPath };
+    if (options.verbose) {
+      reportOptions.reportType = 'full';
+    }
+    const report = runReport(reportOptions);
     for (const warning of report.warnings) {
       process.stderr.write(`warning: ${warning}\n`);
     }
@@ -121,16 +126,13 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
 
     const allowedIds = new Set(scopeConfig.allowlist.map((entry) => entry.id));
     const foundIds = new Set(report.results.map((r) => r.id));
+    const allowlistById = new Map<string, AllowlistEntry>(scopeConfig.allowlist.map((entry) => [entry.id, entry]));
     const scopeResult: ScopeCheckResult = { allowed: [], stale: [], unallowed: [] };
 
     for (const result of report.results) {
       if (allowedIds.has(result.id)) {
-        scopeResult.allowed.push({
-          id: result.id,
-          path: result.path,
-          severity: result.severity,
-          url: result.url,
-        });
+        const entry = allowlistById.get(result.id);
+        scopeResult.allowed.push(buildAllowedVuln(result, entry));
       } else {
         scopeResult.unallowed.push(result);
       }
@@ -146,7 +148,11 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
     checkResult[scope] = scopeResult;
   }
 
-  if (options.json) {
+  if (options.verbose && options.json) {
+    process.stdout.write(formatCheckVerboseJson(checkResult, scopes));
+  } else if (options.verbose) {
+    process.stdout.write(formatCheckVerboseText(checkResult, scopes));
+  } else if (options.json) {
     process.stdout.write(formatCheckJson(checkResult, scopes));
   } else {
     process.stdout.write(formatCheckText(checkResult, scopes));
@@ -226,6 +232,23 @@ export async function generateCommand(options: CommandOptions): Promise<number> 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Merge an `AuditResult` with an `AllowlistEntry` into an `AllowedVuln`, omitting absent optional fields. */
+function buildAllowedVuln(result: AuditResult, entry: AllowlistEntry | undefined): AllowedVuln {
+  const allowed: AllowedVuln = {
+    id: result.id,
+    path: result.path,
+    paths: result.paths,
+    url: result.url,
+  };
+  if (result.severity !== undefined) allowed.severity = result.severity;
+  if (result.title !== undefined) allowed.title = result.title;
+  if (result.description !== undefined) allowed.description = result.description;
+  if (result.cvss !== undefined) allowed.cvss = result.cvss;
+  if (entry?.reason !== undefined) allowed.reason = entry.reason;
+  if (entry?.addedAt !== undefined) allowed.addedAt = entry.addedAt;
+  return allowed;
+}
 
 /** Wrap `generateAuditCiConfig` with a scope-contextual error message. */
 async function generateScopeConfig(

--- a/packages/audit-deps/src/format-actions.ts
+++ b/packages/audit-deps/src/format-actions.ts
@@ -1,0 +1,27 @@
+import type { CheckResult } from './format-check.ts';
+import type { AuditScope } from './types.ts';
+
+const HINT_ADD = 'Run `audit-deps sync` to add vulnerabilities to the allowlist.';
+const HINT_REMOVE = 'Run `audit-deps sync` to remove stale allowlist entries.';
+const HINT_BOTH = 'Run `audit-deps sync` to add vulnerabilities to the allowlist and remove stale entries.';
+
+/**
+ * Compute the "Actions:" footer for check output.
+ *
+ * Returns an empty string when the allowlist is fully current. Otherwise returns
+ * `\nActions:\n  <hint>\n` describing what sync would do.
+ */
+export function formatActionHints(result: CheckResult, scopes: AuditScope[]): string {
+  const hasUnallowed = scopes.some((scope) => result[scope].unallowed.length > 0);
+  const hasStale = scopes.some((scope) => result[scope].stale.length > 0);
+
+  if (hasUnallowed && hasStale) return footer(HINT_BOTH);
+  if (hasUnallowed) return footer(HINT_ADD);
+  if (hasStale) return footer(HINT_REMOVE);
+  return '';
+}
+
+/** Wrap a single hint line in the "Actions:" footer format. */
+function footer(hint: string): string {
+  return `\nActions:\n  ${hint}\n`;
+}

--- a/packages/audit-deps/src/format-check.ts
+++ b/packages/audit-deps/src/format-check.ts
@@ -1,4 +1,5 @@
-import type { AuditResult } from './types.ts';
+import { formatActionHints } from './format-actions.ts';
+import type { AuditResult, AuditScope } from './types.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -6,9 +7,15 @@ import type { AuditResult } from './types.ts';
 
 /** Classification of an allowlist entry relative to current audit findings. */
 export interface AllowedVuln {
+  addedAt?: string | undefined;
+  cvss?: { score?: number; vectorString?: string } | undefined;
+  description?: string | undefined;
   id: string;
   path: string;
+  paths: string[];
+  reason?: string | undefined;
   severity?: string | undefined;
+  title?: string | undefined;
   url: string;
 }
 
@@ -53,7 +60,7 @@ export function severityIndicator(severity: string | undefined): string {
 // ---------------------------------------------------------------------------
 
 /** Scope display metadata. */
-const SCOPE_HEADERS: Record<'dev' | 'prod', string> = {
+const SCOPE_HEADERS: Record<AuditScope, string> = {
   prod: '-- \u{1F4E6} prod --',
   dev: '-- \u{1F527} dev --',
 };
@@ -70,7 +77,7 @@ function formatVulnLine(
 }
 
 /** Format a single scope's check results as text lines. */
-function formatScopeText(scope: 'dev' | 'prod', result: ScopeCheckResult): string {
+function formatScopeText(scope: AuditScope, result: ScopeCheckResult): string {
   const lines: string[] = [SCOPE_HEADERS[scope]];
 
   const hasFindings = result.unallowed.length > 0 || result.allowed.length > 0 || result.stale.length > 0;
@@ -89,21 +96,21 @@ function formatScopeText(scope: 'dev' | 'prod', result: ScopeCheckResult): strin
   }
 
   for (const entry of result.stale) {
-    lines.push(`  ${entry.id} \u{1F5D1}\u{FE0F} not needed`);
+    lines.push(`  \u{1F5D1}\u{FE0F} ${entry.id}  not needed`);
   }
 
   return lines.join('\n');
 }
 
 /** Format check results as human-readable text output. */
-export function formatCheckText(result: CheckResult, scopes: Array<'dev' | 'prod'>): string {
+export function formatCheckText(result: CheckResult, scopes: AuditScope[]): string {
   const sections: string[] = [];
 
   for (const scope of scopes) {
     sections.push(formatScopeText(scope, result[scope]));
   }
 
-  return sections.join('\n\n') + '\n';
+  return sections.join('\n\n') + '\n' + formatActionHints(result, scopes);
 }
 
 // ---------------------------------------------------------------------------
@@ -111,7 +118,7 @@ export function formatCheckText(result: CheckResult, scopes: Array<'dev' | 'prod
 // ---------------------------------------------------------------------------
 
 /** Format check results as a JSON string. */
-export function formatCheckJson(result: CheckResult, scopes: Array<'dev' | 'prod'>): string {
+export function formatCheckJson(result: CheckResult, scopes: AuditScope[]): string {
   const output: Record<string, ScopeCheckResult> = {};
   for (const scope of scopes) {
     output[scope] = result[scope];

--- a/packages/audit-deps/src/format-verbose.ts
+++ b/packages/audit-deps/src/format-verbose.ts
@@ -148,6 +148,8 @@ function formatAllowedSuffix(addedAt: string, now: Date): string {
  *
  * Uses millisecond math for units up through weeks to avoid DST/timezone drift on
  * short intervals, and UTC calendar math for months and years.
+ *
+ * @internal — exported for test access; consumers should use `formatAllowedSuffix`.
  */
 export function formatRelativeTime(fromIso: string, now: Date): string {
   const from = parseDateUtc(fromIso);
@@ -215,7 +217,7 @@ function formatDescriptionLines(description: string): string[] {
 
 /** Word-wrap a single paragraph to the given column width. */
 function wrapParagraph(paragraph: string, columns: number): string[] {
-  if (paragraph.length === 0) return [''];
+  if (paragraph.length === 0) return [];
   const words = paragraph.split(/\s+/);
   const lines: string[] = [];
   let current = '';

--- a/packages/audit-deps/src/format-verbose.ts
+++ b/packages/audit-deps/src/format-verbose.ts
@@ -1,0 +1,265 @@
+import { formatActionHints } from './format-actions.ts';
+import type { AllowedVuln, CheckResult, ScopeCheckResult, StaleEntry } from './format-check.ts';
+import { severityIndicator } from './format-check.ts';
+import type { AuditResult, AuditScope } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Display constants
+// ---------------------------------------------------------------------------
+
+const STATUS_UNALLOWED = '\u{1F6A8}';
+const STATUS_ALLOWED = '\u{26A0}\u{FE0F}';
+const STATUS_STALE = '\u{1F5D1}\u{FE0F}';
+
+/** Scope display metadata. */
+const SCOPE_HEADERS: Record<AuditScope, string> = {
+  prod: '-- \u{1F4E6} prod --',
+  dev: '-- \u{1F527} dev --',
+};
+
+/** Indentation for entry detail lines (below the marker + id line). */
+const DETAIL_INDENT = '     ';
+
+/** Approximate target width for wrapped description lines. */
+const WRAP_COLUMNS = 72;
+
+// ---------------------------------------------------------------------------
+// Text formatter
+// ---------------------------------------------------------------------------
+
+/** Format the verbose per-vulnerability check output as text. */
+export function formatCheckVerboseText(result: CheckResult, scopes: AuditScope[], now?: Date): string {
+  const effectiveNow = now ?? new Date();
+  const sections: string[] = [];
+
+  for (const scope of scopes) {
+    sections.push(formatScopeVerbose(scope, result[scope], effectiveNow));
+  }
+
+  return sections.join('\n\n') + '\n' + formatActionHints(result, scopes);
+}
+
+/** Format a single scope's verbose check results. */
+function formatScopeVerbose(scope: AuditScope, result: ScopeCheckResult, now: Date): string {
+  const lines: string[] = [SCOPE_HEADERS[scope]];
+  const hasFindings = result.unallowed.length > 0 || result.allowed.length > 0 || result.stale.length > 0;
+
+  if (!hasFindings) {
+    lines.push('  (none)');
+    return lines.join('\n');
+  }
+
+  const blocks: string[] = [];
+  for (const vuln of result.unallowed) {
+    blocks.push(formatUnallowedBlock(vuln));
+  }
+  for (const vuln of result.allowed) {
+    blocks.push(formatAllowedBlock(vuln, now));
+  }
+  for (const entry of result.stale) {
+    blocks.push(formatStaleLine(entry));
+  }
+
+  // Join blocks with a blank line between them.
+  return lines.concat(blocks.join('\n\n')).join('\n');
+}
+
+/** Format an unallowed vulnerability block with 🚨 marker. */
+function formatUnallowedBlock(vuln: AuditResult): string {
+  const headerLine = `  ${STATUS_UNALLOWED} ${vuln.id}${formatSeveritySuffix(vuln.severity)}`;
+  const detail = formatAdvisoryDetail(vuln);
+  return [headerLine, ...detail].join('\n');
+}
+
+/** Format an allowed vulnerability block with ⚠️ marker plus reason/addedAt context. */
+function formatAllowedBlock(vuln: AllowedVuln, now: Date): string {
+  const allowedSuffix = vuln.addedAt !== undefined ? formatAllowedSuffix(vuln.addedAt, now) : '';
+  const headerLine = `  ${STATUS_ALLOWED} ${vuln.id}${formatSeveritySuffix(vuln.severity)}${allowedSuffix}`;
+  const detail = formatAdvisoryDetail(vuln);
+  if (vuln.reason !== undefined) {
+    const reasonLineIndex = findReasonInsertionIndex(detail);
+    detail.splice(reasonLineIndex, 0, `${DETAIL_INDENT}reason: ${vuln.reason}`);
+  }
+  return [headerLine, ...detail].join('\n');
+}
+
+/** Format a stale entry as a single line with 🗑️ marker. */
+function formatStaleLine(entry: StaleEntry): string {
+  return `  ${STATUS_STALE} ${entry.id}  not needed`;
+}
+
+/** Shared advisory detail lines (title, paths, link, description) for unallowed or allowed entries. */
+function formatAdvisoryDetail(vuln: {
+  description?: string | undefined;
+  paths: string[];
+  title?: string | undefined;
+  url: string;
+}): string[] {
+  const lines: string[] = [];
+  if (vuln.title !== undefined) {
+    lines.push(`${DETAIL_INDENT}${vuln.title}`);
+  }
+  lines.push(...formatPathsLines(vuln.paths), `${DETAIL_INDENT}link: ${vuln.url}`);
+  if (vuln.description !== undefined) {
+    lines.push('', ...formatDescriptionLines(vuln.description));
+  }
+  return lines;
+}
+
+/** Find the index at which to insert the `reason:` line: just after the title (or at top if no title). */
+function findReasonInsertionIndex(detail: string[]): number {
+  // Title, if present, is always the first line. Reason goes right after it so the advisory block
+  // reads: id header, title, reason, paths, link, description.
+  if (detail.length === 0) return 0;
+  const first = detail[0];
+  if (
+    first !== undefined &&
+    (first.startsWith(`${DETAIL_INDENT}path:`) ||
+      first.startsWith(`${DETAIL_INDENT}paths:`) ||
+      first.startsWith(`${DETAIL_INDENT}link:`))
+  ) {
+    return 0;
+  }
+  return 1;
+}
+
+/** Build `path:` or `paths:` lines for a single or multiple paths. */
+function formatPathsLines(paths: string[]): string[] {
+  if (paths.length === 0) return [];
+  if (paths.length === 1) {
+    const firstPath = paths[0] ?? '';
+    return [`${DETAIL_INDENT}path: ${firstPath}`];
+  }
+  const lines = [`${DETAIL_INDENT}paths:`];
+  for (const pathValue of paths) {
+    lines.push(`${DETAIL_INDENT}  - ${pathValue}`);
+  }
+  return lines;
+}
+
+/** Build the severity suffix like `  🔴 high` (leading two spaces separator). */
+function formatSeveritySuffix(severity: string | undefined): string {
+  if (severity === undefined || severity === '') return '';
+  const emoji = severityIndicator(severity);
+  const emojiPart = emoji.length > 0 ? `${emoji} ` : '';
+  return `  ${emojiPart}${severity}`;
+}
+
+/** Build the "allowed X ago (YYYY-MM-DD)" suffix for entries with `addedAt`. */
+function formatAllowedSuffix(addedAt: string, now: Date): string {
+  const relative = formatRelativeTime(addedAt, now);
+  return `  allowed ${relative} (${addedAt})`;
+}
+
+/**
+ * Produce a human-readable relative-time string such as "just now", "N minutes ago",
+ * "yesterday", "N months ago", "N years ago".
+ *
+ * Uses millisecond math for units up through weeks to avoid DST/timezone drift on
+ * short intervals, and UTC calendar math for months and years.
+ */
+export function formatRelativeTime(fromIso: string, now: Date): string {
+  const from = parseDateUtc(fromIso);
+  if (from === undefined) return '';
+
+  const deltaMs = now.getTime() - from.getTime();
+  if (deltaMs < 60_000) return 'just now';
+
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 60) return pluralize(minutes, 'minute');
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return pluralize(hours, 'hour');
+
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'yesterday';
+  if (days < 7) return pluralize(days, 'day');
+
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return pluralize(weeks, 'week');
+
+  const months = diffMonthsUtc(from, now);
+  if (months < 12) return pluralize(months, 'month');
+
+  const years = Math.floor(months / 12);
+  return pluralize(years, 'year');
+}
+
+/** Parse a YYYY-MM-DD (or full ISO) string into a UTC Date; return undefined if invalid. */
+function parseDateUtc(iso: string): Date | undefined {
+  // Allow both YYYY-MM-DD and full ISO strings.
+  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (dateOnlyMatch !== null) {
+    const [, yearText, monthText, dayText] = dateOnlyMatch;
+    if (yearText === undefined || monthText === undefined || dayText === undefined) return undefined;
+    const year = Number(yearText);
+    const month = Number(monthText);
+    const day = Number(dayText);
+    return new Date(Date.UTC(year, month - 1, day));
+  }
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+/** Compute the number of whole months between two dates in UTC. */
+function diffMonthsUtc(from: Date, now: Date): number {
+  let months = (now.getUTCFullYear() - from.getUTCFullYear()) * 12 + (now.getUTCMonth() - from.getUTCMonth());
+  if (now.getUTCDate() < from.getUTCDate()) {
+    months -= 1;
+  }
+  return Math.max(0, months);
+}
+
+/** Format an integer count + unit, pluralizing with a simple `s`. */
+function pluralize(count: number, unit: string): string {
+  return `${count} ${unit}${count === 1 ? '' : 's'} ago`;
+}
+
+/** Wrap a description (possibly multi-paragraph) to the detail indent. */
+function formatDescriptionLines(description: string): string[] {
+  const paragraphs = description.split(/\n\s*\n/);
+  const lines: string[] = [];
+  paragraphs.forEach((paragraph, idx) => {
+    if (idx > 0) lines.push('');
+    const wrapped = wrapParagraph(paragraph.trim(), WRAP_COLUMNS);
+    for (const wrappedLine of wrapped) {
+      lines.push(`${DETAIL_INDENT}${wrappedLine}`);
+    }
+  });
+  return lines;
+}
+
+/** Word-wrap a single paragraph to the given column width. */
+function wrapParagraph(paragraph: string, columns: number): string[] {
+  if (paragraph.length === 0) return [''];
+  const words = paragraph.split(/\s+/);
+  const lines: string[] = [];
+  let current = '';
+  for (const word of words) {
+    if (current === '') {
+      current = word;
+      continue;
+    }
+    if (current.length + 1 + word.length > columns) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = `${current} ${word}`;
+    }
+  }
+  if (current !== '') lines.push(current);
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// JSON formatter
+// ---------------------------------------------------------------------------
+
+/** Format the verbose check result as a JSON string with full advisory detail. */
+export function formatCheckVerboseJson(result: CheckResult, scopes: AuditScope[]): string {
+  const output: Record<string, ScopeCheckResult> = {};
+  for (const scope of scopes) {
+    output[scope] = result[scope];
+  }
+  return JSON.stringify(output, null, 2) + '\n';
+}

--- a/packages/audit-deps/src/format-verbose.ts
+++ b/packages/audit-deps/src/format-verbose.ts
@@ -75,9 +75,10 @@ function formatUnallowedBlock(vuln: AuditResult): string {
 function formatAllowedBlock(vuln: AllowedVuln, now: Date): string {
   const allowedSuffix = vuln.addedAt !== undefined ? formatAllowedSuffix(vuln.addedAt, now) : '';
   const headerLine = `  ${STATUS_ALLOWED} ${vuln.id}${formatSeveritySuffix(vuln.severity)}${allowedSuffix}`;
+  const hasTitle = vuln.title !== undefined;
   const detail = formatAdvisoryDetail(vuln);
   if (vuln.reason !== undefined) {
-    const reasonLineIndex = findReasonInsertionIndex(detail);
+    const reasonLineIndex = findReasonInsertionIndex(hasTitle);
     detail.splice(reasonLineIndex, 0, `${DETAIL_INDENT}reason: ${vuln.reason}`);
   }
   return [headerLine, ...detail].join('\n');
@@ -107,28 +108,17 @@ function formatAdvisoryDetail(vuln: {
 }
 
 /** Find the index at which to insert the `reason:` line: just after the title (or at top if no title). */
-function findReasonInsertionIndex(detail: string[]): number {
-  // Title, if present, is always the first line. Reason goes right after it so the advisory block
+function findReasonInsertionIndex(hasTitle: boolean): number {
+  // Title, when present, is the first detail line. Reason goes right after it so the advisory block
   // reads: id header, title, reason, paths, link, description.
-  if (detail.length === 0) return 0;
-  const first = detail[0];
-  if (
-    first !== undefined &&
-    (first.startsWith(`${DETAIL_INDENT}path:`) ||
-      first.startsWith(`${DETAIL_INDENT}paths:`) ||
-      first.startsWith(`${DETAIL_INDENT}link:`))
-  ) {
-    return 0;
-  }
-  return 1;
+  return hasTitle ? 1 : 0;
 }
 
 /** Build `path:` or `paths:` lines for a single or multiple paths. */
 function formatPathsLines(paths: string[]): string[] {
   if (paths.length === 0) return [];
   if (paths.length === 1) {
-    const firstPath = paths[0] ?? '';
-    return [`${DETAIL_INDENT}path: ${firstPath}`];
+    return [`${DETAIL_INDENT}path: ${paths[0]}`];
   }
   const lines = [`${DETAIL_INDENT}paths:`];
   for (const pathValue of paths) {
@@ -148,6 +138,7 @@ function formatSeveritySuffix(severity: string | undefined): string {
 /** Build the "allowed X ago (YYYY-MM-DD)" suffix for entries with `addedAt`. */
 function formatAllowedSuffix(addedAt: string, now: Date): string {
   const relative = formatRelativeTime(addedAt, now);
+  if (relative.length === 0) return `  allowed (${addedAt})`;
   return `  allowed ${relative} (${addedAt})`;
 }
 
@@ -187,16 +178,7 @@ export function formatRelativeTime(fromIso: string, now: Date): string {
 
 /** Parse a YYYY-MM-DD (or full ISO) string into a UTC Date; return undefined if invalid. */
 function parseDateUtc(iso: string): Date | undefined {
-  // Allow both YYYY-MM-DD and full ISO strings.
-  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
-  if (dateOnlyMatch !== null) {
-    const [, yearText, monthText, dayText] = dateOnlyMatch;
-    if (yearText === undefined || monthText === undefined || dayText === undefined) return undefined;
-    const year = Number(yearText);
-    const month = Number(monthText);
-    const day = Number(dayText);
-    return new Date(Date.UTC(year, month - 1, day));
-  }
+  // ECMAScript parses date-only ISO strings (YYYY-MM-DD) and full ISO strings as UTC.
   const parsed = new Date(iso);
   return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 }
@@ -219,13 +201,15 @@ function pluralize(count: number, unit: string): string {
 function formatDescriptionLines(description: string): string[] {
   const paragraphs = description.split(/\n\s*\n/);
   const lines: string[] = [];
-  paragraphs.forEach((paragraph, idx) => {
-    if (idx > 0) lines.push('');
+  let needsSeparator = false;
+  for (const paragraph of paragraphs) {
+    if (needsSeparator) lines.push('');
     const wrapped = wrapParagraph(paragraph.trim(), WRAP_COLUMNS);
     for (const wrappedLine of wrapped) {
       lines.push(`${DETAIL_INDENT}${wrappedLine}`);
     }
-  });
+    needsSeparator = true;
+  }
   return lines;
 }
 
@@ -249,17 +233,4 @@ function wrapParagraph(paragraph: string, columns: number): string[] {
   }
   if (current !== '') lines.push(current);
   return lines;
-}
-
-// ---------------------------------------------------------------------------
-// JSON formatter
-// ---------------------------------------------------------------------------
-
-/** Format the verbose check result as a JSON string with full advisory detail. */
-export function formatCheckVerboseJson(result: CheckResult, scopes: AuditScope[]): string {
-  const output: Record<string, ScopeCheckResult> = {};
-  for (const scope of scopes) {
-    output[scope] = result[scope];
-  }
-  return JSON.stringify(output, null, 2) + '\n';
 }

--- a/packages/audit-deps/src/run-audit.ts
+++ b/packages/audit-deps/src/run-audit.ts
@@ -18,11 +18,14 @@ export function resolveAuditCiBin(): string {
 }
 
 interface AuditCiAdvisory {
+  cvss?: { score?: number; vectorString?: string };
+  findings: Array<{ paths: string[] }>;
   id: number | string;
   module_name: string;
+  overview?: string;
   severity?: string;
+  title?: string;
   url: string;
-  findings: Array<{ paths: string[] }>;
 }
 
 /** Result of parsing audit-ci output, including any warnings. */
@@ -60,13 +63,25 @@ export function parseAuditCiOutput(jsonString: string): ParseResult {
   const advisories = extractAdvisories(parsed);
   const results: AuditResult[] = [];
   for (const advisory of advisories) {
+    const paths = extractPaths(advisory);
+    const firstPath = paths[0] ?? advisory.module_name;
     const result: AuditResult = {
       id: String(advisory.id),
-      path: extractPath(advisory),
+      path: firstPath,
+      paths,
       url: advisory.url,
     };
     if (typeof advisory.severity === 'string') {
       result.severity = advisory.severity;
+    }
+    if (typeof advisory.title === 'string') {
+      result.title = advisory.title;
+    }
+    if (typeof advisory.overview === 'string') {
+      result.description = advisory.overview;
+    }
+    if (advisory.cvss !== undefined) {
+      result.cvss = advisory.cvss;
     }
     results.push(result);
   }
@@ -116,11 +131,19 @@ function extractAdvisories(parsed: unknown): AuditCiAdvisory[] {
   return [];
 }
 
-/** Extract the first dependency path from an advisory's findings. */
-function extractPath(advisory: AuditCiAdvisory): string {
-  const firstFinding = advisory.findings[0];
-  const firstPath = firstFinding?.paths[0];
-  return firstPath ?? advisory.module_name;
+/** Extract all dependency paths across an advisory's findings, deduplicated in insertion order. */
+function extractPaths(advisory: AuditCiAdvisory): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const finding of advisory.findings) {
+    for (const pathValue of finding.paths) {
+      if (!seen.has(pathValue)) {
+        seen.add(pathValue);
+        ordered.push(pathValue);
+      }
+    }
+  }
+  return ordered;
 }
 
 /** Result of extracting stale entries, including any warnings. */
@@ -159,6 +182,7 @@ interface RunAuditOptions {
   configPath: string;
   cwd?: string;
   json?: boolean;
+  reportType?: 'important' | 'full';
 }
 
 /** Result from a normal audit run. */
@@ -218,9 +242,12 @@ export interface ReportResult {
  *
  * Always returns exit code 0. Parses JSON output into typed `AuditResult` objects.
  */
-export function runReport({ configPath, cwd }: Omit<RunAuditOptions, 'json'>): ReportResult {
+export function runReport({ configPath, cwd, reportType }: Omit<RunAuditOptions, 'json'>): ReportResult {
   const bin = resolveAuditCiBin();
   const args = ['--config', configPath, '--output-format', 'json'];
+  if (reportType === 'full') {
+    args.push('--report-type', 'full');
+  }
 
   const result = spawnSync(process.execPath, [bin, ...args], {
     cwd: cwd ?? process.cwd(),

--- a/packages/audit-deps/src/run-audit.ts
+++ b/packages/audit-deps/src/run-audit.ts
@@ -182,7 +182,7 @@ interface RunAuditOptions {
   configPath: string;
   cwd?: string;
   json?: boolean;
-  reportType?: 'important' | 'full';
+  reportType?: 'full';
 }
 
 /** Result from a normal audit run. */

--- a/packages/audit-deps/src/sync.ts
+++ b/packages/audit-deps/src/sync.ts
@@ -3,7 +3,7 @@ import { writeFile } from 'node:fs/promises';
 import type { AllowlistEntry, AuditDepsConfig, AuditResult, AuditScope } from './types.ts';
 
 /** Produce a UTC date string in YYYY-MM-DD format. */
-function formatUtcDate(date: Date): string {
+export function formatUtcDate(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
@@ -14,6 +14,7 @@ function formatUtcDate(date: Date): string {
  */
 function serializeEntry(entry: AllowlistEntry): Record<string, string> {
   return {
+    ...(entry.addedAt !== undefined && { addedAt: entry.addedAt }),
     id: entry.id,
     path: entry.path,
     ...(entry.reason !== undefined && { reason: entry.reason }),
@@ -49,15 +50,17 @@ export function computeSyncDiff(
   const removed: AllowlistEntry[] = [];
 
   // Identify new and kept entries
+  const nowIso = formatUtcDate(now);
   for (const [id, result] of auditById) {
     const existing = currentById.get(id);
     if (existing !== undefined) {
       kept.push(existing);
     } else {
       added.push({
+        addedAt: nowIso,
         id: result.id,
         path: result.path,
-        reason: `Added by audit-deps sync on ${formatUtcDate(now)}`,
+        reason: `Added by audit-deps sync on ${nowIso}`,
         url: result.url,
       });
     }

--- a/packages/audit-deps/src/types.ts
+++ b/packages/audit-deps/src/types.ts
@@ -16,6 +16,7 @@ export const AUDIT_SCOPES: readonly AuditScope[] = ['dev', 'prod'];
 
 /** A single allowlisted advisory with metadata for traceability. */
 export interface AllowlistEntry {
+  addedAt?: string | undefined;
   id: string;
   path: string;
   reason?: string | undefined;
@@ -24,6 +25,7 @@ export interface AllowlistEntry {
 
 /** Zod schema for an allowlist entry. */
 export const allowlistEntrySchema = z.object({
+  addedAt: z.string().optional(),
   id: z.string(),
   path: z.string(),
   reason: z.string().optional(),
@@ -77,9 +79,13 @@ export const auditDepsConfigSchema = z.object({
 
 /** A single vulnerability found by audit-ci. */
 export interface AuditResult {
+  cvss?: { score?: number; vectorString?: string } | undefined;
+  description?: string | undefined;
   id: string;
   path: string;
+  paths: string[];
   severity?: string | undefined;
+  title?: string | undefined;
   url: string;
 }
 
@@ -92,4 +98,5 @@ export interface CommandOptions {
   configPath?: string | undefined;
   json: boolean;
   scopes: AuditScope[];
+  verbose: boolean;
 }


### PR DESCRIPTION
## What

Adds a `--verbose` / `-v` flag to the default `audit-deps` check that produces a detailed per-vulnerability report — advisory title, severity, every affected dependency path, link, and description — replacing the need to chase the URL for each finding. Both bare and verbose outputs gain an `Actions:` footer that tells the user exactly which `audit-deps sync` invocation will resolve the current state, and `sync` now stamps an `addedAt` date on allowlist entries so allowed vulnerabilities carry an `allowed X ago (YYYY-MM-DD)` line when displayed in verbose mode.

## Why

The bare check output is scannable but context-free: a 🚨 marker names the advisory ID and severity but no title, no description, no full path list, and — for allowed entries — no indication of when the exception was granted or why. Weekly triage turned into URL-chasing. The ticket's sample output specifies a denser per-vulnerability view that keeps the existing grouped scaffold (prod / dev sections, scope filtering, stale-entry detection) but surfaces enough advisory data inline to judge each finding without leaving the terminal. Adding `addedAt` closes the loop on "when did we accept this risk, and should we re-examine it?" — a question the existing allowlist format could not answer at all.

## Details

### Features

- `--verbose` / `-v` flag on the default check command. Composes with `--dev`, `--prod`, `--config`, and `--json` (all combinations have test coverage).
- Verbose text output: 🚨 unallowed, ⚠️ allowed, 🗑️ stale status markers; inline severity emoji + word (🔴 high, 🟠 moderate, 🟡 low); singular `path:` vs plural `paths:` rendering; word-wrapped descriptions indented 5 spaces with paragraph breaks preserved; `reason:` and `allowed X ago (YYYY-MM-DD)` lines on allowed entries when present.
- `formatRelativeTime` helper supporting "just now" through "N years ago". Uses millisecond math through weeks, switches to UTC calendar math for months and years to avoid DST and month-boundary drift.
- `Actions:` footer on bare and verbose text output — three variants (`add to allowlist` / `remove stale entries` / both) that fire only when the current result would actually benefit. JSON output deliberately omits the hints.
- `addedAt` ISO-date field on `AllowlistEntry` (optional in the zod schema; serialized alphabetically before `id`). Populated on new entries by `sync`; kept entries preserve their existing value (or lack thereof).

### Refactoring

- `AuditResult` carries richer advisory data: `paths` (deduplicated across all findings), `title`, `description`, `cvss`, `severity` as optional fields. `path` (singular) preserved as `paths[0]` for existing consumers.
- `AllowedVuln` enriched with the full advisory fields plus `reason` and `addedAt`, so `CheckResult` fully describes what formatters need — no parallel lookup data structures at render time.
- `runReport` accepts an optional `reportType: 'full'` that appends `--report-type full` to the audit-ci args. The verbose check always requests full data; bare checks remain lean (unchanged wire format).
- Bare formatter's stale-entry line reordered from `<id> 🗑️ not needed` to `🗑️ <id>  not needed` to harmonize with the verbose convention and the ticket's sample output.
- `formatUtcDate` exported from `sync.ts` so both the sync writer and the verbose formatter share a single UTC-date source.
- New `format-actions.ts` module — shared footer computation — consumed by both `formatCheckText` and `formatCheckVerboseText`.
- README gains a `--verbose` / `-v` entry under "Other options" and describes the new `addedAt` field.

### Tests

- 180 tests in `packages/audit-deps` (up from 114 at branch point). New files: `format-verbose.test.ts`, `format-actions.test.ts`. Extended: `cli.test.ts`, `format-check.test.ts`, `route.test.ts`, `run-audit.test.ts`, `sync.test.ts`.
- `formatRelativeTime` coverage spans every branch — "just now", singular/plural for minutes/hours/days/weeks/months/years, "yesterday", the 5-week → 1-month boundary, and unparseable input.
- Verbose rendering tests cover single-path vs multi-path vulns, `addedAt` present vs absent, `reason` present vs absent, description wrapping, stale-only scopes, and the "(none)" empty-scope fallback.
- Route tests confirm `--verbose` composes correctly with `--json`, `--dev`, `--prod`, and `--config`.
- `sync.test.ts` updated for the new alphabetical key order (`addedAt`, `id`, `path`, `reason`, `url`) and asserts that kept entries preserve their timestamp (or its absence).

Closes #208 