### PR TITLE
#239 Add `push` command for safe two-step tag pushing

### DIFF
--- a/packages/release-kit/src/__tests__/pushCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/pushCommand.unit.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPushRelease = vi.hoisted(() => vi.fn());
+const mockResolveCommandTags = vi.hoisted(() => vi.fn());
+
+vi.mock('../pushRelease.ts', () => ({
+  pushRelease: mockPushRelease,
+}));
+
+vi.mock('../resolveCommandTags.ts', () => ({
+  resolveCommandTags: mockResolveCommandTags,
+}));
+
+import { pushCommand } from '../pushCommand.ts';
+import type { ResolvedTag } from '../resolveReleaseTags.ts';
+
+/** Sentinel error thrown by the mocked process.exit. */
+class ExitError extends Error {
+  constructor(public readonly code: number | undefined) {
+    super(`process.exit(${code})`);
+  }
+}
+
+const TAGS: ResolvedTag[] = [
+  { tag: 'core-v1.2.0', dir: 'core', workspacePath: 'packages/core' },
+  { tag: 'cli-v0.5.0', dir: 'cli', workspacePath: 'packages/cli' },
+];
+
+describe(pushCommand, () => {
+  beforeEach(() => {
+    mockResolveCommandTags.mockResolvedValue(TAGS);
+    mockPushRelease.mockReturnValue([]);
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new ExitError(typeof code === 'number' ? code : undefined);
+    });
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockPushRelease.mockReset();
+    mockResolveCommandTags.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('delegates to pushRelease with default options', async () => {
+    await pushCommand([]);
+
+    expect(mockResolveCommandTags).toHaveBeenCalledWith(undefined);
+    expect(mockPushRelease).toHaveBeenCalledWith(TAGS, { dryRun: false, tagsOnly: false });
+  });
+
+  it('passes dryRun when --dry-run is provided', async () => {
+    await pushCommand(['--dry-run']);
+
+    expect(mockPushRelease).toHaveBeenCalledWith(TAGS, { dryRun: true, tagsOnly: false });
+  });
+
+  it('passes tagsOnly when --tags-only is provided', async () => {
+    await pushCommand(['--tags-only']);
+
+    expect(mockPushRelease).toHaveBeenCalledWith(TAGS, { dryRun: false, tagsOnly: true });
+  });
+
+  it('passes only filter to resolveCommandTags', async () => {
+    await pushCommand(['--only=core,cli']);
+
+    expect(mockResolveCommandTags).toHaveBeenCalledWith(['core', 'cli']);
+  });
+
+  it('exits with code 1 on unknown flags', async () => {
+    let thrown: ExitError | undefined;
+    try {
+      await pushCommand(['--unknown']);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
+    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
+    expect(mockPushRelease).not.toHaveBeenCalled();
+  });
+
+  it('exits with code 1 when pushRelease throws', async () => {
+    mockPushRelease.mockImplementation(() => {
+      throw new Error('push failed');
+    });
+
+    let thrown: ExitError | undefined;
+    try {
+      await pushCommand([]);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
+    expect(console.error).toHaveBeenCalledWith('push failed');
+  });
+
+  it('skips pushRelease when no tags are resolved', async () => {
+    mockResolveCommandTags.mockResolvedValue([]);
+
+    await pushCommand([]);
+
+    expect(mockPushRelease).not.toHaveBeenCalled();
+  });
+});

--- a/packages/release-kit/src/__tests__/pushRelease.unit.test.ts
+++ b/packages/release-kit/src/__tests__/pushRelease.unit.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+import { pushRelease } from '../pushRelease.ts';
+import type { ResolvedTag } from '../resolveReleaseTags.ts';
+
+const TAGS: ResolvedTag[] = [
+  { tag: 'core-v1.2.0', dir: 'core', workspacePath: 'packages/core' },
+  { tag: 'cli-v0.5.0', dir: 'cli', workspacePath: 'packages/cli' },
+];
+
+describe(pushRelease, () => {
+  beforeEach(() => {
+    // Default: git rev-parse returns a branch name.
+    mockExecFileSync.mockReturnValue('main\n');
+  });
+
+  afterEach(() => {
+    mockExecFileSync.mockReset();
+  });
+
+  it('pushes branch then each tag individually', () => {
+    pushRelease(TAGS);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['rev-parse', '--abbrev-ref', 'HEAD'], expect.any(Object));
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['push', 'origin', 'main'], { stdio: 'inherit' });
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['push', '--no-follow-tags', 'origin', 'core-v1.2.0'], {
+      stdio: 'inherit',
+    });
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['push', '--no-follow-tags', 'origin', 'cli-v0.5.0'], {
+      stdio: 'inherit',
+    });
+  });
+
+  it('skips branch resolution and push when tagsOnly is true', () => {
+    pushRelease(TAGS, { tagsOnly: true });
+
+    expect(mockExecFileSync).not.toHaveBeenCalledWith('git', ['rev-parse', '--abbrev-ref', 'HEAD'], expect.anything());
+    expect(mockExecFileSync).not.toHaveBeenCalledWith('git', ['push', 'origin', expect.any(String)], expect.anything());
+  });
+
+  it('does not execute git push in dry-run mode', () => {
+    pushRelease(TAGS, { dryRun: true });
+
+    expect(mockExecFileSync).not.toHaveBeenCalledWith('git', expect.arrayContaining(['push']), { stdio: 'inherit' });
+  });
+
+  it('still resolves branch name in dry-run mode', () => {
+    pushRelease(TAGS, { dryRun: true });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['rev-parse', '--abbrev-ref', 'HEAD'], expect.any(Object));
+  });
+
+  it('returns steps for branch and all tags', () => {
+    const steps = pushRelease(TAGS);
+
+    expect(steps).toEqual([
+      { type: 'branch', ref: 'main', command: ['git', 'push', 'origin', 'main'] },
+      { type: 'tag', ref: 'core-v1.2.0', command: ['git', 'push', '--no-follow-tags', 'origin', 'core-v1.2.0'] },
+      { type: 'tag', ref: 'cli-v0.5.0', command: ['git', 'push', '--no-follow-tags', 'origin', 'cli-v0.5.0'] },
+    ]);
+  });
+
+  it('returns only tag steps when tagsOnly is true', () => {
+    const steps = pushRelease(TAGS, { tagsOnly: true });
+
+    expect(steps).toEqual([
+      { type: 'tag', ref: 'core-v1.2.0', command: ['git', 'push', '--no-follow-tags', 'origin', 'core-v1.2.0'] },
+      { type: 'tag', ref: 'cli-v0.5.0', command: ['git', 'push', '--no-follow-tags', 'origin', 'cli-v0.5.0'] },
+    ]);
+  });
+
+  it('returns steps without executing in dry-run mode', () => {
+    const steps = pushRelease(TAGS, { dryRun: true });
+
+    expect(steps).toHaveLength(3);
+    expect(steps[0]).toEqual({ type: 'branch', ref: 'main', command: ['git', 'push', 'origin', 'main'] });
+  });
+});

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -9,6 +9,7 @@ import { githubReleaseCommand } from '../githubReleaseCommand.ts';
 import { initCommand } from '../init/initCommand.ts';
 import { prepareCommand } from '../prepareCommand.ts';
 import { publishCommand } from '../publishCommand.ts';
