### PR TITLE
#256 Scaffold release-notes injection and check markers

### DIFF
--- a/.readyup/kits/__tests__/release-kit-checks.test.ts
+++ b/.readyup/kits/__tests__/release-kit-checks.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Minimal Dirent-shape covering the fields the kit reads. Using a structural
+// type avoids importing Dirent and casting through `unknown`, which the
+// repo's lint rules disallow.
+interface DirentLike {
+  name: string;
+  isDirectory(): boolean;
+  isFile(): boolean;
+}
+
+const { mockedExistsSync, mockedReaddirSync, mockedReadFile } = vi.hoisted(() => ({
+  mockedExistsSync: vi.fn<(path: string) => boolean>(),
+  mockedReaddirSync: vi.fn<(path: string, options: { withFileTypes: true }) => DirentLike[]>(),
+  mockedReadFile: vi.fn<(path: string) => string | undefined>(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: { ...actual, existsSync: mockedExistsSync, readdirSync: mockedReaddirSync },
+    existsSync: mockedExistsSync,
+    readdirSync: mockedReaddirSync,
+  };
+});
+
+vi.mock('readyup', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('readyup')>();
+  return {
+    ...actual,
+    readFile: mockedReadFile,
+  };
+});
+
+import {
+  getPublishablePackages,
+  readmeHasReleaseNotesMarkers,
+  readmesHaveReleaseNotesMarkers,
+} from '../release-kit.ts';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Build a minimal Dirent-shaped object for a directory entry. */
+function dirEntry(name: string): DirentLike {
+  return { name, isDirectory: () => true, isFile: () => false };
+}
+
+/** Build a Dirent-shaped object for a non-directory entry. */
+function fileEntry(name: string): DirentLike {
+  return { name, isDirectory: () => false, isFile: () => true };
+}
+
+describe(getPublishablePackages, () => {
+  it('returns [] when packages/ does not exist', () => {
+    mockedExistsSync.mockReturnValue(false);
+
+    expect(getPublishablePackages()).toEqual([]);
+    expect(mockedReaddirSync).not.toHaveBeenCalled();
+  });
+
+  it('returns all packages whose package.json is not marked private', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('beta'), dirEntry('gamma')]);
+    mockedReadFile.mockImplementation((path) => {
+      if (path === 'packages/alpha/package.json') return JSON.stringify({ name: '@scope/alpha' });
+      if (path === 'packages/beta/package.json') return JSON.stringify({ name: '@scope/beta', private: false });
+      if (path === 'packages/gamma/package.json') return JSON.stringify({ name: '@scope/gamma' });
+      return undefined;
+    });
+
+    expect(getPublishablePackages()).toEqual([
+      { dir: 'packages/alpha' },
+      { dir: 'packages/beta' },
+      { dir: 'packages/gamma' },
+    ]);
+  });
+
+  it('excludes packages with "private": true', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('hidden')]);
+    mockedReadFile.mockImplementation((path) => {
+      if (path === 'packages/alpha/package.json') return JSON.stringify({ name: '@scope/alpha' });
+      if (path === 'packages/hidden/package.json') return JSON.stringify({ name: '@scope/hidden', private: true });
+      return undefined;
+    });
+
+    expect(getPublishablePackages()).toEqual([{ dir: 'packages/alpha' }]);
+  });
+
+  it('skips entries that are not directories', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReaddirSync.mockReturnValue([dirEntry('alpha'), fileEntry('README.md')]);
+    mockedReadFile.mockReturnValue(JSON.stringify({ name: '@scope/alpha' }));
+
+    expect(getPublishablePackages()).toEqual([{ dir: 'packages/alpha' }]);
+  });
+
+  it('skips directories without a package.json', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('orphan')]);
+    mockedReadFile.mockImplementation((path) => {
+      if (path === 'packages/alpha/package.json') return JSON.stringify({ name: '@scope/alpha' });
+      return undefined;
+    });
+
+    expect(getPublishablePackages()).toEqual([{ dir: 'packages/alpha' }]);
+  });
+
+  it('treats unparseable package.json as non-private (publishable)', () => {
+    // parseJsonRecord returns undefined for invalid JSON; we treat that as
+    // "no private field" so the package is included rather than silently dropped.
+    mockedExistsSync.mockReturnValue(true);
+    mockedReaddirSync.mockReturnValue([dirEntry('garbled')]);
+    mockedReadFile.mockReturnValue('not valid JSON');
+
+    expect(getPublishablePackages()).toEqual([{ dir: 'packages/garbled' }]);
+  });
+
+  it('does not treat string "true" as private', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReaddirSync.mockReturnValue([dirEntry('alpha')]);
+    mockedReadFile.mockReturnValue(JSON.stringify({ private: 'true' }));
+
+    expect(getPublishablePackages()).toEqual([{ dir: 'packages/alpha' }]);
+  });
+});
+
+describe(readmeHasReleaseNotesMarkers, () => {
+  it('returns true when both opening and closing markers are present', () => {
+    const content = '# Title\n<!-- section:release-notes -->\nNotes here\n<!-- /section:release-notes -->\n';
+
+    expect(readmeHasReleaseNotesMarkers(content)).toBe(true);
+  });
+
+  it('returns false when only the opening marker is present', () => {
+    const content = '# Title\n<!-- section:release-notes -->\nNotes here\n';
+
+    expect(readmeHasReleaseNotesMarkers(content)).toBe(false);
+  });
+
+  it('returns false when only the closing marker is present', () => {
+    const content = '# Title\nNotes here\n<!-- /section:release-notes -->\n';
+
+    expect(readmeHasReleaseNotesMarkers(content)).toBe(false);
+  });
+
+  it('returns false when neither marker is present', () => {
+    expect(readmeHasReleaseNotesMarkers('# Title\nJust some content.\n')).toBe(false);
+  });
+});
+
+describe(readmesHaveReleaseNotesMarkers, () => {
+  describe('single-package mode', () => {
+    it('returns true when root README contains both markers', () => {
+      mockedExistsSync.mockReturnValue(false); // pnpm-workspace.yaml absent
+      mockedReadFile.mockImplementation((path) => {
+        if (path === 'package.json') return JSON.stringify({ name: 'consumer' });
+        if (path === 'README.md') return '<!-- section:release-notes -->\n<!-- /section:release-notes -->';
+        return undefined;
+      });
+
+      expect(readmesHaveReleaseNotesMarkers()).toBe(true);
+    });
+
+    it('returns false when root README is missing', () => {
+      mockedExistsSync.mockReturnValue(false);
+      mockedReadFile.mockImplementation((path) => {
+        if (path === 'package.json') return JSON.stringify({ name: 'consumer' });
+        return undefined;
+      });
+
+      expect(readmesHaveReleaseNotesMarkers()).toBe(false);
+    });
+
+    it('returns false when root README lacks markers', () => {
+      mockedExistsSync.mockReturnValue(false);
+      mockedReadFile.mockImplementation((path) => {
+        if (path === 'package.json') return JSON.stringify({ name: 'consumer' });
+        if (path === 'README.md') return '# Plain README';
+        return undefined;
+      });
+
+      expect(readmesHaveReleaseNotesMarkers()).toBe(false);
+    });
+  });
+
+  describe('monorepo mode', () => {
+    it('returns true when every publishable package README has both markers', () => {
+      mockedExistsSync.mockReturnValue(true); // pnpm-workspace.yaml present → monorepo
+      mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('beta')]);
+      mockedReadFile.mockImplementation((path) => {
+        if (path === 'packages/alpha/package.json') return JSON.stringify({ name: 'alpha' });
+        if (path === 'packages/beta/package.json') return JSON.stringify({ name: 'beta' });
+        if (path === 'packages/alpha/README.md')
+          return '<!-- section:release-notes -->\n<!-- /section:release-notes -->';
+        if (path === 'packages/beta/README.md')
+          return '<!-- section:release-notes -->\n<!-- /section:release-notes -->';
+        return undefined;
+      });
+
+      expect(readmesHaveReleaseNotesMarkers()).toBe(true);
+    });
+
+    it('aggregates failing packages into CheckOutcome.detail', () => {
+      mockedExistsSync.mockReturnValue(true);
+      mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('beta'), dirEntry('gamma')]);
+      mockedReadFile.mockImplementation((path) => {
+        if (path === 'packages/alpha/package.json') return JSON.stringify({ name: 'alpha' });
+        if (path === 'packages/beta/package.json') return JSON.stringify({ name: 'beta' });
+        if (path === 'packages/gamma/package.json') return JSON.stringify({ name: 'gamma' });
+        if (path === 'packages/alpha/README.md')
+          return '<!-- section:release-notes -->\n<!-- /section:release-notes -->';
+        if (path === 'packages/beta/README.md') return '# Plain README, no markers';
+        // gamma README missing entirely
+        return undefined;
+      });
+
+      expect(readmesHaveReleaseNotesMarkers()).toEqual({
+        ok: false,
+        detail: 'missing markers or README: packages/beta/README.md, packages/gamma/README.md',
+      });
+    });
+
+    it('skips packages marked private', () => {
+      mockedExistsSync.mockReturnValue(true);
+      mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('hidden')]);
+      mockedReadFile.mockImplementation((path) => {
+        if (path === 'packages/alpha/package.json') return JSON.stringify({ name: 'alpha' });
+        if (path === 'packages/hidden/package.json') return JSON.stringify({ name: 'hidden', private: true });
+        if (path === 'packages/alpha/README.md')
+          return '<!-- section:release-notes -->\n<!-- /section:release-notes -->';
+        // hidden has no README — would fail if not filtered out
+        return undefined;
+      });
+
+      expect(readmesHaveReleaseNotesMarkers()).toBe(true);
+    });
+
+    it('returns true when there are no publishable packages', () => {
+      mockedExistsSync.mockReturnValue(true);
+      mockedReaddirSync.mockReturnValue([]);
+
+      expect(readmesHaveReleaseNotesMarkers()).toBe(true);
+    });
+  });
+});

