### PR TITLE
#228 Allow audit-deps to work without a config

### DIFF
--- a/.config/audit-deps.config.json
+++ b/.config/audit-deps.config.json
@@ -1,19 +1,11 @@
 {
+  "$schema": "https://github.com/williamthorsen/node-monorepo-tools/raw/audit-deps-v0.3.0/packages/audit-deps/schemas/config.json",
   "dev": {
-    "allowlist": [
-      {
-        "addedAt": "2026-04-17",
-        "id": "1115540",
-        "path": ".>eslint>minimatch>brace-expansion",
-        "reason": "Added by audit-deps sync on 2026-04-17",
-        "url": "https://github.com/advisories/GHSA-f886-m6hf-6m8v"
-      }
-    ],
-    "moderate": true
+    "severityThreshold": "high",
+    "allowlist": []
   },
-  "outDir": "../tmp",
   "prod": {
-    "allowlist": [],
-    "high": true
+    "severityThreshold": "moderate",
+    "allowlist": []
   }
 }

--- a/.readyup/kits/__tests__/audit-deps-checks.test.ts
+++ b/.readyup/kits/__tests__/audit-deps-checks.test.ts
@@ -1,17 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { mockedFileExists, mockedExistsSync } = vi.hoisted(() => ({
-  mockedFileExists: vi.fn<(path: string) => boolean>(),
+const { mockedExistsSync } = vi.hoisted(() => ({
   mockedExistsSync: vi.fn<(path: string) => boolean>(),
 }));
-
-vi.mock('readyup', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('readyup')>();
-  return {
-    ...actual,
-    fileExists: mockedFileExists,
-  };
-});
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
@@ -22,25 +13,10 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
-import { auditDepsConfigExists, noLegacyAuditCiDirectory, skipLegacyAuditCiCheck } from '../audit-deps.ts';
+import { noLegacyAuditCiDirectory, skipLegacyAuditCiCheck } from '../audit-deps.ts';
 
 afterEach(() => {
   vi.restoreAllMocks();
-});
-
-describe(auditDepsConfigExists, () => {
-  it('returns true when config file exists', () => {
-    mockedFileExists.mockReturnValue(true);
-
-    expect(auditDepsConfigExists()).toBe(true);
-    expect(mockedFileExists).toHaveBeenCalledWith('.config/audit-deps.config.json');
-  });
-
-  it('returns false when config file is absent', () => {
-    mockedFileExists.mockReturnValue(false);
-
-    expect(auditDepsConfigExists()).toBe(false);
-  });
 });
 
 describe(noLegacyAuditCiDirectory, () => {

--- a/.readyup/kits/audit-deps.js
+++ b/.readyup/kits/audit-deps.js
@@ -169,13 +169,6 @@ var audit_deps_default = defineRdyKit({
             }
           ]
         },
-        // -- Config existence ----------------------------------------------------
-        {
-          name: ".config/audit-deps.config.json exists",
-          severity: "warn",
-          check: auditDepsConfigExists,
-          fix: "Create .config/audit-deps.config.json with audit-deps configuration"
-        },
         // -- Audit-ci config migration -------------------------------------------
         {
           name: "audit-ci configs are under .config/audit-ci/",
@@ -203,9 +196,6 @@ var audit_deps_default = defineRdyKit({
     }
   ]
 });
-function auditDepsConfigExists() {
-  return fileExists(".config/audit-deps.config.json");
-}
 function skipLegacyAuditCiCheck() {
   return !existsSync2(join2(process.cwd(), ".audit-ci")) ? "no legacy .audit-ci/ directory" : false;
 }
@@ -214,7 +204,6 @@ function noLegacyAuditCiDirectory() {
 }
 export {
   AUDIT_WORKFLOW_HASH,
-  auditDepsConfigExists,
   audit_deps_default as default,
   noLegacyAuditCiDirectory,
   skipLegacyAuditCiCheck

--- a/.readyup/kits/audit-deps.ts
+++ b/.readyup/kits/audit-deps.ts
@@ -45,14 +45,6 @@ export default defineRdyKit({
           ],
         },
 
-        // -- Config existence ----------------------------------------------------
-        {
-          name: '.config/audit-deps.config.json exists',
-          severity: 'warn',
-          check: auditDepsConfigExists,
-          fix: 'Create .config/audit-deps.config.json with audit-deps configuration',
-        },
-
         // -- Audit-ci config migration -------------------------------------------
         {
           name: 'audit-ci configs are under .config/audit-ci/',
@@ -83,11 +75,6 @@ export default defineRdyKit({
 });
 
 // -- Helpers -----------------------------------------------------------------
-
-/** Check that `.config/audit-deps.config.json` exists. */
-export function auditDepsConfigExists(): boolean {
-  return fileExists('.config/audit-deps.config.json');
-}
 
 /** Skip the legacy audit-ci check when there is no `.audit-ci/` directory. */
 export function skipLegacyAuditCiCheck(): string | false {

--- a/packages/audit-deps/README.md
+++ b/packages/audit-deps/README.md
@@ -32,7 +32,7 @@ The source-of-truth config lives at `.config/audit-deps.config.json`:
 
 ```json
 {
-  "$schema": "https://github.com/williamthorsen/node-monorepo-tools/raw/audit-deps-v0.3.0/packages/audit-deps/schemas/config.json",
+  "$schema": "https://github.com/williamthorsen/node-monorepo-tools/raw/audit-deps-v<version>/packages/audit-deps/schemas/config.json",
   "dev": {
     "severityThreshold": "high",
     "allowlist": [

--- a/packages/audit-deps/README.md
+++ b/packages/audit-deps/README.md
@@ -11,18 +11,20 @@ pnpm add -D @williamthorsen/audit-deps
 ## Quick start
 
 ```shell
-# Scaffold a starter config
+# Run a vulnerability check with sensible defaults (no config needed)
+npx @williamthorsen/audit-deps
+
+# Scaffold a starter config for customization
 npx audit-deps init
-
-# Grouped vulnerability check across all scopes (default)
-npx audit-deps
-
-# Raw audit-ci passthrough
-npx audit-deps --raw
 
 # Sync allowlists with current findings
 npx audit-deps sync
+
+# Raw audit-ci passthrough
+npx audit-deps --raw
 ```
+
+No config file is required. When `.config/audit-deps.config.json` is absent, the tool uses built-in defaults: `severityThreshold: 'high'` for dev, `severityThreshold: 'moderate'` for prod, and empty allowlists.
 
 ## Configuration
 
@@ -30,9 +32,9 @@ The source-of-truth config lives at `.config/audit-deps.config.json`:
 
 ```json
 {
-  "outDir": "../tmp",
+  "$schema": "https://github.com/williamthorsen/node-monorepo-tools/raw/audit-deps-v0.3.0/packages/audit-deps/schemas/config.json",
   "dev": {
-    "moderate": true,
+    "severityThreshold": "high",
     "allowlist": [
       {
         "addedAt": "2026-04-15",
@@ -44,7 +46,7 @@ The source-of-truth config lives at `.config/audit-deps.config.json`:
     ]
   },
   "prod": {
-    "high": true,
+    "severityThreshold": "moderate",
     "allowlist": []
   }
 }
@@ -52,9 +54,9 @@ The source-of-truth config lives at `.config/audit-deps.config.json`:
 
 ### Fields
 
-- **`outDir`** (optional) — Directory for generated flat audit-ci config files, resolved relative to the config file's directory. Defaults to the config file's directory.
+- **`$schema`** (optional) — JSON Schema URL for editor autocomplete and validation. Automatically included by `init` and `sync`.
 - **`dev`** / **`prod`** — Scope-specific settings:
-  - **`critical`**, **`high`**, **`moderate`**, **`low`** — Severity thresholds (pass to audit-ci).
+  - **`severityThreshold`** (optional) — Fail on advisories at or above this severity. Valid values: `'low'`, `'moderate'`, `'high'`, `'critical'`. When omitted, audit-ci uses its own defaults.
   - **`allowlist`** — Typed advisory entries with `id`, `path`, `url`, and optional `reason` and `addedAt`. `addedAt` is an ISO date (UTC, `YYYY-MM-DD`) populated automatically by `audit-deps sync` on new entries; existing entries retain whatever value they had.
 
 ## CLI reference
@@ -66,7 +68,6 @@ Usage: audit-deps [options]
 Commands:
   (default)            Grouped vulnerability check with severity indicators
   sync                 Synchronize allowlists with current audit findings
-  generate             Regenerate flat audit-ci config files
   init                 Scaffold a starter config file
 
 Scope options:
@@ -88,3 +89,19 @@ Other options:
   --dry-run, -n   Preview changes without writing files
   --force, -f     Overwrite existing files
 ```
+
+## Migration from v0.3
+
+v0.4 introduces breaking changes to the config schema:
+
+- **`outDir` removed.** Intermediate audit-ci files are now written to a temp directory and cleaned up automatically. Remove `outDir` from your config.
+- **Severity booleans replaced by `severityThreshold`.** Replace `"moderate": true` with `"severityThreshold": "moderate"`, `"high": true` with `"severityThreshold": "high"`, etc. Only one threshold per scope is supported.
+- **`generate` subcommand removed.** The `audit-deps generate` command no longer exists. Flat audit-ci configs are now managed internally.
+- **Config is optional.** All commands now work without a config file, using built-in defaults.
+
+To migrate an existing config:
+
+1. Remove the `outDir` field.
+2. Replace severity booleans with `severityThreshold` in each scope.
+3. Optionally add a `$schema` field (run `audit-deps init --force` to regenerate, or add it manually).
+4. Delete any generated `audit-ci.*.json` files that were in your config directory.

--- a/packages/audit-deps/README.md
+++ b/packages/audit-deps/README.md
@@ -24,7 +24,7 @@ npx audit-deps sync
 npx audit-deps --raw
 ```
 
-No config file is required. When `.config/audit-deps.config.json` is absent, the tool uses built-in defaults: `severityThreshold: 'high'` for dev, `severityThreshold: 'moderate'` for prod, and empty allowlists.
+No config file is required. When `.config/audit-deps.config.json` is absent, the tool uses built-in defaults: `severityThreshold: 'moderate'` for dev, `severityThreshold: 'low'` for prod, and empty allowlists.
 
 ## Configuration
 
@@ -34,7 +34,7 @@ The source-of-truth config lives at `.config/audit-deps.config.json`:
 {
   "$schema": "https://github.com/williamthorsen/node-monorepo-tools/raw/audit-deps-v<version>/packages/audit-deps/schemas/config.json",
   "dev": {
-    "severityThreshold": "high",
+    "severityThreshold": "moderate",
     "allowlist": [
       {
         "addedAt": "2026-04-15",
@@ -46,7 +46,7 @@ The source-of-truth config lives at `.config/audit-deps.config.json`:
     ]
   },
   "prod": {
-    "severityThreshold": "moderate",
+    "severityThreshold": "low",
     "allowlist": []
   }
 }

--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { LoadConfigResult } from '../src/config.ts';
 import type { AuditDepsConfig, CommandOptions } from '../src/types.ts';
 
 // ---------------------------------------------------------------------------
@@ -7,19 +8,28 @@ import type { AuditDepsConfig, CommandOptions } from '../src/types.ts';
 // ---------------------------------------------------------------------------
 
 const mocks = vi.hoisted(() => ({
-  generateAuditCiConfig: vi.fn<() => Promise<string>>(),
-  loadConfig: vi.fn<() => Promise<{ config: AuditDepsConfig; configDir: string; configFilePath: string }>>(),
+  loadConfig: vi.fn<() => Promise<LoadConfigResult>>(),
+  mkdirAsync: vi.fn<() => Promise<string | undefined>>(),
   runAudit: vi.fn(),
   runReport: vi.fn(),
   syncAllowlist: vi.fn(),
+  withTempDir: vi.fn(),
 }));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    mkdir: mocks.mkdirAsync,
+  };
+});
 
 vi.mock('../src/config.ts', () => ({
   loadConfig: mocks.loadConfig,
 }));
 
 vi.mock('../src/generate.ts', () => ({
-  generateAuditCiConfig: mocks.generateAuditCiConfig,
+  generateAuditCiConfig: vi.fn().mockResolvedValue('/fake/tmp/audit-ci.json'),
 }));
 
 vi.mock('../src/run-audit.ts', async (importOriginal) => {
@@ -39,7 +49,11 @@ vi.mock('../src/sync.ts', async (importOriginal) => {
   };
 });
 
-import { auditCommand, checkCommand, generateCommand, syncCommand } from '../src/cli.ts';
+vi.mock('../src/tmp.ts', () => ({
+  withTempDir: mocks.withTempDir,
+}));
+
+import { auditCommand, checkCommand, syncCommand } from '../src/cli.ts';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -57,12 +71,22 @@ function makeOptions(overrides?: Partial<CommandOptions>): CommandOptions {
   return { json: false, scopes: [], verbose: false, ...overrides };
 }
 
-function setupLoadConfig(config?: AuditDepsConfig): void {
+function setupLoadConfig(config?: AuditDepsConfig, source: 'defaults' | 'file' = 'file'): void {
   mocks.loadConfig.mockResolvedValue({
     config: config ?? makeConfig(),
     configDir: '/fake/dir',
     configFilePath: '/fake/dir/audit-deps.config.json',
+    configSource: source,
   });
+}
+
+/**
+ * Configure withTempDir mock to execute the callback with a fake temp path.
+ *
+ * Must be called before each test that exercises commands using temp dirs.
+ */
+function setupTempDir(): void {
+  mocks.withTempDir.mockImplementation(async (fn: (dir: string) => Promise<unknown>) => fn('/fake/tmp'));
 }
 
 // ---------------------------------------------------------------------------
@@ -83,6 +107,8 @@ beforeEach(() => {
     stdoutOutput += String(chunk);
     return true;
   });
+  setupTempDir();
+  mocks.mkdirAsync.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -106,7 +132,6 @@ describe(auditCommand, () => {
 
   it('forwards stale entry warnings to stderr', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
     mocks.runAudit.mockReturnValue({
       exitCode: 0,
       staleEntries: ['GHSA-1234', 'GHSA-5678'],
@@ -122,7 +147,6 @@ describe(auditCommand, () => {
 
   it('forwards audit-ci warnings to stderr', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
     mocks.runAudit.mockReturnValue({
       exitCode: 0,
       staleEntries: [],
@@ -138,9 +162,6 @@ describe(auditCommand, () => {
 
   it('returns non-zero exit code when any scope fails', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig
-      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
-      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
     mocks.runAudit
       .mockReturnValueOnce({ exitCode: 0, staleEntries: [], stderr: '', stdout: '', warnings: [] })
       .mockReturnValueOnce({ exitCode: 1, staleEntries: [], stderr: '', stdout: '', warnings: [] });
@@ -152,9 +173,6 @@ describe(auditCommand, () => {
 
   it('returns 0 when all scopes pass', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig
-      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
-      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
     mocks.runAudit.mockReturnValue({ exitCode: 0, staleEntries: [], stderr: '', stdout: '', warnings: [] });
 
     const exitCode = await auditCommand(makeOptions());
@@ -164,7 +182,6 @@ describe(auditCommand, () => {
 
   it('writes deduplicated JSON in JSON mode', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
     mocks.runAudit.mockReturnValue({
       exitCode: 0,
       staleEntries: [],
@@ -185,7 +202,6 @@ describe(auditCommand, () => {
 
   it('writes stderr when stdout is empty and stderr has content', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
     mocks.runAudit.mockReturnValue({
       exitCode: 1,
       staleEntries: [],
@@ -201,9 +217,6 @@ describe(auditCommand, () => {
 
   it('deduplicates advisory IDs across scopes in JSON mode', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig
-      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
-      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
 
     const sharedAdvisory = {
       id: 'GHSA-shared',
@@ -259,9 +272,6 @@ describe(auditCommand, () => {
 
   it('audits both scopes when no scopes are specified', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig
-      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
-      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
     mocks.runAudit.mockReturnValue({ exitCode: 0, staleEntries: [], stderr: '', stdout: '', warnings: [] });
 
     await auditCommand(makeOptions());
@@ -286,7 +296,6 @@ describe(checkCommand, () => {
 
   it('returns 0 when no vulnerabilities are found', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
 
     const exitCode = await checkCommand(makeOptions({ scopes: ['prod'] }));
@@ -297,7 +306,6 @@ describe(checkCommand, () => {
 
   it('returns 1 when unallowed vulnerabilities exist', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
       results: [
         { id: 'GHSA-bad', path: 'bad-pkg', paths: ['bad-pkg'], severity: 'high', url: 'https://example.com/bad' },
@@ -320,7 +328,6 @@ describe(checkCommand, () => {
       },
     });
     setupLoadConfig(config);
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
     mocks.runReport.mockReturnValue({
       results: [
         { id: 'GHSA-ok', path: 'safe-pkg', paths: ['safe-pkg'], severity: 'moderate', url: 'https://example.com/ok' },
@@ -351,7 +358,6 @@ describe(checkCommand, () => {
       },
     });
     setupLoadConfig(config);
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
       results: [
         {
@@ -400,7 +406,6 @@ describe(checkCommand, () => {
       },
     });
     setupLoadConfig(config);
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
 
     const exitCode = await checkCommand(makeOptions({ scopes: ['prod'] }));
@@ -412,7 +417,6 @@ describe(checkCommand, () => {
 
   it('outputs JSON when json option is true', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
       results: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/1' }],
       stdout: '',
@@ -428,7 +432,6 @@ describe(checkCommand, () => {
 
   it('checks both scopes when none are specified', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.json');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
 
     await checkCommand(makeOptions());
@@ -440,7 +443,6 @@ describe(checkCommand, () => {
 
   it('displays prod before dev even when scopes are passed in reverse order', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.json');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
 
     await checkCommand(makeOptions({ scopes: ['dev', 'prod'] }));
@@ -452,18 +454,8 @@ describe(checkCommand, () => {
     expect(prodIndex).toBeLessThan(devIndex);
   });
 
-  it('wraps generateAuditCiConfig errors with scope context', async () => {
-    setupLoadConfig();
-    mocks.generateAuditCiConfig.mockRejectedValue(new Error('EACCES: permission denied'));
-
-    await expect(checkCommand(makeOptions({ scopes: ['prod'] }))).rejects.toThrow(
-      "Failed to generate config for scope 'prod': EACCES: permission denied",
-    );
-  });
-
   it('forwards report stderr to process stderr', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
       results: [],
       stdout: '',
@@ -478,7 +470,6 @@ describe(checkCommand, () => {
 
   it('forwards report warnings to stderr', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
       results: [],
       stdout: '',
@@ -493,7 +484,6 @@ describe(checkCommand, () => {
 
   it('invokes runReport with reportType "full" when verbose is true', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
 
     await checkCommand(makeOptions({ scopes: ['prod'], verbose: true }));
@@ -503,7 +493,6 @@ describe(checkCommand, () => {
 
   it('omits reportType when verbose is false', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
 
     await checkCommand(makeOptions({ scopes: ['prod'] }));
@@ -527,7 +516,6 @@ describe(checkCommand, () => {
       },
     });
     setupLoadConfig(config);
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
       results: [
         {
@@ -559,7 +547,6 @@ describe(checkCommand, () => {
       },
     });
     setupLoadConfig(config);
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
     mocks.runReport.mockReturnValue({
       results: [
         {
@@ -617,7 +604,6 @@ describe(syncCommand, () => {
       dev: { allowlist: [{ id: 'GHSA-existing', path: 'pkg', url: 'https://example.com' }] },
     });
     setupLoadConfig(config);
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
     mocks.syncAllowlist.mockResolvedValue({
       syncResult: { added: [], kept: [], removed: [], scope: 'dev' },
@@ -626,18 +612,12 @@ describe(syncCommand, () => {
 
     await syncCommand(makeOptions({ scopes: ['dev'] }));
 
-    // The first generateAuditCiConfig call should receive a stripped scope with empty allowlist
-    expect(mocks.generateAuditCiConfig).toHaveBeenCalledWith(
-      expect.objectContaining({ allowlist: [] }),
-      'dev',
-      '/fake/dir',
-      undefined,
-    );
+    // Verify generateAuditCiConfig was called (via the temp dir mock)
+    expect(mocks.runReport).toHaveBeenCalled();
   });
 
   it('prints text summary in non-JSON mode', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
     mocks.syncAllowlist.mockResolvedValue({
       syncResult: { added: ['a'], kept: [], removed: ['b', 'c'], scope: 'dev' },
@@ -653,7 +633,6 @@ describe(syncCommand, () => {
 
   it('prints JSON in json mode', async () => {
     setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.dev.json');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
     mocks.syncAllowlist.mockResolvedValue({
       syncResult: { added: [], kept: [], removed: [], scope: 'dev' },
@@ -666,69 +645,16 @@ describe(syncCommand, () => {
     expect(parsed).toStrictEqual(expect.objectContaining({ added: [], kept: [], removed: [] }));
   });
 
-  it('wraps generateAuditCiConfig errors with scope context', async () => {
-    setupLoadConfig();
-    mocks.generateAuditCiConfig.mockRejectedValue(new Error('EACCES: permission denied'));
-
-    await expect(syncCommand(makeOptions({ scopes: ['dev'] }))).rejects.toThrow(
-      "Failed to generate config for scope 'dev': EACCES: permission denied",
-    );
-  });
-
-  it('throws when post-sync generateAuditCiConfig fails', async () => {
-    const config = makeConfig();
-    setupLoadConfig(config);
-
-    // First call (stripped config) succeeds
-    mocks.generateAuditCiConfig.mockResolvedValueOnce('/fake/out/audit-ci.dev.json');
+  it('reports config creation when source is defaults', async () => {
+    setupLoadConfig(undefined, 'defaults');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
     mocks.syncAllowlist.mockResolvedValue({
       syncResult: { added: [], kept: [], removed: [], scope: 'dev' },
-      updatedConfig: config,
+      updatedConfig: makeConfig(),
     });
 
-    // Second call (post-sync regeneration) fails
-    mocks.generateAuditCiConfig.mockRejectedValueOnce(new Error('Disk full'));
+    await syncCommand(makeOptions({ scopes: ['dev'] }));
 
-    await expect(syncCommand(makeOptions({ scopes: ['dev'] }))).rejects.toThrow(
-      "Failed to generate config for scope 'dev'",
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// generateCommand
-// ---------------------------------------------------------------------------
-
-describe(generateCommand, () => {
-  it('returns 1 when config loading fails', async () => {
-    mocks.loadConfig.mockRejectedValue(new Error('Config not found'));
-
-    const exitCode = await generateCommand(makeOptions());
-
-    expect(exitCode).toBe(1);
-  });
-
-  it('prints generated paths', async () => {
-    setupLoadConfig();
-    mocks.generateAuditCiConfig
-      .mockResolvedValueOnce('/fake/out/audit-ci.dev.json')
-      .mockResolvedValueOnce('/fake/out/audit-ci.prod.json');
-
-    await generateCommand(makeOptions());
-
-    expect(stdoutOutput).toContain('Generated: /fake/out/audit-ci.dev.json');
-    expect(stdoutOutput).toContain('Generated: /fake/out/audit-ci.prod.json');
-  });
-
-  it('generates only the requested scope', async () => {
-    setupLoadConfig();
-    mocks.generateAuditCiConfig.mockResolvedValue('/fake/out/audit-ci.prod.json');
-
-    await generateCommand(makeOptions({ scopes: ['prod'] }));
-
-    expect(mocks.generateAuditCiConfig).toHaveBeenCalledTimes(1);
-    expect(stdoutOutput).toContain('Generated: /fake/out/audit-ci.prod.json');
-    expect(stdoutOutput).not.toContain('audit-ci.dev.json');
+    expect(stderrOutput).toContain('Created config at');
   });
 });

--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -10,23 +10,19 @@ import type { AuditDepsConfig, CommandOptions } from '../src/types.ts';
 const mocks = vi.hoisted(() => ({
   generateAuditCiConfig: vi.fn<() => Promise<string>>(),
   loadConfig: vi.fn<() => Promise<LoadConfigResult>>(),
-  mkdirAsync: vi.fn<() => Promise<string | undefined>>(),
   runAudit: vi.fn(),
   runReport: vi.fn(),
+  scaffoldConfig: vi.fn(),
   syncAllowlist: vi.fn(),
   withTempDir: vi.fn(),
 }));
 
-vi.mock('node:fs/promises', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs/promises')>();
-  return {
-    ...actual,
-    mkdir: mocks.mkdirAsync,
-  };
-});
-
 vi.mock('../src/config.ts', () => ({
   loadConfig: mocks.loadConfig,
+}));
+
+vi.mock('../src/init/scaffold.ts', () => ({
+  scaffoldConfig: mocks.scaffoldConfig,
 }));
 
 vi.mock('../src/generate.ts', () => ({
@@ -110,7 +106,7 @@ beforeEach(() => {
   });
   setupTempDir();
   mocks.generateAuditCiConfig.mockResolvedValue('/fake/tmp/audit-ci.json');
-  mocks.mkdirAsync.mockResolvedValue(undefined);
+  mocks.scaffoldConfig.mockReturnValue({ configResult: { outcome: 'created' } });
 });
 
 afterEach(() => {
@@ -652,7 +648,20 @@ describe(syncCommand, () => {
   });
 
   it('reports config creation when source is defaults', async () => {
-    setupLoadConfig(undefined, 'defaults');
+    // First call returns defaults; second call (after scaffold) returns file.
+    mocks.loadConfig
+      .mockResolvedValueOnce({
+        config: makeConfig(),
+        configDir: '/fake/dir',
+        configFilePath: '/fake/dir/audit-deps.config.json',
+        configSource: 'defaults',
+      })
+      .mockResolvedValueOnce({
+        config: makeConfig(),
+        configDir: '/fake/dir',
+        configFilePath: '/fake/dir/audit-deps.config.json',
+        configSource: 'file',
+      });
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
     mocks.syncAllowlist.mockResolvedValue({
       syncResult: { added: [], kept: [], removed: [], scope: 'dev' },
@@ -664,8 +673,21 @@ describe(syncCommand, () => {
     expect(stdoutOutput).toContain('Created config at');
   });
 
-  it('creates config directory when source is defaults', async () => {
-    setupLoadConfig(undefined, 'defaults');
+  it('scaffolds a config file when source is defaults', async () => {
+    // First call returns defaults; second call (after scaffold) returns file.
+    mocks.loadConfig
+      .mockResolvedValueOnce({
+        config: makeConfig(),
+        configDir: '/fake/dir',
+        configFilePath: '/fake/dir/audit-deps.config.json',
+        configSource: 'defaults',
+      })
+      .mockResolvedValueOnce({
+        config: makeConfig(),
+        configDir: '/fake/dir',
+        configFilePath: '/fake/dir/audit-deps.config.json',
+        configSource: 'file',
+      });
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
     mocks.syncAllowlist.mockResolvedValue({
       syncResult: { added: [], kept: [], removed: [], scope: 'dev' },
@@ -674,10 +696,10 @@ describe(syncCommand, () => {
 
     await syncCommand(makeOptions({ scopes: ['dev'] }));
 
-    expect(mocks.mkdirAsync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+    expect(mocks.scaffoldConfig).toHaveBeenCalledWith({ dryRun: false, force: false });
   });
 
-  it('does not create config directory when source is file', async () => {
+  it('does not scaffold when source is file', async () => {
     setupLoadConfig(undefined, 'file');
     mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
     mocks.syncAllowlist.mockResolvedValue({
@@ -687,6 +709,21 @@ describe(syncCommand, () => {
 
     await syncCommand(makeOptions({ scopes: ['dev'] }));
 
-    expect(mocks.mkdirAsync).not.toHaveBeenCalled();
+    expect(mocks.scaffoldConfig).not.toHaveBeenCalled();
+  });
+
+  it('returns 1 when scaffold fails', async () => {
+    mocks.loadConfig.mockResolvedValueOnce({
+      config: makeConfig(),
+      configDir: '/fake/dir',
+      configFilePath: '/fake/dir/audit-deps.config.json',
+      configSource: 'defaults',
+    });
+    mocks.scaffoldConfig.mockReturnValue({ configResult: { outcome: 'failed' } });
+
+    const exitCode = await syncCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(exitCode).toBe(1);
+    expect(stderrOutput).toContain('Failed to create config file');
   });
 });

--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -8,6 +8,7 @@ import type { AuditDepsConfig, CommandOptions } from '../src/types.ts';
 // ---------------------------------------------------------------------------
 
 const mocks = vi.hoisted(() => ({
+  generateAuditCiConfig: vi.fn<() => Promise<string>>(),
   loadConfig: vi.fn<() => Promise<LoadConfigResult>>(),
   mkdirAsync: vi.fn<() => Promise<string | undefined>>(),
   runAudit: vi.fn(),
@@ -29,7 +30,7 @@ vi.mock('../src/config.ts', () => ({
 }));
 
 vi.mock('../src/generate.ts', () => ({
-  generateAuditCiConfig: vi.fn().mockResolvedValue('/fake/tmp/audit-ci.json'),
+  generateAuditCiConfig: mocks.generateAuditCiConfig,
 }));
 
 vi.mock('../src/run-audit.ts', async (importOriginal) => {
@@ -108,6 +109,7 @@ beforeEach(() => {
     return true;
   });
   setupTempDir();
+  mocks.generateAuditCiConfig.mockResolvedValue('/fake/tmp/audit-ci.json');
   mocks.mkdirAsync.mockResolvedValue(undefined);
 });
 
@@ -612,8 +614,12 @@ describe(syncCommand, () => {
 
     await syncCommand(makeOptions({ scopes: ['dev'] }));
 
-    // Verify generateAuditCiConfig was called (via the temp dir mock)
-    expect(mocks.runReport).toHaveBeenCalled();
+    // Verify the allowlist was stripped (emptied) before generating the audit-ci config.
+    expect(mocks.generateAuditCiConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ allowlist: [] }),
+      'dev',
+      expect.any(String),
+    );
   });
 
   it('prints text summary in non-JSON mode', async () => {
@@ -655,6 +661,32 @@ describe(syncCommand, () => {
 
     await syncCommand(makeOptions({ scopes: ['dev'] }));
 
-    expect(stderrOutput).toContain('Created config at');
+    expect(stdoutOutput).toContain('Created config at');
+  });
+
+  it('creates config directory when source is defaults', async () => {
+    setupLoadConfig(undefined, 'defaults');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+    mocks.syncAllowlist.mockResolvedValue({
+      syncResult: { added: [], kept: [], removed: [], scope: 'dev' },
+      updatedConfig: makeConfig(),
+    });
+
+    await syncCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(mocks.mkdirAsync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+  });
+
+  it('does not create config directory when source is file', async () => {
+    setupLoadConfig(undefined, 'file');
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+    mocks.syncAllowlist.mockResolvedValue({
+      syncResult: { added: [], kept: [], removed: [], scope: 'dev' },
+      updatedConfig: makeConfig(),
+    });
+
+    await syncCommand(makeOptions({ scopes: ['dev'] }));
+
+    expect(mocks.mkdirAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/audit-deps/__tests__/config.test.ts
+++ b/packages/audit-deps/__tests__/config.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { loadConfig } from '../src/config.ts';
+import { DEFAULT_CONFIG } from '../src/types.ts';
 
 describe(loadConfig, () => {
   let tempDir: string;
@@ -23,21 +24,30 @@ describe(loadConfig, () => {
     await mkdir(configDir, { recursive: true });
 
     const config = {
-      outDir: '../tmp',
-      dev: { moderate: true, allowlist: [] },
-      prod: { high: true, allowlist: [{ id: 'GHSA-1234', path: 'lodash', url: 'https://example.com' }] },
+      dev: { severityThreshold: 'high', allowlist: [] },
+      prod: {
+        severityThreshold: 'moderate',
+        allowlist: [{ id: 'GHSA-1234', path: 'lodash', url: 'https://example.com' }],
+      },
     };
     await writeFile(path.join(configDir, 'audit-deps.config.json'), JSON.stringify(config), 'utf8');
 
     const result = await loadConfig(undefined, tempDir);
-    expect(result.config.outDir).toBe('../tmp');
-    expect(result.config.dev.moderate).toBe(true);
+    expect(result.config.dev.severityThreshold).toBe('high');
     expect(result.config.prod.allowlist).toHaveLength(1);
     expect(result.configDir).toBe(configDir);
+    expect(result.configSource).toBe('file');
   });
 
-  it('throws when the config file does not exist', async () => {
-    await expect(loadConfig(undefined, tempDir)).rejects.toThrow(/Config file not found/);
+  it('returns defaults when no config file exists and no explicit path is given', async () => {
+    const result = await loadConfig(undefined, tempDir);
+    expect(result.config).toStrictEqual(DEFAULT_CONFIG);
+    expect(result.configSource).toBe('defaults');
+    expect(result.configFilePath).toBe(path.resolve(tempDir, '.config/audit-deps.config.json'));
+  });
+
+  it('throws when an explicit config path does not exist', async () => {
+    await expect(loadConfig('nonexistent.json', tempDir)).rejects.toThrow(/Config file not found/);
   });
 
   it('throws when the config file is not valid JSON', async () => {
@@ -56,6 +66,31 @@ describe(loadConfig, () => {
     await expect(loadConfig(undefined, tempDir)).rejects.toThrow(/Invalid config/);
   });
 
+  it('rejects configs with old boolean severity fields', async () => {
+    const configDir = path.join(tempDir, '.config');
+    await mkdir(configDir, { recursive: true });
+    const config = {
+      dev: { moderate: true, allowlist: [] },
+      prod: { allowlist: [] },
+    };
+    await writeFile(path.join(configDir, 'audit-deps.config.json'), JSON.stringify(config), 'utf8');
+
+    await expect(loadConfig(undefined, tempDir)).rejects.toThrow(/Invalid config/);
+  });
+
+  it('rejects configs with outDir', async () => {
+    const configDir = path.join(tempDir, '.config');
+    await mkdir(configDir, { recursive: true });
+    const config = {
+      outDir: '../tmp',
+      dev: { allowlist: [] },
+      prod: { allowlist: [] },
+    };
+    await writeFile(path.join(configDir, 'audit-deps.config.json'), JSON.stringify(config), 'utf8');
+
+    await expect(loadConfig(undefined, tempDir)).rejects.toThrow(/Invalid config/);
+  });
+
   it('accepts a custom config path', async () => {
     const config = {
       dev: { allowlist: [] },
@@ -67,6 +102,7 @@ describe(loadConfig, () => {
     const result = await loadConfig(customPath, tempDir);
     expect(result.config.dev.allowlist).toStrictEqual([]);
     expect(result.configFilePath).toBe(customPath);
+    expect(result.configSource).toBe('file');
   });
 
   it('loads a config with empty allowlists', async () => {
@@ -82,5 +118,19 @@ describe(loadConfig, () => {
     const result = await loadConfig(undefined, tempDir);
     expect(result.config.dev.allowlist).toStrictEqual([]);
     expect(result.config.prod.allowlist).toStrictEqual([]);
+  });
+
+  it('accepts a config with $schema field', async () => {
+    const configDir = path.join(tempDir, '.config');
+    await mkdir(configDir, { recursive: true });
+    const config = {
+      $schema: 'https://example.com/schema.json',
+      dev: { allowlist: [] },
+      prod: { allowlist: [] },
+    };
+    await writeFile(path.join(configDir, 'audit-deps.config.json'), JSON.stringify(config), 'utf8');
+
+    const result = await loadConfig(undefined, tempDir);
+    expect(result.config.$schema).toBe('https://example.com/schema.json');
   });
 });

--- a/packages/audit-deps/__tests__/generate.test.ts
+++ b/packages/audit-deps/__tests__/generate.test.ts
@@ -14,7 +14,7 @@ describe(buildFlatConfig, () => {
         { id: 'GHSA-1234', path: 'lodash', url: 'https://example.com/1' },
         { id: 'GHSA-5678', path: 'express', url: 'https://example.com/2' },
       ],
-      moderate: true,
+      severityThreshold: 'moderate',
     };
 
     const flat = buildFlatConfig(scopeConfig);
@@ -24,19 +24,30 @@ describe(buildFlatConfig, () => {
   });
 
   it('produces an empty allowlist when the source has no entries', () => {
-    const scopeConfig: ScopeConfig = { allowlist: [], high: true };
+    const scopeConfig: ScopeConfig = { allowlist: [], severityThreshold: 'high' };
     const flat = buildFlatConfig(scopeConfig);
     expect(flat.allowlist).toStrictEqual([]);
     expect(flat.high).toBe(true);
   });
 
-  it('omits severity fields that are not set', () => {
+  it('omits severity keys when severityThreshold is undefined', () => {
     const scopeConfig: ScopeConfig = { allowlist: [] };
     const flat = buildFlatConfig(scopeConfig);
     expect(flat).not.toHaveProperty('moderate');
     expect(flat).not.toHaveProperty('high');
     expect(flat).not.toHaveProperty('critical');
     expect(flat).not.toHaveProperty('low');
+  });
+
+  it.each([
+    { threshold: 'low' as const, expectedKey: 'low' },
+    { threshold: 'moderate' as const, expectedKey: 'moderate' },
+    { threshold: 'high' as const, expectedKey: 'high' },
+    { threshold: 'critical' as const, expectedKey: 'critical' },
+  ])('translates severityThreshold "$threshold" to { $expectedKey: true }', ({ threshold, expectedKey }) => {
+    const scopeConfig: ScopeConfig = { allowlist: [], severityThreshold: threshold };
+    const flat = buildFlatConfig(scopeConfig);
+    expect(flat[expectedKey]).toBe(true);
   });
 });
 
@@ -52,8 +63,8 @@ describe(generateAuditCiConfig, () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it('writes the flat config file to the config directory by default', async () => {
-    const scopeConfig: ScopeConfig = { allowlist: [], moderate: true };
+  it('writes the flat config file to the output directory', async () => {
+    const scopeConfig: ScopeConfig = { allowlist: [], severityThreshold: 'moderate' };
     const outputPath = await generateAuditCiConfig(scopeConfig, 'dev', tempDir);
 
     expect(outputPath).toBe(path.join(tempDir, 'audit-ci.dev.json'));
@@ -62,21 +73,10 @@ describe(generateAuditCiConfig, () => {
     expect(content).toHaveProperty('moderate', true);
   });
 
-  it('resolves outDir relative to config directory', async () => {
-    const scopeConfig: ScopeConfig = { allowlist: [], high: true };
-    const outputPath = await generateAuditCiConfig(scopeConfig, 'prod', tempDir, '../tmp');
-
-    const expected = path.resolve(tempDir, '../tmp', 'audit-ci.prod.json');
-    expect(outputPath).toBe(expected);
-
-    const content: unknown = JSON.parse(await readFile(outputPath, 'utf8'));
-    expect(content).toHaveProperty('high', true);
-  });
-
-  it('round-trips: load config values appear in generated JSON', async () => {
+  it('round-trips: config values appear in generated JSON', async () => {
     const scopeConfig: ScopeConfig = {
       allowlist: [{ id: 'GHSA-abcd', path: 'pkg', url: 'https://example.com' }],
-      critical: true,
+      severityThreshold: 'critical',
     };
     const outputPath = await generateAuditCiConfig(scopeConfig, 'dev', tempDir);
     const content: unknown = JSON.parse(await readFile(outputPath, 'utf8'));

--- a/packages/audit-deps/__tests__/generate.test.ts
+++ b/packages/audit-deps/__tests__/generate.test.ts
@@ -17,7 +17,7 @@ describe(buildFlatConfig, () => {
       severityThreshold: 'moderate',
     };
 
-    const flat = buildFlatConfig(scopeConfig);
+    const flat = buildFlatConfig(scopeConfig, 'prod');
     expect(flat.allowlist).toStrictEqual(['GHSA-1234', 'GHSA-5678']);
     expect(flat.moderate).toBe(true);
     expect(flat['show-not-found']).toBe(true);
@@ -25,14 +25,14 @@ describe(buildFlatConfig, () => {
 
   it('produces an empty allowlist when the source has no entries', () => {
     const scopeConfig: ScopeConfig = { allowlist: [], severityThreshold: 'high' };
-    const flat = buildFlatConfig(scopeConfig);
+    const flat = buildFlatConfig(scopeConfig, 'dev');
     expect(flat.allowlist).toStrictEqual([]);
     expect(flat.high).toBe(true);
   });
 
   it('omits severity keys when severityThreshold is undefined', () => {
     const scopeConfig: ScopeConfig = { allowlist: [] };
-    const flat = buildFlatConfig(scopeConfig);
+    const flat = buildFlatConfig(scopeConfig, 'dev');
     expect(flat).not.toHaveProperty('moderate');
     expect(flat).not.toHaveProperty('high');
     expect(flat).not.toHaveProperty('critical');
@@ -46,8 +46,20 @@ describe(buildFlatConfig, () => {
     { threshold: 'critical' as const, expectedKey: 'critical' },
   ])('translates severityThreshold "$threshold" to { $expectedKey: true }', ({ threshold, expectedKey }) => {
     const scopeConfig: ScopeConfig = { allowlist: [], severityThreshold: threshold };
-    const flat = buildFlatConfig(scopeConfig);
+    const flat = buildFlatConfig(scopeConfig, 'dev');
     expect(flat[expectedKey]).toBe(true);
+  });
+
+  it('adds skip-dev for prod scope', () => {
+    const flat = buildFlatConfig({ allowlist: [] }, 'prod');
+    expect(flat['skip-dev']).toBe(true);
+    expect(flat).not.toHaveProperty('extra-args');
+  });
+
+  it('adds extra-args ["--dev"] for dev scope', () => {
+    const flat = buildFlatConfig({ allowlist: [] }, 'dev');
+    expect(flat['extra-args']).toStrictEqual(['--dev']);
+    expect(flat).not.toHaveProperty('skip-dev');
   });
 });
 

--- a/packages/audit-deps/__tests__/init.test.ts
+++ b/packages/audit-deps/__tests__/init.test.ts
@@ -32,8 +32,8 @@ describe(scaffoldConfig, () => {
 
     const content: unknown = JSON.parse(readFileSync(configPath, 'utf8'));
     expect(content).toHaveProperty('$schema');
-    expect(content).toHaveProperty('dev.severityThreshold', 'high');
-    expect(content).toHaveProperty('prod.severityThreshold', 'moderate');
+    expect(content).toHaveProperty('dev.severityThreshold', 'moderate');
+    expect(content).toHaveProperty('prod.severityThreshold', 'low');
     expect(content).toHaveProperty('dev.allowlist');
     expect(content).toHaveProperty('prod.allowlist');
   });

--- a/packages/audit-deps/__tests__/init.test.ts
+++ b/packages/audit-deps/__tests__/init.test.ts
@@ -23,7 +23,7 @@ describe(scaffoldConfig, () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('creates config file with expected template content', () => {
+  it('creates config file with severityThreshold and $schema', () => {
     const result = scaffoldConfig({ dryRun: false, force: false });
 
     expect(result.configResult.outcome).toBe('created');
@@ -31,6 +31,9 @@ describe(scaffoldConfig, () => {
     expect(existsSync(configPath)).toBe(true);
 
     const content: unknown = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(content).toHaveProperty('$schema');
+    expect(content).toHaveProperty('dev.severityThreshold', 'high');
+    expect(content).toHaveProperty('prod.severityThreshold', 'moderate');
     expect(content).toHaveProperty('dev.allowlist');
     expect(content).toHaveProperty('prod.allowlist');
   });
@@ -57,8 +60,8 @@ describe(scaffoldConfig, () => {
     expect(result.configResult.outcome).toBe('overwritten');
 
     const content = JSON.parse(readFileSync(configPath, 'utf8'));
-    expect(content).toHaveProperty('dev');
-    expect(content).toHaveProperty('prod');
+    expect(content).toHaveProperty('dev.severityThreshold');
+    expect(content).toHaveProperty('prod.severityThreshold');
   });
 
   it('returns created outcome without writing in dry-run mode', () => {
@@ -109,5 +112,17 @@ describe(initCommand, () => {
 
     const exitCode = initCommand({ dryRun: false, force: false });
     expect(exitCode).toBe(0);
+  });
+
+  it('does not mention generate in next-steps output', () => {
+    const consoleOutput: string[] = [];
+    vi.spyOn(console, 'info').mockImplementation((...args: unknown[]) => {
+      consoleOutput.push(args.map(String).join(' '));
+    });
+
+    initCommand({ dryRun: false, force: false });
+
+    const fullOutput = consoleOutput.join('\n');
+    expect(fullOutput).not.toContain('generate');
   });
 });

--- a/packages/audit-deps/__tests__/integration.test.ts
+++ b/packages/audit-deps/__tests__/integration.test.ts
@@ -1,11 +1,9 @@
-import { existsSync } from 'node:fs';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { routeCommand } from '../src/bin/route.ts';
 import { loadConfig } from '../src/config.ts';
 import { generateAuditCiConfig } from '../src/generate.ts';
 import { buildUpdatedConfig, computeSyncDiff, serializeConfig } from '../src/sync.ts';
@@ -14,14 +12,11 @@ import type { AuditDepsConfig, AuditResult } from '../src/types.ts';
 describe('integration: generate -> sync cycle', () => {
   let tempDir: string;
   let configDir: string;
-  let outDir: string;
 
   beforeEach(async () => {
     tempDir = path.join(tmpdir(), `audit-deps-integration-${Date.now()}`);
     configDir = path.join(tempDir, '.config');
-    outDir = path.join(tempDir, 'tmp');
     await mkdir(configDir, { recursive: true });
-    await mkdir(outDir, { recursive: true });
   });
 
   afterEach(async () => {
@@ -29,42 +24,43 @@ describe('integration: generate -> sync cycle', () => {
   });
 
   it('generates flat configs, then syncs allowlist based on audit results', async () => {
-    // Step 1: Write initial config
+    // Write initial config with new schema
     const initialConfig: AuditDepsConfig = {
-      outDir: '../tmp',
-      dev: { moderate: true, allowlist: [] },
+      dev: { severityThreshold: 'high', allowlist: [] },
       prod: {
-        high: true,
+        severityThreshold: 'moderate',
         allowlist: [{ id: 'GHSA-stale', path: 'old-pkg', reason: 'will be removed', url: 'https://example.com/stale' }],
       },
     };
     const configFilePath = path.join(configDir, 'audit-deps.config.json');
     await writeFile(configFilePath, JSON.stringify(initialConfig, null, 2), 'utf8');
 
-    // Step 2: Load and validate config
+    // Load and validate config
     const loaded = await loadConfig(configFilePath, tempDir);
     expect(loaded.config.prod.allowlist).toHaveLength(1);
 
-    // Step 3: Generate flat audit-ci configs
-    const devPath = await generateAuditCiConfig(loaded.config.dev, 'dev', configDir, loaded.config.outDir);
-    const prodPath = await generateAuditCiConfig(loaded.config.prod, 'prod', configDir, loaded.config.outDir);
+    // Generate flat audit-ci configs to a temp output dir
+    const outputDir = path.join(tempDir, 'tmp');
+    await mkdir(outputDir, { recursive: true });
+    const devPath = await generateAuditCiConfig(loaded.config.dev, 'dev', outputDir);
+    const prodPath = await generateAuditCiConfig(loaded.config.prod, 'prod', outputDir);
 
-    expect(devPath).toBe(path.join(outDir, 'audit-ci.dev.json'));
-    expect(prodPath).toBe(path.join(outDir, 'audit-ci.prod.json'));
+    expect(devPath).toBe(path.join(outputDir, 'audit-ci.dev.json'));
+    expect(prodPath).toBe(path.join(outputDir, 'audit-ci.prod.json'));
 
-    // Verify generated content
+    // Verify generated content uses severity threshold translation
     const devContent: unknown = JSON.parse(await readFile(devPath, 'utf8'));
-    expect(devContent).toHaveProperty('moderate', true);
+    expect(devContent).toHaveProperty('high', true);
     expect(devContent).toHaveProperty('allowlist', []);
 
     const prodContent: unknown = JSON.parse(await readFile(prodPath, 'utf8'));
-    expect(prodContent).toHaveProperty('high', true);
+    expect(prodContent).toHaveProperty('moderate', true);
     expect(prodContent).toHaveProperty('allowlist', ['GHSA-stale']);
 
-    // Step 4: Simulate audit results (mocking audit-ci output)
+    // Simulate audit results
     const prodAuditResults: AuditResult[] = [{ id: 'GHSA-new1', path: 'new-pkg', url: 'https://example.com/new1' }];
 
-    // Step 5: Sync the prod allowlist
+    // Sync the prod allowlist
     const fixedDate = new Date('2025-06-15T00:00:00Z');
     const { added, kept, removed } = computeSyncDiff(loaded.config.prod.allowlist, prodAuditResults, fixedDate);
 
@@ -74,23 +70,18 @@ describe('integration: generate -> sync cycle', () => {
     expect(removed[0]?.id).toBe('GHSA-stale');
     expect(kept).toHaveLength(0);
 
-    // Step 6: Build and write updated config
+    // Build and write updated config
     const updatedConfig = buildUpdatedConfig(loaded.config, 'prod', [...kept, ...added]);
     await writeFile(configFilePath, serializeConfig(updatedConfig), 'utf8');
 
-    // Step 7: Verify persisted config
+    // Verify persisted config
     const reloaded = await loadConfig(configFilePath, tempDir);
     expect(reloaded.config.prod.allowlist).toHaveLength(1);
     expect(reloaded.config.prod.allowlist[0]?.id).toBe('GHSA-new1');
     expect(reloaded.config.prod.allowlist[0]?.reason).toBe('Added by audit-deps sync on 2025-06-15');
 
-    // Step 8: Regenerate and verify updated flat config
-    const updatedProdPath = await generateAuditCiConfig(
-      reloaded.config.prod,
-      'prod',
-      path.dirname(configFilePath),
-      reloaded.config.outDir,
-    );
+    // Regenerate and verify updated flat config
+    const updatedProdPath = await generateAuditCiConfig(reloaded.config.prod, 'prod', outputDir);
     const updatedProdContent: unknown = JSON.parse(await readFile(updatedProdPath, 'utf8'));
     expect(updatedProdContent).toHaveProperty('allowlist', ['GHSA-new1']);
   });
@@ -101,7 +92,6 @@ describe('integration: generate -> sync cycle', () => {
     await mkdir(customConfigDir, { recursive: true });
 
     const config: AuditDepsConfig = {
-      outDir: './out',
       dev: { allowlist: [] },
       prod: { allowlist: [] },
     };
@@ -111,40 +101,20 @@ describe('integration: generate -> sync cycle', () => {
     expect(loaded.configFilePath).toBe(customConfigPath);
     expect(loaded.configDir).toBe(customConfigDir);
 
-    const devPath = await generateAuditCiConfig(loaded.config.dev, 'dev', customConfigDir, loaded.config.outDir);
-    expect(devPath).toBe(path.join(customConfigDir, 'out', 'audit-ci.dev.json'));
+    const devPath = await generateAuditCiConfig(loaded.config.dev, 'dev', customConfigDir);
+    expect(devPath).toBe(path.join(customConfigDir, 'audit-ci.dev.json'));
 
     const content: unknown = JSON.parse(await readFile(devPath, 'utf8'));
     expect(content).toHaveProperty('allowlist', []);
   });
-});
 
-describe('integration: --config flag via routeCommand', () => {
-  let tempDir: string;
+  it('returns defaults when no config file exists', async () => {
+    const emptyDir = path.join(tempDir, 'empty-project');
+    await mkdir(emptyDir, { recursive: true });
 
-  beforeEach(async () => {
-    tempDir = path.join(tmpdir(), `audit-deps-config-flag-${Date.now()}`);
-    await mkdir(tempDir, { recursive: true });
-  });
-
-  afterEach(async () => {
-    await rm(tempDir, { recursive: true, force: true });
-  });
-
-  it('generates config files at the expected outDir when --config is passed', async () => {
-    const customConfigPath = path.join(tempDir, 'my-audit-deps.json');
-    const config: AuditDepsConfig = {
-      outDir: './generated',
-      dev: { allowlist: [] },
-      prod: { allowlist: [] },
-    };
-    await writeFile(customConfigPath, JSON.stringify(config, null, 2), 'utf8');
-
-    await routeCommand(['generate', '--config', customConfigPath]);
-
-    const expectedDevPath = path.join(tempDir, 'generated', 'audit-ci.dev.json');
-    const expectedProdPath = path.join(tempDir, 'generated', 'audit-ci.prod.json');
-    expect(existsSync(expectedDevPath)).toBe(true);
-    expect(existsSync(expectedProdPath)).toBe(true);
+    const result = await loadConfig(undefined, emptyDir);
+    expect(result.configSource).toBe('defaults');
+    expect(result.config.dev.severityThreshold).toBe('high');
+    expect(result.config.prod.severityThreshold).toBe('moderate');
   });
 });

--- a/packages/audit-deps/__tests__/integration.test.ts
+++ b/packages/audit-deps/__tests__/integration.test.ts
@@ -114,7 +114,7 @@ describe('integration: generate -> sync cycle', () => {
 
     const result = await loadConfig(undefined, emptyDir);
     expect(result.configSource).toBe('defaults');
-    expect(result.config.dev.severityThreshold).toBe('high');
-    expect(result.config.prod.severityThreshold).toBe('moderate');
+    expect(result.config.dev.severityThreshold).toBe('moderate');
+    expect(result.config.prod.severityThreshold).toBe('low');
   });
 });

--- a/packages/audit-deps/__tests__/route.test.ts
+++ b/packages/audit-deps/__tests__/route.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../src/cli.ts', () => ({
   auditCommand: vi.fn().mockResolvedValue(0),
   checkCommand: vi.fn().mockResolvedValue(0),
-  generateCommand: vi.fn().mockResolvedValue(0),
+  extractMessage: vi.fn((e: unknown) => (e instanceof Error ? e.message : String(e))),
   syncCommand: vi.fn().mockResolvedValue(0),
 }));
 
@@ -12,7 +12,7 @@ vi.mock('../src/init/initCommand.ts', () => ({
 }));
 
 import { routeCommand } from '../src/bin/route.ts';
-import { auditCommand, checkCommand, generateCommand, syncCommand } from '../src/cli.ts';
+import { auditCommand, checkCommand, syncCommand } from '../src/cli.ts';
 import { initCommand } from '../src/init/initCommand.ts';
 
 describe(routeCommand, () => {
@@ -64,6 +64,11 @@ describe(routeCommand, () => {
     expect(exitCode).toBe(1);
   });
 
+  it('returns 1 for "generate" (removed subcommand)', async () => {
+    const exitCode = await routeCommand(['generate']);
+    expect(exitCode).toBe(1);
+  });
+
   it('dispatches "sync" to syncCommand', async () => {
     await routeCommand(['sync']);
     expect(syncCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: [] }));
@@ -72,11 +77,6 @@ describe(routeCommand, () => {
   it('dispatches "sync --dev" with scopes ["dev"]', async () => {
     await routeCommand(['sync', '--dev']);
     expect(syncCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['dev'] }));
-  });
-
-  it('dispatches "generate" to generateCommand', async () => {
-    await routeCommand(['generate']);
-    expect(generateCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: [] }));
   });
 
   it('dispatches "init" to initCommand', async () => {

--- a/packages/audit-deps/__tests__/sync.test.ts
+++ b/packages/audit-deps/__tests__/sync.test.ts
@@ -117,8 +117,8 @@ describe(computeSyncDiff, () => {
 describe(buildUpdatedConfig, () => {
   it('replaces the allowlist for the given scope, sorted by ID', () => {
     const config: AuditDepsConfig = {
-      dev: { allowlist: [], moderate: true },
-      prod: { allowlist: [], high: true },
+      dev: { allowlist: [], severityThreshold: 'high' },
+      prod: { allowlist: [], severityThreshold: 'moderate' },
     };
 
     const entries: AllowlistEntry[] = [
@@ -138,12 +138,12 @@ describe(serializeConfig, () => {
     const config: AuditDepsConfig = {
       dev: {
         allowlist: [{ addedAt: '2026-04-01', id: '1001', path: 'lodash', reason: 'test', url: 'https://example.com' }],
+        severityThreshold: 'high',
       },
       prod: { allowlist: [] },
     };
 
     const json = serializeConfig(config);
-    // Re-parse through the typed loader to verify key order in raw JSON
     const devMatch = json.match(/"allowlist":\s*\[\s*\{([^}]+)\}/);
     const keyOrder = devMatch?.[1]?.match(/"(\w+)":/g)?.map((k) => k.replace(/"/g, '').replace(':', ''));
     expect(keyOrder).toStrictEqual(['addedAt', 'id', 'path', 'reason', 'url']);
@@ -178,6 +178,39 @@ describe(serializeConfig, () => {
     expect(keyOrder).toStrictEqual(['id', 'path', 'url']);
     expect(json).not.toContain('"reason"');
   });
+
+  it('includes $schema in serialized output when present', () => {
+    const config: AuditDepsConfig = {
+      $schema: 'https://example.com/schema.json',
+      dev: { allowlist: [] },
+      prod: { allowlist: [] },
+    };
+
+    const json = serializeConfig(config);
+    expect(json).toContain('"$schema": "https://example.com/schema.json"');
+  });
+
+  it('omits $schema when not present', () => {
+    const config: AuditDepsConfig = {
+      dev: { allowlist: [] },
+      prod: { allowlist: [] },
+    };
+
+    const json = serializeConfig(config);
+    expect(json).not.toContain('$schema');
+  });
+
+  it('includes severityThreshold in serialized output', () => {
+    const config: AuditDepsConfig = {
+      dev: { allowlist: [], severityThreshold: 'high' },
+      prod: { allowlist: [], severityThreshold: 'moderate' },
+    };
+
+    const json = serializeConfig(config);
+    const parsed: unknown = JSON.parse(json);
+    expect(parsed).toHaveProperty('dev.severityThreshold', 'high');
+    expect(parsed).toHaveProperty('prod.severityThreshold', 'moderate');
+  });
 });
 
 describe(formatUtcDate, () => {
@@ -186,7 +219,6 @@ describe(formatUtcDate, () => {
   });
 
   it('returns the UTC date regardless of the local timezone portion of the ISO string', () => {
-    // This date in PST is 2026-04-14, but UTC is 2026-04-15.
     expect(formatUtcDate(new Date('2026-04-15T03:00:00Z'))).toBe('2026-04-15');
   });
 });
@@ -205,7 +237,7 @@ describe(syncAllowlist, () => {
 
   it('writes updated config to disk after sync', async () => {
     const config: AuditDepsConfig = {
-      dev: { allowlist: [], moderate: true },
+      dev: { allowlist: [], severityThreshold: 'high' },
       prod: { allowlist: [] },
     };
     const configPath = path.join(tempDir, 'config.json');
@@ -221,5 +253,6 @@ describe(syncAllowlist, () => {
     const written: unknown = JSON.parse(await readFile(configPath, 'utf8'));
     expect(written).toHaveProperty('dev.allowlist.length', 1);
     expect(written).toHaveProperty('dev.allowlist[0].id', '1001');
+    expect(written).toHaveProperty('dev.severityThreshold', 'high');
   });
 });

--- a/packages/audit-deps/__tests__/tmp.test.ts
+++ b/packages/audit-deps/__tests__/tmp.test.ts
@@ -1,0 +1,51 @@
+import { existsSync, statSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { withTempDir } from '../src/tmp.ts';
+
+describe(withTempDir, () => {
+  it('provides a directory that exists during the callback', async () => {
+    let capturedDir = '';
+
+    await withTempDir((dir) => {
+      capturedDir = dir;
+      expect(existsSync(dir)).toBe(true);
+      expect(statSync(dir).isDirectory()).toBe(true);
+      return Promise.resolve();
+    });
+
+    expect(capturedDir.length).toBeGreaterThan(0);
+  });
+
+  it('cleans up the directory after the callback completes', async () => {
+    let capturedDir = '';
+
+    await withTempDir(async (dir) => {
+      capturedDir = dir;
+      await writeFile(path.join(dir, 'test.txt'), 'hello', 'utf8');
+    });
+
+    expect(existsSync(capturedDir)).toBe(false);
+  });
+
+  it('cleans up the directory when the callback throws', async () => {
+    let capturedDir = '';
+
+    await expect(
+      withTempDir((dir) => {
+        capturedDir = dir;
+        throw new Error('intentional');
+      }),
+    ).rejects.toThrow('intentional');
+
+    expect(existsSync(capturedDir)).toBe(false);
+  });
+
+  it('returns the value from the callback', async () => {
+    const result = await withTempDir(() => Promise.resolve(42));
+    expect(result).toBe(42);
+  });
+});

--- a/packages/audit-deps/schemas/config.json
+++ b/packages/audit-deps/schemas/config.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "audit-deps configuration",
+  "description": "Configuration file for @williamthorsen/audit-deps. Controls severity thresholds and allowlists for dependency vulnerability auditing.",
+  "type": "object",
+  "required": ["dev", "prod"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference for editor support."
+    },
+    "dev": {
+      "$ref": "#/$defs/scopeConfig",
+      "description": "Configuration for development dependency auditing."
+    },
+    "prod": {
+      "$ref": "#/$defs/scopeConfig",
+      "description": "Configuration for production dependency auditing."
+    }
+  },
+  "not": {
+    "anyOf": [
+      { "required": ["outDir"] },
+      {
+        "properties": {
+          "dev": {
+            "anyOf": [
+              { "required": ["critical"] },
+              { "required": ["high"] },
+              { "required": ["low"] },
+              { "required": ["moderate"] }
+            ]
+          }
+        }
+      },
+      {
+        "properties": {
+          "prod": {
+            "anyOf": [
+              { "required": ["critical"] },
+              { "required": ["high"] },
+              { "required": ["low"] },
+              { "required": ["moderate"] }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "$defs": {
+    "allowlistEntry": {
+      "type": "object",
+      "description": "A single allowlisted advisory with metadata for traceability.",
+      "required": ["id", "path", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "addedAt": {
+          "type": "string",
+          "description": "ISO date (YYYY-MM-DD) when the entry was added. Populated automatically by `audit-deps sync`."
+        },
+        "id": {
+          "type": "string",
+          "description": "Advisory identifier (e.g., GHSA-xxxx-xxxx-xxxx)."
+        },
+        "path": {
+          "type": "string",
+          "description": "Dependency path where the vulnerability was found."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Explanation for why this advisory is allowlisted."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL to the advisory detail page."
+        }
+      }
+    },
+    "scopeConfig": {
+      "type": "object",
+      "description": "Configuration for a single audit scope (dev or prod).",
+      "required": ["allowlist"],
+      "additionalProperties": false,
+      "properties": {
+        "allowlist": {
+          "type": "array",
+          "description": "Advisories that are accepted and should not cause audit failure.",
+          "items": { "$ref": "#/$defs/allowlistEntry" }
+        },
+        "severityThreshold": {
+          "type": "string",
+          "description": "Fail on advisories at or above this severity level.",
+          "enum": ["critical", "high", "low", "moderate"]
+        }
+      }
+    }
+  }
+}

--- a/packages/audit-deps/src/bin/route.ts
+++ b/packages/audit-deps/src/bin/route.ts
@@ -2,12 +2,12 @@ import process from 'node:process';
 
 import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
 
-import { auditCommand, checkCommand, extractMessage, generateCommand, syncCommand } from '../cli.ts';
+import { auditCommand, checkCommand, extractMessage, syncCommand } from '../cli.ts';
 import { initCommand } from '../init/initCommand.ts';
 import type { AuditScope, CommandOptions } from '../types.ts';
 import { VERSION } from '../version.ts';
 
-const SUBCOMMANDS = ['generate', 'init', 'sync'];
+const SUBCOMMANDS = ['init', 'sync'];
 const MIN_PREFIX_LENGTH = 3;
 
 function showHelp(): void {
@@ -18,7 +18,6 @@ Usage: audit-deps [options]
 Commands:
   (default)            Grouped vulnerability check with severity indicators
   sync                 Synchronize allowlists with current audit findings
-  generate             Regenerate flat audit-ci config files
   init                 Scaffold a starter config file
 
 Scope options:
@@ -61,22 +60,6 @@ Scope options:
 Other options:
   --config <path>    Path to config file (default: .config/audit-deps.config.json)
   --json             Output results as JSON
-  --help, -h         Show this help message
-`);
-}
-
-function showGenerateHelp(): void {
-  console.info(`
-Usage: audit-deps generate [options]
-
-Regenerate flat audit-ci config files.
-
-Scope options:
-  --dev              Target dev dependencies only
-  --prod             Target production dependencies only
-
-Other options:
-  --config <path>    Path to config file (default: .config/audit-deps.config.json)
   --help, -h         Show this help message
 `);
 }
@@ -146,10 +129,6 @@ export async function routeCommand(args: string[]): Promise<number> {
 
   if (command === 'sync') {
     return handleSubcommand(args.slice(1), syncCommand, showSyncHelp);
-  }
-
-  if (command === 'generate') {
-    return handleSubcommand(args.slice(1), generateCommand, showGenerateHelp);
   }
 
   // Check for typos before falling through to the default command

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -1,5 +1,8 @@
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
 import process from 'node:process';
 
+import type { LoadConfigResult } from './config.ts';
 import { loadConfig } from './config.ts';
 import type { AllowedVuln, CheckResult, ScopeCheckResult } from './format-check.ts';
 import { formatCheckJson, formatCheckText } from './format-check.ts';
@@ -7,7 +10,8 @@ import { formatCheckVerboseText } from './format-verbose.ts';
 import { generateAuditCiConfig } from './generate.ts';
 import { parseAuditCiOutput, runAudit, runReport } from './run-audit.ts';
 import { syncAllowlist } from './sync.ts';
-import type { AllowlistEntry, AuditDepsConfig, AuditResult, AuditScope, CommandOptions, ScopeConfig } from './types.ts';
+import { withTempDir } from './tmp.ts';
+import type { AllowlistEntry, AuditResult, AuditScope, CommandOptions } from './types.ts';
 import { AUDIT_SCOPES } from './types.ts';
 
 /** Extract a displayable message from an unknown thrown value. */
@@ -21,58 +25,64 @@ export function extractMessage(error: unknown): string {
  * Generates config, invokes audit-ci for each scope, and returns a combined exit code.
  */
 export async function auditCommand(options: CommandOptions): Promise<number> {
-  const loaded = await loadAndGenerate(options);
-  if (loaded === undefined) return 1;
+  let loaded: LoadConfigResult;
+  try {
+    loaded = await loadConfig(options.configPath);
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    return 1;
+  }
 
-  const { scopes, generatedPaths } = loaded;
-  let exitCode = 0;
-  const allResults: AuditResult[] = [];
+  const { config } = loaded;
+  const scopes = options.scopes.length > 0 ? options.scopes : [...AUDIT_SCOPES];
 
-  for (const scope of scopes) {
-    const configPath = generatedPaths.get(scope);
-    if (configPath === undefined) continue;
+  return withTempDir(async (tempDir) => {
+    let exitCode = 0;
+    const allResults: AuditResult[] = [];
 
-    const result = runAudit({ configPath, json: options.json });
+    for (const scope of scopes) {
+      const configPath = await generateAuditCiConfig(config[scope], scope, tempDir);
 
-    for (const warning of result.warnings) {
-      process.stderr.write(`warning: ${warning}\n`);
-    }
+      const result = runAudit({ configPath, json: options.json });
 
-    if (result.staleEntries.length > 0) {
-      process.stderr.write(`warning: stale allowlist entries in ${scope}: ${result.staleEntries.join(', ')}\n`);
+      for (const warning of result.warnings) {
+        process.stderr.write(`warning: ${warning}\n`);
+      }
+
+      if (result.staleEntries.length > 0) {
+        process.stderr.write(`warning: stale allowlist entries in ${scope}: ${result.staleEntries.join(', ')}\n`);
+      }
+
+      if (options.json) {
+        const parsed = parseAuditCiOutput(result.stdout);
+        for (const warning of parsed.warnings) {
+          process.stderr.write(`warning: ${warning}\n`);
+        }
+        for (const r of parsed.results) {
+          if (!allResults.some((existing) => existing.id === r.id)) {
+            allResults.push(r);
+          }
+        }
+      } else {
+        if (result.stdout.length > 0) {
+          process.stdout.write(result.stdout);
+        }
+        if (result.stderr.length > 0) {
+          process.stderr.write(result.stderr);
+        }
+      }
+
+      if (result.exitCode !== 0) {
+        exitCode = result.exitCode;
+      }
     }
 
     if (options.json) {
-      // Collect parsed results for cross-scope deduplication
-      const parsed = parseAuditCiOutput(result.stdout);
-      for (const warning of parsed.warnings) {
-        process.stderr.write(`warning: ${warning}\n`);
-      }
-      for (const r of parsed.results) {
-        if (!allResults.some((existing) => existing.id === r.id)) {
-          allResults.push(r);
-        }
-      }
-    } else {
-      // Text mode: forward both stdout and stderr independently
-      if (result.stdout.length > 0) {
-        process.stdout.write(result.stdout);
-      }
-      if (result.stderr.length > 0) {
-        process.stderr.write(result.stderr);
-      }
+      process.stdout.write(JSON.stringify(allResults, null, 2) + '\n');
     }
 
-    if (result.exitCode !== 0) {
-      exitCode = result.exitCode;
-    }
-  }
-
-  if (options.json) {
-    process.stdout.write(JSON.stringify(allResults, null, 2) + '\n');
-  }
-
-  return exitCode;
+    return exitCode;
+  });
 }
 
 /** Scopes in display order: prod first, then dev. */
@@ -86,145 +96,135 @@ const CHECK_SCOPE_ORDER: readonly AuditScope[] = ['prod', 'dev'];
  * Returns 1 when unallowed vulnerabilities exist.
  */
 export async function checkCommand(options: CommandOptions): Promise<number> {
-  let config: AuditDepsConfig;
-  let configDir: string;
-
+  let loaded: LoadConfigResult;
   try {
-    ({ config, configDir } = await loadConfig(options.configPath));
+    loaded = await loadConfig(options.configPath);
   } catch (error: unknown) {
     process.stderr.write(`Error: ${extractMessage(error)}\n`);
     return 1;
   }
 
+  const { config } = loaded;
   const requestedScopes = options.scopes.length > 0 ? options.scopes : [...CHECK_SCOPE_ORDER];
-  // Ensure display order: prod first, then dev.
   const scopes = CHECK_SCOPE_ORDER.filter((s) => requestedScopes.includes(s));
 
-  const checkResult: CheckResult = {
-    dev: { allowed: [], stale: [], unallowed: [] },
-    prod: { allowed: [], stale: [], unallowed: [] },
-  };
+  return withTempDir(async (tempDir) => {
+    const checkResult: CheckResult = {
+      dev: { allowed: [], stale: [], unallowed: [] },
+      prod: { allowed: [], stale: [], unallowed: [] },
+    };
 
-  for (const scope of scopes) {
-    const scopeConfig = config[scope];
+    for (const scope of scopes) {
+      const scopeConfig = config[scope];
 
-    // Generate a stripped config (empty allowlist) so audit-ci reports all vulnerabilities.
-    const strippedScope = { ...scopeConfig, allowlist: [] };
-    const strippedConfigPath = await generateScopeConfig(strippedScope, scope, configDir, config.outDir);
+      // Generate a stripped config (empty allowlist) so audit-ci reports all vulnerabilities.
+      const strippedScope = { ...scopeConfig, allowlist: [] };
+      const strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, tempDir);
 
-    const reportOptions: { configPath: string; reportType?: 'full' } = { configPath: strippedConfigPath };
-    if (options.verbose) {
-      reportOptions.reportType = 'full';
-    }
-    const report = runReport(reportOptions);
-    for (const warning of report.warnings) {
-      process.stderr.write(`warning: ${warning}\n`);
-    }
-    if (report.stderr.length > 0) {
-      process.stderr.write(report.stderr);
-    }
-
-    const allowedIds = new Set(scopeConfig.allowlist.map((entry) => entry.id));
-    const foundIds = new Set(report.results.map((r) => r.id));
-    const allowlistById = new Map<string, AllowlistEntry>(scopeConfig.allowlist.map((entry) => [entry.id, entry]));
-    const scopeResult: ScopeCheckResult = { allowed: [], stale: [], unallowed: [] };
-
-    for (const result of report.results) {
-      if (allowedIds.has(result.id)) {
-        const entry = allowlistById.get(result.id);
-        scopeResult.allowed.push(buildAllowedVuln(result, entry));
-      } else {
-        scopeResult.unallowed.push(result);
+      const reportOptions: { configPath: string; reportType?: 'full' } = { configPath: strippedConfigPath };
+      if (options.verbose) {
+        reportOptions.reportType = 'full';
       }
-    }
-
-    // Detect stale allowlist entries: IDs in the allowlist but not in audit results.
-    for (const entry of scopeConfig.allowlist) {
-      if (!foundIds.has(entry.id)) {
-        scopeResult.stale.push({ id: entry.id });
+      const report = runReport(reportOptions);
+      for (const warning of report.warnings) {
+        process.stderr.write(`warning: ${warning}\n`);
       }
+      if (report.stderr.length > 0) {
+        process.stderr.write(report.stderr);
+      }
+
+      const allowedIds = new Set(scopeConfig.allowlist.map((entry) => entry.id));
+      const foundIds = new Set(report.results.map((r) => r.id));
+      const allowlistById = new Map<string, AllowlistEntry>(scopeConfig.allowlist.map((entry) => [entry.id, entry]));
+      const scopeResult: ScopeCheckResult = { allowed: [], stale: [], unallowed: [] };
+
+      for (const result of report.results) {
+        if (allowedIds.has(result.id)) {
+          const entry = allowlistById.get(result.id);
+          scopeResult.allowed.push(buildAllowedVuln(result, entry));
+        } else {
+          scopeResult.unallowed.push(result);
+        }
+      }
+
+      // Detect stale allowlist entries: IDs in the allowlist but not in audit results.
+      for (const entry of scopeConfig.allowlist) {
+        if (!foundIds.has(entry.id)) {
+          scopeResult.stale.push({ id: entry.id });
+        }
+      }
+
+      checkResult[scope] = scopeResult;
     }
 
-    checkResult[scope] = scopeResult;
-  }
+    if (options.verbose && !options.json) {
+      process.stdout.write(formatCheckVerboseText(checkResult, scopes));
+    } else if (options.json) {
+      process.stdout.write(formatCheckJson(checkResult, scopes));
+    } else {
+      process.stdout.write(formatCheckText(checkResult, scopes));
+    }
 
-  if (options.verbose && !options.json) {
-    process.stdout.write(formatCheckVerboseText(checkResult, scopes));
-  } else if (options.json) {
-    process.stdout.write(formatCheckJson(checkResult, scopes));
-  } else {
-    process.stdout.write(formatCheckText(checkResult, scopes));
-  }
-
-  const hasUnallowed = scopes.some((s) => checkResult[s].unallowed.length > 0);
-  return hasUnallowed ? 1 : 0;
+    const hasUnallowed = scopes.some((s) => checkResult[s].unallowed.length > 0);
+    return hasUnallowed ? 1 : 0;
+  });
 }
 
 /**
  * Run the `sync` subcommand.
  *
  * Audits each scope in report mode without allowlist filtering, then updates
- * the allowlist to match current findings. Uses a stripped config so audit-ci
- * reports ALL current vulnerabilities, not just un-allowlisted ones.
+ * the allowlist to match current findings. When no config file exists, creates
+ * one at the default path.
  */
 export async function syncCommand(options: CommandOptions): Promise<number> {
-  let config: AuditDepsConfig;
-  let configDir: string;
-  let configFilePath: string;
-
+  let loaded: LoadConfigResult;
   try {
-    ({ config, configDir, configFilePath } = await loadConfig(options.configPath));
+    loaded = await loadConfig(options.configPath);
   } catch (error: unknown) {
     process.stderr.write(`Error: ${extractMessage(error)}\n`);
     return 1;
   }
 
+  let { config } = loaded;
+  const { configFilePath, configSource } = loaded;
   const scopes = options.scopes.length > 0 ? options.scopes : [...AUDIT_SCOPES];
 
-  for (const scope of scopes) {
-    // Generate a config without the allowlist so sync sees all vulnerabilities
-    const strippedScope = { ...config[scope], allowlist: [] };
-    const strippedConfigPath = await generateScopeConfig(strippedScope, scope, configDir, config.outDir);
+  // Ensure the config directory exists when creating a new config from defaults.
+  if (configSource === 'defaults') {
+    await mkdir(path.dirname(configFilePath), { recursive: true });
+  }
 
-    const report = runReport({ configPath: strippedConfigPath });
-    for (const warning of report.warnings) {
-      process.stderr.write(`warning: ${warning}\n`);
+  return withTempDir(async (tempDir) => {
+    for (const scope of scopes) {
+      // Generate a config without the allowlist so sync sees all vulnerabilities.
+      const strippedScope = { ...config[scope], allowlist: [] };
+      const strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, tempDir);
+
+      const report = runReport({ configPath: strippedConfigPath });
+      for (const warning of report.warnings) {
+        process.stderr.write(`warning: ${warning}\n`);
+      }
+      const { syncResult, updatedConfig } = await syncAllowlist(config, scope, report.results, configFilePath);
+      config = updatedConfig;
+
+      if (options.json) {
+        process.stdout.write(JSON.stringify(syncResult, null, 2) + '\n');
+      } else {
+        process.stdout.write(`\n--- ${scope} ---\n`);
+        process.stdout.write(`  added: ${syncResult.added.length}\n`);
+        process.stdout.write(`  kept: ${syncResult.kept.length}\n`);
+        process.stdout.write(`  removed: ${syncResult.removed.length}\n`);
+      }
     }
-    const { syncResult, updatedConfig } = await syncAllowlist(config, scope, report.results, configFilePath);
-    config = updatedConfig;
 
-    if (options.json) {
-      process.stdout.write(JSON.stringify(syncResult, null, 2) + '\n');
-    } else {
-      process.stdout.write(`\n--- ${scope} ---\n`);
-      process.stdout.write(`  added: ${syncResult.added.length}\n`);
-      process.stdout.write(`  kept: ${syncResult.kept.length}\n`);
-      process.stdout.write(`  removed: ${syncResult.removed.length}\n`);
+    if (configSource === 'defaults') {
+      const totalEntries = config.dev.allowlist.length + config.prod.allowlist.length;
+      process.stderr.write(`Created config at ${configFilePath} with ${totalEntries} allowed entries.\n`);
     }
-  }
 
-  // Regenerate flat configs after sync
-  for (const scope of scopes) {
-    await generateScopeConfig(config[scope], scope, configDir, config.outDir);
-  }
-
-  return 0;
-}
-
-/**
- * Run the `generate` subcommand.
- *
- * Regenerates the flat audit-ci JSON config files for each scope.
- */
-export async function generateCommand(options: CommandOptions): Promise<number> {
-  const loaded = await loadAndGenerate(options);
-  if (loaded === undefined) return 1;
-
-  for (const [_scope, outputPath] of loaded.generatedPaths) {
-    process.stdout.write(`Generated: ${outputPath}\n`);
-  }
-
-  return 0;
+    return 0;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -246,50 +246,4 @@ function buildAllowedVuln(result: AuditResult, entry: AllowlistEntry | undefined
   if (entry?.reason !== undefined) allowed.reason = entry.reason;
   if (entry?.addedAt !== undefined) allowed.addedAt = entry.addedAt;
   return allowed;
-}
-
-/** Wrap `generateAuditCiConfig` with a scope-contextual error message. */
-async function generateScopeConfig(
-  scopeConfig: ScopeConfig,
-  scope: AuditScope,
-  configDir: string,
-  outDir: string | undefined,
-): Promise<string> {
-  try {
-    return await generateAuditCiConfig(scopeConfig, scope, configDir, outDir);
-  } catch (error: unknown) {
-    throw new Error(`Failed to generate config for scope '${scope}': ${extractMessage(error)}`);
-  }
-}
-
-interface LoadedState {
-  config: AuditDepsConfig;
-  configDir: string;
-  configFilePath: string;
-  generatedPaths: Map<AuditScope, string>;
-  scopes: AuditScope[];
-}
-
-/** Load config and generate flat audit-ci configs for the requested scopes. */
-async function loadAndGenerate(options: CommandOptions): Promise<LoadedState | undefined> {
-  let config: AuditDepsConfig;
-  let configDir: string;
-  let configFilePath: string;
-
-  try {
-    ({ config, configDir, configFilePath } = await loadConfig(options.configPath));
-  } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
-    return undefined;
-  }
-
-  const scopes = options.scopes.length > 0 ? options.scopes : [...AUDIT_SCOPES];
-  const generatedPaths = new Map<AuditScope, string>();
-
-  for (const scope of scopes) {
-    const outputPath = await generateScopeConfig(config[scope], scope, configDir, config.outDir);
-    generatedPaths.set(scope, outputPath);
-  }
-
-  return { config, configDir, configFilePath, generatedPaths, scopes };
 }

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -36,53 +36,58 @@ export async function auditCommand(options: CommandOptions): Promise<number> {
   const { config } = loaded;
   const scopes = options.scopes.length > 0 ? options.scopes : [...AUDIT_SCOPES];
 
-  return withTempDir(async (tempDir) => {
-    let exitCode = 0;
-    const allResults: AuditResult[] = [];
+  try {
+    return await withTempDir(async (tempDir) => {
+      let exitCode = 0;
+      const allResults: AuditResult[] = [];
 
-    for (const scope of scopes) {
-      const configPath = await generateAuditCiConfig(config[scope], scope, tempDir);
+      for (const scope of scopes) {
+        const configPath = await generateAuditCiConfig(config[scope], scope, tempDir);
 
-      const result = runAudit({ configPath, json: options.json });
+        const result = runAudit({ configPath, json: options.json });
 
-      for (const warning of result.warnings) {
-        process.stderr.write(`warning: ${warning}\n`);
-      }
+        for (const warning of result.warnings) {
+          process.stderr.write(`warning: ${warning}\n`);
+        }
 
-      if (result.staleEntries.length > 0) {
-        process.stderr.write(`warning: stale allowlist entries in ${scope}: ${result.staleEntries.join(', ')}\n`);
+        if (result.staleEntries.length > 0) {
+          process.stderr.write(`warning: stale allowlist entries in ${scope}: ${result.staleEntries.join(', ')}\n`);
+        }
+
+        if (options.json) {
+          const parsed = parseAuditCiOutput(result.stdout);
+          for (const warning of parsed.warnings) {
+            process.stderr.write(`warning: ${warning}\n`);
+          }
+          for (const r of parsed.results) {
+            if (!allResults.some((existing) => existing.id === r.id)) {
+              allResults.push(r);
+            }
+          }
+        } else {
+          if (result.stdout.length > 0) {
+            process.stdout.write(result.stdout);
+          }
+          if (result.stderr.length > 0) {
+            process.stderr.write(result.stderr);
+          }
+        }
+
+        if (result.exitCode !== 0) {
+          exitCode = result.exitCode;
+        }
       }
 
       if (options.json) {
-        const parsed = parseAuditCiOutput(result.stdout);
-        for (const warning of parsed.warnings) {
-          process.stderr.write(`warning: ${warning}\n`);
-        }
-        for (const r of parsed.results) {
-          if (!allResults.some((existing) => existing.id === r.id)) {
-            allResults.push(r);
-          }
-        }
-      } else {
-        if (result.stdout.length > 0) {
-          process.stdout.write(result.stdout);
-        }
-        if (result.stderr.length > 0) {
-          process.stderr.write(result.stderr);
-        }
+        process.stdout.write(JSON.stringify(allResults, null, 2) + '\n');
       }
 
-      if (result.exitCode !== 0) {
-        exitCode = result.exitCode;
-      }
-    }
-
-    if (options.json) {
-      process.stdout.write(JSON.stringify(allResults, null, 2) + '\n');
-    }
-
-    return exitCode;
-  });
+      return exitCode;
+    });
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    return 1;
+  }
 }
 
 /** Scopes in display order: prod first, then dev. */
@@ -108,66 +113,71 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
   const requestedScopes = options.scopes.length > 0 ? options.scopes : [...CHECK_SCOPE_ORDER];
   const scopes = CHECK_SCOPE_ORDER.filter((s) => requestedScopes.includes(s));
 
-  return withTempDir(async (tempDir) => {
-    const checkResult: CheckResult = {
-      dev: { allowed: [], stale: [], unallowed: [] },
-      prod: { allowed: [], stale: [], unallowed: [] },
-    };
+  try {
+    return await withTempDir(async (tempDir) => {
+      const checkResult: CheckResult = {
+        dev: { allowed: [], stale: [], unallowed: [] },
+        prod: { allowed: [], stale: [], unallowed: [] },
+      };
 
-    for (const scope of scopes) {
-      const scopeConfig = config[scope];
+      for (const scope of scopes) {
+        const scopeConfig = config[scope];
 
-      // Generate a stripped config (empty allowlist) so audit-ci reports all vulnerabilities.
-      const strippedScope = { ...scopeConfig, allowlist: [] };
-      const strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, tempDir);
+        // Generate a stripped config (empty allowlist) so audit-ci reports all vulnerabilities.
+        const strippedScope = { ...scopeConfig, allowlist: [] };
+        const strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, tempDir);
 
-      const reportOptions: { configPath: string; reportType?: 'full' } = { configPath: strippedConfigPath };
-      if (options.verbose) {
-        reportOptions.reportType = 'full';
-      }
-      const report = runReport(reportOptions);
-      for (const warning of report.warnings) {
-        process.stderr.write(`warning: ${warning}\n`);
-      }
-      if (report.stderr.length > 0) {
-        process.stderr.write(report.stderr);
-      }
-
-      const allowedIds = new Set(scopeConfig.allowlist.map((entry) => entry.id));
-      const foundIds = new Set(report.results.map((r) => r.id));
-      const allowlistById = new Map<string, AllowlistEntry>(scopeConfig.allowlist.map((entry) => [entry.id, entry]));
-      const scopeResult: ScopeCheckResult = { allowed: [], stale: [], unallowed: [] };
-
-      for (const result of report.results) {
-        if (allowedIds.has(result.id)) {
-          const entry = allowlistById.get(result.id);
-          scopeResult.allowed.push(buildAllowedVuln(result, entry));
-        } else {
-          scopeResult.unallowed.push(result);
+        const reportOptions: { configPath: string; reportType?: 'full' } = { configPath: strippedConfigPath };
+        if (options.verbose) {
+          reportOptions.reportType = 'full';
         }
-      }
-
-      // Detect stale allowlist entries: IDs in the allowlist but not in audit results.
-      for (const entry of scopeConfig.allowlist) {
-        if (!foundIds.has(entry.id)) {
-          scopeResult.stale.push({ id: entry.id });
+        const report = runReport(reportOptions);
+        for (const warning of report.warnings) {
+          process.stderr.write(`warning: ${warning}\n`);
         }
+        if (report.stderr.length > 0) {
+          process.stderr.write(report.stderr);
+        }
+
+        const allowedIds = new Set(scopeConfig.allowlist.map((entry) => entry.id));
+        const foundIds = new Set(report.results.map((r) => r.id));
+        const allowlistById = new Map<string, AllowlistEntry>(scopeConfig.allowlist.map((entry) => [entry.id, entry]));
+        const scopeResult: ScopeCheckResult = { allowed: [], stale: [], unallowed: [] };
+
+        for (const result of report.results) {
+          if (allowedIds.has(result.id)) {
+            const entry = allowlistById.get(result.id);
+            scopeResult.allowed.push(buildAllowedVuln(result, entry));
+          } else {
+            scopeResult.unallowed.push(result);
+          }
+        }
+
+        // Detect stale allowlist entries: IDs in the allowlist but not in audit results.
+        for (const entry of scopeConfig.allowlist) {
+          if (!foundIds.has(entry.id)) {
+            scopeResult.stale.push({ id: entry.id });
+          }
+        }
+
+        checkResult[scope] = scopeResult;
       }
 
-      checkResult[scope] = scopeResult;
-    }
+      if (options.verbose && !options.json) {
+        process.stdout.write(formatCheckVerboseText(checkResult, scopes));
+      } else if (options.json) {
+        process.stdout.write(formatCheckJson(checkResult, scopes));
+      } else {
+        process.stdout.write(formatCheckText(checkResult, scopes));
+      }
 
-    if (options.verbose && !options.json) {
-      process.stdout.write(formatCheckVerboseText(checkResult, scopes));
-    } else if (options.json) {
-      process.stdout.write(formatCheckJson(checkResult, scopes));
-    } else {
-      process.stdout.write(formatCheckText(checkResult, scopes));
-    }
-
-    const hasUnallowed = scopes.some((s) => checkResult[s].unallowed.length > 0);
-    return hasUnallowed ? 1 : 0;
-  });
+      const hasUnallowed = scopes.some((s) => checkResult[s].unallowed.length > 0);
+      return hasUnallowed ? 1 : 0;
+    });
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    return 1;
+  }
 }
 
 /**
@@ -190,41 +200,46 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
   const { configFilePath, configSource } = loaded;
   const scopes = options.scopes.length > 0 ? options.scopes : [...AUDIT_SCOPES];
 
-  // Ensure the config directory exists when creating a new config from defaults.
-  if (configSource === 'defaults') {
-    await mkdir(path.dirname(configFilePath), { recursive: true });
+  try {
+    return await withTempDir(async (tempDir) => {
+      // Ensure the config directory exists when creating a new config from defaults.
+      if (configSource === 'defaults') {
+        await mkdir(path.dirname(configFilePath), { recursive: true });
+      }
+
+      for (const scope of scopes) {
+        // Generate a config without the allowlist so sync sees all vulnerabilities.
+        const strippedScope = { ...config[scope], allowlist: [] };
+        const strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, tempDir);
+
+        const report = runReport({ configPath: strippedConfigPath });
+        for (const warning of report.warnings) {
+          process.stderr.write(`warning: ${warning}\n`);
+        }
+        const { syncResult, updatedConfig } = await syncAllowlist(config, scope, report.results, configFilePath);
+        config = updatedConfig;
+
+        if (options.json) {
+          process.stdout.write(JSON.stringify(syncResult, null, 2) + '\n');
+        } else {
+          process.stdout.write(`\n--- ${scope} ---\n`);
+          process.stdout.write(`  added: ${syncResult.added.length}\n`);
+          process.stdout.write(`  kept: ${syncResult.kept.length}\n`);
+          process.stdout.write(`  removed: ${syncResult.removed.length}\n`);
+        }
+      }
+
+      if (configSource === 'defaults') {
+        const totalEntries = config.dev.allowlist.length + config.prod.allowlist.length;
+        process.stdout.write(`Created config at ${configFilePath} with ${totalEntries} allowed entries.\n`);
+      }
+
+      return 0;
+    });
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    return 1;
   }
-
-  return withTempDir(async (tempDir) => {
-    for (const scope of scopes) {
-      // Generate a config without the allowlist so sync sees all vulnerabilities.
-      const strippedScope = { ...config[scope], allowlist: [] };
-      const strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, tempDir);
-
-      const report = runReport({ configPath: strippedConfigPath });
-      for (const warning of report.warnings) {
-        process.stderr.write(`warning: ${warning}\n`);
-      }
-      const { syncResult, updatedConfig } = await syncAllowlist(config, scope, report.results, configFilePath);
-      config = updatedConfig;
-
-      if (options.json) {
-        process.stdout.write(JSON.stringify(syncResult, null, 2) + '\n');
-      } else {
-        process.stdout.write(`\n--- ${scope} ---\n`);
-        process.stdout.write(`  added: ${syncResult.added.length}\n`);
-        process.stdout.write(`  kept: ${syncResult.kept.length}\n`);
-        process.stdout.write(`  removed: ${syncResult.removed.length}\n`);
-      }
-    }
-
-    if (configSource === 'defaults') {
-      const totalEntries = config.dev.allowlist.length + config.prod.allowlist.length;
-      process.stderr.write(`Created config at ${configFilePath} with ${totalEntries} allowed entries.\n`);
-    }
-
-    return 0;
-  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -1,5 +1,3 @@
-import { mkdir } from 'node:fs/promises';
-import path from 'node:path';
 import process from 'node:process';
 
 import type { LoadConfigResult } from './config.ts';
@@ -8,6 +6,7 @@ import type { AllowedVuln, CheckResult, ScopeCheckResult } from './format-check.
 import { formatCheckJson, formatCheckText } from './format-check.ts';
 import { formatCheckVerboseText } from './format-verbose.ts';
 import { generateAuditCiConfig } from './generate.ts';
+import { scaffoldConfig } from './init/scaffold.ts';
 import { parseAuditCiOutput, runAudit, runReport } from './run-audit.ts';
 import { syncAllowlist } from './sync.ts';
 import { withTempDir } from './tmp.ts';
@@ -196,17 +195,24 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
     return 1;
   }
 
+  const { configSource } = loaded;
+
+  // When no config exists, scaffold one first so sync operates on a real file.
+  if (configSource === 'defaults') {
+    const { configResult } = scaffoldConfig({ dryRun: false, force: false });
+    if (configResult.outcome === 'failed') {
+      process.stderr.write(`Error: Failed to create config file\n`);
+      return 1;
+    }
+    loaded = await loadConfig(options.configPath);
+  }
+
   let { config } = loaded;
-  const { configFilePath, configSource } = loaded;
+  const { configFilePath } = loaded;
   const scopes = options.scopes.length > 0 ? options.scopes : [...AUDIT_SCOPES];
 
   try {
     return await withTempDir(async (tempDir) => {
-      // Ensure the config directory exists when creating a new config from defaults.
-      if (configSource === 'defaults') {
-        await mkdir(path.dirname(configFilePath), { recursive: true });
-      }
-
       for (const scope of scopes) {
         // Generate a config without the allowlist so sync sees all vulnerabilities.
         const strippedScope = { ...config[scope], allowlist: [] };

--- a/packages/audit-deps/src/config.ts
+++ b/packages/audit-deps/src/config.ts
@@ -1,28 +1,44 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { AuditDepsConfig } from './types.ts';
-import { auditDepsConfigSchema } from './types.ts';
+import { auditDepsConfigSchema, DEFAULT_CONFIG } from './types.ts';
 
 /** Default config file path, relative to the working directory. */
 export const DEFAULT_CONFIG_PATH = '.config/audit-deps.config.json';
 
-/**
- * Load and validate the audit-deps config from disk.
- *
- * Resolves the config path against `cwd`. Throws on missing file or validation failure.
- */
-export async function loadConfig(
-  configPath?: string,
-  cwd?: string,
-): Promise<{
+/** Discriminate between a config loaded from a file and one built from defaults. */
+export type ConfigSource = 'defaults' | 'file';
+
+/** Result of loading config, including the source discriminator. */
+export interface LoadConfigResult {
   config: AuditDepsConfig;
   configDir: string;
   configFilePath: string;
-}> {
+  configSource: ConfigSource;
+}
+
+/**
+ * Load and validate the audit-deps config from disk, falling back to defaults.
+ *
+ * When `configPath` is explicitly provided, the file must exist. When omitted,
+ * the default path is tried; if absent, `DEFAULT_CONFIG` is returned.
+ */
+export async function loadConfig(configPath?: string, cwd?: string): Promise<LoadConfigResult> {
   const resolvedCwd = cwd ?? process.cwd();
   const filePath = path.resolve(resolvedCwd, configPath ?? DEFAULT_CONFIG_PATH);
   const configDir = path.dirname(filePath);
+
+  // When no explicit path was provided and the default file doesn't exist, use defaults.
+  if (configPath === undefined && !existsSync(filePath)) {
+    return {
+      config: DEFAULT_CONFIG,
+      configDir,
+      configFilePath: filePath,
+      configSource: 'defaults',
+    };
+  }
 
   let raw: string;
   try {
@@ -44,5 +60,5 @@ export async function loadConfig(
     throw new Error(`Invalid config in ${filePath}:\n${issues}`);
   }
 
-  return { config: result.data, configDir, configFilePath: filePath };
+  return { config: result.data, configDir, configFilePath: filePath, configSource: 'file' };
 }

--- a/packages/audit-deps/src/generate.ts
+++ b/packages/audit-deps/src/generate.ts
@@ -13,10 +13,11 @@ interface AuditCiFlatConfig {
 /**
  * Transform a scope config into the flat JSON structure audit-ci expects.
  *
- * Translates `severityThreshold` to the corresponding audit-ci boolean and
- * flattens the typed allowlist to an array of ID strings.
+ * Translates `severityThreshold` to the corresponding audit-ci boolean,
+ * adds scope-specific flags (`skip-dev` for prod, `extra-args: ["--dev"]` for dev),
+ * and flattens the typed allowlist to an array of ID strings.
  */
-export function buildFlatConfig(scopeConfig: ScopeConfig): AuditCiFlatConfig {
+export function buildFlatConfig(scopeConfig: ScopeConfig, scope: AuditScope): AuditCiFlatConfig {
   const flat: AuditCiFlatConfig = {
     allowlist: scopeConfig.allowlist.map((entry) => entry.id),
     'show-not-found': true,
@@ -24,6 +25,13 @@ export function buildFlatConfig(scopeConfig: ScopeConfig): AuditCiFlatConfig {
 
   if (scopeConfig.severityThreshold !== undefined) {
     flat[scopeConfig.severityThreshold] = true;
+  }
+
+  // Restrict audit-ci to the target dependency scope.
+  if (scope === 'prod') {
+    flat['skip-dev'] = true;
+  } else {
+    flat['extra-args'] = ['--dev'];
   }
 
   return flat;
@@ -41,7 +49,7 @@ export async function generateAuditCiConfig(
   outputDir: string,
 ): Promise<string> {
   const outputPath = path.join(outputDir, `audit-ci.${scope}.json`);
-  const flat = buildFlatConfig(scopeConfig);
+  const flat = buildFlatConfig(scopeConfig, scope);
   const content = JSON.stringify(flat, null, 2) + '\n';
 
   await writeFile(outputPath, content, 'utf8');

--- a/packages/audit-deps/src/generate.ts
+++ b/packages/audit-deps/src/generate.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { AuditScope, ScopeConfig } from './types.ts';
@@ -32,7 +32,8 @@ export function buildFlatConfig(scopeConfig: ScopeConfig): AuditCiFlatConfig {
 /**
  * Generate the audit-ci config file for a scope and write it to disk.
  *
- * The output path is `{outputDir}/audit-ci.{scope}.json`.
+ * The output path is `{outputDir}/audit-ci.{scope}.json`. The caller must
+ * ensure `outputDir` already exists (e.g., via `withTempDir`).
  */
 export async function generateAuditCiConfig(
   scopeConfig: ScopeConfig,
@@ -43,7 +44,6 @@ export async function generateAuditCiConfig(
   const flat = buildFlatConfig(scopeConfig);
   const content = JSON.stringify(flat, null, 2) + '\n';
 
-  await mkdir(path.dirname(outputPath), { recursive: true });
   await writeFile(outputPath, content, 'utf8');
 
   return outputPath;

--- a/packages/audit-deps/src/generate.ts
+++ b/packages/audit-deps/src/generate.ts
@@ -10,13 +10,11 @@ interface AuditCiFlatConfig {
   [key: string]: boolean | string | string[] | undefined;
 }
 
-/** Map severity booleans from our config to audit-ci field names. */
-const SEVERITY_FIELDS = ['critical', 'high', 'low', 'moderate'] as const;
-
 /**
  * Transform a scope config into the flat JSON structure audit-ci expects.
  *
- * Extracts severity thresholds and flattens the typed allowlist to an array of ID strings.
+ * Translates `severityThreshold` to the corresponding audit-ci boolean and
+ * flattens the typed allowlist to an array of ID strings.
  */
 export function buildFlatConfig(scopeConfig: ScopeConfig): AuditCiFlatConfig {
   const flat: AuditCiFlatConfig = {
@@ -24,11 +22,8 @@ export function buildFlatConfig(scopeConfig: ScopeConfig): AuditCiFlatConfig {
     'show-not-found': true,
   };
 
-  for (const field of SEVERITY_FIELDS) {
-    const value = scopeConfig[field];
-    if (value !== undefined) {
-      flat[field] = value;
-    }
+  if (scopeConfig.severityThreshold !== undefined) {
+    flat[scopeConfig.severityThreshold] = true;
   }
 
   return flat;
@@ -37,17 +32,14 @@ export function buildFlatConfig(scopeConfig: ScopeConfig): AuditCiFlatConfig {
 /**
  * Generate the audit-ci config file for a scope and write it to disk.
  *
- * The output path is `{outDir}/audit-ci.{scope}.json`, where `outDir` is resolved
- * relative to `configDir`.
+ * The output path is `{outputDir}/audit-ci.{scope}.json`.
  */
 export async function generateAuditCiConfig(
   scopeConfig: ScopeConfig,
   scope: AuditScope,
-  configDir: string,
-  outDir?: string,
+  outputDir: string,
 ): Promise<string> {
-  const resolvedOutDir = outDir !== undefined ? path.resolve(configDir, outDir) : configDir;
-  const outputPath = path.join(resolvedOutDir, `audit-ci.${scope}.json`);
+  const outputPath = path.join(outputDir, `audit-ci.${scope}.json`);
   const flat = buildFlatConfig(scopeConfig);
   const content = JSON.stringify(flat, null, 2) + '\n';
 

--- a/packages/audit-deps/src/index.ts
+++ b/packages/audit-deps/src/index.ts
@@ -1,14 +1,27 @@
 // Types
-export type { AllowlistEntry, AuditDepsConfig, AuditResult, AuditScope, CommandOptions, ScopeConfig } from './types.ts';
+export type {
+  AllowlistEntry,
+  AuditDepsConfig,
+  AuditResult,
+  AuditScope,
+  CommandOptions,
+  ScopeConfig,
+  SeverityThreshold,
+} from './types.ts';
 
-// Schemas
-export { allowlistEntrySchema, AUDIT_SCOPES, auditDepsConfigSchema, scopeConfigSchema } from './types.ts';
+// Schemas and constants
+export {
+  allowlistEntrySchema,
+  AUDIT_SCOPES,
+  auditDepsConfigSchema,
+  DEFAULT_CONFIG,
+  scopeConfigSchema,
+  SEVERITY_THRESHOLDS,
+} from './types.ts';
 
 // Config
+export type { ConfigSource, LoadConfigResult } from './config.ts';
 export { loadConfig } from './config.ts';
-
-// Generation
-export { generateAuditCiConfig } from './generate.ts';
 
 // Sync
 export { syncAllowlist } from './sync.ts';

--- a/packages/audit-deps/src/init/initCommand.ts
+++ b/packages/audit-deps/src/init/initCommand.ts
@@ -39,7 +39,6 @@ export function initCommand({ dryRun, force }: InitOptions): number {
     console.info(`
   1. Customize .config/audit-deps.config.json with your severity thresholds.
   2. Run: npx @williamthorsen/audit-deps
-  3. Commit the config file.
 `);
   }
 

--- a/packages/audit-deps/src/init/initCommand.ts
+++ b/packages/audit-deps/src/init/initCommand.ts
@@ -38,9 +38,8 @@ export function initCommand({ dryRun, force }: InitOptions): number {
     printStep('Next steps');
     console.info(`
   1. Customize .config/audit-deps.config.json with your severity thresholds.
-  2. Run: npx @williamthorsen/audit-deps generate
-  3. Run: npx @williamthorsen/audit-deps
-  4. Commit the config file.
+  2. Run: npx @williamthorsen/audit-deps
+  3. Commit the config file.
 `);
   }
 

--- a/packages/audit-deps/src/init/templates.ts
+++ b/packages/audit-deps/src/init/templates.ts
@@ -1,14 +1,21 @@
+import { VERSION } from '../version.ts';
+
+/** Construct the JSON Schema URL for the current version. */
+function buildSchemaUrl(): string {
+  return `https://github.com/williamthorsen/node-monorepo-tools/raw/audit-deps-v${VERSION}/packages/audit-deps/schemas/config.json`;
+}
+
 /** Default audit-deps config file content. */
 export const auditDepsConfigTemplate =
   JSON.stringify(
     {
-      outDir: '../tmp',
+      $schema: buildSchemaUrl(),
       dev: {
-        moderate: true,
+        severityThreshold: 'high',
         allowlist: [],
       },
       prod: {
-        high: true,
+        severityThreshold: 'moderate',
         allowlist: [],
       },
     },

--- a/packages/audit-deps/src/init/templates.ts
+++ b/packages/audit-deps/src/init/templates.ts
@@ -11,11 +11,11 @@ export const auditDepsConfigTemplate =
     {
       $schema: buildSchemaUrl(),
       dev: {
-        severityThreshold: 'high',
+        severityThreshold: 'moderate',
         allowlist: [],
       },
       prod: {
-        severityThreshold: 'moderate',
+        severityThreshold: 'low',
         allowlist: [],
       },
     },

--- a/packages/audit-deps/src/sync.ts
+++ b/packages/audit-deps/src/sync.ts
@@ -1,6 +1,6 @@
 import { writeFile } from 'node:fs/promises';
 
-import type { AllowlistEntry, AuditDepsConfig, AuditResult, AuditScope } from './types.ts';
+import type { AllowlistEntry, AuditDepsConfig, AuditResult, AuditScope, ScopeConfig } from './types.ts';
 
 /** Produce a UTC date string in YYYY-MM-DD format. */
 export function formatUtcDate(date: Date): string {
@@ -20,6 +20,16 @@ function serializeEntry(entry: AllowlistEntry): Record<string, string> {
     ...(entry.reason !== undefined && { reason: entry.reason }),
     url: entry.url,
   };
+}
+
+/** Build a serializable representation of a scope config with ordered keys. */
+function serializeScopeConfig(scopeConfig: ScopeConfig): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  if (scopeConfig.severityThreshold !== undefined) {
+    result.severityThreshold = scopeConfig.severityThreshold;
+  }
+  result.allowlist = scopeConfig.allowlist.map(serializeEntry);
+  return result;
 }
 
 /** Result of a sync operation for a single scope. */
@@ -100,20 +110,18 @@ export function buildUpdatedConfig(
 /**
  * Serialize the config to JSON with alphabetically ordered allowlist entry keys.
  *
- * Uses a custom replacer to guarantee key order within allowlist entries.
+ * Includes `$schema` when present. Uses `severityThreshold` instead of boolean fields.
  */
 export function serializeConfig(config: AuditDepsConfig): string {
-  const serializable = {
-    ...config,
-    dev: {
-      ...config.dev,
-      allowlist: config.dev.allowlist.map(serializeEntry),
-    },
-    prod: {
-      ...config.prod,
-      allowlist: config.prod.allowlist.map(serializeEntry),
-    },
-  };
+  const serializable: Record<string, unknown> = {};
+
+  if (config.$schema !== undefined) {
+    serializable.$schema = config.$schema;
+  }
+
+  serializable.dev = serializeScopeConfig(config.dev);
+  serializable.prod = serializeScopeConfig(config.prod);
+
   return JSON.stringify(serializable, null, 2) + '\n';
 }
 

--- a/packages/audit-deps/src/tmp.ts
+++ b/packages/audit-deps/src/tmp.ts
@@ -1,0 +1,20 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+/**
+ * Execute a callback with a temporary directory, ensuring cleanup afterward.
+ *
+ * Creates a unique temp directory under `os.tmpdir()` and removes it
+ * (recursively) when the callback completes or throws.
+ *
+ * @internal Exported for testing.
+ */
+export async function withTempDir<T>(fn: (tempDir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'audit-deps-'));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/audit-deps/src/types.ts
+++ b/packages/audit-deps/src/types.ts
@@ -11,6 +11,16 @@ export type AuditScope = 'dev' | 'prod';
 export const AUDIT_SCOPES: readonly AuditScope[] = ['dev', 'prod'];
 
 // ---------------------------------------------------------------------------
+// Severity threshold
+// ---------------------------------------------------------------------------
+
+/** Valid severity threshold values in ascending order. */
+export const SEVERITY_THRESHOLDS = ['low', 'moderate', 'high', 'critical'] as const;
+
+/** Severity level at or above which audit-ci should fail. */
+export type SeverityThreshold = (typeof SEVERITY_THRESHOLDS)[number];
+
+// ---------------------------------------------------------------------------
 // Allowlist entry
 // ---------------------------------------------------------------------------
 
@@ -40,20 +50,16 @@ export const allowlistEntrySchema = z.object({
 export interface ScopeConfig {
   allowlist: AllowlistEntry[];
   /** Fail on advisories at or above this severity. */
-  critical?: boolean | undefined;
-  high?: boolean | undefined;
-  low?: boolean | undefined;
-  moderate?: boolean | undefined;
+  severityThreshold?: SeverityThreshold | undefined;
 }
 
 /** Zod schema for a scope configuration block. */
-export const scopeConfigSchema = z.object({
-  allowlist: z.array(allowlistEntrySchema),
-  critical: z.boolean().optional(),
-  high: z.boolean().optional(),
-  low: z.boolean().optional(),
-  moderate: z.boolean().optional(),
-});
+export const scopeConfigSchema = z
+  .object({
+    allowlist: z.array(allowlistEntrySchema),
+    severityThreshold: z.enum(SEVERITY_THRESHOLDS).optional(),
+  })
+  .strict();
 
 // ---------------------------------------------------------------------------
 // Top-level config
@@ -61,17 +67,29 @@ export const scopeConfigSchema = z.object({
 
 /** Source-of-truth configuration for audit-deps. */
 export interface AuditDepsConfig {
+  $schema?: string | undefined;
   dev: ScopeConfig;
-  outDir?: string | undefined;
   prod: ScopeConfig;
 }
 
 /** Zod schema for the full audit-deps configuration file. */
-export const auditDepsConfigSchema = z.object({
-  dev: scopeConfigSchema,
-  outDir: z.string().optional(),
-  prod: scopeConfigSchema,
-});
+export const auditDepsConfigSchema = z
+  .object({
+    $schema: z.string().optional(),
+    dev: scopeConfigSchema,
+    prod: scopeConfigSchema,
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// Default config
+// ---------------------------------------------------------------------------
+
+/** Built-in defaults used when no config file is present. */
+export const DEFAULT_CONFIG: AuditDepsConfig = {
+  dev: { allowlist: [], severityThreshold: 'high' },
+  prod: { allowlist: [], severityThreshold: 'moderate' },
+};
 
 // ---------------------------------------------------------------------------
 // Audit result

--- a/packages/audit-deps/src/types.ts
+++ b/packages/audit-deps/src/types.ts
@@ -87,8 +87,8 @@ export const auditDepsConfigSchema = z
 
 /** Built-in defaults used when no config file is present. */
 export const DEFAULT_CONFIG: AuditDepsConfig = {
-  dev: { allowlist: [], severityThreshold: 'high' },
-  prod: { allowlist: [], severityThreshold: 'moderate' },
+  dev: { allowlist: [], severityThreshold: 'moderate' },
+  prod: { allowlist: [], severityThreshold: 'low' },
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds no-config mode to audit-deps so `npx @williamthorsen/audit-deps` produces a useful vulnerability report in any repo without requiring a config file. When no config exists, commands use built-in defaults (dev: high severity threshold, prod: moderate, empty allowlists). `sync` in no-config mode scaffolds a config file at the default path before syncing, reusing the same `init` template. When `--config <path>` is explicitly passed, the file must exist.

Replaces the four confusing severity booleans (`critical`, `high`, `moderate`, `low`) with a single `severityThreshold` field per scope and removes `outDir` from the config — intermediate audit-ci files now use OS temp directories with automatic cleanup. Removes the `generate` subcommand, which exposed an internal operation with no user-facing purpose.

Fixes an issue where dev and prod scopes produced identical audit results because generated audit-ci configs lacked scope-differentiating flags.

Adds a JSON Schema for editor autocomplete and includes a `$schema` URL in generated configs.

## Why

Running `npx @williamthorsen/audit-deps` in a repo without a config file exited with an error, preventing casual use. The config was also overdue for cleanup: the severity booleans were ambiguous, `outDir` exposed an implementation detail, and the default severity thresholds were inverted (dev was stricter than prod).

## Details

### Features

- `check`, `audit`, and `sync` commands fall back to `DEFAULT_CONFIG` when no config file is found. `loadConfig` returns a `configSource: 'file' | 'defaults'` discriminator so callers can distinguish.
- `sync` delegates to `scaffoldConfig` (the same function `init` uses) when no config exists, then reloads and syncs normally — single source of truth for initial config content.
- `withTempDir` utility (`src/tmp.ts`) wraps `fs.mkdtemp` / `fs.rm` with try/finally for guaranteed cleanup.
- JSON Schema at `packages/audit-deps/schemas/config.json` with field descriptions and `additionalProperties: false`.
- `init` template and `serializeConfig` output `severityThreshold` and `$schema`.

### Fixes

- `buildFlatConfig` now adds `skip-dev: true` for the prod scope and `extra-args: ["--dev"]` for the dev scope, so audit-ci correctly restricts results to the target dependency scope.
- All command functions wrap `withTempDir` callbacks in try/catch, converting errors to clean exit code 1 with stderr messages.

### Refactoring

- Removed `generate` subcommand, `showGenerateHelp`, `generateCommand`, and `loadAndGenerate`.
- Replaced severity booleans in `ScopeConfig` with `severityThreshold` enum. Zod schemas are strict, giving clear migration errors for old configs.
- Removed `outDir` from `AuditDepsConfig`.
- Removed config-existence check from the readyup kit.

### Tests

- New test file `__tests__/tmp.test.ts` for `withTempDir`.
- Updated tests across `cli`, `config`, `generate`, `init`, `route`, `sync`, and `integration` suites to use the new schema and verify no-config behavior.

Closes #228