### PR TITLE
#220 Add check:fixable convenience script

### DIFF
--- a/.readyup/kits/nmr.js
+++ b/.readyup/kits/nmr.js
@@ -13,6 +13,7 @@ var rootScripts = {
   "audit:prod": "pnpm dlx audit-ci@^7 --config .config/audit-ci/config.prod.json5",
   build: "pnpm --recursive exec nmr build",
   check: ["typecheck", "fmt:check", "lint:check", "test"],
+  "check:fixable": ["fmt:check", "lint:check"],
   "check:strict": ["typecheck", "fmt:check", "lint:strict", "test:coverage"],
   ci: ["build", "check:strict", "audit"],
   clean: "pnpm --recursive exec nmr clean",

--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -133,6 +133,7 @@ These scripts are available out of the box. Repo-wide config (tier 2) and per-pa
 | ------------------ | -------------------------------------------------------- |
 | `build`            | `compile`, `generate-typings`                            |
 | `check`            | `typecheck`, `fmt:check`, `lint:check`, `test`           |
+| `check:fixable`    | `fmt:check`, `lint:check`                                |
 | `check:strict`     | `typecheck`, `fmt:check`, `lint:strict`, `test:coverage` |
 | `clean`            | `pnpm exec rimraf dist/*`                                |
 | `compile`          | `tsx ../../config/build.ts`                              |
@@ -172,10 +173,11 @@ Packages with a `vitest.integration.config.ts` file get different test commands.
 
 #### Check and quality
 
-| Command        | Runs                                                              |
-| -------------- | ----------------------------------------------------------------- |
-| `check`        | `typecheck`, `fmt:check`, `lint:check`, `test`                    |
-| `check:strict` | `typecheck`, `fmt:check`, `audit`, `lint:strict`, `test:coverage` |
+| Command         | Runs                                                              |
+| --------------- | ----------------------------------------------------------------- |
+| `check`         | `typecheck`, `fmt:check`, `lint:check`, `test`                    |
+| `check:fixable` | `fmt:check`, `lint:check`                                         |
+| `check:strict`  | `typecheck`, `fmt:check`, `audit`, `lint:strict`, `test:coverage` |
 
 #### Test
 

--- a/packages/nmr/__tests__/resolve-scripts.test.ts
+++ b/packages/nmr/__tests__/resolve-scripts.test.ts
@@ -8,6 +8,7 @@ describe('getDefaultWorkspaceScripts', () => {
 
     expect(scripts.build).toEqual(['compile', 'generate-typings']);
     expect(scripts.check).toEqual(['typecheck', 'fmt:check', 'lint:check', 'test']);
+    expect(scripts['check:fixable']).toStrictEqual(['fmt:check', 'lint:check']);
     expect(scripts.clean).toBe('pnpm exec rimraf dist/*');
     expect(scripts.compile).toBe('tsx ../../config/build.ts');
     expect(scripts.typecheck).toBe('tsgo --noEmit');
@@ -37,6 +38,7 @@ describe('getDefaultRootScripts', () => {
 
     expect(scripts.audit).toEqual(['audit:prod', 'audit:dev']);
     expect(scripts.check).toEqual(['typecheck', 'fmt:check', 'lint:check', 'test']);
+    expect(scripts['check:fixable']).toStrictEqual(['fmt:check', 'lint:check']);
     expect(scripts.ci).toEqual(['build', 'check:strict', 'audit']);
     expect(scripts.clean).toBe('pnpm --recursive exec nmr clean');
     expect(scripts['fmt:all']).toEqual(['fmt', 'fmt:sh']);

--- a/packages/nmr/src/default-scripts.ts
+++ b/packages/nmr/src/default-scripts.ts
@@ -7,6 +7,7 @@ export type ScriptRegistry = Record<string, ScriptValue>;
 export const commonWorkspaceScripts: ScriptRegistry = {
   build: ['compile', 'generate-typings'],
   check: ['typecheck', 'fmt:check', 'lint:check', 'test'],
+  'check:fixable': ['fmt:check', 'lint:check'],
   'check:strict': ['typecheck', 'fmt:check', 'lint:strict', 'test:coverage'],
   clean: 'pnpm exec rimraf dist/*',
   compile: 'tsx ../../config/build.ts',
@@ -49,6 +50,7 @@ export const rootScripts: ScriptRegistry = {
   'audit:prod': 'pnpm dlx audit-ci@^7 --config .config/audit-ci/config.prod.json5',
   build: 'pnpm --recursive exec nmr build',
   check: ['typecheck', 'fmt:check', 'lint:check', 'test'],
+  'check:fixable': ['fmt:check', 'lint:check'],
   'check:strict': ['typecheck', 'fmt:check', 'lint:strict', 'test:coverage'],
   ci: ['build', 'check:strict', 'audit'],
   clean: 'pnpm --recursive exec nmr clean',


### PR DESCRIPTION
## What

Adds a new `check:fixable` convenience script to the `nmr` default script registries, providing a read-only partner to the existing `fix` script. Running `nmr check:fixable` expands to `nmr fmt:check && nmr lint:check`, verifying that a tree is clean of auto-fixable violations without modifying any files.

## Why

Developers wanting to verify a clean tree before pushing or as part of an ad-hoc quality check had to run `nmr fmt:check && nmr lint:check` manually. The new script captures this common pattern as a single command.

## Details

### Features

- Adds `check:fixable: ['fmt:check', 'lint:check']` to both `commonWorkspaceScripts` and `rootScripts` in `packages/nmr/src/default-scripts.ts`.
- Sub-script order is `fmt:check` first (faster, enabling fail-fast), intentionally differing from `fix` where `lint` runs first because auto-fixes can dirty formatting.
- Documents the new script in both the Workspace scripts and Root "Check and quality" tables in the README.

Closes #220 