### PR TITLE
#233 Store full ISO 8601 datetime in allowlist `addedAt`

### DIFF
--- a/packages/audit-deps/README.md
+++ b/packages/audit-deps/README.md
@@ -37,7 +37,7 @@ The source-of-truth config lives at `.config/audit-deps.config.json`:
     "severityThreshold": "moderate",
     "allowlist": [
       {
-        "addedAt": "2026-04-15",
+        "addedAt": "2026-04-15T09:30:00.000Z",
         "id": "GHSA-1234-5678-abcd",
         "path": "lodash",
         "reason": "Accepted risk: no user input reaches this path",
@@ -57,7 +57,7 @@ The source-of-truth config lives at `.config/audit-deps.config.json`:
 - **`$schema`** (optional) — JSON Schema URL for editor autocomplete and validation. Automatically included by `init` and `sync`.
 - **`dev`** / **`prod`** — Scope-specific settings:
   - **`severityThreshold`** (optional) — Fail on advisories at or above this severity. Valid values: `'low'`, `'moderate'`, `'high'`, `'critical'`. When omitted, audit-ci uses its own defaults.
-  - **`allowlist`** — Typed advisory entries with `id`, `path`, `url`, and optional `reason` and `addedAt`. `addedAt` is an ISO date (UTC, `YYYY-MM-DD`) populated automatically by `audit-deps sync` on new entries; existing entries retain whatever value they had.
+  - **`allowlist`** — Typed advisory entries with `id`, `path`, `url`, and optional `reason` and `addedAt`. `addedAt` is an ISO 8601 UTC datetime (e.g., `2026-04-15T09:30:00.000Z`) populated automatically by `audit-deps sync` on new entries; existing entries retain whatever value they had. Older `YYYY-MM-DD` values are still accepted.
 
 ## CLI reference
 

--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -346,7 +346,7 @@ describe(checkCommand, () => {
       prod: {
         allowlist: [
           {
-            addedAt: '2026-04-01',
+            addedAt: '2026-04-01T00:00:00.000Z',
             id: 'GHSA-enriched',
             path: 'pkg',
             reason: 'Accepted risk',
@@ -382,7 +382,7 @@ describe(checkCommand, () => {
         prod: expect.objectContaining({
           allowed: [
             expect.objectContaining({
-              addedAt: '2026-04-01',
+              addedAt: '2026-04-01T00:00:00.000Z',
               cvss: { score: 7.5 },
               description: 'Detailed description',
               id: 'GHSA-enriched',
@@ -504,7 +504,7 @@ describe(checkCommand, () => {
       prod: {
         allowlist: [
           {
-            addedAt: '2026-04-01',
+            addedAt: '2026-04-01T00:00:00.000Z',
             id: 'GHSA-allowed',
             path: 'pkg',
             reason: 'Accepted',
@@ -541,7 +541,9 @@ describe(checkCommand, () => {
   it('renders verbose JSON output when both verbose and json are true', async () => {
     const config = makeConfig({
       prod: {
-        allowlist: [{ addedAt: '2026-04-01', id: 'GHSA-1', path: 'pkg', reason: 'r', url: 'https://example.com/1' }],
+        allowlist: [
+          { addedAt: '2026-04-01T00:00:00.000Z', id: 'GHSA-1', path: 'pkg', reason: 'r', url: 'https://example.com/1' },
+        ],
       },
     });
     setupLoadConfig(config);
@@ -571,7 +573,7 @@ describe(checkCommand, () => {
         prod: expect.objectContaining({
           allowed: [
             expect.objectContaining({
-              addedAt: '2026-04-01',
+              addedAt: '2026-04-01T00:00:00.000Z',
               cvss: { score: 7.5 },
               description: 'desc',
               reason: 'r',

--- a/packages/audit-deps/__tests__/format-check.test.ts
+++ b/packages/audit-deps/__tests__/format-check.test.ts
@@ -242,7 +242,7 @@ describe(formatCheckJson, () => {
       prod: {
         allowed: [
           {
-            addedAt: '2026-04-01',
+            addedAt: '2026-04-01T00:00:00.000Z',
             cvss: { score: 7.5 },
             description: 'Detailed description',
             id: 'GHSA-allowed',
@@ -265,7 +265,7 @@ describe(formatCheckJson, () => {
         prod: expect.objectContaining({
           allowed: [
             expect.objectContaining({
-              addedAt: '2026-04-01',
+              addedAt: '2026-04-01T00:00:00.000Z',
               cvss: { score: 7.5 },
               description: 'Detailed description',
               paths: ['pkg', 'other-pkg>pkg'],

--- a/packages/audit-deps/__tests__/format-verbose.test.ts
+++ b/packages/audit-deps/__tests__/format-verbose.test.ts
@@ -212,6 +212,27 @@ describe(formatCheckVerboseText, () => {
     expect(output).toContain('\u{1F7E0} moderate');
   });
 
+  it('renders an allowed entry with a full ISO datetime in the suffix', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [
+          {
+            addedAt: '2026-04-01T14:30:00.000Z',
+            id: 'GHSA-iso',
+            path: 'pkg',
+            paths: ['pkg'],
+            url: 'https://example.com/iso',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('allowed 1 week ago (2026-04-01T14:30:00.000Z)');
+  });
+
   it('omits "allowed X ago" line when addedAt is absent', () => {
     const result = makeCheckResult({
       prod: {

--- a/packages/audit-deps/__tests__/integration.test.ts
+++ b/packages/audit-deps/__tests__/integration.test.ts
@@ -78,7 +78,7 @@ describe('integration: generate -> sync cycle', () => {
     const reloaded = await loadConfig(configFilePath, tempDir);
     expect(reloaded.config.prod.allowlist).toHaveLength(1);
     expect(reloaded.config.prod.allowlist[0]?.id).toBe('GHSA-new1');
-    expect(reloaded.config.prod.allowlist[0]?.reason).toBe('Added by audit-deps sync on 2025-06-15');
+    expect(reloaded.config.prod.allowlist[0]?.reason).toBe('Added by audit-deps sync at 2025-06-15 00:00:00 UTC');
 
     // Regenerate and verify updated flat config
     const updatedProdPath = await generateAuditCiConfig(reloaded.config.prod, 'prod', outputDir);

--- a/packages/audit-deps/__tests__/sync.test.ts
+++ b/packages/audit-deps/__tests__/sync.test.ts
@@ -4,7 +4,14 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { buildUpdatedConfig, computeSyncDiff, formatUtcDate, serializeConfig, syncAllowlist } from '../src/sync.ts';
+import {
+  buildUpdatedConfig,
+  computeSyncDiff,
+  formatFriendlyUtc,
+  formatUtcDatetime,
+  serializeConfig,
+  syncAllowlist,
+} from '../src/sync.ts';
 import type { AllowlistEntry, AuditDepsConfig, AuditResult } from '../src/types.ts';
 
 function makeAuditResult(overrides: Partial<AuditResult> & Pick<AuditResult, 'id' | 'path' | 'url'>): AuditResult {
@@ -21,8 +28,8 @@ describe(computeSyncDiff, () => {
     const { added, kept, removed } = computeSyncDiff(current, audit, fixedDate);
 
     expect(added).toHaveLength(1);
-    expect(added[0]?.reason).toBe('Added by audit-deps sync on 2025-06-15');
-    expect(added[0]?.addedAt).toBe('2025-06-15');
+    expect(added[0]?.reason).toBe('Added by audit-deps sync at 2025-06-15 00:00:00 UTC');
+    expect(added[0]?.addedAt).toBe('2025-06-15T00:00:00.000Z');
     expect(kept).toHaveLength(0);
     expect(removed).toHaveLength(0);
   });
@@ -213,13 +220,19 @@ describe(serializeConfig, () => {
   });
 });
 
-describe(formatUtcDate, () => {
-  it('returns a YYYY-MM-DD date string in UTC', () => {
-    expect(formatUtcDate(new Date('2026-04-15T12:34:56Z'))).toBe('2026-04-15');
+describe(formatFriendlyUtc, () => {
+  it('returns a human-friendly "YYYY-MM-DD HH:MM:SS UTC" string', () => {
+    expect(formatFriendlyUtc(new Date('2026-04-15T14:30:05.123Z'))).toBe('2026-04-15 14:30:05 UTC');
+  });
+});
+
+describe(formatUtcDatetime, () => {
+  it('returns a full ISO 8601 UTC datetime string', () => {
+    expect(formatUtcDatetime(new Date('2026-04-15T12:34:56Z'))).toBe('2026-04-15T12:34:56.000Z');
   });
 
-  it('returns the UTC date regardless of the local timezone portion of the ISO string', () => {
-    expect(formatUtcDate(new Date('2026-04-15T03:00:00Z'))).toBe('2026-04-15');
+  it('preserves the full UTC time including milliseconds', () => {
+    expect(formatUtcDatetime(new Date('2026-04-15T03:00:00.123Z'))).toBe('2026-04-15T03:00:00.123Z');
   });
 });
 

--- a/packages/audit-deps/src/format-verbose.ts
+++ b/packages/audit-deps/src/format-verbose.ts
@@ -135,7 +135,7 @@ function formatSeveritySuffix(severity: string | undefined): string {
   return `  ${emojiPart}${severity}`;
 }
 
-/** Build the "allowed X ago (YYYY-MM-DD)" suffix for entries with `addedAt`. */
+/** Build the "allowed X ago (datetime)" suffix for entries with `addedAt`. */
 function formatAllowedSuffix(addedAt: string, now: Date): string {
   const relative = formatRelativeTime(addedAt, now);
   if (relative.length === 0) return `  allowed (${addedAt})`;

--- a/packages/audit-deps/src/sync.ts
+++ b/packages/audit-deps/src/sync.ts
@@ -2,9 +2,15 @@ import { writeFile } from 'node:fs/promises';
 
 import type { AllowlistEntry, AuditDepsConfig, AuditResult, AuditScope, ScopeConfig } from './types.ts';
 
-/** Produce a UTC date string in YYYY-MM-DD format. */
-export function formatUtcDate(date: Date): string {
-  return date.toISOString().slice(0, 10);
+/** Produce a full ISO 8601 UTC datetime string. */
+export function formatUtcDatetime(date: Date): string {
+  return date.toISOString();
+}
+
+/** Format a Date as a human-friendly UTC string for use in reason messages. */
+export function formatFriendlyUtc(date: Date): string {
+  const iso = date.toISOString();
+  return iso.slice(0, 10) + ' ' + iso.slice(11, 19) + ' UTC';
 }
 
 /**
@@ -60,7 +66,7 @@ export function computeSyncDiff(
   const removed: AllowlistEntry[] = [];
 
   // Identify new and kept entries
-  const nowIso = formatUtcDate(now);
+  const nowIso = formatUtcDatetime(now);
   for (const [id, result] of auditById) {
     const existing = currentById.get(id);
     if (existing !== undefined) {
@@ -70,7 +76,7 @@ export function computeSyncDiff(
         addedAt: nowIso,
         id: result.id,
         path: result.path,
-        reason: `Added by audit-deps sync on ${nowIso}`,
+        reason: `Added by audit-deps sync at ${formatFriendlyUtc(now)}`,
         url: result.url,
       });
     }


### PR DESCRIPTION
## What

Stores a full ISO 8601 UTC datetime (e.g., `2026-04-15T14:30:00.000Z`) in allowlist `addedAt` fields instead of the ambiguous date-only `YYYY-MM-DD` format. This removes timezone interpretation ambiguity and adds time-of-day precision, enabling more accurate relative-time display in verbose output. The auto-generated reason string now uses a human-friendly format (e.g., "Added by audit-deps sync at 2026-04-15 14:30:00 UTC"). Existing configs with `YYYY-MM-DD` values continue to parse and display correctly.

## Why

The date-only `YYYY-MM-DD` format was ambiguous — different parsers could interpret it as midnight UTC or midnight local time — and lost time-of-day precision that the `formatRelativeTime` function was already capable of using for sub-day intervals.

## Details

### Features

- Renames `formatUtcDate` to `formatUtcDatetime`, which returns the full `Date.toISOString()` output instead of slicing to 10 characters.
- Adds `formatFriendlyUtc` for human-readable reason strings, producing `YYYY-MM-DD HH:MM:SS UTC` format.
- Updates the auto-reason template from "Added by audit-deps sync on {date}" to "Added by audit-deps sync at {friendly datetime}".

### Tests

- Adds test for `formatFriendlyUtc` output format.
- Adds test verifying full ISO datetime renders correctly in verbose allowed-entry display.
- Updates `addedAt` literals across cli, format-check, format-verbose, sync, and integration tests.
- Preserves existing `YYYY-MM-DD` inputs in `formatRelativeTime` tests to verify backward compatibility.

## Test plan

- [ ] Verify `audit-deps sync` produces full ISO datetime in `addedAt` and friendly format in `reason`
- [ ] Verify existing configs with `YYYY-MM-DD` values still display correctly in verbose output

Closes #233