### PR TITLE
#224 Narrow detectRepoType catch to ENOENT only

### DIFF
--- a/packages/release-kit/src/init/__tests__/detectRepoType.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/detectRepoType.unit.test.ts
@@ -23,25 +23,32 @@ describe(detectRepoType, () => {
   });
 
   it('returns monorepo when package.json has a workspaces field', () => {
-    mockExistsSync.mockReturnValue(false);
+    mockExistsSync.mockImplementation((path: string) => path === 'package.json');
     mockReadFileSync.mockReturnValue(JSON.stringify({ workspaces: ['packages/*'] }));
 
     expect(detectRepoType()).toBe('monorepo');
   });
 
   it('returns single-package when neither indicator is present', () => {
-    mockExistsSync.mockReturnValue(false);
+    mockExistsSync.mockImplementation((path: string) => path === 'package.json');
     mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'my-app' }));
 
     expect(detectRepoType()).toBe('single-package');
   });
 
-  it('returns single-package when package.json cannot be read', () => {
+  it('returns single-package when package.json does not exist', () => {
     mockExistsSync.mockReturnValue(false);
-    mockReadFileSync.mockImplementation(() => {
-      throw new Error('ENOENT');
-    });
 
     expect(detectRepoType()).toBe('single-package');
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it('throws when package.json exists but cannot be read', () => {
+    mockExistsSync.mockImplementation((path: string) => path === 'package.json');
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    expect(() => detectRepoType()).toThrow('EACCES: permission denied');
   });
 });

--- a/packages/release-kit/src/init/detectRepoType.ts
+++ b/packages/release-kit/src/init/detectRepoType.ts
@@ -16,14 +16,12 @@ export function detectRepoType(): RepoType {
     return 'monorepo';
   }
 
-  try {
+  if (existsSync('package.json')) {
     const raw = readFileSync('package.json', 'utf8');
     const pkg = parseJsonRecord(raw);
     if (pkg !== undefined && Array.isArray(pkg.workspaces)) {
       return 'monorepo';
     }
-  } catch {
-    // Fall through to single-package
   }
 
   return 'single-package';


### PR DESCRIPTION
## What

Fixes silent swallowing of unexpected filesystem errors in `detectRepoType`. Previously, errors like `EACCES` (permission denied) or `EMFILE` (too many open files) when reading `package.json` were caught and discarded, causing the function to silently return `'single-package'` instead of surfacing the problem.

## Why

The broad `catch` block masked genuine environmental errors, making the function return an incorrect result with no diagnostic signal. While rare in practice, silent wrong answers are worse than loud failures for a detection function that downstream code relies on.

## Details

### Fixes

- Replaces the try/catch around `readFileSync`/`parseJsonRecord` with an `existsSync('package.json')` guard, consistent with the existing `pnpm-workspace.yaml` check in the same function. Missing `package.json` falls through to `'single-package'`; unexpected read errors now propagate.

### Tests

- Updates existing test mocks to be path-aware (`mockImplementation` instead of blanket `mockReturnValue`).
- Splits the old "cannot be read" test into two cases: file missing (returns `'single-package'`, confirms `readFileSync` is not called) and file exists but unreadable (error propagates).

## Test plan

- [ ] Verify `detectRepoType` returns `'monorepo'` when `pnpm-workspace.yaml` exists
- [ ] Verify `detectRepoType` returns `'monorepo'` when `package.json` has `workspaces` field
- [ ] Verify `detectRepoType` returns `'single-package'` when neither indicator is present
- [ ] Verify `detectRepoType` returns `'single-package'` when `package.json` does not exist
- [ ] Verify unexpected filesystem errors (e.g. EACCES) propagate instead of being swallowed

Closes #224 