### PR TITLE
#216 Migrate to workflow/ tag namespace and converge caller workflows

### DIFF
--- a/.github/workflows/publish.reusable.yaml
+++ b/.github/workflows/publish.reusable.yaml
@@ -6,8 +6,8 @@ name: Publish
 # Triggered by tag pushes. Installs `@williamthorsen/release-kit` globally and
 # runs `release-kit publish` with OIDC-based npm authentication.
 # Pass `provenance: true` to enable npm provenance attestations (requires a public repo).
-# Pass `build-local: true` to build release-kit from source instead of installing from npm
-# (required when publishing release-kit itself to avoid bootstrap problems).
+# When running in the `williamthorsen/node-monorepo-tools` repo, release-kit is
+# built from source instead of installed from npm (auto-detected).
 # The calling workflow must grant `id-token: write` and `contents: read` permissions.
 #
 # Usage:
@@ -28,11 +28,6 @@ on:
         required: false
         type: boolean
         default: false
-      build-local:
-        description: 'Build release-kit from source instead of installing from npm'
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   id-token: write
@@ -45,6 +40,7 @@ jobs:
     timeout-minutes: 15
 
     env:
+      BUILD_LOCAL: ${{ github.repository == 'williamthorsen/node-monorepo-tools' }}
       # Allow npx to run even when package.json declares a different package
       # manager (e.g., pnpm). Without this, Corepack blocks npm/npx.
       COREPACK_ENABLE_STRICT: '0'
@@ -56,41 +52,47 @@ jobs:
       # Strip the packageManager field so that actions/setup-node does not
       # try to install it. The field is irrelevant for publishing.
       - name: Neutralize packageManager field
-        if: ${{ !inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL != 'true' }}
         run: node -e "const fs=require('fs'),f='package.json',p=JSON.parse(fs.readFileSync(f));delete p.packageManager;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
 
       # Preserve the packageManager field so pnpm/action-setup can read the version.
       - name: Set up pnpm
-        if: ${{ inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL == 'true' }}
         uses: pnpm/action-setup@v6
+
+      # Materialize the cache flag via step output because the `env` context
+      # is not evaluated in `with:` blocks.
+      - name: Resolve pnpm cache flag
+        id: cache-flag
+        run: echo "value=${{ env.BUILD_LOCAL == 'true' && 'pnpm' || '' }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: https://registry.npmjs.org
-          cache: ${{ inputs.build-local && 'pnpm' || '' }}
+          cache: ${{ steps.cache-flag.outputs.value }}
 
       - name: Disable Corepack
-        if: ${{ !inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL != 'true' }}
         run: corepack disable
 
       - name: Install release-kit from npm
-        if: ${{ !inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL != 'true' }}
         run: npm install --global @williamthorsen/release-kit
 
       # Build release-kit from source to avoid bootstrap problems when
       # publishing a version that introduces new CLI flags.
       - name: Install dependencies
