### PR TITLE
#231 Improve DX of audit-deps bare output

### DIFF
--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -299,7 +299,7 @@ describe(checkCommand, () => {
     const exitCode = await checkCommand(makeOptions({ scopes: ['prod'] }));
 
     expect(exitCode).toBe(0);
-    expect(stdoutOutput).toContain('(none)');
+    expect(stdoutOutput).toContain('No known vulnerabilities found.');
   });
 
   it('returns 1 when unallowed vulnerabilities exist', async () => {
@@ -338,7 +338,7 @@ describe(checkCommand, () => {
     const exitCode = await checkCommand(makeOptions({ scopes: ['dev'] }));
 
     expect(exitCode).toBe(0);
-    expect(stdoutOutput).toContain('allowed');
+    expect(stdoutOutput).toContain('\u{26A0}\u{FE0F}');
   });
 
   it('populates allowed entries with advisory fields from the audit result and metadata from the allowlist entry', async () => {
@@ -435,18 +435,28 @@ describe(checkCommand, () => {
     await checkCommand(makeOptions());
 
     expect(mocks.runReport).toHaveBeenCalledTimes(2);
-    expect(stdoutOutput).toContain('prod');
-    expect(stdoutOutput).toContain('dev');
+    expect(stdoutOutput).toContain('Auditing dependencies');
+    expect(stdoutOutput).toContain('No known vulnerabilities found.');
   });
 
   it('displays prod before dev even when scopes are passed in reverse order', async () => {
-    setupLoadConfig();
-    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+    const config = makeConfig({
+      prod: {
+        allowlist: [{ id: 'GHSA-prod-entry', path: 'pkg', url: 'https://example.com/prod' }],
+      },
+    });
+    setupLoadConfig(config);
+    mocks.runReport.mockReturnValue({
+      results: [{ id: 'GHSA-prod-entry', path: 'pkg', paths: ['pkg'], url: 'https://example.com/prod' }],
+      stdout: '',
+      stderr: '',
+      warnings: [],
+    });
 
     await checkCommand(makeOptions({ scopes: ['dev', 'prod'] }));
 
-    const prodIndex = stdoutOutput.indexOf('prod');
-    const devIndex = stdoutOutput.indexOf('dev');
+    const prodIndex = stdoutOutput.indexOf('\u{1F4E6} prod:');
+    const devIndex = stdoutOutput.indexOf('\u{1F527} dev:');
     expect(prodIndex).toBeGreaterThanOrEqual(0);
     expect(devIndex).toBeGreaterThanOrEqual(0);
     expect(prodIndex).toBeLessThan(devIndex);

--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -397,6 +397,52 @@ describe(checkCommand, () => {
     );
   });
 
+  it('propagates ghsaId from audit result to allowed entry in JSON output', async () => {
+    const config = makeConfig({
+      prod: {
+        allowlist: [
+          {
+            id: 'GHSA-ghsa-test',
+            path: 'pkg',
+            url: 'https://example.com/ghsa-test',
+          },
+        ],
+      },
+    });
+    setupLoadConfig(config);
+    mocks.runReport.mockReturnValue({
+      results: [
+        {
+          ghsaId: 'GHSA-ghsa-test',
+          id: 'GHSA-ghsa-test',
+          path: 'pkg',
+          paths: ['pkg'],
+          severity: 'high',
+          url: 'https://example.com/ghsa-test',
+        },
+      ],
+      stdout: '',
+      stderr: '',
+      warnings: [],
+    });
+
+    await checkCommand(makeOptions({ json: true, scopes: ['prod'] }));
+
+    const parsed: unknown = JSON.parse(stdoutOutput);
+    expect(parsed).toStrictEqual(
+      expect.objectContaining({
+        prod: expect.objectContaining({
+          allowed: [
+            expect.objectContaining({
+              ghsaId: 'GHSA-ghsa-test',
+              id: 'GHSA-ghsa-test',
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
   it('detects stale allowlist entries and returns 0', async () => {
     const config = makeConfig({
       prod: {

--- a/packages/audit-deps/__tests__/format-actions.test.ts
+++ b/packages/audit-deps/__tests__/format-actions.test.ts
@@ -16,12 +16,12 @@ function makeCheckResult(overrides?: Partial<CheckResult>): CheckResult {
 }
 
 describe(formatActionHints, () => {
-  it('returns empty string when no unallowed or stale entries exist', () => {
+  it('returns empty string when no unallowed, allowed, or stale entries exist', () => {
     const result = makeCheckResult();
     expect(formatActionHints(result, ['prod', 'dev'])).toBe('');
   });
 
-  it('returns the add-only hint when only unallowed vulnerabilities exist', () => {
+  it('returns verbose and sync hints when unallowed vulnerabilities exist', () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
@@ -31,10 +31,12 @@ describe(formatActionHints, () => {
     });
 
     const output = formatActionHints(result, ['prod']);
-    expect(output).toBe('\nActions:\n  Run `audit-deps sync` to add vulnerabilities to the allowlist.\n');
+    expect(output).toContain('Actions:');
+    expect(output).toContain('  \u{2022} Run `audit-deps --prod --verbose` for full report');
+    expect(output).toContain('  \u{2022} Run `audit-deps sync` to add vulnerabilities to the allowlist.');
   });
 
-  it('returns the remove-only hint when only stale entries exist', () => {
+  it('returns remove-only hint without verbose hint when only stale entries exist', () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
@@ -44,10 +46,11 @@ describe(formatActionHints, () => {
     });
 
     const output = formatActionHints(result, ['prod']);
-    expect(output).toBe('\nActions:\n  Run `audit-deps sync` to remove stale allowlist entries.\n');
+    expect(output).toContain('  \u{2022} Run `audit-deps sync` to remove stale allowlist entries.');
+    expect(output).not.toContain('--verbose');
   });
 
-  it('returns the combined hint when both unallowed and stale entries exist', () => {
+  it('returns combined sync hint when both unallowed and stale entries exist', () => {
     const result = makeCheckResult({
       dev: {
         allowed: [],
@@ -62,9 +65,7 @@ describe(formatActionHints, () => {
     });
 
     const output = formatActionHints(result, ['prod', 'dev']);
-    expect(output).toBe(
-      '\nActions:\n  Run `audit-deps sync` to add vulnerabilities to the allowlist and remove stale entries.\n',
-    );
+    expect(output).toContain('add vulnerabilities to the allowlist and remove stale entries');
   });
 
   it('only considers scopes included in the scopes array', () => {
@@ -78,5 +79,46 @@ describe(formatActionHints, () => {
 
     // Only 'prod' is passed; dev's unallowed should be ignored.
     expect(formatActionHints(result, ['prod'])).toBe('');
+  });
+
+  it('uses --verbose without scope flag when both scopes are audited', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
+      },
+    });
+
+    const output = formatActionHints(result, ['prod', 'dev']);
+    expect(output).toContain('Run `audit-deps --verbose` for full report');
+  });
+
+  it('uses --dev --verbose when only dev scope is audited', () => {
+    const result = makeCheckResult({
+      dev: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
+      },
+    });
+
+    const output = formatActionHints(result, ['dev']);
+    expect(output).toContain('Run `audit-deps --dev --verbose` for full report');
+  });
+
+  it('shows verbose hint when only allowed vulns exist', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/1' }],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatActionHints(result, ['prod']);
+    expect(output).toContain('Run `audit-deps --prod --verbose` for full report');
+    // No sync hint since nothing to sync
+    expect(output).not.toContain('audit-deps sync');
   });
 });

--- a/packages/audit-deps/__tests__/format-actions.test.ts
+++ b/packages/audit-deps/__tests__/format-actions.test.ts
@@ -107,6 +107,20 @@ describe(formatActionHints, () => {
     expect(output).toContain('Run `audit-deps --dev --verbose` for full report');
   });
 
+  it('shows verbose hint and remove-only sync hint when allowed and stale entries exist without unallowed', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/1' }],
+        stale: [{ id: 'GHSA-stale' }],
+        unallowed: [],
+      },
+    });
+
+    const output = formatActionHints(result, ['prod']);
+    expect(output).toContain('Run `audit-deps --prod --verbose` for full report');
+    expect(output).toContain('Run `audit-deps sync` to remove stale allowlist entries.');
+  });
+
   it('shows verbose hint when only allowed vulns exist', () => {
     const result = makeCheckResult({
       prod: {

--- a/packages/audit-deps/__tests__/format-check.test.ts
+++ b/packages/audit-deps/__tests__/format-check.test.ts
@@ -7,6 +7,8 @@ import { formatCheckJson, formatCheckText, severityIndicator } from '../src/form
 // Helpers
 // ---------------------------------------------------------------------------
 
+const FIXED_NOW = new Date('2026-04-15T00:00:00Z');
+
 function emptyScopeResult(): ScopeCheckResult {
   return { allowed: [], stale: [], unallowed: [] };
 }
@@ -48,58 +50,185 @@ describe(severityIndicator, () => {
 // ---------------------------------------------------------------------------
 
 describe(formatCheckText, () => {
-  it('shows "(none)" when a scope has no findings', () => {
-    const result = makeCheckResult();
-    const output = formatCheckText(result, ['prod', 'dev']);
+  // --- All clean ---
 
-    expect(output).toContain('-- \u{1F4E6} prod --');
-    expect(output).toContain('  (none)');
-    expect(output).toContain('-- \u{1F527} dev --');
+  it('prints "No known vulnerabilities found." when both scopes are clean', () => {
+    const result = makeCheckResult();
+    const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW);
+
+    expect(output).toContain('\u{1F52C} Auditing dependencies ...');
+    expect(output).toContain('No known vulnerabilities found.');
+    expect(output).not.toContain('\u{1F4E6}');
+    expect(output).not.toContain('\u{1F527}');
   });
 
-  it('separates scope sections with a blank line', () => {
+  it('prints "No known vulnerabilities found." when a single clean scope is audited', () => {
     const result = makeCheckResult();
-    const output = formatCheckText(result, ['prod', 'dev']);
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
 
-    // Verify a blank line separates the prod and dev sections.
-    const prodIndex = output.indexOf('prod');
-    const devIndex = output.indexOf('dev');
-    const between = output.slice(prodIndex, devIndex);
-    expect(between).toContain('\n\n');
+    expect(output).toContain('\u{1F52C} Auditing prod dependencies ...');
+    expect(output).toContain('No known vulnerabilities found.');
   });
 
-  it('lists unallowed vulnerabilities with severity indicators', () => {
+  // --- Intro banner ---
+
+  it('includes "dev" in the intro banner when only dev is audited', () => {
+    const result = makeCheckResult();
+    const output = formatCheckText(result, ['dev'], FIXED_NOW);
+    expect(output).toContain('\u{1F52C} Auditing dev dependencies ...');
+  });
+
+  it('omits scope name from intro banner when both scopes are audited', () => {
+    const result = makeCheckResult();
+    const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW);
+    expect(output).toContain('\u{1F52C} Auditing dependencies ...');
+  });
+
+  // --- Multi-scope with findings ---
+
+  it('shows scope headers when multiple scopes are audited and at least one has findings', () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
         stale: [],
         unallowed: [
-          { id: 'GHSA-1', path: 'lodash', paths: ['lodash'], severity: 'high', url: 'https://example.com/1' },
+          {
+            id: 'GHSA-1',
+            ghsaId: 'GHSA-1',
+            path: 'lodash',
+            paths: ['lodash'],
+            severity: 'high',
+            url: 'https://example.com/1',
+          },
         ],
       },
     });
 
-    const output = formatCheckText(result, ['prod']);
-    expect(output).toContain('\u{1F534} GHSA-1: lodash (https://example.com/1)');
-    expect(output).not.toContain('allowed');
+    const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW);
+    expect(output).toContain('  \u{1F4E6} prod:');
+    expect(output).toContain('  \u{1F527} dev:');
   });
 
-  it('annotates allowed vulnerabilities', () => {
+  it('shows "No known vulnerabilities found." for a clean scope when another has findings', () => {
+    const result = makeCheckResult({
+      dev: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            id: '1234',
+            ghsaId: 'GHSA-dev1',
+            path: 'pkg',
+            paths: ['pkg'],
+            severity: 'moderate',
+            url: 'https://example.com/dev',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW);
+    expect(output).toContain('  \u{1F4E6} prod:');
+    expect(output).toContain('  No known vulnerabilities found.');
+    expect(output).toContain('  \u{1F527} dev:');
+    expect(output).toContain('GHSA-dev1');
+  });
+
+  // --- Unallowed vulnerabilities ---
+
+  it('lists unallowed vulnerabilities with GHSA ID and severity suffix', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            id: '1234',
+            ghsaId: 'GHSA-abcd-efgh-1234',
+            path: '.>path>to>dep',
+            paths: ['.>path>to>dep'],
+            severity: 'critical',
+            url: 'https://example.com/1',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('  \u{2022} \u{1F6A8} GHSA-abcd-efgh-1234: .>path>to>dep  \u{1F534} critical');
+  });
+
+  it('falls back to numeric ID when ghsaId is absent', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: '1234', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/1' }],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('\u{1F6A8} 1234: pkg');
+  });
+
+  it('omits severity suffix when severity is undefined', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-1', ghsaId: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('  \u{2022} \u{1F6A8} GHSA-1: pkg');
+    expect(output).not.toContain('\u{1F534}');
+    expect(output).not.toContain('\u{1F7E0}');
+  });
+
+  // --- Allowed vulnerabilities ---
+
+  it('annotates allowed vulnerabilities with relative time and addedAt', () => {
     const result = makeCheckResult({
       dev: {
         allowed: [
-          { id: 'GHSA-2', path: 'express', paths: ['express'], severity: 'moderate', url: 'https://example.com/2' },
+          {
+            addedAt: '2026-04-01T00:00:00.000Z',
+            ghsaId: 'GHSA-allowed',
+            id: '1234',
+            path: 'express',
+            paths: ['express'],
+            severity: 'moderate',
+            url: 'https://example.com/2',
+          },
         ],
         stale: [],
         unallowed: [],
       },
     });
 
-    const output = formatCheckText(result, ['dev']);
-    expect(output).toContain('\u{1F7E0} GHSA-2: express (https://example.com/2) \u{1F6AB} allowed');
+    const output = formatCheckText(result, ['dev'], FIXED_NOW);
+    expect(output).toContain('\u{26A0}\u{FE0F} GHSA-allowed: express  \u{1F7E0} moderate');
+    expect(output).toContain('\u{2705} allowed since 2 weeks ago (2026-04-01T00:00:00.000Z)');
   });
 
-  it('flags stale entries with emoji-first ordering', () => {
+  it('omits "allowed since" suffix when addedAt is absent', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [{ id: '1234', ghsaId: 'GHSA-nodate', path: 'pkg', paths: ['pkg'], url: 'https://example.com' }],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('GHSA-nodate');
+    expect(output).not.toContain('allowed');
+  });
+
+  // --- Stale entries ---
+
+  it('renders stale entries with bullet format', () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
@@ -108,24 +237,41 @@ describe(formatCheckText, () => {
       },
     });
 
-    const output = formatCheckText(result, ['prod']);
-    expect(output).toContain('  \u{1F5D1}\u{FE0F} GHSA-old  not needed');
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('  \u{2022} \u{1F5D1}\u{FE0F} GHSA-old \u{2022} not needed');
   });
+
+  // --- Mixed findings ---
 
   it('renders mixed findings in a single scope', () => {
     const result = makeCheckResult({
       prod: {
         allowed: [
-          { id: 'GHSA-ok', path: 'safe-pkg', paths: ['safe-pkg'], severity: 'low', url: 'https://example.com/ok' },
+          {
+            addedAt: '2026-04-01',
+            id: 'ok',
+            ghsaId: 'GHSA-ok',
+            path: 'safe-pkg',
+            paths: ['safe-pkg'],
+            severity: 'low',
+            url: 'https://example.com/ok',
+          },
         ],
         stale: [{ id: 'GHSA-stale' }],
         unallowed: [
-          { id: 'GHSA-bad', path: 'bad-pkg', paths: ['bad-pkg'], severity: 'critical', url: 'https://example.com/bad' },
+          {
+            id: 'bad',
+            ghsaId: 'GHSA-bad',
+            path: 'bad-pkg',
+            paths: ['bad-pkg'],
+            severity: 'critical',
+            url: 'https://example.com/bad',
+          },
         ],
       },
     });
 
-    const output = formatCheckText(result, ['prod']);
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
     expect(output).toContain('GHSA-bad');
     expect(output).toContain('GHSA-ok');
     expect(output).toContain('GHSA-stale');
@@ -136,34 +282,23 @@ describe(formatCheckText, () => {
       dev: {
         allowed: [],
         stale: [],
-        unallowed: [{ id: 'GHSA-dev', path: 'pkg', paths: ['pkg'], url: 'https://example.com/dev' }],
+        unallowed: [{ id: 'dev1', ghsaId: 'GHSA-dev', path: 'pkg', paths: ['pkg'], url: 'https://example.com/dev' }],
       },
       prod: {
         allowed: [],
         stale: [],
-        unallowed: [{ id: 'GHSA-prod', path: 'pkg', paths: ['pkg'], url: 'https://example.com/prod' }],
+        unallowed: [{ id: 'prod1', ghsaId: 'GHSA-prod', path: 'pkg', paths: ['pkg'], url: 'https://example.com/prod' }],
       },
     });
 
-    const output = formatCheckText(result, ['prod']);
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
     expect(output).toContain('GHSA-prod');
     expect(output).not.toContain('GHSA-dev');
   });
 
-  it('omits severity prefix when severity is undefined', () => {
-    const result = makeCheckResult({
-      prod: {
-        allowed: [],
-        stale: [],
-        unallowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
-      },
-    });
+  // --- Actions footer ---
 
-    const output = formatCheckText(result, ['prod']);
-    expect(output).toContain('  GHSA-1: pkg (https://example.com/1)');
-  });
-
-  it('appends an Actions footer with the add-only hint when only unallowed vulnerabilities exist', () => {
+  it('appends an Actions footer with verbose and sync hints when unallowed vulnerabilities exist', () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
@@ -172,10 +307,10 @@ describe(formatCheckText, () => {
       },
     });
 
-    const output = formatCheckText(result, ['prod']);
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
     expect(output).toContain('Actions:');
+    expect(output).toContain('Run `audit-deps --prod --verbose` for full report');
     expect(output).toContain('Run `audit-deps sync` to add vulnerabilities to the allowlist.');
-    expect(output).not.toContain('and remove stale entries');
   });
 
   it('appends an Actions footer with the remove-only hint when only stale entries exist', () => {
@@ -187,9 +322,11 @@ describe(formatCheckText, () => {
       },
     });
 
-    const output = formatCheckText(result, ['prod']);
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
     expect(output).toContain('Actions:');
     expect(output).toContain('Run `audit-deps sync` to remove stale allowlist entries.');
+    // No verbose hint for stale-only
+    expect(output).not.toContain('--verbose');
   });
 
   it('appends an Actions footer combining both hints when unallowed and stale both exist', () => {
@@ -201,15 +338,32 @@ describe(formatCheckText, () => {
       },
     });
 
-    const output = formatCheckText(result, ['prod']);
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
     expect(output).toContain('Actions:');
     expect(output).toContain('add vulnerabilities to the allowlist and remove stale entries');
   });
 
   it('omits the Actions footer when the allowlist is fully current', () => {
     const result = makeCheckResult();
-    const output = formatCheckText(result, ['prod', 'dev']);
+    const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW);
     expect(output).not.toContain('Actions:');
+  });
+
+  it('shows verbose hint when only allowed vulns exist (no unallowed, no stale)', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [
+          { id: '1', ghsaId: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/1' },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('Run `audit-deps --prod --verbose` for full report');
+    // No sync hint since nothing to sync
+    expect(output).not.toContain('audit-deps sync');
   });
 });
 

--- a/packages/audit-deps/__tests__/format-check.test.ts
+++ b/packages/audit-deps/__tests__/format-check.test.ts
@@ -371,6 +371,78 @@ describe(formatCheckText, () => {
     expect(output).not.toContain('Actions:');
   });
 
+  // --- Actions footer (multi-scope) ---
+
+  it('appends Actions footer with verbose and sync hints when multi-scope has unallowed vulnerabilities', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            id: 'GHSA-p1',
+            ghsaId: 'GHSA-p1',
+            path: 'pkg-a',
+            paths: ['pkg-a'],
+            severity: 'high',
+            url: 'https://example.com/p1',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW);
+    expect(output).toContain('Actions:');
+    expect(output).toContain('Run `audit-deps --verbose` for full report');
+    expect(output).toContain('Run `audit-deps sync` to add vulnerabilities to the allowlist.');
+  });
+
+  it('appends Actions footer with remove-only sync hint when multi-scope has only stale entries', () => {
+    const result = makeCheckResult({
+      dev: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale-dev' }],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW);
+    expect(output).toContain('Actions:');
+    expect(output).toContain('Run `audit-deps sync` to remove stale allowlist entries.');
+    expect(output).not.toContain('--verbose');
+  });
+
+  it('appends Actions footer with combined sync hint when multi-scope has both unallowed and stale', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale-prod' }],
+        unallowed: [
+          {
+            id: 'GHSA-bad',
+            ghsaId: 'GHSA-bad',
+            path: 'pkg',
+            paths: ['pkg'],
+            severity: 'critical',
+            url: 'https://example.com/bad',
+          },
+        ],
+      },
+      dev: {
+        allowed: [],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW);
+    expect(output).toContain('Actions:');
+    expect(output).toContain('add vulnerabilities to the allowlist and remove stale entries');
+    expect(output).toContain('Run `audit-deps --verbose` for full report');
+  });
+
+  // --- Actions footer (single-scope) ---
+
   it('shows verbose hint when only allowed vulns exist (no unallowed, no stale)', () => {
     const result = makeCheckResult({
       prod: {

--- a/packages/audit-deps/__tests__/format-check.test.ts
+++ b/packages/audit-deps/__tests__/format-check.test.ts
@@ -212,6 +212,28 @@ describe(formatCheckText, () => {
     expect(output).toContain('\u{2705} allowed since 2 weeks ago (2026-04-01T00:00:00.000Z)');
   });
 
+  it('renders "allowed (addedAt)" without "since" when addedAt is unparseable', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [
+          {
+            addedAt: 'not-a-date',
+            id: 'GHSA-baddate',
+            path: 'pkg',
+            paths: ['pkg'],
+            url: 'https://example.com/baddate',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('\u{2705} allowed (not-a-date)');
+    expect(output).not.toContain('since');
+  });
+
   it('omits "allowed since" suffix when addedAt is absent', () => {
     const result = makeCheckResult({
       prod: {

--- a/packages/audit-deps/__tests__/format-verbose.test.ts
+++ b/packages/audit-deps/__tests__/format-verbose.test.ts
@@ -40,7 +40,8 @@ describe(formatCheckVerboseText, () => {
         stale: [],
         unallowed: [
           {
-            id: 'GHSA-unallowed',
+            ghsaId: 'GHSA-unallowed',
+            id: '1234',
             path: 'lodash',
             paths: ['my-app>lodash'],
             severity: 'high',
@@ -57,6 +58,26 @@ describe(formatCheckVerboseText, () => {
     expect(output).toContain('Prototype pollution in lodash');
     expect(output).toContain('path: my-app>lodash');
     expect(output).toContain('link: https://github.com/advisories/GHSA-unallowed');
+  });
+
+  it('falls back to numeric ID when ghsaId is absent', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [],
+        unallowed: [
+          {
+            id: '1234',
+            path: 'pkg',
+            paths: ['pkg'],
+            url: 'https://example.com/1234',
+          },
+        ],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('\u{1F6A8} 1234');
   });
 
   it('renders multi-path vulnerabilities with a plural "paths:" list', () => {
@@ -190,7 +211,8 @@ describe(formatCheckVerboseText, () => {
         allowed: [
           {
             addedAt: '2026-04-01',
-            id: 'GHSA-allowed',
+            ghsaId: 'GHSA-allowed',
+            id: '1234',
             path: 'pkg',
             paths: ['pkg'],
             reason: 'Accepted risk: no user input reaches this path',

--- a/packages/audit-deps/__tests__/format-verbose.test.ts
+++ b/packages/audit-deps/__tests__/format-verbose.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type { CheckResult, ScopeCheckResult } from '../src/format-check.ts';
-import { formatCheckVerboseText, formatRelativeTime } from '../src/format-verbose.ts';
+import { formatRelativeTime } from '../src/format-time.ts';
+import { formatCheckVerboseText } from '../src/format-verbose.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -335,6 +336,33 @@ describe(formatCheckVerboseText, () => {
 
     const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
     expect(output).toContain('  \u{1F5D1}\u{FE0F} GHSA-stale-entry-0000  not needed');
+  });
+
+  it('ends output with a newline when actions are present', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale' }],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toMatch(/\n$/);
+  });
+
+  it('separates the Actions footer from scope content with a blank line', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        stale: [{ id: 'GHSA-stale' }],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('not needed\n\n');
+    expect(output).toContain('Actions:');
   });
 
   it('appends an Actions footer when unallowed or stale entries exist', () => {

--- a/packages/audit-deps/__tests__/run-audit.test.ts
+++ b/packages/audit-deps/__tests__/run-audit.test.ts
@@ -94,6 +94,40 @@ describe(parseAuditCiOutput, () => {
     expect(results).toStrictEqual([]);
   });
 
+  it('extracts ghsaId from github_advisory_id when present', () => {
+    const json = JSON.stringify({
+      advisories: {
+        '1234': {
+          id: 1234,
+          github_advisory_id: 'GHSA-f886-m6hf-6m8u',
+          module_name: 'lodash',
+          url: 'https://github.com/advisories/GHSA-f886-m6hf-6m8u',
+          findings: [{ paths: ['lodash'] }],
+        },
+      },
+    });
+
+    const { results } = parseAuditCiOutput(json);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.ghsaId).toBe('GHSA-f886-m6hf-6m8u');
+  });
+
+  it('omits ghsaId when github_advisory_id is absent', () => {
+    const json = JSON.stringify({
+      advisories: {
+        '1234': {
+          id: 1234,
+          module_name: 'lodash',
+          url: 'https://github.com/advisories/GHSA-1234',
+          findings: [{ paths: ['lodash'] }],
+        },
+      },
+    });
+
+    const { results } = parseAuditCiOutput(json);
+    expect(results[0]).not.toHaveProperty('ghsaId');
+  });
+
   it('extracts severity from advisory when present', () => {
     const json = JSON.stringify({
       advisories: {

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -260,6 +260,7 @@ function buildAllowedVuln(result: AuditResult, entry: AllowlistEntry | undefined
     paths: result.paths,
     url: result.url,
   };
+  if (result.ghsaId !== undefined) allowed.ghsaId = result.ghsaId;
   if (result.severity !== undefined) allowed.severity = result.severity;
   if (result.title !== undefined) allowed.title = result.title;
   if (result.description !== undefined) allowed.description = result.description;

--- a/packages/audit-deps/src/format-actions.ts
+++ b/packages/audit-deps/src/format-actions.ts
@@ -5,23 +5,40 @@ const HINT_ADD = 'Run `audit-deps sync` to add vulnerabilities to the allowlist.
 const HINT_REMOVE = 'Run `audit-deps sync` to remove stale allowlist entries.';
 const HINT_BOTH = 'Run `audit-deps sync` to add vulnerabilities to the allowlist and remove stale entries.';
 
+/** Build the `--verbose` flag string reflecting the original scope flags. */
+function buildVerboseFlag(scopes: AuditScope[]): string {
+  if (scopes.length === 1) {
+    return `--${scopes[0]} --verbose`;
+  }
+  return '--verbose';
+}
+
 /**
  * Compute the "Actions:" footer for check output.
  *
  * Returns an empty string when the allowlist is fully current. Otherwise returns
- * `\nActions:\n  <hint>\n` describing what sync would do.
+ * a bulleted action list with a verbose hint (when vulns exist) and a sync hint.
  */
 export function formatActionHints(result: CheckResult, scopes: AuditScope[]): string {
   const hasUnallowed = scopes.some((scope) => result[scope].unallowed.length > 0);
+  const hasAllowed = scopes.some((scope) => result[scope].allowed.length > 0);
   const hasStale = scopes.some((scope) => result[scope].stale.length > 0);
 
-  if (hasUnallowed && hasStale) return footer(HINT_BOTH);
-  if (hasUnallowed) return footer(HINT_ADD);
-  if (hasStale) return footer(HINT_REMOVE);
-  return '';
-}
+  const hasVulns = hasUnallowed || hasAllowed;
+  const needsSync = hasUnallowed || hasStale;
 
-/** Wrap a single hint line in the "Actions:" footer format. */
-function footer(hint: string): string {
-  return `\nActions:\n  ${hint}\n`;
+  if (!hasVulns && !needsSync) return '';
+
+  const bullets: string[] = [];
+
+  if (hasVulns) {
+    bullets.push(`  \u{2022} Run \`audit-deps ${buildVerboseFlag(scopes)}\` for full report`);
+  }
+
+  if (needsSync) {
+    const hint = hasUnallowed && hasStale ? HINT_BOTH : hasUnallowed ? HINT_ADD : HINT_REMOVE;
+    bullets.push(`  \u{2022} ${hint}`);
+  }
+
+  return `  Actions:\n${bullets.join('\n')}`;
 }

--- a/packages/audit-deps/src/format-check.ts
+++ b/packages/audit-deps/src/format-check.ts
@@ -76,8 +76,8 @@ const SCOPE_LABELS: Record<AuditScope, string> = {
 };
 
 const SCOPE_NAMES: Record<AuditScope, string> = {
-  dev: 'dev ',
-  prod: 'prod ',
+  dev: 'dev',
+  prod: 'prod',
 };
 
 // ---------------------------------------------------------------------------
@@ -87,14 +87,15 @@ const SCOPE_NAMES: Record<AuditScope, string> = {
 /** Build the intro banner reflecting the scopes being audited. */
 function formatIntroBanner(scopes: AuditScope[]): string {
   const first = scopes[0];
+  // `first` is always defined here; the guard narrows for TypeScript.
   if (scopes.length === 1 && first !== undefined) {
-    return `\u{1F52C} Auditing ${SCOPE_NAMES[first]}dependencies ...`;
+    return `\u{1F52C} Auditing ${SCOPE_NAMES[first]} dependencies ...`;
   }
   return '\u{1F52C} Auditing dependencies ...';
 }
 
 /** Build the severity suffix for a finding line, e.g. `  🔴 critical`. */
-function formatSeveritySuffix(severity: string | undefined): string {
+export function formatSeveritySuffix(severity: string | undefined): string {
   if (severity === undefined || severity === '') return '';
   const emoji = severityIndicator(severity);
   const emojiPart = emoji.length > 0 ? `${emoji} ` : '';
@@ -166,11 +167,7 @@ export function formatCheckText(result: CheckResult, scopes: AuditScope[], now?:
   if (singleScope !== undefined) {
     const scope = singleScope;
     const scopeResult = result[scope];
-    if (hasFindings(scopeResult)) {
-      lines.push(...formatScopeFindings(scopeResult, effectiveNow));
-    } else {
-      lines.push('No known vulnerabilities found.');
-    }
+    lines.push(...formatScopeFindings(scopeResult, effectiveNow));
     const actions = formatActionHints(result, scopes);
     if (actions.length > 0) {
       lines.push('', ...actions.split('\n').filter((l) => l.length > 0));

--- a/packages/audit-deps/src/format-check.ts
+++ b/packages/audit-deps/src/format-check.ts
@@ -1,4 +1,5 @@
 import { formatActionHints } from './format-actions.ts';
+import { formatRelativeTime } from './format-time.ts';
 import type { AuditResult, AuditScope } from './types.ts';
 
 // ---------------------------------------------------------------------------
@@ -10,6 +11,7 @@ export interface AllowedVuln {
   addedAt?: string | undefined;
   cvss?: { score?: number; vectorString?: string } | undefined;
   description?: string | undefined;
+  ghsaId?: string | undefined;
   id: string;
   path: string;
   paths: string[];
@@ -56,61 +58,144 @@ export function severityIndicator(severity: string | undefined): string {
 }
 
 // ---------------------------------------------------------------------------
+// Display ID helper
+// ---------------------------------------------------------------------------
+
+/** Resolve the best display ID for a vulnerability: GHSA ID if available, otherwise the numeric ID. */
+function displayId(vuln: { ghsaId?: string | undefined; id: string }): string {
+  return vuln.ghsaId ?? vuln.id;
+}
+
+// ---------------------------------------------------------------------------
+// Scope labels
+// ---------------------------------------------------------------------------
+
+const SCOPE_LABELS: Record<AuditScope, string> = {
+  dev: '  \u{1F527} dev:',
+  prod: '  \u{1F4E6} prod:',
+};
+
+const SCOPE_NAMES: Record<AuditScope, string> = {
+  dev: 'dev ',
+  prod: 'prod ',
+};
+
+// ---------------------------------------------------------------------------
 // Text formatter
 // ---------------------------------------------------------------------------
 
-/** Scope display metadata. */
-const SCOPE_HEADERS: Record<AuditScope, string> = {
-  prod: '-- \u{1F4E6} prod --',
-  dev: '-- \u{1F527} dev --',
-};
-
-/** Format a vulnerability line with optional severity indicator and suffix. */
-function formatVulnLine(
-  vuln: { id: string; path: string; severity?: string | undefined; url: string },
-  suffix?: string,
-): string {
-  const indicator = severityIndicator(vuln.severity);
-  const prefix = indicator.length > 0 ? `${indicator} ` : '';
-  const tail = suffix !== undefined ? ` ${suffix}` : '';
-  return `  ${prefix}${vuln.id}: ${vuln.path} (${vuln.url})${tail}`;
+/** Build the intro banner reflecting the scopes being audited. */
+function formatIntroBanner(scopes: AuditScope[]): string {
+  const first = scopes[0];
+  if (scopes.length === 1 && first !== undefined) {
+    return `\u{1F52C} Auditing ${SCOPE_NAMES[first]}dependencies ...`;
+  }
+  return '\u{1F52C} Auditing dependencies ...';
 }
 
-/** Format a single scope's check results as text lines. */
-function formatScopeText(scope: AuditScope, result: ScopeCheckResult): string {
-  const lines: string[] = [SCOPE_HEADERS[scope]];
+/** Build the severity suffix for a finding line, e.g. `  🔴 critical`. */
+function formatSeveritySuffix(severity: string | undefined): string {
+  if (severity === undefined || severity === '') return '';
+  const emoji = severityIndicator(severity);
+  const emojiPart = emoji.length > 0 ? `${emoji} ` : '';
+  return `  ${emojiPart}${severity}`;
+}
 
-  const hasFindings = result.unallowed.length > 0 || result.allowed.length > 0 || result.stale.length > 0;
+/** Build the "allowed since X ago (datetime)" suffix for entries with `addedAt`. */
+function formatAllowedSuffix(addedAt: string, now: Date): string {
+  const relative = formatRelativeTime(addedAt, now);
+  if (relative.length === 0) return ` \u{2022} \u{2705} allowed (${addedAt})`;
+  return ` \u{2022} \u{2705} allowed since ${relative} (${addedAt})`;
+}
 
-  if (!hasFindings) {
-    lines.push('  (none)');
-    return lines.join('\n');
-  }
+/** Format a single unallowed vulnerability as a bullet line. */
+function formatUnallowedLine(vuln: AuditResult): string {
+  return `  \u{2022} \u{1F6A8} ${displayId(vuln)}: ${vuln.path}${formatSeveritySuffix(vuln.severity)}`;
+}
 
+/** Format a single allowed vulnerability as a bullet line. */
+function formatAllowedLine(vuln: AllowedVuln, now: Date): string {
+  const suffix = vuln.addedAt !== undefined ? formatAllowedSuffix(vuln.addedAt, now) : '';
+  return `  \u{2022} \u{26A0}\u{FE0F} ${displayId(vuln)}: ${vuln.path}${formatSeveritySuffix(vuln.severity)}${suffix}`;
+}
+
+/** Format a single stale entry as a bullet line. */
+function formatStaleLine(entry: StaleEntry): string {
+  return `  \u{2022} \u{1F5D1}\u{FE0F} ${entry.id} \u{2022} not needed`;
+}
+
+/** Check whether a scope has any findings. */
+function hasFindings(result: ScopeCheckResult): boolean {
+  return result.unallowed.length > 0 || result.allowed.length > 0 || result.stale.length > 0;
+}
+
+/** Format a scope's finding lines (without scope header). */
+function formatScopeFindings(result: ScopeCheckResult, now: Date): string[] {
+  const lines: string[] = [];
   for (const vuln of result.unallowed) {
-    lines.push(formatVulnLine(vuln));
+    lines.push(formatUnallowedLine(vuln));
   }
-
   for (const vuln of result.allowed) {
-    lines.push(formatVulnLine(vuln, '\u{1F6AB} allowed'));
+    lines.push(formatAllowedLine(vuln, now));
   }
-
   for (const entry of result.stale) {
-    lines.push(`  \u{1F5D1}\u{FE0F} ${entry.id}  not needed`);
+    lines.push(formatStaleLine(entry));
   }
-
-  return lines.join('\n');
+  return lines;
 }
 
-/** Format check results as human-readable text output. */
-export function formatCheckText(result: CheckResult, scopes: AuditScope[]): string {
-  const sections: string[] = [];
+/**
+ * Format check results as human-readable text output.
+ *
+ * Produces an intro banner, scoped findings with severity labels and GHSA IDs,
+ * and an action hints footer.
+ */
+export function formatCheckText(result: CheckResult, scopes: AuditScope[], now?: Date): string {
+  const effectiveNow = now ?? new Date();
+  const lines: string[] = [formatIntroBanner(scopes)];
 
-  for (const scope of scopes) {
-    sections.push(formatScopeText(scope, result[scope]));
+  const anyFindings = scopes.some((scope) => hasFindings(result[scope]));
+
+  if (!anyFindings) {
+    lines.push('No known vulnerabilities found.');
+    return lines.join('\n') + '\n';
   }
 
-  return sections.join('\n\n') + '\n' + formatActionHints(result, scopes);
+  // Single scope: no scope header, findings directly below banner.
+  const singleScope = scopes.length === 1 ? scopes[0] : undefined;
+  if (singleScope !== undefined) {
+    const scope = singleScope;
+    const scopeResult = result[scope];
+    if (hasFindings(scopeResult)) {
+      lines.push(...formatScopeFindings(scopeResult, effectiveNow));
+    } else {
+      lines.push('No known vulnerabilities found.');
+    }
+    const actions = formatActionHints(result, scopes);
+    if (actions.length > 0) {
+      lines.push('', ...actions.split('\n').filter((l) => l.length > 0));
+    }
+    return lines.join('\n') + '\n';
+  }
+
+  // Multiple scopes: show scope headers.
+  for (const scope of scopes) {
+    const scopeResult = result[scope];
+    lines.push(SCOPE_LABELS[scope]);
+    if (hasFindings(scopeResult)) {
+      lines.push(...formatScopeFindings(scopeResult, effectiveNow));
+    } else {
+      lines.push('  No known vulnerabilities found.');
+    }
+    lines.push('');
+  }
+
+  const actions = formatActionHints(result, scopes);
+  if (actions.length > 0) {
+    lines.push(...actions.split('\n').filter((l) => l.length > 0));
+  }
+
+  return lines.join('\n') + '\n';
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/audit-deps/src/format-check.ts
+++ b/packages/audit-deps/src/format-check.ts
@@ -62,7 +62,7 @@ export function severityIndicator(severity: string | undefined): string {
 // ---------------------------------------------------------------------------
 
 /** Resolve the best display ID for a vulnerability: GHSA ID if available, otherwise the numeric ID. */
-function displayId(vuln: { ghsaId?: string | undefined; id: string }): string {
+export function displayId(vuln: { ghsaId?: string | undefined; id: string }): string {
   return vuln.ghsaId ?? vuln.id;
 }
 

--- a/packages/audit-deps/src/format-time.ts
+++ b/packages/audit-deps/src/format-time.ts
@@ -1,0 +1,56 @@
+/**
+ * Produce a human-readable relative-time string such as "just now", "N minutes ago",
+ * "yesterday", "N months ago", "N years ago".
+ *
+ * Uses millisecond math for units up through weeks to avoid DST/timezone drift on
+ * short intervals, and UTC calendar math for months and years.
+ *
+ * @internal — exported for test access; consumers should use higher-level formatting helpers.
+ */
+export function formatRelativeTime(fromIso: string, now: Date): string {
+  const from = parseDateUtc(fromIso);
+  if (from === undefined) return '';
+
+  const deltaMs = now.getTime() - from.getTime();
+  if (deltaMs < 60_000) return 'just now';
+
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 60) return pluralize(minutes, 'minute');
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return pluralize(hours, 'hour');
+
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'yesterday';
+  if (days < 7) return pluralize(days, 'day');
+
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return pluralize(weeks, 'week');
+
+  const months = diffMonthsUtc(from, now);
+  if (months < 12) return pluralize(months, 'month');
+
+  const years = Math.floor(months / 12);
+  return pluralize(years, 'year');
+}
+
+/** Parse a YYYY-MM-DD (or full ISO) string into a UTC Date; return undefined if invalid. */
+function parseDateUtc(iso: string): Date | undefined {
+  // ECMAScript parses date-only ISO strings (YYYY-MM-DD) and full ISO strings as UTC.
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+/** Compute the number of whole months between two dates in UTC. */
+function diffMonthsUtc(from: Date, now: Date): number {
+  let months = (now.getUTCFullYear() - from.getUTCFullYear()) * 12 + (now.getUTCMonth() - from.getUTCMonth());
+  if (now.getUTCDate() < from.getUTCDate()) {
+    months -= 1;
+  }
+  return Math.max(0, months);
+}
+
+/** Format an integer count + unit, pluralizing with a simple `s`. */
+function pluralize(count: number, unit: string): string {
+  return `${count} ${unit}${count === 1 ? '' : 's'} ago`;
+}

--- a/packages/audit-deps/src/format-verbose.ts
+++ b/packages/audit-deps/src/format-verbose.ts
@@ -1,7 +1,10 @@
 import { formatActionHints } from './format-actions.ts';
 import type { AllowedVuln, CheckResult, ScopeCheckResult, StaleEntry } from './format-check.ts';
 import { severityIndicator } from './format-check.ts';
+import { formatRelativeTime } from './format-time.ts';
 import type { AuditResult, AuditScope } from './types.ts';
+
+export { formatRelativeTime } from './format-time.ts';
 
 // ---------------------------------------------------------------------------
 // Display constants
@@ -64,9 +67,14 @@ function formatScopeVerbose(scope: AuditScope, result: ScopeCheckResult, now: Da
   return lines.concat(blocks.join('\n\n')).join('\n');
 }
 
+/** Resolve the best display ID for a vulnerability: GHSA ID if available, otherwise the numeric ID. */
+function displayId(vuln: { ghsaId?: string | undefined; id: string }): string {
+  return vuln.ghsaId ?? vuln.id;
+}
+
 /** Format an unallowed vulnerability block with 🚨 marker. */
 function formatUnallowedBlock(vuln: AuditResult): string {
-  const headerLine = `  ${STATUS_UNALLOWED} ${vuln.id}${formatSeveritySuffix(vuln.severity)}`;
+  const headerLine = `  ${STATUS_UNALLOWED} ${displayId(vuln)}${formatSeveritySuffix(vuln.severity)}`;
   const detail = formatAdvisoryDetail(vuln);
   return [headerLine, ...detail].join('\n');
 }
@@ -74,7 +82,7 @@ function formatUnallowedBlock(vuln: AuditResult): string {
 /** Format an allowed vulnerability block with ⚠️ marker plus reason/addedAt context. */
 function formatAllowedBlock(vuln: AllowedVuln, now: Date): string {
   const allowedSuffix = vuln.addedAt !== undefined ? formatAllowedSuffix(vuln.addedAt, now) : '';
-  const headerLine = `  ${STATUS_ALLOWED} ${vuln.id}${formatSeveritySuffix(vuln.severity)}${allowedSuffix}`;
+  const headerLine = `  ${STATUS_ALLOWED} ${displayId(vuln)}${formatSeveritySuffix(vuln.severity)}${allowedSuffix}`;
   const hasTitle = vuln.title !== undefined;
   const detail = formatAdvisoryDetail(vuln);
   if (vuln.reason !== undefined) {
@@ -140,63 +148,6 @@ function formatAllowedSuffix(addedAt: string, now: Date): string {
   const relative = formatRelativeTime(addedAt, now);
   if (relative.length === 0) return `  allowed (${addedAt})`;
   return `  allowed ${relative} (${addedAt})`;
-}
-
-/**
- * Produce a human-readable relative-time string such as "just now", "N minutes ago",
- * "yesterday", "N months ago", "N years ago".
- *
- * Uses millisecond math for units up through weeks to avoid DST/timezone drift on
- * short intervals, and UTC calendar math for months and years.
- *
- * @internal — exported for test access; consumers should use `formatAllowedSuffix`.
- */
-export function formatRelativeTime(fromIso: string, now: Date): string {
-  const from = parseDateUtc(fromIso);
-  if (from === undefined) return '';
-
-  const deltaMs = now.getTime() - from.getTime();
-  if (deltaMs < 60_000) return 'just now';
-
-  const minutes = Math.floor(deltaMs / 60_000);
-  if (minutes < 60) return pluralize(minutes, 'minute');
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return pluralize(hours, 'hour');
-
-  const days = Math.floor(hours / 24);
-  if (days === 1) return 'yesterday';
-  if (days < 7) return pluralize(days, 'day');
-
-  const weeks = Math.floor(days / 7);
-  if (weeks < 5) return pluralize(weeks, 'week');
-
-  const months = diffMonthsUtc(from, now);
-  if (months < 12) return pluralize(months, 'month');
-
-  const years = Math.floor(months / 12);
-  return pluralize(years, 'year');
-}
-
-/** Parse a YYYY-MM-DD (or full ISO) string into a UTC Date; return undefined if invalid. */
-function parseDateUtc(iso: string): Date | undefined {
-  // ECMAScript parses date-only ISO strings (YYYY-MM-DD) and full ISO strings as UTC.
-  const parsed = new Date(iso);
-  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
-}
-
-/** Compute the number of whole months between two dates in UTC. */
-function diffMonthsUtc(from: Date, now: Date): number {
-  let months = (now.getUTCFullYear() - from.getUTCFullYear()) * 12 + (now.getUTCMonth() - from.getUTCMonth());
-  if (now.getUTCDate() < from.getUTCDate()) {
-    months -= 1;
-  }
-  return Math.max(0, months);
-}
-
-/** Format an integer count + unit, pluralizing with a simple `s`. */
-function pluralize(count: number, unit: string): string {
-  return `${count} ${unit}${count === 1 ? '' : 's'} ago`;
 }
 
 /** Wrap a description (possibly multi-paragraph) to the detail indent. */

--- a/packages/audit-deps/src/format-verbose.ts
+++ b/packages/audit-deps/src/format-verbose.ts
@@ -1,10 +1,8 @@
 import { formatActionHints } from './format-actions.ts';
 import type { AllowedVuln, CheckResult, ScopeCheckResult, StaleEntry } from './format-check.ts';
-import { severityIndicator } from './format-check.ts';
+import { displayId, severityIndicator } from './format-check.ts';
 import { formatRelativeTime } from './format-time.ts';
 import type { AuditResult, AuditScope } from './types.ts';
-
-export { formatRelativeTime } from './format-time.ts';
 
 // ---------------------------------------------------------------------------
 // Display constants
@@ -39,7 +37,10 @@ export function formatCheckVerboseText(result: CheckResult, scopes: AuditScope[]
     sections.push(formatScopeVerbose(scope, result[scope], effectiveNow));
   }
 
-  return sections.join('\n\n') + '\n' + formatActionHints(result, scopes);
+  const actions = formatActionHints(result, scopes);
+  const body = sections.join('\n\n') + '\n';
+  if (actions.length === 0) return body;
+  return body + '\n' + actions + '\n';
 }
 
 /** Format a single scope's verbose check results. */
@@ -65,11 +66,6 @@ function formatScopeVerbose(scope: AuditScope, result: ScopeCheckResult, now: Da
 
   // Join blocks with a blank line between them.
   return lines.concat(blocks.join('\n\n')).join('\n');
-}
-
-/** Resolve the best display ID for a vulnerability: GHSA ID if available, otherwise the numeric ID. */
-function displayId(vuln: { ghsaId?: string | undefined; id: string }): string {
-  return vuln.ghsaId ?? vuln.id;
 }
 
 /** Format an unallowed vulnerability block with 🚨 marker. */

--- a/packages/audit-deps/src/format-verbose.ts
+++ b/packages/audit-deps/src/format-verbose.ts
@@ -1,6 +1,6 @@
 import { formatActionHints } from './format-actions.ts';
 import type { AllowedVuln, CheckResult, ScopeCheckResult, StaleEntry } from './format-check.ts';
-import { displayId, severityIndicator } from './format-check.ts';
+import { displayId, formatSeveritySuffix } from './format-check.ts';
 import { formatRelativeTime } from './format-time.ts';
 import type { AuditResult, AuditScope } from './types.ts';
 
@@ -129,14 +129,6 @@ function formatPathsLines(paths: string[]): string[] {
     lines.push(`${DETAIL_INDENT}  - ${pathValue}`);
   }
   return lines;
-}
-
-/** Build the severity suffix like `  🔴 high` (leading two spaces separator). */
-function formatSeveritySuffix(severity: string | undefined): string {
-  if (severity === undefined || severity === '') return '';
-  const emoji = severityIndicator(severity);
-  const emojiPart = emoji.length > 0 ? `${emoji} ` : '';
-  return `  ${emojiPart}${severity}`;
 }
 
 /** Build the "allowed X ago (datetime)" suffix for entries with `addedAt`. */

--- a/packages/audit-deps/src/run-audit.ts
+++ b/packages/audit-deps/src/run-audit.ts
@@ -20,6 +20,7 @@ export function resolveAuditCiBin(): string {
 interface AuditCiAdvisory {
   cvss?: { score?: number; vectorString?: string };
   findings: Array<{ paths: string[] }>;
+  github_advisory_id?: string;
   id: number | string;
   module_name: string;
   overview?: string;
@@ -71,6 +72,9 @@ export function parseAuditCiOutput(jsonString: string): ParseResult {
       paths,
       url: advisory.url,
     };
+    if (typeof advisory.github_advisory_id === 'string') {
+      result.ghsaId = advisory.github_advisory_id;
+    }
     if (typeof advisory.severity === 'string') {
       result.severity = advisory.severity;
     }

--- a/packages/audit-deps/src/types.ts
+++ b/packages/audit-deps/src/types.ts
@@ -99,6 +99,7 @@ export const DEFAULT_CONFIG: AuditDepsConfig = {
 export interface AuditResult {
   cvss?: { score?: number; vectorString?: string } | undefined;
   description?: string | undefined;
+  ghsaId?: string | undefined;
   id: string;
   path: string;
   paths: string[];


### PR DESCRIPTION
## What

Redesigns the `audit-deps` bare output format to show GHSA IDs instead of npm-specific numeric advisory IDs, add severity text labels, and guide developers toward next steps. The new format includes an intro banner reflecting the audit scope, scope-labeled sections with emoji markers, bulleted findings with severity indicators, relative-time annotations on allowed vulnerabilities, and a unified `Actions:` footer with context-aware verbose and sync hints. Extracts shared time-formatting helpers into a dedicated module to support relative timestamps in both bare and verbose formatters.

## Why

The bare format is what developers see most often, but it was uninformative — numeric IDs aren't searchable, `(none)` for clean results gives no positive signal, severity levels weren't visible, and there was no guidance toward `--verbose` or `sync`. GHSA IDs are the cross-ecosystem standard and directly link to GitHub Security Advisories.

## Details

### Features

- Add optional `ghsaId` field to `AuditResult`, parsed from audit-ci's `github_advisory_id` field
- Rewrite `formatCheckText` to produce intro banner, scoped sections, bulleted findings with GHSA ID and severity, and clean-scope messages
- Rewrite `formatActionHints` to produce a bulleted `Actions:` section — verbose hint first (only when vulns exist, reflecting original scope flags), sync hint second
- Update verbose formatter to prefer GHSA ID via shared `displayId` helper

### Refactoring

- Extract `formatRelativeTime`, `parseDateUtc`, `diffMonthsUtc`, and `pluralize` from `format-verbose.ts` into `format-time.ts` to break a circular dependency
- Deduplicate `displayId` and `formatSeveritySuffix` — exported from `format-check.ts` and imported by `format-verbose.ts`

### Tests

- Add tests for `ghsaId` extraction in parser, propagation through `buildAllowedVuln` in CLI, and display in both formatters
- Add tests for all bare output scenarios: both scopes clean, single scope clean, mixed findings, single scope with findings
- Add tests for action hints: stale-only + allowed vulns combination, multi-scope Actions footer
- Add test for `formatAllowedSuffix` invalid-date fallback branch

## Test plan

- [ ] Run `audit-deps` in a project with known vulnerabilities and verify the output matches the redesigned format
- [ ] Run `audit-deps --verbose` and verify GHSA IDs appear in the verbose output
- [ ] Run `audit-deps` with `--prod` and `--dev` flags separately and verify scope-specific intro banners and action hints
- [ ] Run `audit-deps` in a clean project and verify "No known vulnerabilities found." message

Closes #231