### PR TITLE
#221 Show package name in override-script messages

### DIFF
--- a/packages/nmr/__tests__/cli.test.ts
+++ b/packages/nmr/__tests__/cli.test.ts
@@ -1,7 +1,9 @@
 import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const MONOREPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
 const NMR_PACKAGE_DIR = path.resolve(MONOREPO_ROOT, 'packages', 'nmr');
@@ -71,6 +73,51 @@ describe('nmr CLI', () => {
     const { stdout, exitCode } = runNmr('postinstall');
     expect(exitCode).toBe(0);
     expect(stdout).not.toContain('Using override script');
+  });
+
+  describe('override script messages', () => {
+    let tempRoot: string;
+    let overridePkgDir: string;
+    let noopPkgDir: string;
+
+    beforeAll(() => {
+      tempRoot = mkdtempSync(path.join(tmpdir(), 'nmr-test-'));
+      writeFileSync(path.join(tempRoot, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
+
+      overridePkgDir = path.join(tempRoot, 'packages', 'test-override');
+      mkdirSync(overridePkgDir, { recursive: true });
+      writeFileSync(
+        path.join(overridePkgDir, 'package.json'),
+        JSON.stringify({ name: 'test-override', scripts: { build: 'echo ok' } }),
+      );
+
+      noopPkgDir = path.join(tempRoot, 'packages', 'test-noop');
+      mkdirSync(noopPkgDir, { recursive: true });
+      writeFileSync(
+        path.join(noopPkgDir, 'package.json'),
+        JSON.stringify({ name: 'test-noop', scripts: { build: ':' } }),
+      );
+    });
+
+    afterAll(() => {
+      rmSync(tempRoot, { recursive: true, force: true });
+    });
+
+    it('includes package name in override-script message', () => {
+      const { stdout } = runNmr('build', { cwd: overridePkgDir });
+      expect(stdout).toContain('📦 test-override: Using override script: echo ok');
+    });
+
+    it('logs no-op message for colon override', () => {
+      const { stdout, exitCode } = runNmr('build', { cwd: noopPkgDir });
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('⛔ test-noop: Override script is a no-op. Skipping.');
+    });
+
+    it('suppresses override-script message in quiet mode', () => {
+      const { stdout } = runNmr('--quiet build', { cwd: overridePkgDir });
+      expect(stdout).not.toContain('Using override script');
+    });
   });
 
   describe('NMR_RUN_IF_PRESENT', () => {

--- a/packages/nmr/src/cli.ts
+++ b/packages/nmr/src/cli.ts
@@ -1,6 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
+import path from 'node:path';
 import process from 'node:process';
 
 import { resolveContext } from './context.js';
@@ -146,15 +147,24 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  const packageName = path.basename(packageDir);
+
   if (resolved.command === '') {
     if (!parsed.quiet) {
-      console.info('Override script is defined but empty. Skipping.');
+      console.info(`⛔ ${packageName}: Override script is defined but empty. Skipping.`);
+    }
+    process.exit(0);
+  }
+
+  if (resolved.command === ':') {
+    if (!parsed.quiet) {
+      console.info(`⛔ ${packageName}: Override script is a no-op. Skipping.`);
     }
     process.exit(0);
   }
 
   if (resolved.source === 'package' && !parsed.quiet && registry[command] !== undefined) {
-    console.info(`Using override script: ${resolved.command}`);
+    console.info(`📦 ${packageName}: Using override script: ${resolved.command}`);
   }
 
   const substitutedCommand = applyDevBin(resolved.command, context.config.devBin, context.monorepoRoot);


### PR DESCRIPTION
## What

Adds the package directory name as a prefix to override-script log messages, making it easy to identify which package each message belongs to when running commands across multiple workspaces. Also introduces a distinct no-op (`:`) condition that logs a skip message and exits cleanly, separate from the existing empty-string case.

## Why

When `nmr build` or other commands run recursively across packages, the override-script messages didn't identify which package they belonged to, making output difficult to scan in monorepos with many workspaces.

## Details

### Features

- Override-script messages now display as `📦 {name}: Using override script: {command}`, where `{name}` is the package directory basename.
- No-op overrides (`:`) log `⛔ {name}: Override script is a no-op. Skipping.` and exit 0.
- Empty-string overrides log `⛔ {name}: Override script is defined but empty. Skipping.` and exit 0.
- All three messages are suppressed by `--quiet`.

### Tests

- Added integration tests verifying the package name appears in override-script output and that quiet mode suppresses it.

## Test plan

- [ ] Run `nmr build` from monorepo root and verify override messages show package names
- [ ] Verify `--quiet` suppresses all override messages

Closes #221