### PR TITLE
#260 Adopt readyup `pickJson` and shared helpers in `.readyup/kits/`

### DIFF
--- a/.readyup/kits/audit-deps.js
+++ b/.readyup/kits/audit-deps.js
@@ -96,62 +96,14 @@ function hasMinDevDependencyVersion(name, minVersion, options) {
   return compareVersions(versionMatch, minVersion) >= 0;
 }
 
-// packages/audit-deps/package.json
-var package_default = {
-  name: "@williamthorsen/audit-deps",
-  version: "0.4.0",
-  private: false,
-  description: "Wrap audit-ci with a richer config model, typed JSON source of truth, and sync workflow",
-  keywords: [
-    "audit",
-    "audit-ci",
-    "dependencies",
-    "security",
-    "vulnerabilities"
-  ],
-  homepage: "https://github.com/williamthorsen/node-monorepo-tools/tree/main/packages/audit-deps#readme",
-  bugs: {
-    url: "https://github.com/williamthorsen/node-monorepo-tools/issues"
-  },
-  repository: {
-    type: "git",
-    url: "https://github.com/williamthorsen/node-monorepo-tools.git",
-    directory: "packages/audit-deps"
-  },
-  license: "ISC",
-  author: "William Thorsen <william@thorsen.dev> (https://github.com/williamthorsen)",
-  type: "module",
-  exports: {
-    ".": {
-      import: "./dist/esm/index.js",
-      types: "./dist/esm/index.d.ts"
-    }
-  },
-  bin: {
-    "audit-deps": "bin/audit-deps.js"
-  },
-  files: [
-    "bin",
-    "dist"
-  ],
-  scripts: {
-    prepare: "tsx ../../config/generateVersion.ts && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json"
-  },
-  dependencies: {
-    "@williamthorsen/node-monorepo-core": "workspace:*",
-    "audit-ci": "7.1.0",
-    zod: "4.3.6"
-  },
-  engines: {
-    node: ">=18.17.0"
-  },
-  publishConfig: {
-    access: "public"
-  }
-};
-
 // .readyup/kits/audit-deps.ts