+import { pushCommand } from '../pushCommand.ts';
 import { generateCommand } from '../sync-labels/generateCommand.ts';
 import { syncLabelsInitCommand } from '../sync-labels/initCommand.ts';
 import { syncLabelsCommand } from '../sync-labels/syncCommand.ts';
@@ -23,6 +24,7 @@ Commands:
   prepare          Run release preparation (auto-discovers workspaces)
   commit           Stage changes and create the release commit
   tag              Create annotated git tags from the tags file
+  push             Push release commit and tags (one push per tag)
   publish          Publish packages with release tags on HEAD
   github-release   Create GitHub Releases from changelog.json for tags on HEAD
   init             Initialize release-kit in the current repository
@@ -142,6 +144,21 @@ Options:
 `);
 }
 
+function showPushHelp(): void {
+  console.info(`
+Usage: release-kit push [options]
+
+Push the release commit and each tag individually, ensuring GitHub Actions
+fires a separate workflow run per tag.
+
+Options:
+  --dry-run              Preview without pushing
+  --only=name1,name2     Only push tags for the named packages (comma-separated, monorepo only)
+  --tags-only            Skip the branch push (push tags only)
+  --help, -h             Show this help message
+`);
+}
+
 function showGithubReleaseHelp(): void {
   console.info(`
 Usage: release-kit github-release [options]
@@ -216,6 +233,16 @@ if (command === 'tag') {
   }
 
   tagCommand(flags);
+  process.exit(0);
+}
+
+if (command === 'push') {
+  if (flags.some((f) => f === '--help' || f === '-h')) {
+    showPushHelp();
+    process.exit(0);
+  }
+
+  await pushCommand(flags);
   process.exit(0);
 }
 

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -57,6 +57,8 @@ export { injectSection } from './injectSection.ts';
 export { COMMIT_PREPROCESSOR_PATTERNS, parseCommitMessage } from './parseCommitMessage.ts';
 export { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE, writeReleaseTags } from './prepareCommand.ts';
 export { publishPackage } from './publish.ts';
+export type { PushReleaseOptions } from './pushRelease.ts';
+export { pushRelease } from './pushRelease.ts';
 export { releasePrepare } from './releasePrepare.ts';
 export { releasePrepareMono } from './releasePrepareMono.ts';
 export type { RenderOptions } from './renderReleaseNotes.ts';