--- a/.readyup/kits/release-kit.js
+++ b/.readyup/kits/release-kit.js
@@ -2,6 +2,10 @@
 /* eslint-disable */
 
 
+// .readyup/kits/release-kit.ts
+import { existsSync as existsSync3, readdirSync } from "node:fs";
+import { join as join2 } from "node:path";
+
 // node_modules/.pnpm/readyup@0.17.0_esbuild@0.28.0/node_modules/readyup/dist/esm/authoring.js
 function defineRdyKit(kit) {
   return kit;
@@ -236,7 +240,15 @@ var release_kit_default = defineRdyKit({
           severity: "warn",
           skip: () => !fileExists(".config/release-kit.config.ts") ? "no release-kit config file" : false,
           check: () => releaseNotesInjectsIntoReadme(),
-          fix: "Set releaseNotes.shouldInjectIntoReadme to true in .config/release-kit.config.ts"
+          fix: "Set releaseNotes.shouldInjectIntoReadme to true in .config/release-kit.config.ts",
+          checks: [
+            {
+              name: "README contains release-notes section markers",
+              severity: "warn",
+              check: readmesHaveReleaseNotesMarkers,
+              fix: "Add `<!-- section:release-notes -->` and `<!-- /section:release-notes -->` markers to each affected README"
+            }
+          ]
         },
         {
           name: "git-cliff not in devDependencies",
@@ -310,12 +322,49 @@ function releaseNotesInjectsIntoReadme() {
   if (content === void 0) return false;
   return /shouldInjectIntoReadme\s*:\s*true/.test(content);
 }
+function readmeHasReleaseNotesMarkers(content) {
+  return content.includes("<!-- section:release-notes -->") && content.includes("<!-- /section:release-notes -->");
+}
+function readmesHaveReleaseNotesMarkers() {
+  if (detectRepoType() === "single-package") {
+    const content = readFile("README.md");
+    return content !== void 0 && readmeHasReleaseNotesMarkers(content);
+  }
+  const failing = [];
+  for (const { dir } of getPublishablePackages()) {
+    const content = readFile(`${dir}/README.md`);
+    if (content === void 0 || !readmeHasReleaseNotesMarkers(content)) {
+      failing.push(`${dir}/README.md`);
+    }
+  }
+  if (failing.length === 0) return true;
+  return {
+    ok: false,
+    detail: `missing markers or README: ${failing.join(", ")}`
+  };
+}
 function labelsHaveCurrentPresetHash(presetName, expectedHash) {
   const content = readFile(".github/labels.yaml");
   if (content === void 0) return false;
   const pattern = new RegExp(`^# ${presetName} preset hash: (.+)$`, "m");
   const match = pattern.exec(content);
   return match !== null && match[1] === expectedHash;
+}
+function getPublishablePackages() {
+  const packagesDir = join2(process.cwd(), "packages");
+  if (!existsSync3(packagesDir)) return [];
+  const entries = readdirSync(packagesDir, { withFileTypes: true });
+  const publishable = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const dir = `packages/${entry.name}`;
+    const content = readFile(`${dir}/package.json`);
+    if (content === void 0) continue;
+    const pkg = parseJsonRecord(content);
+    if (pkg?.private === true) continue;
+    publishable.push({ dir });
+  }
+  return publishable;
 }
 export {
   CLIFF_TEMPLATE_HASH,
@@ -325,5 +374,8 @@ export {
   RELEASE_WORKFLOW_HASH_MONOREPO,
   RELEASE_WORKFLOW_HASH_SINGLE,
   SYNC_LABELS_WORKFLOW_HASH,
-  release_kit_default as default
+  release_kit_default as default,
+  getPublishablePackages,
+  readmeHasReleaseNotesMarkers,
+  readmesHaveReleaseNotesMarkers
 };

--- a/.readyup/kits/release-kit.ts
+++ b/.readyup/kits/release-kit.ts
@@ -9,6 +9,10 @@
  * Run from a target repo's working directory:
  *   rdy run --file <path-to>/release-kit.js
  */
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { CheckOutcome } from 'readyup';
 import {
   defineRdyKit,
   fileDoesNotContain,
@@ -21,6 +25,7 @@ import {
 } from 'readyup';
 
 import { detectRepoType } from '../../packages/release-kit/src/init/detectRepoType.ts';
+import { parseJsonRecord } from '../../packages/release-kit/src/init/parseJsonRecord.ts';
 
 // `pickJson` is a compile-time helper: `rdy compile` rewrites the call to inline
 // only the listed fields. Defer the call into a function so module load does
@@ -138,6 +143,14 @@ export default defineRdyKit({
           skip: () => (!fileExists('.config/release-kit.config.ts') ? 'no release-kit config file' : false),
           check: () => releaseNotesInjectsIntoReadme(),
           fix: 'Set releaseNotes.shouldInjectIntoReadme to true in .config/release-kit.config.ts',
+          checks: [
+            {
+              name: 'README contains release-notes section markers',
+              severity: 'warn',
+              check: readmesHaveReleaseNotesMarkers,
+              fix: 'Add `<!-- section:release-notes -->` and `<!-- /section:release-notes -->` markers to each affected README',
+            },
+          ],
         },
         {
           name: 'git-cliff not in devDependencies',
@@ -224,6 +237,46 @@ function releaseNotesInjectsIntoReadme(): boolean {
   return /shouldInjectIntoReadme\s*:\s*true/.test(content);
 }
 
+/**
+ * Test whether a README's content contains the release-notes section marker pair.
+ *
+ * Both `<!-- section:release-notes -->` and `<!-- /section:release-notes -->`
+ * must be present. Order and proximity are not enforced; release-kit's injector
+ * locates each marker independently.
+ */
+export function readmeHasReleaseNotesMarkers(content: string): boolean {
+  return content.includes('<!-- section:release-notes -->') && content.includes('<!-- /section:release-notes -->');
+}
+
+/**
+ * Check README markers across the consumer repo, adapting to repo type.
+ *
+ * Single-package: validates the root `README.md`. A missing README fails the check.
+ * Monorepo: validates `${dir}/README.md` for each publishable package and aggregates
+ * failures into the `CheckOutcome.detail` field. A missing README within a package
+ * counts as a failure for that package (no README → no markers).
+ */
+export function readmesHaveReleaseNotesMarkers(): boolean | CheckOutcome {
+  if (detectRepoType() === 'single-package') {
+    const content = readFile('README.md');
+    return content !== undefined && readmeHasReleaseNotesMarkers(content);
+  }
+
+  const failing: string[] = [];
+  for (const { dir } of getPublishablePackages()) {
+    const content = readFile(`${dir}/README.md`);
+    if (content === undefined || !readmeHasReleaseNotesMarkers(content)) {
+      failing.push(`${dir}/README.md`);
+    }
+  }
+
+  if (failing.length === 0) return true;
+  return {
+    ok: false,
+    detail: `missing markers or README: ${failing.join(', ')}`,
+  };
+}
+
 /** Check that `.github/labels.yaml` contains the expected hash for a named preset. */
 function labelsHaveCurrentPresetHash(presetName: string, expectedHash: string): boolean {
   const content = readFile('.github/labels.yaml');
@@ -231,4 +284,31 @@ function labelsHaveCurrentPresetHash(presetName: string, expectedHash: string): 
   const pattern = new RegExp(`^# ${presetName} preset hash: (.+)$`, 'm');
   const match = pattern.exec(content);
   return match !== null && match[1] === expectedHash;
+}
+
+/**
+ * Enumerate publishable workspace packages by walking `packages/{dir}` and
+ * filtering out any whose `package.json` has `"private": true`.
+ *
+ * Returns `[]` when `packages/` does not exist. Assumes the conventional
+ * `packages/{dir}` layout (matches the existing pattern used in
+ * `.readyup/kits/nmr.ts`); does not parse `pnpm-workspace.yaml` or root
+ * `package.json` `workspaces`.
+ */
+export function getPublishablePackages(): Array<{ dir: string }> {
+  const packagesDir = join(process.cwd(), 'packages');
+  if (!existsSync(packagesDir)) return [];
+
+  const entries = readdirSync(packagesDir, { withFileTypes: true });
+  const publishable: Array<{ dir: string }> = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const dir = `packages/${entry.name}`;
+    const content = readFile(`${dir}/package.json`);
+    if (content === undefined) continue;
+    const pkg = parseJsonRecord(content);
+    if (pkg?.private === true) continue;
+    publishable.push({ dir });
+  }
+  return publishable;
 }

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -29,7 +29,7 @@
       "name": "release-kit",
       "path": "kits/release-kit.js",
       "source": "kits/release-kit.ts",
-      "sourceHash": "8c839d98"
+      "sourceHash": "71ae05c7"
     }
   ]
 }

--- a/packages/release-kit/src/init/__tests__/templates.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/templates.unit.test.ts
@@ -33,6 +33,16 @@ describe(releaseConfigScript, () => {
     expect(mono).not.toContain('heading:');
     expect(single).not.toContain('heading:');
   });
+
+  it.each(['monorepo', 'single-package'] as const)(
+    'scaffolds releaseNotes.shouldInjectIntoReadme as true (%s)',
+    (repoType) => {
+      const script = releaseConfigScript(repoType);
+
+      expect(script).toContain('releaseNotes: {');
+      expect(script).toContain('shouldInjectIntoReadme: true');
+    },
+  );
 });
 
 describe(publishWorkflow, () => {

--- a/packages/release-kit/src/init/templates.ts
+++ b/packages/release-kit/src/init/templates.ts
@@ -10,6 +10,10 @@ export function releaseConfigScript(repoType: RepoType): string {
     return `import type { ReleaseKitConfig } from '@williamthorsen/release-kit';
 
 const config: ReleaseKitConfig = {
+  releaseNotes: {
+    shouldInjectIntoReadme: true,
+  },
+
   // Uncomment to exclude components from release processing:
   // components: [
   //   { dir: 'my-package', shouldExclude: true },
@@ -31,6 +35,10 @@ export default config;
   return `import type { ReleaseKitConfig } from '@williamthorsen/release-kit';
 
 const config: ReleaseKitConfig = {
+  releaseNotes: {
+    shouldInjectIntoReadme: true,
+  },
+
   // Formatting: prettier is auto-detected. Set formatCommand to override.
 
   // Uncomment to override the default version patterns:


### PR DESCRIPTION
## What

Adds release-notes injection to the configs scaffolded by `release-kit init`, so newly-onboarded consumers get the feature without having to discover or toggle the flag. The release-kit readyup kit gains a check that warns when a consumer's README is missing the marker pair where injected notes should land — without those markers, injection silently prepends to the top of the file, pushing the README's title below the notes.

## Why

The injection flag was off by default in scaffolded configs and never surfaced as a visible field, so users effectively never opted in. Even consumers who did enable injection could end up with awkward README layouts because nothing validated that the target markers existed. Scaffolding the flag as enabled and warning on missing markers closes both gaps in one pass.

## Details

### Features

- Scaffold the `releaseNotes: { shouldInjectIntoReadme: true }` block at the top of `release-kit init`'s generated config, for both monorepo and single-package templates. The programmatic default in `defaults.ts` stays `false`, so existing consumers with empty configs are unaffected.
- Restructure the readyup kit's `releaseNotes.shouldInjectIntoReadme is true` check into a parent with a nested child check, `README contains release-notes section markers`. The child runs only when injection is enabled.
- Auto-adapt the marker check to repo type via `detectRepoType()`: single-package mode inspects the root `README.md`; monorepo mode enumerates non-private workspace packages and inspects each `packages/{dir}/README.md`. A missing README counts as a failure for that package.
- Aggregate per-package failures into a single `CheckOutcome.detail` listing the affected READMEs, so the warning points the consumer directly at the files to update.
- Add `getPublishablePackages()`, a new helper in the release-kit readyup kit that walks `packages/{dir}` and excludes any whose `package.json` has `"private": true`.

### Tests

- New `release-kit-checks.test.ts` covers `getPublishablePackages` (empty workspace, mixed private/non-private packages, missing `package.json`, non-directory entries, unparseable `package.json`), `readmeHasReleaseNotesMarkers` (both markers, opening only, closing only, neither), and `readmesHaveReleaseNotesMarkers` (single-package present/missing/markerless, monorepo aggregation across mixed pass/fail/no-readme states, private-package filtering, empty workspace).
- Templates test gains an `it.each` block confirming both repo types' scaffolds contain `releaseNotes: {` and `shouldInjectIntoReadme: true`.

Closes #256