### PR TITLE
#238 Pin pnpm 10 in reusable workflows and push tags individually

### DIFF
--- a/.github/workflows/audit.reusable.yaml
+++ b/.github/workflows/audit.reusable.yaml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10
 
       - uses: actions/setup-node@v6
         with:
@@ -119,6 +121,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/publish.reusable.yaml
+++ b/.github/workflows/publish.reusable.yaml
@@ -55,10 +55,12 @@ jobs:
         if: ${{ env.BUILD_LOCAL != 'true' }}
         run: node -e "const fs=require('fs'),f='package.json',p=JSON.parse(fs.readFileSync(f));delete p.packageManager;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
 
-      # Preserve the packageManager field so pnpm/action-setup can read the version.
+      # Pin pnpm 10.x explicitly — pnpm/action-setup@v6 bundles a v11 beta by default.
       - name: Set up pnpm
         if: ${{ env.BUILD_LOCAL == 'true' }}
         uses: pnpm/action-setup@v6
+        with:
+          version: 10
 
       # Materialize the cache flag via step output because the `env` context
       # is not evaluated in `with:` blocks.

--- a/.github/workflows/release.reusable.yaml
+++ b/.github/workflows/release.reusable.yaml
@@ -70,10 +70,12 @@ jobs:
         if: ${{ env.BUILD_LOCAL != 'true' }}
         run: node -e "const fs=require('fs'),f='package.json',p=JSON.parse(fs.readFileSync(f));delete p.packageManager;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
 
-      # Preserve the packageManager field so pnpm/action-setup can read the version.
+      # Pin pnpm 10.x explicitly — pnpm/action-setup@v6 bundles a v11 beta by default.
       - name: Set up pnpm
         if: ${{ env.BUILD_LOCAL == 'true' }}
         uses: pnpm/action-setup@v6
+        with:
+          version: 10
 
       # Materialize the cache flag via step output because the `env` context
       # is not evaluated in `with:` blocks.
@@ -158,4 +160,7 @@ jobs:
           release-kit commit
           release-kit tag --no-git-checks
 
-          git push origin HEAD ${{ steps.tags.outputs.tags }}
+          git push origin HEAD
+          for tag in ${{ steps.tags.outputs.tags }}; do
+            git push --no-follow-tags origin "$tag"
+          done


### PR DESCRIPTION
## What

Fixes two CI failures in the reusable workflows. `pnpm/action-setup@v6` bundles pnpm 11 beta by default, which breaks `pnpm install` with `ERR_PNPM_IGNORED_BUILDS`. All four `pnpm/action-setup` steps across `audit.reusable.yaml`, `publish.reusable.yaml`, and `release.reusable.yaml` now pin `version: 10` to ensure a stable pnpm release is used.

In `release.reusable.yaml`, tags are now pushed individually with `--no-follow-tags` instead of bundled with the branch push, so GitHub fires a separate push event per tag and the publish workflow triggers correctly.

## Why

The release workflow produced two cascading failures: `pnpm install` failed because pnpm 11 beta requires `pnpm approve-builds` instead of `onlyBuiltDependencies`, and even when builds succeeded manually, the publish workflow never ran because GitHub treated the bundled branch-and-tags push as a single branch event.

## Details

### Fixes

- Adds `version: 10` to all `pnpm/action-setup@v6` steps in `audit.reusable.yaml` (2 instances), `publish.reusable.yaml` (1 instance), and `release.reusable.yaml` (1 instance).
- Replaces the single `git push origin HEAD <tags>` in `release.reusable.yaml` with a branch push followed by a loop that pushes each tag individually using `--no-follow-tags`.
- Updates stale comments in `publish.reusable.yaml` and `release.reusable.yaml` that referenced `pnpm/action-setup` reading the `packageManager` field — the version is now explicitly pinned.

Closes #238