--- a/packages/release-kit/src/pushCommand.ts
+++ b/packages/release-kit/src/pushCommand.ts
@@ -1,0 +1,59 @@
+/* eslint n/no-process-exit: off */
+/* eslint unicorn/no-process-exit: off */
+
+import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
+
+import { pushRelease } from './pushRelease.ts';
+import { resolveCommandTags } from './resolveCommandTags.ts';
+
+const pushFlagSchema = {
+  dryRun: { long: '--dry-run', type: 'boolean' as const },
+  only: { long: '--only', type: 'string' as const },
+  tagsOnly: { long: '--tags-only', type: 'boolean' as const },
+};
+
+/**
+ * Orchestrate the CLI `push` command: parse flags, resolve tags from HEAD, and push
+ * the release commit and each tag individually.
+ */
+export async function pushCommand(argv: string[]): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs(argv, pushFlagSchema);
+  } catch (error: unknown) {
+    console.error(`Error: ${translateParseError(error)}`);
+    process.exit(1);
+  }
+
+  const { dryRun, tagsOnly } = parsed.flags;
+  const only = parsed.flags.only?.split(',');
+
+  const resolvedTags = await resolveCommandTags(only);
+
+  if (resolvedTags.length === 0) {
+    return;
+  }
+
+  const prefix = dryRun ? '[dry-run] Would push' : 'Pushing';
+  if (!tagsOnly) {
+    console.info(`${prefix} branch and ${resolvedTags.length} tag(s):`);
+  } else {
+    console.info(`${prefix} ${resolvedTags.length} tag(s):`);
+  }
+  for (const { tag } of resolvedTags) {
+    console.info(`  ${tag}`);
+  }
+
+  try {
+    const steps = pushRelease(resolvedTags, { dryRun, tagsOnly });
+
+    if (dryRun) {
+      for (const step of steps) {
+        console.info(`[dry-run] ${step.command.join(' ')}`);
+      }
+    }
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/packages/release-kit/src/pushRelease.ts
+++ b/packages/release-kit/src/pushRelease.ts
@@ -1,0 +1,49 @@
+import { execFileSync } from 'node:child_process';
+
+import type { ResolvedTag } from './resolveReleaseTags.ts';
+
+export interface PushReleaseOptions {
+  dryRun?: boolean;
+  tagsOnly?: boolean;
+}
+
+export interface PushStep {
+  type: 'branch' | 'tag';
+  ref: string;
+  command: readonly [string, ...string[]];
+}
+
+/**
+ * Push the release commit and each tag individually so that GitHub Actions fires
+ * a separate workflow run per tag.
+ *
+ * Returns the list of push steps that were executed (or would be executed in dry-run mode).
+ */
+export function pushRelease(resolvedTags: ResolvedTag[], options: PushReleaseOptions = {}): PushStep[] {
+  const { dryRun = false, tagsOnly = false } = options;
+
+  const steps: PushStep[] = [];
+
+  if (!tagsOnly) {
+    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    const command = ['git', 'push', 'origin', branch] as const;
+    steps.push({ type: 'branch', ref: branch, command });
+  }
+
+  for (const { tag } of resolvedTags) {
+    const command = ['git', 'push', '--no-follow-tags', 'origin', tag] as const;
+    steps.push({ type: 'tag', ref: tag, command });
+  }
+
+  if (!dryRun) {
+    for (const step of steps) {
+      execFileSync(step.command[0], step.command.slice(1), { stdio: 'inherit' });
+    }
+  }
+
+  return steps;
+}


### PR DESCRIPTION
## What

Adds a `release-kit push` command that safely pushes the release commit and each tag individually, ensuring GitHub Actions fires a separate workflow run per tag. The command performs a `1 + N` push sequence: one branch push followed by one `git push --no-follow-tags origin <tag>` per resolved tag. Supports `--dry-run` (preview without pushing), `--only` (filter tags by package name), and `--tags-only` (skip the branch push).

## Why

When releasing locally, using `git push --follow-tags` or pushing multiple tags in a single invocation bundles all refs into one push event. GitHub Actions processes this as a single event, so tag-triggered workflows (like the publish workflow) silently fail to run for all but one tag. Users had to remember to run separate push commands manually, which was error-prone.

## Details

### Features

- `pushRelease` core logic module that resolves the current branch via `git rev-parse --abbrev-ref HEAD`, pushes the branch, then pushes each tag individually with `--no-follow-tags`. Returns structured `PushStep[]` results for the caller to present.
- `pushCommand` CLI wrapper that parses flags, resolves tags from HEAD via `resolveCommandTags`, and delegates to `pushRelease`.
- CLI registration in `bin/release-kit.ts` with help text and routing. The `push` command is positioned between `tag` and `publish` in the usage output, matching the workflow order.
- Public API exports (`pushRelease`, `PushReleaseOptions`) from the package index.

### Tests

- 14 unit tests across `pushRelease` and `pushCommand` covering default behavior, all flag combinations, error paths (unknown flags, push failures), empty tag resolution, and dry-run mode.

## Test plan

- [ ] `release-kit push --help` displays correct help text
- [ ] `release-kit push --dry-run` lists tags and commands without executing
- [ ] `release-kit push` pushes branch then each tag individually in a real repo with tags on HEAD

Closes #239