### PR TITLE
#246 Fix publish workflow: install pnpm unconditionally

### DIFF
--- a/.github/workflows/publish.reusable.yaml
+++ b/.github/workflows/publish.reusable.yaml
@@ -41,40 +41,20 @@ jobs:
 
     env:
       BUILD_LOCAL: ${{ github.repository == 'williamthorsen/node-monorepo-tools' }}
-      # Allow npx to run even when package.json declares a different package
-      # manager (e.g., pnpm). Without this, Corepack blocks npm/npx.
-      COREPACK_ENABLE_STRICT: '0'
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      # Strip the packageManager field so that actions/setup-node does not
-      # try to install it. The field is irrelevant for publishing.
-      - name: Neutralize packageManager field
-        if: ${{ env.BUILD_LOCAL != 'true' }}
-        run: node -e "const fs=require('fs'),f='package.json',p=JSON.parse(fs.readFileSync(f));delete p.packageManager;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
-
       - name: Set up pnpm
-        if: ${{ env.BUILD_LOCAL == 'true' }}
-        uses: pnpm/action-setup@v4
-
-      # Materialize the cache flag via step output because the `env` context
-      # is not evaluated in `with:` blocks.
-      - name: Resolve pnpm cache flag
-        id: cache-flag
-        run: echo "value=${{ env.BUILD_LOCAL == 'true' && 'pnpm' || '' }}" >> "$GITHUB_OUTPUT"
+        uses: pnpm/action-setup@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: https://registry.npmjs.org
-          cache: ${{ steps.cache-flag.outputs.value }}
-
-      - name: Disable Corepack
-        if: ${{ env.BUILD_LOCAL != 'true' }}
-        run: corepack disable
+          cache: pnpm
 
       - name: Install release-kit from npm
         if: ${{ env.BUILD_LOCAL != 'true' }}


### PR DESCRIPTION
## What

Fixes `release-kit publish` failing with `spawnSync pnpm ENOENT` in consumer repos by installing pnpm unconditionally in the reusable publish workflow. Upgrades `pnpm/action-setup` from `@v4` to `@v5` and removes four workarounds that compensated for pnpm's absence: `COREPACK_ENABLE_STRICT`, the `packageManager` field neutralization step, the Corepack disable step, and the cache-flag indirection step.

## Why

Consumer repos that use pnpm (e.g., `workshop`) could not publish via the reusable workflow. The workflow only installed pnpm for self-publishing inside `node-monorepo-tools`, but `release-kit` detects the consumer repo's package manager and calls `pnpm publish` — which fails when pnpm is not on PATH.

## Details

### Fixes

- Makes `pnpm/action-setup` unconditional so pnpm is available on PATH in all repos, not just `node-monorepo-tools`.
- Upgrades from `pnpm/action-setup@v4` to `@v5` (stable, Node.js 24, respects `packageManager` field). `@v6` is avoided due to a PATH ordering bug (pnpm/action-setup#230).
- Removes `COREPACK_ENABLE_STRICT: '0'` env var.
- Removes the "Neutralize packageManager field" step that stripped `packageManager` from `package.json`.
- Removes the "Disable Corepack" step.
- Removes the "Resolve pnpm cache flag" step and sets `cache: pnpm` directly on `actions/setup-node`.
- Preserves `BUILD_LOCAL` conditionals for install/build/link steps (these solve the bootstrap problem for self-publishing).

## Test plan

- Verify publish workflow succeeds in `node-monorepo-tools` (self-publishing path)
- Verify publish workflow succeeds in a consumer repo (e.g., `workshop`)
- Confirm no Node.js 20 deprecation warnings from the action

Closes #246