-var MIN_VERSION = package_default.version;
+function getMinVersion() {
+  const picked = { "version": "0.4.0" };
+  if (typeof picked.version !== "string") {
+    throw new TypeError("audit-deps/package.json: 'version' must be a string");
+  }
+  return picked.version;
+}
 var AUDIT_WORKFLOW_HASH = "cdcab39d794ed7ec5ea45e8f3c887eb5d15edb63eab65e515714556933d9b03f";
 var audit_deps_default = defineRdyKit({
   checklists: [
@@ -166,12 +118,16 @@ var audit_deps_default = defineRdyKit({
           fix: "pnpm add --save-dev @williamthorsen/audit-deps",
           checks: [
             {
-              name: `@williamthorsen/audit-deps >= ${MIN_VERSION}`,
+              get name() {
+                return `@williamthorsen/audit-deps >= ${getMinVersion()}`;
+              },
               severity: "error",
-              check: () => hasMinDevDependencyVersion("@williamthorsen/audit-deps", MIN_VERSION, {
+              check: () => hasMinDevDependencyVersion("@williamthorsen/audit-deps", getMinVersion(), {
                 exempt: (range) => range.startsWith("workspace:")
               }),
-              fix: `pnpm add --save-dev @williamthorsen/audit-deps@^${MIN_VERSION}`
+              get fix() {
+                return `pnpm add --save-dev @williamthorsen/audit-deps@^${getMinVersion()}`;
+              }
             }
           ]
         },

--- a/.readyup/kits/audit-deps.ts
+++ b/.readyup/kits/audit-deps.ts
@@ -11,11 +11,26 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { defineRdyKit, fileExists, fileMatchesHash, hasDevDependency, hasMinDevDependencyVersion } from 'readyup';
+import {
+  defineRdyKit,
+  fileExists,
+  fileMatchesHash,
+  hasDevDependency,
+  hasMinDevDependencyVersion,
+  pickJson,
+} from 'readyup';
 
-import auditDepsPackageJson from '../../packages/audit-deps/package.json' with { type: 'json' };
-
-const MIN_VERSION = auditDepsPackageJson.version;
+// `pickJson` is a compile-time helper: `rdy compile` rewrites the call to inline
+// only the listed fields. The runtime stub throws, so defer the call into a
+// function — this keeps the module importable in tests that don't go through
+// the readyup compile step.
+function getMinVersion(): string {
+  const picked = pickJson('../../packages/audit-deps/package.json', ['version']);
+  if (typeof picked.version !== 'string') {
+    throw new TypeError("audit-deps/package.json: 'version' must be a string");
+  }
+  return picked.version;
+}
 
 // SHA-256 hash of the canonical .github/workflows/audit.yaml wrapper.
 // Keep in sync — verified by __tests__/rdy-kit-hashes.app.test.ts.
@@ -34,13 +49,17 @@ export default defineRdyKit({
           fix: 'pnpm add --save-dev @williamthorsen/audit-deps',
           checks: [
             {
-              name: `@williamthorsen/audit-deps >= ${MIN_VERSION}`,
+              get name() {
+                return `@williamthorsen/audit-deps >= ${getMinVersion()}`;
+              },
               severity: 'error',
               check: () =>
-                hasMinDevDependencyVersion('@williamthorsen/audit-deps', MIN_VERSION, {
+                hasMinDevDependencyVersion('@williamthorsen/audit-deps', getMinVersion(), {
                   exempt: (range) => range.startsWith('workspace:'),
                 }),
-              fix: `pnpm add --save-dev @williamthorsen/audit-deps@^${MIN_VERSION}`,
+              get fix() {
+                return `pnpm add --save-dev @williamthorsen/audit-deps@^${getMinVersion()}`;
+              },
             },
           ],
         },

--- a/.readyup/kits/nmr.js
+++ b/.readyup/kits/nmr.js
@@ -149,62 +149,14 @@ function hasMinDevDependencyVersion(name, minVersion, options) {
   return compareVersions(versionMatch, minVersion) >= 0;
 }
 
-// packages/nmr/package.json
-var package_default = {
-  name: "@williamthorsen/nmr",
-  version: "0.11.0",
-  private: false,
-  description: "Context-aware script runner for PNPM monorepos",
-  keywords: [
-    "monorepo",
-    "pnpm",
-    "script-runner",
-    "workspace"
-  ],
-  homepage: "https://github.com/williamthorsen/node-monorepo-tools/tree/main/packages/nmr#readme",
-  bugs: {
-    url: "https://github.com/williamthorsen/node-monorepo-tools/issues"
-  },
-  repository: {
-    type: "git",
-    url: "https://github.com/williamthorsen/node-monorepo-tools.git",
-    directory: "packages/nmr"
-  },
-  license: "ISC",
-  author: "William Thorsen <william@thorsen.dev> (https://github.com/williamthorsen)",
-  type: "module",
-  exports: {
-    ".": "./dist/esm/index.js",
-    "./scripts": "./dist/esm/scripts.js",
-    "./tests": "./dist/esm/tests/consistency.js"
-  },
-  bin: {
-    "ensure-prepublish-hooks": "bin/ensure-prepublish-hooks.js",
-    nmr: "bin/nmr.js",
-    "nmr-report-overrides": "bin/nmr-report-overrides.js",
-    "nmr-sync-agent-files": "bin/nmr-sync-agent-files.js",
-    "nmr-sync-pnpm-version": "bin/nmr-sync-pnpm-version.js"
-  },
-  files: [
-    "AGENTS.md",
-    "bin",
-    "dist"
-  ],
-  scripts: {
-    prepare: "tsx ../../config/generateVersion.ts && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json"
-  },
-  dependencies: {
-    jiti: "2.6.1",
-    "js-yaml": "4.1.1",
-    zod: "4.3.6"
-  },
-  publishConfig: {
-    access: "public"
-  }
-};
-
 // .readyup/kits/nmr.ts
-var MIN_VERSION = package_default.version;
+function getMinVersion() {
+  const picked = { "version": "0.11.0" };
+  if (typeof picked.version !== "string") {
+    throw new TypeError("nmr/package.json: 'version' must be a string");
+  }
+  return picked.version;
+}
 var nmr_default = defineRdyKit({
   checklists: [
     {
@@ -218,12 +170,16 @@ var nmr_default = defineRdyKit({
           fix: "pnpm add --save-dev @williamthorsen/nmr",
           checks: [
             {
-              name: `@williamthorsen/nmr >= ${MIN_VERSION}`,
+              get name() {
+                return `@williamthorsen/nmr >= ${getMinVersion()}`;
+              },
               severity: "error",
-              check: () => hasMinDevDependencyVersion("@williamthorsen/nmr", MIN_VERSION, {
+              check: () => hasMinDevDependencyVersion("@williamthorsen/nmr", getMinVersion(), {
                 exempt: (range) => range.startsWith("workspace:")
               }),
-              fix: `pnpm add --save-dev @williamthorsen/nmr@^${MIN_VERSION}`
+              get fix() {
+                return `pnpm add --save-dev @williamthorsen/nmr@^${getMinVersion()}`;
+              }
             }
           ]
         },
@@ -313,7 +269,7 @@ function noRedundantRootScripts() {
   const pkg = readPackageJson();
   if (!pkg) return true;
   const scripts = pkg.scripts;
-  if (!isRecord2(scripts)) return true;
+  if (!isRecord(scripts)) return true;
   const builtInNames = Object.keys(getDefaultRootScripts());
   const redundant = Object.keys(scripts).filter((name) => builtInNames.includes(name));
   if (redundant.length === 0) return true;
@@ -367,13 +323,13 @@ function scriptExists(name) {
   const pkg = readPackageJson();
   if (!pkg) return false;
   const scripts = pkg.scripts;
-  return isRecord2(scripts) && name in scripts;
+  return isRecord(scripts) && name in scripts;
 }
 function scriptMatches(name, pattern) {
   const pkg = readPackageJson();
   if (!pkg) return false;
   const scripts = pkg.scripts;
-  if (!isRecord2(scripts)) return false;
+  if (!isRecord(scripts)) return false;
   const value = scripts[name];
   return typeof value === "string" && pattern.test(value);
 }
@@ -381,9 +337,6 @@ function codeQualityWorkflowDoesNotUseNmrCi() {
   const content = readFile(".github/workflows/code-quality.yaml");
   if (content === void 0) return true;
   return !/check-command:\s*pnpm exec nmr ci(\s|$)/.test(content);
-}
-function isRecord2(value) {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 export {
   codeQualityWorkflowDoesNotUseNmrCi,

--- a/.readyup/kits/nmr.ts
+++ b/.readyup/kits/nmr.ts
@@ -20,13 +20,23 @@ import {
   hasDevDependency,
   hasMinDevDependencyVersion,
   hasPackageJsonField,
+  isRecord,
+  pickJson,
   readFile,
   readPackageJson,
 } from 'readyup';
 
-import nmrPackageJson from '../../packages/nmr/package.json' with { type: 'json' };
-
-const MIN_VERSION = nmrPackageJson.version;
+// `pickJson` is a compile-time helper: `rdy compile` rewrites the call to inline
+// only the listed fields. Defer the call into a function so module load does
+// not invoke the runtime stub (which throws) — keeps the module importable in
+// tests that bypass the compile step.
+function getMinVersion(): string {
+  const picked = pickJson('../../packages/nmr/package.json', ['version']);
+  if (typeof picked.version !== 'string') {
+    throw new TypeError("nmr/package.json: 'version' must be a string");
+  }
+  return picked.version;
+}
 
 export default defineRdyKit({
   checklists: [
@@ -41,13 +51,17 @@ export default defineRdyKit({
           fix: 'pnpm add --save-dev @williamthorsen/nmr',
           checks: [
             {
-              name: `@williamthorsen/nmr >= ${MIN_VERSION}`,
+              get name() {
+                return `@williamthorsen/nmr >= ${getMinVersion()}`;
+              },
               severity: 'error',
               check: () =>
-                hasMinDevDependencyVersion('@williamthorsen/nmr', MIN_VERSION, {
+                hasMinDevDependencyVersion('@williamthorsen/nmr', getMinVersion(), {
                   exempt: (range) => range.startsWith('workspace:'),
                 }),
-              fix: `pnpm add --save-dev @williamthorsen/nmr@^${MIN_VERSION}`,
+              get fix() {
+                return `pnpm add --save-dev @williamthorsen/nmr@^${getMinVersion()}`;
+              },
             },
           ],
         },
@@ -238,8 +252,4 @@ export function codeQualityWorkflowDoesNotUseNmrCi(): boolean {
   const content = readFile('.github/workflows/code-quality.yaml');
   if (content === undefined) return true;
   return !/check-command:\s*pnpm exec nmr ci(\s|$)/.test(content);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/.readyup/kits/npm-auto-publish.js
+++ b/.readyup/kits/npm-auto-publish.js
@@ -60,6 +60,16 @@ function safeJsonParse(content) {
   }
 }
 
+// node_modules/.pnpm/readyup@0.17.0_esbuild@0.28.0/node_modules/readyup/dist/esm/check-utils/json-value.js
+function getJsonValue(obj, ...keys) {
+  let current = obj;
+  for (const key of keys) {
+    if (!isRecord(current)) return void 0;
+    current = current[key];
+  }
+  return current;
+}
+
 // node_modules/.pnpm/readyup@0.17.0_esbuild@0.28.0/node_modules/readyup/dist/esm/check-utils/json.js
 function readJsonFile(relativePath) {
   const content = readFile(relativePath);
@@ -161,7 +171,10 @@ function buildPackageCheck(pkg) {
   if (pkg.name.startsWith("@")) {
     children.push({
       name: 'publishConfig.access is "public"',
-      check: () => getNestedString(pkg.packageJson, "publishConfig", "access") === "public",
+      check: () => {
+        const access = getJsonValue(pkg.packageJson, "publishConfig", "access");
+        return typeof access === "string" && access === "public";
+      },
       fix: `Add "publishConfig": { "access": "public" } to ${pkgJsonPath}`
     });
   }
@@ -262,16 +275,6 @@ function discoverWorkspacePackages(workspaceConfigPath) {
 function getNodeMajorVersion() {
   return Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
 }
-function getNestedString(obj, ...keys) {
-  let current = obj;
-  for (const key of keys) {
-    if (!isRecord2(current)) {
-      return void 0;
-    }
-    current = current[key];
-  }
-  return typeof current === "string" ? current : void 0;
-}
 function getOwnerRepo() {
   const url = execSync2("git remote get-url origin", {
     encoding: "utf8"
@@ -319,7 +322,7 @@ function hasTrustedPublisher(packageName, expectedRepo, expectedFile) {
   } catch {
     return false;
   }
-  if (!isRecord2(parsed)) {
+  if (!isRecord(parsed)) {
     return false;
   }
   return parsed.type === "github" && parsed.repository === expectedRepo && parsed.file === expectedFile;
@@ -344,9 +347,6 @@ function isRepoPrivate() {
 }
 function parseProvenanceSetting(workflowContent) {
   return /^[^#]*provenance:\s*['"]?true['"]?/im.test(workflowContent);
-}
-function isRecord2(value) {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function parseWorkspaceGlobs(content) {
   const globs = [];

--- a/.readyup/kits/npm-auto-publish.ts
+++ b/.readyup/kits/npm-auto-publish.ts
@@ -9,6 +9,8 @@ import {
   defineRdyStagedChecklist,
   fileContains,
   fileExists,
+  getJsonValue,
+  isRecord,
   readFile,
   readJsonFile,
 } from 'readyup';
@@ -132,7 +134,10 @@ function buildPackageCheck(pkg: PackageInfo): RdyCheck {
   if (pkg.name.startsWith('@')) {
     children.push({
       name: 'publishConfig.access is "public"',
-      check: () => getNestedString(pkg.packageJson, 'publishConfig', 'access') === 'public',
+      check: () => {
+        const access = getJsonValue(pkg.packageJson, 'publishConfig', 'access');
+        return typeof access === 'string' && access === 'public';
+      },
       fix: `Add "publishConfig": { "access": "public" } to ${pkgJsonPath}`,
     });
   }
@@ -256,18 +261,6 @@ function getNodeMajorVersion(): number {
   return Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
 }
 
-/** Safely access a nested string value in a record. */
-function getNestedString(obj: Record<string, unknown>, ...keys: string[]): string | undefined {
-  let current: unknown = obj;
-  for (const key of keys) {
-    if (!isRecord(current)) {
-      return undefined;
-    }
-    current = current[key];
-  }
-  return typeof current === 'string' ? current : undefined;
-}
-
 /** Derive {owner}/{repo} from the git remote origin URL. */
 function getOwnerRepo(): string {
   const url = execSync('git remote get-url origin', {
@@ -364,10 +357,6 @@ function isRepoPrivate(): boolean {
 /** Check whether the publish.yaml workflow has provenance enabled. */
 function parseProvenanceSetting(workflowContent: string): boolean {
   return /^[^#]*provenance:\s*['"]?true['"]?/im.test(workflowContent);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /** Extract workspace glob patterns from pnpm-workspace.yaml content. */

--- a/.readyup/kits/release-kit.js
+++ b/.readyup/kits/release-kit.js
@@ -97,67 +97,6 @@ function hasMinDevDependencyVersion(name, minVersion, options) {
   return compareVersions(versionMatch, minVersion) >= 0;
 }
 
-// packages/release-kit/package.json
-var package_default = {
-  name: "@williamthorsen/release-kit",
-  version: "4.8.0",
-  description: "Version-bumping and changelog-generation toolkit for release workflows",
-  keywords: [],
-  homepage: "https://github.com/williamthorsen/node-monorepo-tools/tree/main/packages/release-kit#readme",
-  bugs: {
-    url: "https://github.com/williamthorsen/node-monorepo-tools/issues"
-  },
-  repository: {
-    type: "git",
-    url: "https://github.com/williamthorsen/node-monorepo-tools.git",
-    directory: "packages/release-kit"
-  },
-  license: "ISC",
-  author: "William Thorsen <william@thorsen.dev> (https://github.com/williamthorsen)",
-  type: "module",
-  exports: {
-    ".": {
-      import: "./dist/esm/index.js"
-    }
-  },
-  bin: {
-    "release-kit": "./bin/release-kit.js"
-  },
-  files: [
-    "bin",
-    "dist/*",
-    "cliff.toml.template",
-    "presets/**",
-    "CHANGELOG.md"
-  ],
-  scripts: {
-    prepare: "tsx ../../config/generateVersion.ts && tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json",
-    prepublishOnly: "nmr build",
-    test: "pnpm exec vitest --config=vitest.standalone.config.ts",
-    "test:coverage": "pnpm exec vitest --config=vitest.standalone.config.ts --coverage",
-    "test:integration": "pnpm exec vitest --config=vitest.integration.config.ts",
-    "test:watch": "pnpm exec vitest --config=vitest.standalone.config.ts --watch"
-  },
-  dependencies: {
-    "@williamthorsen/node-monorepo-core": "workspace:*",
-    glob: "13.0.6",
-    jiti: "2.6.1",
-    "js-yaml": "4.1.1",
-    "json-stringify-pretty-compact": "4.0.0"
-  },
-  devDependencies: {
-    "@types/js-yaml": "4.0.9",
-    "smol-toml": "1.6.1"
-  },
-  engines: {
-    node: ">=18.17.0"
-  },
-  publishConfig: {
-    access: "public",
-    registry: "https://registry.npmjs.org"
-  }
-};
-
 // packages/release-kit/src/init/detectRepoType.ts
 import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
 
@@ -193,7 +132,13 @@ function detectRepoType() {
 }
 
 // .readyup/kits/release-kit.ts
-var MIN_VERSION = package_default.version;
+function getMinVersion() {
+  const picked = { "version": "4.8.0" };
+  if (typeof picked.version !== "string") {
+    throw new TypeError("release-kit/package.json: 'version' must be a string");
+  }
+  return picked.version;
+}
 var CLIFF_TEMPLATE_HASH = "520ffdde4cbbef671f229d1e1f63c09a3c4ef0b2d76208386e372419d18065c7";
 var COMMON_PRESET_HASH = "d12ffccbd5e4d9af8ecf47744b143f6c9f80bcf5e496cf1983b66834f0ae7825";
 var SYNC_LABELS_WORKFLOW_HASH = "4dfde2454bac03280381f0da70c9c735916a7812100dec5437853b843c4bd797";
@@ -213,12 +158,16 @@ var release_kit_default = defineRdyKit({
           fix: "pnpm add --save-dev @williamthorsen/release-kit",
           checks: [
             {
-              name: `@williamthorsen/release-kit >= ${MIN_VERSION}`,
+              get name() {
+                return `@williamthorsen/release-kit >= ${getMinVersion()}`;
+              },
               severity: "error",
-              check: () => hasMinDevDependencyVersion("@williamthorsen/release-kit", MIN_VERSION, {
+              check: () => hasMinDevDependencyVersion("@williamthorsen/release-kit", getMinVersion(), {
                 exempt: (range) => range.startsWith("workspace:")
               }),
-              fix: `pnpm add --save-dev @williamthorsen/release-kit@^${MIN_VERSION}`
+              get fix() {
+                return `pnpm add --save-dev @williamthorsen/release-kit@^${getMinVersion()}`;
+              }
             }
           ]
         },

--- a/.readyup/kits/release-kit.ts
+++ b/.readyup/kits/release-kit.ts
@@ -16,13 +16,23 @@ import {
   fileMatchesHash,
   hasDevDependency,
   hasMinDevDependencyVersion,
+  pickJson,
   readFile,
 } from 'readyup';
 
-import releaseKitPackageJson from '../../packages/release-kit/package.json' with { type: 'json' };
 import { detectRepoType } from '../../packages/release-kit/src/init/detectRepoType.ts';
 
-const MIN_VERSION = releaseKitPackageJson.version;
+// `pickJson` is a compile-time helper: `rdy compile` rewrites the call to inline
+// only the listed fields. Defer the call into a function so module load does
+// not invoke the runtime stub (which throws) — keeps the module importable in
+// tests that bypass the compile step.
+function getMinVersion(): string {
+  const picked = pickJson('../../packages/release-kit/package.json', ['version']);
+  if (typeof picked.version !== 'string') {
+    throw new TypeError("release-kit/package.json: 'version' must be a string");
+  }
+  return picked.version;
+}
 
 // SHA-256 hashes of release-kit artifacts. Keep in sync —
 // verified by __tests__/rdy-kit-hashes.app.test.ts.
@@ -46,13 +56,17 @@ export default defineRdyKit({
           fix: 'pnpm add --save-dev @williamthorsen/release-kit',
           checks: [
             {
-              name: `@williamthorsen/release-kit >= ${MIN_VERSION}`,
+              get name() {
+                return `@williamthorsen/release-kit >= ${getMinVersion()}`;
+              },
               severity: 'error',
               check: () =>
-                hasMinDevDependencyVersion('@williamthorsen/release-kit', MIN_VERSION, {
+                hasMinDevDependencyVersion('@williamthorsen/release-kit', getMinVersion(), {
                   exempt: (range) => range.startsWith('workspace:'),
                 }),
-              fix: `pnpm add --save-dev @williamthorsen/release-kit@^${MIN_VERSION}`,
+              get fix() {
+                return `pnpm add --save-dev @williamthorsen/release-kit@^${getMinVersion()}`;
+              },
             },
           ],
         },

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -5,7 +5,7 @@
       "name": "audit-deps",
       "path": "kits/audit-deps.js",
       "source": "kits/audit-deps.ts",
-      "sourceHash": "11860996"
+      "sourceHash": "fc6261a2"
     },
     {
       "name": "default",
@@ -17,19 +17,19 @@
       "name": "nmr",
       "path": "kits/nmr.js",
       "source": "kits/nmr.ts",
-      "sourceHash": "67d87a44"
+      "sourceHash": "4bfd8d74"
     },
     {
       "name": "npm-auto-publish",
       "path": "kits/npm-auto-publish.js",
       "source": "kits/npm-auto-publish.ts",
-      "sourceHash": "2ec98029"
+      "sourceHash": "1370ed6a"
     },
     {
       "name": "release-kit",
       "path": "kits/release-kit.js",
       "source": "kits/release-kit.ts",
-      "sourceHash": "b6c6fa27"
+      "sourceHash": "29796d0d"
     }
   ]
 }

--- a/__tests__/rdy-kit-source-guards.app.test.ts
+++ b/__tests__/rdy-kit-source-guards.app.test.ts
@@ -1,0 +1,27 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const kitsDir = join(import.meta.dirname, '..', '.readyup', 'kits');
+const JSON_IMPORT_ATTRIBUTE_PATTERN = /\b(?:with|assert)\s*\{\s*type\s*:\s*['"]json['"]\s*\}/;
+
+const kitSourceFiles = readdirSync(kitsDir).filter((name) => name.endsWith('.ts'));
+
+/**
+ * Guards against reintroducing the JSON-inlining footgun in `.readyup/kits/*.ts`.
+ * A native `with { type: 'json' }` import causes esbuild (invoked by `rdy compile`)
+ * to inline the entire JSON file into the compiled kit. Use `pickJson` instead.
+ */
+describe('rdy kit source files', () => {
+  for (const file of kitSourceFiles) {
+    it(`${file} uses no JSON import attributes`, () => {
+      const content = readFileSync(join(kitsDir, file), 'utf8');
+      expect(
+        JSON_IMPORT_ATTRIBUTE_PATTERN.test(content),
+        `${file} contains a \`with { type: 'json' }\` or \`assert { type: 'json' }\` import attribute. ` +
+          'Replace it with `pickJson(relativePath, keys)` from readyup — the native JSON import inlines the entire file into the compiled kit.',
+      ).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
## What

Shrinks the three compiled readyup kits in `.readyup/kits/` by stopping the full sibling `package.json` from being inlined into each one. `audit-deps.js`, `nmr.js`, and `release-kit.js` now contain only the single `version` field each kit actually reads, rather than an entire copy of the source package's `devDependencies`, `scripts`, and other internal metadata. Consolidates the kits on shared helpers exported from `readyup`, removing three local helper definitions that duplicated functionality the shared library already provides.

## Why

Each kit previously used a native `with { type: 'json' }` import attribute purely to read `.version`, but esbuild treats that syntax as a request to inline the entire file. The compiled kits grew to include unrelated fields from the source `package.json` — fields consumers of the kits never need and should never see in a distributable artifact. `readyup` exposes a compile-time `pickJson(relativePath, keys)` helper whose esbuild plugin narrows the inlined data to the requested fields, so the fix was available as soon as we switched to it. The helper consolidation is an adjacent cleanup: `readyup` 0.16+ now exports `isRecord` and `getJsonValue`, which made the three local copies in this repo redundant.

## Details

### Refactoring

- Replaced the JSON import attribute in `audit-deps.ts`, `nmr.ts`, and `release-kit.ts` with `pickJson('../../packages/<pkg>/package.json', ['version'])`. The compiled kits are materially smaller as a result: `audit-deps.js` 216 → 172 lines, `nmr.js` 387 → 342, `release-kit.js` 368 → 317.
- Removed the local `isRecord` definitions from `nmr.ts` and `npm-auto-publish.ts` in favor of the helper re-exported from `readyup`.
- Replaced the local `getNestedString` helper in `npm-auto-publish.ts` with `readyup`'s `getJsonValue` plus an inline `typeof === 'string'` guard at the sole call site.
- Deferred each `pickJson` call into a local `getMinVersion()` function, and converted the check `name` / `fix` fields that interpolate the version into getters. This preserves importability of kit modules in contexts that bypass `rdy compile` (e.g., direct source imports from tests), since the runtime `pickJson` stub throws by design.

### Tests

- Added `__tests__/rdy-kit-source-guards.app.test.ts`, a scan-based guard that fails if any `.readyup/kits/*.ts` file reintroduces `with { type: 'json' }` or `assert { type: 'json' }`. A complementary upstream request to detect the same footgun inside `rdy compile` / `rdy validate` is tracked at williamthorsen/workshop#68.

Closes #260 