### PR TITLE
#240 Show below-threshold vulnerabilities and threshold in check output

### DIFF
--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -594,6 +594,60 @@ describe(checkCommand, () => {
     expect(stdoutOutput).toContain('reason: Accepted');
   });
 
+  it('classifies below-threshold vulnerabilities separately and returns 0', async () => {
+    const config = makeConfig({
+      prod: {
+        allowlist: [],
+        severityThreshold: 'high',
+      },
+    });
+    setupLoadConfig(config);
+    mocks.runReport.mockReturnValue({
+      results: [
+        { id: 'GHSA-low', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/low' },
+        { id: 'GHSA-moderate', path: 'pkg2', paths: ['pkg2'], severity: 'moderate', url: 'https://example.com/mod' },
+      ],
+      stdout: '',
+      stderr: '',
+      warnings: [],
+    });
+
+    const exitCode = await checkCommand(makeOptions({ json: true, scopes: ['prod'] }));
+
+    expect(exitCode).toBe(0);
+    const parsed: unknown = JSON.parse(stdoutOutput);
+    expect(parsed).toStrictEqual(
+      expect.objectContaining({
+        prod: expect.objectContaining({
+          belowThreshold: expect.arrayContaining([
+            expect.objectContaining({ id: 'GHSA-low' }),
+            expect.objectContaining({ id: 'GHSA-moderate' }),
+          ]),
+          unallowed: [],
+        }),
+      }),
+    );
+  });
+
+  it('passes severityThreshold "low" to generateAuditCiConfig', async () => {
+    const config = makeConfig({
+      prod: {
+        allowlist: [],
+        severityThreshold: 'high',
+      },
+    });
+    setupLoadConfig(config);
+    mocks.runReport.mockReturnValue({ results: [], stdout: '', stderr: '', warnings: [] });
+
+    await checkCommand(makeOptions({ scopes: ['prod'] }));
+
+    expect(mocks.generateAuditCiConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ severityThreshold: 'low' }),
+      'prod',
+      expect.any(String),
+    );
+  });
+
   it('renders verbose JSON output when both verbose and json are true', async () => {
     const config = makeConfig({
       prod: {

--- a/packages/audit-deps/__tests__/cli.test.ts
+++ b/packages/audit-deps/__tests__/cli.test.ts
@@ -629,7 +629,37 @@ describe(checkCommand, () => {
     );
   });
 
-  it('passes severityThreshold "low" to generateAuditCiConfig', async () => {
+  it('classifies an allowlisted vulnerability as belowThreshold when its severity is below the threshold', async () => {
+    const config = makeConfig({
+      prod: {
+        allowlist: [{ id: 'GHSA-low', path: 'pkg', url: 'https://example.com/low' }],
+        severityThreshold: 'high',
+      },
+    });
+    setupLoadConfig(config);
+    mocks.runReport.mockReturnValue({
+      results: [{ id: 'GHSA-low', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/low' }],
+      stdout: '',
+      stderr: '',
+      warnings: [],
+    });
+
+    const exitCode = await checkCommand(makeOptions({ json: true, scopes: ['prod'] }));
+
+    expect(exitCode).toBe(0);
+    const parsed: unknown = JSON.parse(stdoutOutput);
+    expect(parsed).toStrictEqual(
+      expect.objectContaining({
+        prod: expect.objectContaining({
+          allowed: [],
+          belowThreshold: [expect.objectContaining({ id: 'GHSA-low' })],
+          stale: [],
+        }),
+      }),
+    );
+  });
+
+  it('always passes severityThreshold "low" to generateAuditCiConfig regardless of config threshold', async () => {
     const config = makeConfig({
       prod: {
         allowlist: [],

--- a/packages/audit-deps/__tests__/format-actions.test.ts
+++ b/packages/audit-deps/__tests__/format-actions.test.ts
@@ -4,7 +4,7 @@ import { formatActionHints } from '../src/format-actions.ts';
 import type { CheckResult, ScopeCheckResult } from '../src/format-check.ts';
 
 function emptyScopeResult(): ScopeCheckResult {
-  return { allowed: [], stale: [], unallowed: [] };
+  return { allowed: [], belowThreshold: [], stale: [], unallowed: [] };
 }
 
 function makeCheckResult(overrides?: Partial<CheckResult>): CheckResult {
@@ -25,6 +25,7 @@ describe(formatActionHints, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
       },
@@ -40,6 +41,7 @@ describe(formatActionHints, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale' }],
         unallowed: [],
       },
@@ -54,11 +56,13 @@ describe(formatActionHints, () => {
     const result = makeCheckResult({
       dev: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale' }],
         unallowed: [],
       },
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
       },
@@ -72,6 +76,7 @@ describe(formatActionHints, () => {
     const result = makeCheckResult({
       dev: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [{ id: 'GHSA-dev', path: 'pkg', paths: ['pkg'], url: 'https://example.com/dev' }],
       },
@@ -85,6 +90,7 @@ describe(formatActionHints, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
       },
@@ -98,6 +104,7 @@ describe(formatActionHints, () => {
     const result = makeCheckResult({
       dev: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
       },
@@ -111,6 +118,7 @@ describe(formatActionHints, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/1' }],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale' }],
         unallowed: [],
       },
@@ -125,6 +133,7 @@ describe(formatActionHints, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/1' }],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -134,5 +143,20 @@ describe(formatActionHints, () => {
     expect(output).toContain('Run `audit-deps --prod --verbose` for full report');
     // No sync hint since nothing to sync
     expect(output).not.toContain('audit-deps sync');
+  });
+
+  it('returns empty string when only below-threshold findings exist', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        belowThreshold: [
+          { id: 'GHSA-bt', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/bt' },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    expect(formatActionHints(result, ['prod'])).toBe('');
   });
 });

--- a/packages/audit-deps/__tests__/format-check.test.ts
+++ b/packages/audit-deps/__tests__/format-check.test.ts
@@ -536,6 +536,31 @@ describe(formatCheckText, () => {
     expect(output).toContain('\u{1F527} dev: (threshold: \u{1F534} high)');
   });
 
+  it('renders below-threshold vulnerability line in multi-scope output', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        belowThreshold: [
+          {
+            id: 'GHSA-bt',
+            ghsaId: 'GHSA-bt',
+            path: 'brace-expansion',
+            paths: ['brace-expansion'],
+            severity: 'low',
+            url: 'https://example.com/bt',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW, { prod: 'moderate' });
+    expect(output).toContain('\u{2139}\u{FE0F} GHSA-bt: brace-expansion');
+    expect(output).toContain('\u{1F6AB} ignored');
+    expect(output).toContain('\u{1F4E6} prod: (threshold: \u{1F7E0} moderate)');
+  });
+
   // --- Existing tests ---
 
   it('shows verbose hint when only allowed vulns exist (no unallowed, no stale)', () => {

--- a/packages/audit-deps/__tests__/format-check.test.ts
+++ b/packages/audit-deps/__tests__/format-check.test.ts
@@ -10,7 +10,7 @@ import { formatCheckJson, formatCheckText, severityIndicator } from '../src/form
 const FIXED_NOW = new Date('2026-04-15T00:00:00Z');
 
 function emptyScopeResult(): ScopeCheckResult {
-  return { allowed: [], stale: [], unallowed: [] };
+  return { allowed: [], belowThreshold: [], stale: [], unallowed: [] };
 }
 
 function makeCheckResult(overrides?: Partial<CheckResult>): CheckResult {
@@ -90,6 +90,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -113,6 +114,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       dev: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -140,6 +142,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -162,6 +165,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [{ id: '1234', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/1' }],
       },
@@ -175,6 +179,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [{ id: 'GHSA-1', ghsaId: 'GHSA-1', path: 'pkg', paths: ['pkg'], url: 'https://example.com/1' }],
       },
@@ -202,6 +207,7 @@ describe(formatCheckText, () => {
             url: 'https://example.com/2',
           },
         ],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -224,6 +230,7 @@ describe(formatCheckText, () => {
             url: 'https://example.com/baddate',
           },
         ],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -238,6 +245,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [{ id: '1234', ghsaId: 'GHSA-nodate', path: 'pkg', paths: ['pkg'], url: 'https://example.com' }],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -254,6 +262,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-old' }],
         unallowed: [],
       },
@@ -279,6 +288,7 @@ describe(formatCheckText, () => {
             url: 'https://example.com/ok',
           },
         ],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale' }],
         unallowed: [
           {
@@ -303,11 +313,13 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       dev: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [{ id: 'dev1', ghsaId: 'GHSA-dev', path: 'pkg', paths: ['pkg'], url: 'https://example.com/dev' }],
       },
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [{ id: 'prod1', ghsaId: 'GHSA-prod', path: 'pkg', paths: ['pkg'], url: 'https://example.com/prod' }],
       },
@@ -324,6 +336,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [{ id: 'GHSA-bad', path: 'pkg', paths: ['pkg'], url: 'https://example.com/bad' }],
       },
@@ -339,6 +352,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale' }],
         unallowed: [],
       },
@@ -355,6 +369,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale' }],
         unallowed: [{ id: 'GHSA-bad', path: 'pkg', paths: ['pkg'], url: 'https://example.com/bad' }],
       },
@@ -377,6 +392,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -401,6 +417,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       dev: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale-dev' }],
         unallowed: [],
       },
@@ -416,6 +433,7 @@ describe(formatCheckText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale-prod' }],
         unallowed: [
           {
@@ -430,6 +448,7 @@ describe(formatCheckText, () => {
       },
       dev: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -443,12 +462,89 @@ describe(formatCheckText, () => {
 
   // --- Actions footer (single-scope) ---
 
+  // --- Below-threshold vulnerabilities ---
+
+  it('renders below-threshold vulnerabilities with "ignored" annotation', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        belowThreshold: [
+          {
+            id: 'GHSA-low',
+            ghsaId: 'GHSA-low',
+            path: 'brace-expansion',
+            paths: ['brace-expansion'],
+            severity: 'low',
+            url: 'https://example.com/low',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('\u{2139}\u{FE0F} GHSA-low: brace-expansion');
+    expect(output).toContain('\u{1F6AB} ignored');
+  });
+
+  it('does not print "No known vulnerabilities found." when only below-threshold vulns exist', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        belowThreshold: [
+          { id: 'GHSA-bt', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/bt' },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod'], FIXED_NOW);
+    expect(output).not.toContain('No known vulnerabilities found.');
+  });
+
+  // --- Threshold annotation ---
+
+  it('shows threshold in intro banner for single-scope when above low', () => {
+    const result = makeCheckResult();
+    const output = formatCheckText(result, ['prod'], FIXED_NOW, { prod: 'moderate' });
+    expect(output).toContain('\u{1F52C} Auditing prod dependencies (threshold: \u{1F7E0} moderate) ...');
+  });
+
+  it('omits threshold from intro banner when threshold is low', () => {
+    const result = makeCheckResult();
+    const output = formatCheckText(result, ['prod'], FIXED_NOW, { prod: 'low' });
+    expect(output).toContain('\u{1F52C} Auditing prod dependencies ...');
+    expect(output).not.toContain('threshold:');
+  });
+
+  it('shows threshold in scope headers for multi-scope when above low', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        belowThreshold: [
+          { id: 'GHSA-bt', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/bt' },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW, { prod: 'moderate', dev: 'high' });
+    expect(output).toContain('\u{1F4E6} prod: (threshold: \u{1F7E0} moderate)');
+    expect(output).toContain('\u{1F527} dev: (threshold: \u{1F534} high)');
+  });
+
+  // --- Existing tests ---
+
   it('shows verbose hint when only allowed vulns exist (no unallowed, no stale)', () => {
     const result = makeCheckResult({
       prod: {
         allowed: [
           { id: '1', ghsaId: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/1' },
         ],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -470,6 +566,7 @@ describe(formatCheckJson, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/1' }],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-old' }],
         unallowed: [],
       },
@@ -479,6 +576,7 @@ describe(formatCheckJson, () => {
     expect(parsed).toStrictEqual({
       prod: {
         allowed: [{ id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/1' }],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-old' }],
         unallowed: [],
       },
@@ -502,6 +600,7 @@ describe(formatCheckJson, () => {
             url: 'https://example.com/allowed',
           },
         ],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -521,6 +620,28 @@ describe(formatCheckJson, () => {
               title: 'Prototype pollution',
             }),
           ],
+        }),
+      }),
+    );
+  });
+
+  it('includes below-threshold array in JSON output', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        belowThreshold: [
+          { id: 'GHSA-bt', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/bt' },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const parsed: unknown = JSON.parse(formatCheckJson(result, ['prod']));
+    expect(parsed).toStrictEqual(
+      expect.objectContaining({
+        prod: expect.objectContaining({
+          belowThreshold: [expect.objectContaining({ id: 'GHSA-bt', severity: 'low' })],
         }),
       }),
     );

--- a/packages/audit-deps/__tests__/format-verbose.test.ts
+++ b/packages/audit-deps/__tests__/format-verbose.test.ts
@@ -9,7 +9,7 @@ import { formatCheckVerboseText } from '../src/format-verbose.ts';
 // ---------------------------------------------------------------------------
 
 function emptyScopeResult(): ScopeCheckResult {
-  return { allowed: [], stale: [], unallowed: [] };
+  return { allowed: [], belowThreshold: [], stale: [], unallowed: [] };
 }
 
 function makeCheckResult(overrides?: Partial<CheckResult>): CheckResult {
@@ -38,6 +38,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -65,6 +66,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -85,6 +87,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -109,6 +112,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -132,6 +136,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -158,6 +163,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -185,6 +191,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [],
         unallowed: [
           {
@@ -222,6 +229,7 @@ describe(formatCheckVerboseText, () => {
             url: 'https://example.com/allowed',
           },
         ],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -247,6 +255,7 @@ describe(formatCheckVerboseText, () => {
             url: 'https://example.com/iso',
           },
         ],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -268,6 +277,7 @@ describe(formatCheckVerboseText, () => {
             url: 'https://example.com/noAddedAt',
           },
         ],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -290,6 +300,7 @@ describe(formatCheckVerboseText, () => {
             url: 'https://example.com/badDate',
           },
         ],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -312,6 +323,7 @@ describe(formatCheckVerboseText, () => {
             url: 'https://example.com/noReason',
           },
         ],
+        belowThreshold: [],
         stale: [],
         unallowed: [],
       },
@@ -329,6 +341,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale-entry-0000' }],
         unallowed: [],
       },
@@ -342,6 +355,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale' }],
         unallowed: [],
       },
@@ -355,6 +369,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale' }],
         unallowed: [],
       },
@@ -369,6 +384,7 @@ describe(formatCheckVerboseText, () => {
     const result = makeCheckResult({
       prod: {
         allowed: [],
+        belowThreshold: [],
         stale: [{ id: 'GHSA-stale' }],
         unallowed: [
           {
@@ -389,6 +405,52 @@ describe(formatCheckVerboseText, () => {
   it('omits the Actions footer when the allowlist is fully current', () => {
     const output = formatCheckVerboseText(makeCheckResult(), ['prod', 'dev'], FIXED_NOW);
     expect(output).not.toContain('Actions:');
+  });
+
+  // --------------------
+  // Below-threshold entries
+  // --------------------
+
+  it('renders a below-threshold vulnerability with info marker and "ignored (below threshold)" annotation', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        belowThreshold: [
+          {
+            ghsaId: 'GHSA-low',
+            id: '1234',
+            path: 'brace-expansion',
+            paths: ['my-app>brace-expansion'],
+            severity: 'low',
+            title: 'ReDoS in brace-expansion',
+            url: 'https://github.com/advisories/GHSA-low',
+          },
+        ],
+        stale: [],
+        unallowed: [],
+      },
+    });
+
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
+    expect(output).toContain('\u{2139}\u{FE0F} GHSA-low');
+    expect(output).toContain('\u{1F7E1} low');
+    expect(output).toContain('ignored (below threshold)');
+    expect(output).toContain('ReDoS in brace-expansion');
+    expect(output).toContain('path: my-app>brace-expansion');
+    expect(output).toContain('link: https://github.com/advisories/GHSA-low');
+  });
+
+  it('shows threshold in scope header when above low', () => {
+    const result = makeCheckResult();
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW, { prod: 'moderate' });
+    expect(output).toContain('-- \u{1F4E6} prod -- (threshold: \u{1F7E0} moderate)');
+  });
+
+  it('omits threshold from scope header when threshold is low', () => {
+    const result = makeCheckResult();
+    const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW, { prod: 'low' });
+    expect(output).toContain('-- \u{1F4E6} prod --');
+    expect(output).not.toContain('threshold:');
   });
 });
 

--- a/packages/audit-deps/__tests__/types.test.ts
+++ b/packages/audit-deps/__tests__/types.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSeverityAtOrAbove } from '../src/types.ts';
+
+describe(isSeverityAtOrAbove, () => {
+  it.each([
+    ['critical', 'low', true],
+    ['critical', 'moderate', true],
+    ['critical', 'high', true],
+    ['critical', 'critical', true],
+    ['high', 'low', true],
+    ['high', 'moderate', true],
+    ['high', 'high', true],
+    ['high', 'critical', false],
+    ['moderate', 'low', true],
+    ['moderate', 'moderate', true],
+    ['moderate', 'high', false],
+    ['moderate', 'critical', false],
+    ['low', 'low', true],
+    ['low', 'moderate', false],
+    ['low', 'high', false],
+    ['low', 'critical', false],
+  ] as const)('returns %s for severity "%s" with threshold "%s"', (severity, threshold, expected) => {
+    expect(isSeverityAtOrAbove(severity, threshold)).toBe(expected);
+  });
+
+  it('returns true for undefined severity (conservative default)', () => {
+    expect(isSeverityAtOrAbove(undefined, 'critical')).toBe(true);
+  });
+
+  it('returns true for unrecognized severity (conservative default)', () => {
+    expect(isSeverityAtOrAbove('unknown', 'low')).toBe(true);
+  });
+});

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -147,6 +147,10 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
         const scopeResult: ScopeCheckResult = { allowed: [], belowThreshold: [], stale: [], unallowed: [] };
 
         // Classify results: below threshold first, then allowlist, then unallowed.
+        // Threshold check intentionally precedes the allowlist check. Below-threshold vulns are
+        // never checked against the allowlist because the threshold already excludes them from
+        // the fail/pass decision. Even if someone has explicitly allowlisted a low-severity vuln
+        // and the threshold is "moderate", it shows as "ignored" (not "allowed").
         for (const result of report.results) {
           if (!isSeverityAtOrAbove(result.severity, effectiveThreshold)) {
             scopeResult.belowThreshold.push(result);

--- a/packages/audit-deps/src/cli.ts
+++ b/packages/audit-deps/src/cli.ts
@@ -10,8 +10,8 @@ import { scaffoldConfig } from './init/scaffold.ts';
 import { parseAuditCiOutput, runAudit, runReport } from './run-audit.ts';
 import { syncAllowlist } from './sync.ts';
 import { withTempDir } from './tmp.ts';
-import type { AllowlistEntry, AuditResult, AuditScope, CommandOptions } from './types.ts';
-import { AUDIT_SCOPES } from './types.ts';
+import type { AllowlistEntry, AuditResult, AuditScope, CommandOptions, SeverityThreshold } from './types.ts';
+import { AUDIT_SCOPES, isSeverityAtOrAbove } from './types.ts';
 
 /** Extract a displayable message from an unknown thrown value. */
 export function extractMessage(error: unknown): string {
@@ -115,15 +115,18 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
   try {
     return await withTempDir(async (tempDir) => {
       const checkResult: CheckResult = {
-        dev: { allowed: [], stale: [], unallowed: [] },
-        prod: { allowed: [], stale: [], unallowed: [] },
+        dev: { allowed: [], belowThreshold: [], stale: [], unallowed: [] },
+        prod: { allowed: [], belowThreshold: [], stale: [], unallowed: [] },
       };
+      const thresholds: Partial<Record<AuditScope, SeverityThreshold>> = {};
 
       for (const scope of scopes) {
         const scopeConfig = config[scope];
+        const effectiveThreshold = scopeConfig.severityThreshold ?? 'low';
+        thresholds[scope] = effectiveThreshold;
 
-        // Generate a stripped config (empty allowlist) so audit-ci reports all vulnerabilities.
-        const strippedScope = { ...scopeConfig, allowlist: [] };
+        // Generate a stripped config (empty allowlist, low threshold) so audit-ci reports all vulnerabilities.
+        const strippedScope = { ...scopeConfig, allowlist: [], severityThreshold: 'low' as const };
         const strippedConfigPath = await generateAuditCiConfig(strippedScope, scope, tempDir);
 
         const reportOptions: { configPath: string; reportType?: 'full' } = { configPath: strippedConfigPath };
@@ -141,10 +144,13 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
         const allowedIds = new Set(scopeConfig.allowlist.map((entry) => entry.id));
         const foundIds = new Set(report.results.map((r) => r.id));
         const allowlistById = new Map<string, AllowlistEntry>(scopeConfig.allowlist.map((entry) => [entry.id, entry]));
-        const scopeResult: ScopeCheckResult = { allowed: [], stale: [], unallowed: [] };
+        const scopeResult: ScopeCheckResult = { allowed: [], belowThreshold: [], stale: [], unallowed: [] };
 
+        // Classify results: below threshold first, then allowlist, then unallowed.
         for (const result of report.results) {
-          if (allowedIds.has(result.id)) {
+          if (!isSeverityAtOrAbove(result.severity, effectiveThreshold)) {
+            scopeResult.belowThreshold.push(result);
+          } else if (allowedIds.has(result.id)) {
             const entry = allowlistById.get(result.id);
             scopeResult.allowed.push(buildAllowedVuln(result, entry));
           } else {
@@ -163,11 +169,11 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
       }
 
       if (options.verbose && !options.json) {
-        process.stdout.write(formatCheckVerboseText(checkResult, scopes));
+        process.stdout.write(formatCheckVerboseText(checkResult, scopes, undefined, thresholds));
       } else if (options.json) {
         process.stdout.write(formatCheckJson(checkResult, scopes));
       } else {
-        process.stdout.write(formatCheckText(checkResult, scopes));
+        process.stdout.write(formatCheckText(checkResult, scopes, undefined, thresholds));
       }
 
       const hasUnallowed = scopes.some((s) => checkResult[s].unallowed.length > 0);

--- a/packages/audit-deps/src/format-check.ts
+++ b/packages/audit-deps/src/format-check.ts
@@ -1,6 +1,6 @@
 import { formatActionHints } from './format-actions.ts';
 import { formatRelativeTime } from './format-time.ts';
-import type { AuditResult, AuditScope } from './types.ts';
+import type { AuditResult, AuditScope, SeverityThreshold } from './types.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -29,6 +29,7 @@ export interface StaleEntry {
 /** Check results for a single scope. */
 export interface ScopeCheckResult {
   allowed: AllowedVuln[];
+  belowThreshold: AuditResult[];
   stale: StaleEntry[];
   unallowed: AuditResult[];
 }
@@ -84,12 +85,22 @@ const SCOPE_NAMES: Record<AuditScope, string> = {
 // Text formatter
 // ---------------------------------------------------------------------------
 
+/** Format a threshold annotation, e.g. `(threshold: 🟠 moderate)`. Returns empty string for `low` threshold. */
+function formatThresholdAnnotation(threshold: SeverityThreshold | undefined): string {
+  if (threshold === undefined || threshold === 'low') return '';
+  const indicator = severityIndicator(threshold);
+  const indicatorPart = indicator.length > 0 ? `${indicator} ` : '';
+  return `(threshold: ${indicatorPart}${threshold})`;
+}
+
 /** Build the intro banner reflecting the scopes being audited. */
-function formatIntroBanner(scopes: AuditScope[]): string {
+function formatIntroBanner(scopes: AuditScope[], thresholds?: Partial<Record<AuditScope, SeverityThreshold>>): string {
   const first = scopes[0];
   // `first` is always defined here; the guard narrows for TypeScript.
   if (scopes.length === 1 && first !== undefined) {
-    return `\u{1F52C} Auditing ${SCOPE_NAMES[first]} dependencies ...`;
+    const annotation = formatThresholdAnnotation(thresholds?.[first]);
+    const suffix = annotation.length > 0 ? ` ${annotation}` : '';
+    return `\u{1F52C} Auditing ${SCOPE_NAMES[first]} dependencies${suffix} ...`;
   }
   return '\u{1F52C} Auditing dependencies ...';
 }
@@ -125,9 +136,19 @@ function formatStaleLine(entry: StaleEntry): string {
   return `  \u{2022} \u{1F5D1}\u{FE0F} ${entry.id} \u{2022} not needed`;
 }
 
+/** Format a single below-threshold vulnerability as a bullet line. */
+function formatBelowThresholdLine(vuln: AuditResult): string {
+  return `  \u{2022} \u{2139}\u{FE0F} ${displayId(vuln)}: ${vuln.path}${formatSeveritySuffix(vuln.severity)} \u{2022} \u{1F6AB} ignored`;
+}
+
 /** Check whether a scope has any findings. */
 function hasFindings(result: ScopeCheckResult): boolean {
-  return result.unallowed.length > 0 || result.allowed.length > 0 || result.stale.length > 0;
+  return (
+    result.unallowed.length > 0 ||
+    result.allowed.length > 0 ||
+    result.stale.length > 0 ||
+    result.belowThreshold.length > 0
+  );
 }
 
 /** Format a scope's finding lines (without scope header). */
@@ -142,6 +163,9 @@ function formatScopeFindings(result: ScopeCheckResult, now: Date): string[] {
   for (const entry of result.stale) {
     lines.push(formatStaleLine(entry));
   }
+  for (const vuln of result.belowThreshold) {
+    lines.push(formatBelowThresholdLine(vuln));
+  }
   return lines;
 }
 
@@ -151,9 +175,14 @@ function formatScopeFindings(result: ScopeCheckResult, now: Date): string[] {
  * Produces an intro banner, scoped findings with severity labels and GHSA IDs,
  * and an action hints footer.
  */
-export function formatCheckText(result: CheckResult, scopes: AuditScope[], now?: Date): string {
+export function formatCheckText(
+  result: CheckResult,
+  scopes: AuditScope[],
+  now?: Date,
+  thresholds?: Partial<Record<AuditScope, SeverityThreshold>>,
+): string {
   const effectiveNow = now ?? new Date();
-  const lines: string[] = [formatIntroBanner(scopes)];
+  const lines: string[] = [formatIntroBanner(scopes, thresholds)];
 
   const anyFindings = scopes.some((scope) => hasFindings(result[scope]));
 
@@ -178,7 +207,9 @@ export function formatCheckText(result: CheckResult, scopes: AuditScope[], now?:
   // Multiple scopes: show scope headers.
   for (const scope of scopes) {
     const scopeResult = result[scope];
-    lines.push(SCOPE_LABELS[scope]);
+    const annotation = formatThresholdAnnotation(thresholds?.[scope]);
+    const header = annotation.length > 0 ? `${SCOPE_LABELS[scope]} ${annotation}` : SCOPE_LABELS[scope];
+    lines.push(header);
     if (hasFindings(scopeResult)) {
       lines.push(...formatScopeFindings(scopeResult, effectiveNow));
     } else {

--- a/packages/audit-deps/src/format-check.ts
+++ b/packages/audit-deps/src/format-check.ts
@@ -99,8 +99,7 @@ function formatIntroBanner(scopes: AuditScope[], thresholds?: Partial<Record<Aud
   // `first` is always defined here; the guard narrows for TypeScript.
   if (scopes.length === 1 && first !== undefined) {
     const annotation = formatThresholdAnnotation(thresholds?.[first]);
-    const suffix = annotation.length > 0 ? ` ${annotation}` : '';
-    return `\u{1F52C} Auditing ${SCOPE_NAMES[first]} dependencies${suffix} ...`;
+    return `\u{1F52C} Auditing ${SCOPE_NAMES[first]} dependencies${annotation && ` ${annotation}`} ...`;
   }
   return '\u{1F52C} Auditing dependencies ...';
 }
@@ -208,7 +207,7 @@ export function formatCheckText(
   for (const scope of scopes) {
     const scopeResult = result[scope];
     const annotation = formatThresholdAnnotation(thresholds?.[scope]);
-    const header = annotation.length > 0 ? `${SCOPE_LABELS[scope]} ${annotation}` : SCOPE_LABELS[scope];
+    const header = `${SCOPE_LABELS[scope]}${annotation && ` ${annotation}`}`;
     lines.push(header);
     if (hasFindings(scopeResult)) {
       lines.push(...formatScopeFindings(scopeResult, effectiveNow));

--- a/packages/audit-deps/src/format-verbose.ts
+++ b/packages/audit-deps/src/format-verbose.ts
@@ -1,8 +1,8 @@
 import { formatActionHints } from './format-actions.ts';
 import type { AllowedVuln, CheckResult, ScopeCheckResult, StaleEntry } from './format-check.ts';
-import { displayId, formatSeveritySuffix } from './format-check.ts';
+import { displayId, formatSeveritySuffix, severityIndicator } from './format-check.ts';
 import { formatRelativeTime } from './format-time.ts';
-import type { AuditResult, AuditScope } from './types.ts';
+import type { AuditResult, AuditScope, SeverityThreshold } from './types.ts';
 
 // ---------------------------------------------------------------------------
 // Display constants
@@ -10,6 +10,7 @@ import type { AuditResult, AuditScope } from './types.ts';
 
 const STATUS_UNALLOWED = '\u{1F6A8}';
 const STATUS_ALLOWED = '\u{26A0}\u{FE0F}';
+const STATUS_BELOW_THRESHOLD = '\u{2139}\u{FE0F}';
 const STATUS_STALE = '\u{1F5D1}\u{FE0F}';
 
 /** Scope display metadata. */
@@ -29,12 +30,17 @@ const WRAP_COLUMNS = 72;
 // ---------------------------------------------------------------------------
 
 /** Format the verbose per-vulnerability check output as text. */
-export function formatCheckVerboseText(result: CheckResult, scopes: AuditScope[], now?: Date): string {
+export function formatCheckVerboseText(
+  result: CheckResult,
+  scopes: AuditScope[],
+  now?: Date,
+  thresholds?: Partial<Record<AuditScope, SeverityThreshold>>,
+): string {
   const effectiveNow = now ?? new Date();
   const sections: string[] = [];
 
   for (const scope of scopes) {
-    sections.push(formatScopeVerbose(scope, result[scope], effectiveNow));
+    sections.push(formatScopeVerbose(scope, result[scope], effectiveNow, thresholds?.[scope]));
   }
 
   const actions = formatActionHints(result, scopes);
@@ -43,10 +49,28 @@ export function formatCheckVerboseText(result: CheckResult, scopes: AuditScope[]
   return body + '\n' + actions + '\n';
 }
 
+/** Format a threshold annotation for scope headers. Returns empty string for `low` or undefined threshold. */
+function formatThresholdSuffix(threshold: SeverityThreshold | undefined): string {
+  if (threshold === undefined || threshold === 'low') return '';
+  const indicator = severityIndicator(threshold);
+  const indicatorPart = indicator.length > 0 ? `${indicator} ` : '';
+  return ` (threshold: ${indicatorPart}${threshold})`;
+}
+
 /** Format a single scope's verbose check results. */
-function formatScopeVerbose(scope: AuditScope, result: ScopeCheckResult, now: Date): string {
-  const lines: string[] = [SCOPE_HEADERS[scope]];
-  const hasFindings = result.unallowed.length > 0 || result.allowed.length > 0 || result.stale.length > 0;
+function formatScopeVerbose(
+  scope: AuditScope,
+  result: ScopeCheckResult,
+  now: Date,
+  threshold?: SeverityThreshold,
+): string {
+  const thresholdSuffix = formatThresholdSuffix(threshold);
+  const lines: string[] = [`${SCOPE_HEADERS[scope]}${thresholdSuffix}`];
+  const hasFindings =
+    result.unallowed.length > 0 ||
+    result.allowed.length > 0 ||
+    result.stale.length > 0 ||
+    result.belowThreshold.length > 0;
 
   if (!hasFindings) {
     lines.push('  (none)');
@@ -62,6 +86,9 @@ function formatScopeVerbose(scope: AuditScope, result: ScopeCheckResult, now: Da
   }
   for (const entry of result.stale) {
     blocks.push(formatStaleLine(entry));
+  }
+  for (const vuln of result.belowThreshold) {
+    blocks.push(formatBelowThresholdBlock(vuln));
   }
 
   // Join blocks with a blank line between them.
@@ -91,6 +118,13 @@ function formatAllowedBlock(vuln: AllowedVuln, now: Date): string {
 /** Format a stale entry as a single line with 🗑️ marker. */
 function formatStaleLine(entry: StaleEntry): string {
   return `  ${STATUS_STALE} ${entry.id}  not needed`;
+}
+
+/** Format a below-threshold vulnerability block with ℹ️ marker and "ignored (below threshold)" annotation. */
+function formatBelowThresholdBlock(vuln: AuditResult): string {
+  const headerLine = `  ${STATUS_BELOW_THRESHOLD} ${displayId(vuln)}${formatSeveritySuffix(vuln.severity)}  ignored (below threshold)`;
+  const detail = formatAdvisoryDetail(vuln);
+  return [headerLine, ...detail].join('\n');
 }
 
 /** Shared advisory detail lines (title, paths, link, description) for unallowed or allowed entries. */

--- a/packages/audit-deps/src/types.ts
+++ b/packages/audit-deps/src/types.ts
@@ -134,7 +134,8 @@ export interface CommandOptions {
  */
 export function isSeverityAtOrAbove(severity: string | undefined, threshold: SeverityThreshold): boolean {
   if (severity === undefined) return true;
-  const severityIndex = SEVERITY_THRESHOLDS.indexOf(severity);
+  const levels: readonly string[] = SEVERITY_THRESHOLDS;
+  const severityIndex = levels.indexOf(severity);
   const thresholdIndex = SEVERITY_THRESHOLDS.indexOf(threshold);
   // Unrecognized severity: treat as above threshold.
   if (severityIndex === -1) return true;

--- a/packages/audit-deps/src/types.ts
+++ b/packages/audit-deps/src/types.ts
@@ -134,9 +134,8 @@ export interface CommandOptions {
  */
 export function isSeverityAtOrAbove(severity: string | undefined, threshold: SeverityThreshold): boolean {
   if (severity === undefined) return true;
-  const thresholds: readonly string[] = SEVERITY_THRESHOLDS;
-  const severityIndex = thresholds.indexOf(severity);
-  const thresholdIndex = thresholds.indexOf(threshold);
+  const severityIndex = SEVERITY_THRESHOLDS.indexOf(severity);
+  const thresholdIndex = SEVERITY_THRESHOLDS.indexOf(threshold);
   // Unrecognized severity: treat as above threshold.
   if (severityIndex === -1) return true;
   return severityIndex >= thresholdIndex;

--- a/packages/audit-deps/src/types.ts
+++ b/packages/audit-deps/src/types.ts
@@ -119,3 +119,25 @@ export interface CommandOptions {
   scopes: AuditScope[];
   verbose: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Severity comparison
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether a severity string is at or above the given threshold.
+ *
+ * Unrecognized or undefined severities are treated as above threshold
+ * (conservative — surfaces unknown vulns rather than hiding them).
+ *
+ * @internal Exported for testing.
+ */
+export function isSeverityAtOrAbove(severity: string | undefined, threshold: SeverityThreshold): boolean {
+  if (severity === undefined) return true;
+  const thresholds: readonly string[] = SEVERITY_THRESHOLDS;
+  const severityIndex = thresholds.indexOf(severity);
+  const thresholdIndex = thresholds.indexOf(threshold);
+  // Unrecognized severity: treat as above threshold.
+  if (severityIndex === -1) return true;
+  return severityIndex >= thresholdIndex;
+}


### PR DESCRIPTION
## What

Surfaces below-threshold vulnerabilities in the check command's output instead of silently hiding them. When the severity threshold is above `low`, vulnerabilities that fall below it now appear with an `ℹ️` marker and "ignored" annotation in bare output, full advisory detail in verbose output, and a distinct `belowThreshold` array in JSON output. Scope headers display the active threshold (e.g., `📦 prod (threshold: 🟠 moderate):`) so users can see what filtering is in effect. The "No known vulnerabilities found" message now only appears when there are truly zero vulnerabilities across all categories. Exit code behavior is unchanged — only above-threshold, non-allowlisted vulnerabilities cause failure.

## Why

The check command previously delegated severity filtering entirely to audit-ci, which silently dropped below-threshold advisories from its output. This meant a scope could report "No known vulnerabilities found" even when vulnerabilities existed below the threshold, giving users no visibility into what was being filtered.

## Details

### Features

- Added `isSeverityAtOrAbove` utility in `types.ts` that compares severity strings against a threshold using `SEVERITY_THRESHOLDS` index order. Unknown or undefined severities are conservatively treated as above-threshold.
- Extended `ScopeCheckResult` with a `belowThreshold: AuditResult[]` category. The check command now overrides audit-ci's threshold to `'low'` to capture all advisories, then classifies results into `unallowed`, `allowed`, or `belowThreshold` within audit-deps.
- Updated `formatCheckText` to accept per-scope threshold context. Threshold annotations appear in scope headers and intro banners when the threshold is above `low`. Below-threshold vulnerabilities render after stale entries with lowest visual priority.
- Updated `formatCheckVerboseText` with equivalent threshold annotations and a new `ℹ️`-marked detail block for below-threshold entries showing full advisory information.

### Tests

- Added `types.test.ts` with parameterized tests for `isSeverityAtOrAbove` covering at/above/below thresholds, undefined severity, and unrecognized severity.
- Added cli tests for below-threshold classification, allowlisted-below-threshold routing, and the `generateAuditCiConfig` threshold override.
- Added format-check tests for below-threshold rendering in single-scope and multi-scope output, threshold annotations, and the "no vulnerabilities" message suppression.
- Added format-verbose tests for below-threshold detail block rendering and threshold annotations.
- Added format-actions test confirming below-threshold-only results produce no action hints.

## Test plan

- [ ] Manual: run `audit-deps` on a project with a known moderate vuln and threshold set above it — verify it appears as ignored
- [ ] Manual: run `audit-deps --verbose` and confirm full advisory detail for below-threshold vulns
- [ ] Manual: run `audit-deps --json` and confirm `belowThreshold` array in output

Closes #240