-        if: ${{ inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build release-kit from source
-        if: ${{ inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL == 'true' }}
         run: pnpm --filter @williamthorsen/release-kit... run prepare
 
       - name: Link release-kit onto PATH
-        if: ${{ inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL == 'true' }}
         run: npm link --workspace packages/release-kit
 
       - name: Publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,4 +15,3 @@ jobs:
     uses: williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@workflow/publish-v1
     with:
       provenance: true
-      build-local: true

--- a/.github/workflows/release.reusable.yaml
+++ b/.github/workflows/release.reusable.yaml
@@ -12,8 +12,8 @@ name: Release
 # Project dependencies are not installed: release-kit runs git-cliff and prettier
 # via `npx`, so no local node_modules are needed.
 #
-# Pass `build-local: true` to build release-kit from source instead of installing from npm
-# (required when releasing release-kit itself to avoid bootstrap problems).
+# When running in the `williamthorsen/node-monorepo-tools` repo, release-kit is
+# built from source instead of installed from npm (auto-detected).
 #
 # Usage:
 #   jobs:
@@ -36,12 +36,7 @@ on:
         type: string
         default: ''
       force:
-        description: 'Force a version bump even when there are no release-worthy changes'
-        type: boolean
-        default: false
-      build-local:
-        description: 'Build release-kit from source instead of installing from npm'
-        required: false
+        description: 'Force a release even when there are no commits since the last tag (requires --bump)'
         type: boolean
         default: false
 
@@ -56,6 +51,7 @@ jobs:
     timeout-minutes: 15
 
     env:
+      BUILD_LOCAL: ${{ github.repository == 'williamthorsen/node-monorepo-tools' }}
       GITHUB_TOKEN: ${{ github.token }}
       # Allow npx to run even when package.json declares a different package
       # manager (e.g., pnpm). Without this, Corepack blocks npm/npx.
@@ -71,43 +67,49 @@ jobs:
       # Strip the packageManager field so that actions/setup-node does not
       # try to install it. The field is irrelevant for release preparation.
       - name: Neutralize packageManager field
-        if: ${{ !inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL != 'true' }}
         run: node -e "const fs=require('fs'),f='package.json',p=JSON.parse(fs.readFileSync(f));delete p.packageManager;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
 
       # Preserve the packageManager field so pnpm/action-setup can read the version.
       - name: Set up pnpm
-        if: ${{ inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL == 'true' }}
         uses: pnpm/action-setup@v6
+
+      # Materialize the cache flag via step output because the `env` context
+      # is not evaluated in `with:` blocks.
+      - name: Resolve pnpm cache flag
+        id: cache-flag
+        run: echo "value=${{ env.BUILD_LOCAL == 'true' && 'pnpm' || '' }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          cache: ${{ inputs.build-local && 'pnpm' || '' }}
+          cache: ${{ steps.cache-flag.outputs.value }}
 
       - name: Disable Corepack
-        if: ${{ !inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL != 'true' }}
         run: corepack disable
 
       # Install globally so the binary is on PATH.
       # npm exec / npx binary resolution is unreliable with scoped packages
       # on newer npm versions (11.x), so explicit install is more robust.
       - name: Install release-kit from npm
-        if: ${{ !inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL != 'true' }}
         run: npm install --global @williamthorsen/release-kit
 
       # Build release-kit from source to avoid bootstrap problems when
       # releasing a version that introduces new CLI flags.
       - name: Install dependencies
-        if: ${{ inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build release-kit from source
-        if: ${{ inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL == 'true' }}
         run: pnpm --filter @williamthorsen/release-kit... run prepare
 
       - name: Link release-kit onto PATH
-        if: ${{ inputs.build-local }}
+        if: ${{ env.BUILD_LOCAL == 'true' }}
         run: npm link --workspace packages/release-kit
 
       - name: Run release preparation

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ on:
           - minor
           - major
       force:
-        description: 'Bypass "no commits since last tag" check (requires bump)'
+        description: 'Force a release even when there are no commits since the last tag (requires --bump)'
         required: false
         type: boolean
         default: false
@@ -29,11 +29,8 @@ permissions:
 
 jobs:
   release:
-    uses: ./.github/workflows/release.reusable.yaml
+    uses: williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@workflow/release-v1
     with:
-      build-local: true
       only: ${{ inputs.only }}
       bump: ${{ inputs.bump }}
-      # TODO: The reusable workflow (release-pnpm.yaml@v3) does not yet accept `force`.
-      # After updating williamthorsen/.github to declare and forward this input,
-      # add `force: ${{ inputs.force }}` here.
+      force: ${{ inputs.force }}

--- a/.readyup/kits/release-kit.js
+++ b/.readyup/kits/release-kit.js
@@ -24,11 +24,6 @@ function readFile(relativePath) {
   if (!existsSync(fullPath)) return void 0;
   return readFileSync(fullPath, "utf8");
 }
-function fileContains(relativePath, pattern) {
-  const content = readFile(relativePath);
-  if (content === void 0) return false;
-  return pattern.test(content);
-}
 function fileDoesNotContain(relativePath, pattern) {
   const content = readFile(relativePath);
   if (content === void 0) return true;
@@ -157,11 +152,50 @@ var package_default = {
   }
 };
 
+// packages/release-kit/src/init/detectRepoType.ts
+import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
+
+// packages/release-kit/src/typeGuards.ts
+function isRecord2(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// packages/release-kit/src/init/parseJsonRecord.ts
+function parseJsonRecord(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return void 0;
+  }
+  return isRecord2(parsed) ? parsed : void 0;
+}
+
+// packages/release-kit/src/init/detectRepoType.ts
+function detectRepoType() {
+  if (existsSync2("pnpm-workspace.yaml")) {
+    return "monorepo";
+  }
+  try {
+    const raw = readFileSync2("package.json", "utf8");
+    const pkg = parseJsonRecord(raw);
+    if (pkg !== void 0 && Array.isArray(pkg.workspaces)) {
+      return "monorepo";
+    }
+  } catch {
+  }
+  return "single-package";
+}
+
 // .readyup/kits/release-kit.ts
 var MIN_VERSION = package_default.version;
 var CLIFF_TEMPLATE_HASH = "fb5e7d3c5e4856272aa788ed0e69cc491c8f765ba4241643999436410584278e";
 var COMMON_PRESET_HASH = "d12ffccbd5e4d9af8ecf47744b143f6c9f80bcf5e496cf1983b66834f0ae7825";
-var SYNC_LABELS_WORKFLOW_HASH = "c0206871afadf1bf12a8dbe51afbd8e6d49724ca48875c168fbf1da891abcfad";
+var SYNC_LABELS_WORKFLOW_HASH = "4dfde2454bac03280381f0da70c9c735916a7812100dec5437853b843c4bd797";
+var RELEASE_WORKFLOW_HASH_MONOREPO = "d2c297a3974a70485c73ec115c092ecba0d571b5238d5f440096d6a35b64810b";
+var RELEASE_WORKFLOW_HASH_SINGLE = "d80f814468897d920c89ab55959f6c1f97efbd02b99522c92b9d1162ed694c1c";
+var PUBLISH_WORKFLOW_HASH_MONOREPO = "ba9f8e353e0f60498df8b55a9340bd1b88c3b9f55e9862850da26dd9c98d8b23";
+var PUBLISH_WORKFLOW_HASH_SINGLE = "4abbafa80eab871ce5277751e86d0c057490b0b36ec6e4e06a41f39494c990b1";
 var release_kit_default = defineRdyKit({
   checklists: [
     {
@@ -190,15 +224,21 @@ var release_kit_default = defineRdyKit({
           fix: "Add .github/workflows/release.yaml using the release workflow template",
           checks: [
             {
-              name: "release workflow references release.reusable.yaml",
+              name: "release.yaml matches template",
               severity: "warn",
-              check: () => fileContains(
-                ".github/workflows/release.yaml",
-                /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/
-              ),
-              fix: "Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@workflow/release-v1"
+              check: () => {
+                const hash = detectRepoType() === "monorepo" ? RELEASE_WORKFLOW_HASH_MONOREPO : RELEASE_WORKFLOW_HASH_SINGLE;
+                return fileMatchesHash(".github/workflows/release.yaml", hash);
+              },
+              fix: "Run `release-kit init --force` to regenerate release.yaml from the current template"
             }
           ]
+        },
+        {
+          name: "release.yaml does not reference deprecated tag ref",
+          severity: "error",
+          check: () => fileDoesNotContain(".github/workflows/release.yaml", /@(release|publish)-workflow-v[0-9]/),
+          fix: "Update release.yaml to use @workflow/release-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)"
         },
         {
           name: "publish.yaml workflow exists",
@@ -207,15 +247,21 @@ var release_kit_default = defineRdyKit({
           fix: "Add .github/workflows/publish.yaml using the publish workflow template",
           checks: [
             {
-              name: "publish workflow references publish.reusable.yaml",
+              name: "publish.yaml matches template",
               severity: "warn",
-              check: () => fileContains(
-                ".github/workflows/publish.yaml",
-                /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/
-              ),
-              fix: "Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@workflow/publish-v1"
+              check: () => {
+                const hash = detectRepoType() === "monorepo" ? PUBLISH_WORKFLOW_HASH_MONOREPO : PUBLISH_WORKFLOW_HASH_SINGLE;
+                return fileMatchesHash(".github/workflows/publish.yaml", hash);
+              },
+              fix: "Run `release-kit init --force` to regenerate publish.yaml from the current template"
             }
           ]
+        },
+        {
+          name: "publish.yaml does not reference deprecated tag ref",
+          severity: "error",
+          check: () => fileDoesNotContain(".github/workflows/publish.yaml", /@(release|publish)-workflow-v[0-9]/),
+          fix: "Update publish.yaml to use @workflow/publish-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)"
         },
         {
           name: "config does not use removed tagPrefix",
@@ -257,6 +303,12 @@ var release_kit_default = defineRdyKit({
               fix: "Run `release-kit sync-labels init --force` to regenerate the workflow from the current template"
             }
           ]
+        },
+        {
+          name: "sync-labels.yaml does not reference deprecated tag ref",
+          severity: "error",
+          check: () => fileDoesNotContain(".github/workflows/sync-labels.yaml", /@sync-labels-workflow-v[0-9]/),
+          fix: "Update sync-labels.yaml to use @workflow/sync-labels-v1 (run `release-kit sync-labels init --force` to regenerate, or replace the ref manually)"
         },
         {
           name: ".config/sync-labels.config.ts exists",
@@ -302,6 +354,10 @@ function labelsHaveCurrentPresetHash(presetName, expectedHash) {
 export {
   CLIFF_TEMPLATE_HASH,
   COMMON_PRESET_HASH,
+  PUBLISH_WORKFLOW_HASH_MONOREPO,
+  PUBLISH_WORKFLOW_HASH_SINGLE,
+  RELEASE_WORKFLOW_HASH_MONOREPO,
+  RELEASE_WORKFLOW_HASH_SINGLE,
   SYNC_LABELS_WORKFLOW_HASH,
   release_kit_default as default
 };

--- a/.readyup/kits/release-kit.ts
+++ b/.readyup/kits/release-kit.ts
@@ -11,7 +11,6 @@
  */
 import {
   defineRdyKit,
-  fileContains,
   fileDoesNotContain,
   fileExists,
   fileMatchesHash,
@@ -21,6 +20,7 @@ import {
 } from 'readyup';
 
 import releaseKitPackageJson from '../../packages/release-kit/package.json' with { type: 'json' };
+import { detectRepoType } from '../../packages/release-kit/src/init/detectRepoType.ts';
 
 const MIN_VERSION = releaseKitPackageJson.version;
 
@@ -28,7 +28,11 @@ const MIN_VERSION = releaseKitPackageJson.version;
 // verified by __tests__/rdy-kit-hashes.app.test.ts.
 export const CLIFF_TEMPLATE_HASH = 'fb5e7d3c5e4856272aa788ed0e69cc491c8f765ba4241643999436410584278e';
 export const COMMON_PRESET_HASH = 'd12ffccbd5e4d9af8ecf47744b143f6c9f80bcf5e496cf1983b66834f0ae7825';
-export const SYNC_LABELS_WORKFLOW_HASH = 'c0206871afadf1bf12a8dbe51afbd8e6d49724ca48875c168fbf1da891abcfad';
+export const SYNC_LABELS_WORKFLOW_HASH = '4dfde2454bac03280381f0da70c9c735916a7812100dec5437853b843c4bd797';
+export const RELEASE_WORKFLOW_HASH_MONOREPO = 'd2c297a3974a70485c73ec115c092ecba0d571b5238d5f440096d6a35b64810b';
+export const RELEASE_WORKFLOW_HASH_SINGLE = 'd80f814468897d920c89ab55959f6c1f97efbd02b99522c92b9d1162ed694c1c';
+export const PUBLISH_WORKFLOW_HASH_MONOREPO = 'ba9f8e353e0f60498df8b55a9340bd1b88c3b9f55e9862850da26dd9c98d8b23';
+export const PUBLISH_WORKFLOW_HASH_SINGLE = '4abbafa80eab871ce5277751e86d0c057490b0b36ec6e4e06a41f39494c990b1';
 
 export default defineRdyKit({
   checklists: [
@@ -59,16 +63,22 @@ export default defineRdyKit({
           fix: 'Add .github/workflows/release.yaml using the release workflow template',
           checks: [
             {
-              name: 'release workflow references release.reusable.yaml',
+              name: 'release.yaml matches template',
               severity: 'warn',
-              check: () =>
-                fileContains(
-                  '.github/workflows/release.yaml',
-                  /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)release\.reusable\.yaml/,
-                ),
-              fix: 'Update release.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@workflow/release-v1',
+              check: () => {
+                const hash =
+                  detectRepoType() === 'monorepo' ? RELEASE_WORKFLOW_HASH_MONOREPO : RELEASE_WORKFLOW_HASH_SINGLE;
+                return fileMatchesHash('.github/workflows/release.yaml', hash);
+              },
+              fix: 'Run `release-kit init --force` to regenerate release.yaml from the current template',
             },
           ],
+        },
+        {
+          name: 'release.yaml does not reference deprecated tag ref',
+          severity: 'error',
+          check: () => fileDoesNotContain('.github/workflows/release.yaml', /@(release|publish)-workflow-v[0-9]/),
+          fix: 'Update release.yaml to use @workflow/release-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)',
         },
         {
           name: 'publish.yaml workflow exists',
@@ -77,16 +87,22 @@ export default defineRdyKit({
           fix: 'Add .github/workflows/publish.yaml using the publish workflow template',
           checks: [
             {
-              name: 'publish workflow references publish.reusable.yaml',
+              name: 'publish.yaml matches template',
               severity: 'warn',
-              check: () =>
-                fileContains(
-                  '.github/workflows/publish.yaml',
-                  /uses:\s*(?:\.\/\.github\/workflows\/|williamthorsen\/node-monorepo-tools\/.github\/workflows\/)publish\.reusable\.yaml/,
-                ),
-              fix: 'Update publish.yaml to use williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@workflow/publish-v1',
+              check: () => {
+                const hash =
+                  detectRepoType() === 'monorepo' ? PUBLISH_WORKFLOW_HASH_MONOREPO : PUBLISH_WORKFLOW_HASH_SINGLE;
+                return fileMatchesHash('.github/workflows/publish.yaml', hash);
+              },
+              fix: 'Run `release-kit init --force` to regenerate publish.yaml from the current template',
             },
           ],
+        },
+        {
+          name: 'publish.yaml does not reference deprecated tag ref',
+          severity: 'error',
+          check: () => fileDoesNotContain('.github/workflows/publish.yaml', /@(release|publish)-workflow-v[0-9]/),
+          fix: 'Update publish.yaml to use @workflow/publish-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)',
         },
         {
           name: 'config does not use removed tagPrefix',
@@ -128,6 +144,12 @@ export default defineRdyKit({
               fix: 'Run `release-kit sync-labels init --force` to regenerate the workflow from the current template',
             },
           ],
+        },
+        {
+          name: 'sync-labels.yaml does not reference deprecated tag ref',
+          severity: 'error',
+          check: () => fileDoesNotContain('.github/workflows/sync-labels.yaml', /@sync-labels-workflow-v[0-9]/),
+          fix: 'Update sync-labels.yaml to use @workflow/sync-labels-v1 (run `release-kit sync-labels init --force` to regenerate, or replace the ref manually)',
         },
         {
           name: '.config/sync-labels.config.ts exists',

--- a/__tests__/rdy-kit-hashes.app.test.ts
+++ b/__tests__/rdy-kit-hashes.app.test.ts
@@ -5,7 +5,16 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { AUDIT_WORKFLOW_HASH } from '../.readyup/kits/audit-deps.ts';
-import { CLIFF_TEMPLATE_HASH, COMMON_PRESET_HASH, SYNC_LABELS_WORKFLOW_HASH } from '../.readyup/kits/release-kit.ts';
+import {
+  CLIFF_TEMPLATE_HASH,
+  COMMON_PRESET_HASH,
+  PUBLISH_WORKFLOW_HASH_MONOREPO,
+  PUBLISH_WORKFLOW_HASH_SINGLE,
+  RELEASE_WORKFLOW_HASH_MONOREPO,
+  RELEASE_WORKFLOW_HASH_SINGLE,
+  SYNC_LABELS_WORKFLOW_HASH,
+} from '../.readyup/kits/release-kit.ts';
+import { publishWorkflow, releaseWorkflow } from '../packages/release-kit/src/init/templates.ts';
 import { syncLabelsWorkflow } from '../packages/release-kit/src/sync-labels/templates.ts';
 
 /** Compute SHA-256 hex digest, matching readyup's computeHash implementation. */
@@ -59,5 +68,41 @@ describe('rdy kit hashes match source files', () => {
       actualHash,
       `AUDIT_WORKFLOW_HASH in .readyup/kits/audit-deps.ts is stale — update it to: ${actualHash}`,
     ).toBe(AUDIT_WORKFLOW_HASH);
+  });
+
+  it('RELEASE_WORKFLOW_HASH_MONOREPO matches releaseWorkflow("monorepo")', () => {
+    const actualHash = sha256(releaseWorkflow('monorepo'));
+
+    expect(
+      actualHash,
+      `RELEASE_WORKFLOW_HASH_MONOREPO in .readyup/kits/release-kit.ts is stale — update it to: ${actualHash}`,
+    ).toBe(RELEASE_WORKFLOW_HASH_MONOREPO);
+  });
+
+  it('RELEASE_WORKFLOW_HASH_SINGLE matches releaseWorkflow("single-package")', () => {
+    const actualHash = sha256(releaseWorkflow('single-package'));
+
+    expect(
+      actualHash,
+      `RELEASE_WORKFLOW_HASH_SINGLE in .readyup/kits/release-kit.ts is stale — update it to: ${actualHash}`,
+    ).toBe(RELEASE_WORKFLOW_HASH_SINGLE);
+  });
+
+  it('PUBLISH_WORKFLOW_HASH_MONOREPO matches publishWorkflow("monorepo")', () => {
+    const actualHash = sha256(publishWorkflow('monorepo'));
+
+    expect(
+      actualHash,
+      `PUBLISH_WORKFLOW_HASH_MONOREPO in .readyup/kits/release-kit.ts is stale — update it to: ${actualHash}`,
+    ).toBe(PUBLISH_WORKFLOW_HASH_MONOREPO);
+  });
+
+  it('PUBLISH_WORKFLOW_HASH_SINGLE matches publishWorkflow("single-package")', () => {
+    const actualHash = sha256(publishWorkflow('single-package'));
+
+    expect(
+      actualHash,
+      `PUBLISH_WORKFLOW_HASH_SINGLE in .readyup/kits/release-kit.ts is stale — update it to: ${actualHash}`,
+    ).toBe(PUBLISH_WORKFLOW_HASH_SINGLE);
   });
 });

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -389,6 +389,9 @@ describe(parseArgs, () => {
     expect(() => parseArgs(['--help'])).toThrow(ExitError);
     expect(process.exit).toHaveBeenCalledWith(0);
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining('npx @williamthorsen/release-kit prepare'));
+    expect(console.info).toHaveBeenCalledWith(
+      expect.stringContaining('Force a release even when there are no commits since the last tag (requires --bump)'),
+    );
   });
 
   it('throws when --force is used without --bump', () => {

--- a/packages/release-kit/src/init/__tests__/templates.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/templates.unit.test.ts
@@ -36,44 +36,41 @@ describe(releaseConfigScript, () => {
 });
 
 describe(publishWorkflow, () => {
-  it('generates a monorepo workflow with wildcard tag pattern', () => {
+  it('generates a monorepo workflow with tightened tag pattern', () => {
     const workflow = publishWorkflow('monorepo');
 
-    expect(workflow).toContain("'*-v[0-9]*'");
-    expect(workflow).not.toContain("- 'v[0-9]*'");
-    expect(workflow).toContain('publish.reusable.yaml@publish-workflow-v1');
+    expect(workflow).toContain("'*-v[0-9]*.[0-9]*.[0-9]*'");
+    expect(workflow).not.toContain("- 'v[0-9]*.[0-9]*.[0-9]*'");
+    expect(workflow).toContain('publish.reusable.yaml@workflow/publish-v1');
     expect(workflow).toContain('id-token: write');
     expect(workflow).toContain('contents: read');
     expect(workflow).not.toContain('secrets:');
   });
 
-  it('generates a single-package workflow with v-prefixed tag pattern', () => {
+  it('generates a single-package workflow with v-prefixed tightened tag pattern', () => {
     const workflow = publishWorkflow('single-package');
 
-    expect(workflow).toContain("'v[0-9]*'");
-    expect(workflow).not.toContain("'*-v[0-9]*'");
-    expect(workflow).toContain('publish.reusable.yaml@publish-workflow-v1');
+    expect(workflow).toContain("'v[0-9]*.[0-9]*.[0-9]*'");
+    expect(workflow).not.toContain("'*-v[0-9]*.[0-9]*.[0-9]*'");
+    expect(workflow).toContain('publish.reusable.yaml@workflow/publish-v1');
     expect(workflow).toContain('id-token: write');
     expect(workflow).toContain('contents: read');
     expect(workflow).not.toContain('secrets:');
   });
 
-  it.each(['monorepo', 'single-package'] as const)(
-    'includes provenance: false with an explanatory comment (%s)',
-    (repoType) => {
-      const workflow = publishWorkflow(repoType);
+  it.each(['monorepo', 'single-package'] as const)('defaults to provenance: true (%s)', (repoType) => {
+    const workflow = publishWorkflow(repoType);
 
-      expect(workflow).toContain('provenance: false');
-      expect(workflow).toContain('# Set to true for public repos to generate npm provenance attestations');
-    },
-  );
+    expect(workflow).toContain('provenance: true');
+    expect(workflow).not.toContain('provenance: false');
+  });
 });
 
 describe(releaseWorkflow, () => {
   it('generates a monorepo workflow with only input but no monorepo flag', () => {
     const workflow = releaseWorkflow('monorepo');
 
-    expect(workflow).toContain('release.reusable.yaml@release-workflow-v1');
+    expect(workflow).toContain('release.reusable.yaml@workflow/release-v1');
     expect(workflow).not.toContain('monorepo:');
     expect(workflow).toContain('only:');
     expect(workflow).toContain('inputs.only');
@@ -82,7 +79,7 @@ describe(releaseWorkflow, () => {
   it('generates a single-package workflow without only input', () => {
     const workflow = releaseWorkflow('single-package');
 
-    expect(workflow).toContain('release.reusable.yaml@release-workflow-v1');
+    expect(workflow).toContain('release.reusable.yaml@workflow/release-v1');
     expect(workflow).not.toContain('monorepo:');
     expect(workflow).not.toContain('inputs.only');
   });

--- a/packages/release-kit/src/init/templates.ts
+++ b/packages/release-kit/src/init/templates.ts
@@ -51,7 +51,7 @@ export default config;
  * permissions, so GitHub uses those rather than the caller's block.
  */
 export function publishWorkflow(repoType: RepoType): string {
-  const tagPattern = repoType === 'monorepo' ? "'*-v[0-9]*'" : "'v[0-9]*'";
+  const tagPattern = repoType === 'monorepo' ? "'*-v[0-9]*.[0-9]*.[0-9]*'" : "'v[0-9]*.[0-9]*.[0-9]*'";
 
   return `# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Publish
@@ -67,9 +67,9 @@ permissions:
 
 jobs:
   publish:
-    uses: williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@publish-workflow-v1
+    uses: williamthorsen/node-monorepo-tools/.github/workflows/publish.reusable.yaml@workflow/publish-v1
     with:
-      provenance: false # Set to true for public repos to generate npm provenance attestations
+      provenance: true
 `;
 }
 
@@ -96,7 +96,7 @@ on:
           - minor
           - major
       force:
-        description: 'Force a version bump even when there are no release-worthy changes'
+        description: 'Force a release even when there are no commits since the last tag (requires --bump)'
         required: false
         type: boolean
         default: false
@@ -107,7 +107,7 @@ permissions:
 
 jobs:
   release:
-    uses: williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1
+    uses: williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@workflow/release-v1
     with:
       only: \${{ inputs.only }}
       bump: \${{ inputs.bump }}
@@ -131,7 +131,7 @@ on:
           - minor
           - major
       force:
-        description: 'Force a version bump even when there are no release-worthy changes'
+        description: 'Force a release even when there are no commits since the last tag (requires --bump)'
         required: false
         type: boolean
         default: false
@@ -142,7 +142,7 @@ permissions:
 
 jobs:
   release:
-    uses: williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@release-workflow-v1
+    uses: williamthorsen/node-monorepo-tools/.github/workflows/release.reusable.yaml@workflow/release-v1
     with:
       bump: \${{ inputs.bump }}
       force: \${{ inputs.force }}

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -45,7 +45,7 @@ Usage: npx @williamthorsen/release-kit prepare [options]
 Options:
   --dry-run             Run without modifying any files
   --bump=major|minor|patch  Override the bump type for all components
-  --force               Bypass the "no commits since last tag" check (monorepo only, requires --bump)
+  --force               Force a release even when there are no commits since the last tag (requires --bump)
   --no-git-checks, -n   Skip the clean-working-tree check
   --only=name1,name2    Only process the named components (comma-separated, monorepo only)
   --help                Show this help message

--- a/packages/release-kit/src/sync-labels/__tests__/templates.test.ts
+++ b/packages/release-kit/src/sync-labels/__tests__/templates.test.ts
@@ -9,7 +9,7 @@ describe(syncLabelsWorkflow, () => {
 
     expect(result).toContain('workflow_dispatch:');
     expect(result).toContain(
-      'uses: williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@sync-labels-workflow-v1',
+      'uses: williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@workflow/sync-labels-v1',
     );
   });
 

--- a/packages/release-kit/src/sync-labels/templates.ts
+++ b/packages/release-kit/src/sync-labels/templates.ts
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   sync:
-    uses: williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@sync-labels-workflow-v1
+    uses: williamthorsen/node-monorepo-tools/.github/workflows/sync-labels.reusable.yaml@workflow/sync-labels-v1
 `;
 }
 


### PR DESCRIPTION
## What

Migrates release-kit's reusable workflows, templates, readyup kit, and caller workflows to the `workflow/{name}-v{major}` tag namespace established in #215. Eliminates the `build-local` input from both reusable workflows in favor of auto-detection via `github.repository`, so this repo no longer diverges from how every other consumer adopts release-kit. Standardizes the `force` input description across all four surfaces (reusable workflow, template output, caller workflow, CLI help). Changes the `publishWorkflow()` default to `provenance: true` and tightens tag patterns to require full semver. Brings this repo's `release.yaml` and `publish.yaml` to byte-for-byte parity with the generated templates.

## Why

The deprecated `*-workflow-v{N}` tags could never be removed because release-kit's own templates kept emitting them, and this repo couldn't serve as a canonical example of consuming its own templates due to the `build-local` workaround and several accidental divergences between caller workflows and template output.

## Details

### Features

- Removed the `build-local` input from `release.reusable.yaml` and `publish.reusable.yaml`. A job-level `BUILD_LOCAL` env var computed from `github.repository == 'williamthorsen/node-monorepo-tools'` gates the source-build vs. npm-install paths. The pnpm cache flag is bridged through a step output because the `env` context is unavailable in GitHub Actions `with:` blocks.
- Updated `releaseWorkflow()`, `publishWorkflow()`, and `syncLabelsWorkflow()` to emit `@workflow/{name}-v1` refs instead of `@{name}-workflow-v1`.
- Changed `publishWorkflow()` default from `provenance: false` to `provenance: true`; tightened tag patterns to `*-v[0-9]*.[0-9]*.[0-9]*` (monorepo) and `v[0-9]*.[0-9]*.[0-9]*` (single-package).
- Standardized the `force` input description to "Force a release even when there are no commits since the last tag (requires --bump)" across reusable workflow, template output, caller workflow, and CLI `--help`.
- Added four variant-aware hash constants (`RELEASE_WORKFLOW_HASH_MONOREPO`, `RELEASE_WORKFLOW_HASH_SINGLE`, `PUBLISH_WORKFLOW_HASH_MONOREPO`, `PUBLISH_WORKFLOW_HASH_SINGLE`) to the readyup kit with `fileMatchesHash` checks that select the correct variant via `detectRepoType()`.
- Added three error-severity `fileDoesNotContain` migration checks for deprecated `@*-workflow-v` refs in `release.yaml`, `publish.yaml`, and `sync-labels.yaml`.
- Converged `release.yaml` (switched from relative path to external tag ref, passes `force` input) and `publish.yaml` (removed `build-local`) to byte-for-byte template parity.

### Tests

- Added four hash-sync tests for the new constants in `rdy-kit-hashes.app.test.ts`.
- Updated template unit tests to assert the new ref shapes, `provenance: true`, and tightened tag patterns.
- Added assertion for standardized `--force` help text in `prepareCommand.unit.test.ts`.

## Post-merge

After merging, advance the `workflow/release-v1` and `workflow/publish-v1` annotated tags to the merge commit before the next release/publish run. The caller workflows now reference these tags, but they currently point to a pre-branch commit that still has the `build-local` input.

Closes #216