### PR TITLE
#255 Prefer local release-kit in publish workflow

### DIFF
--- a/.github/workflows/publish.reusable.yaml
+++ b/.github/workflows/publish.reusable.yaml
@@ -3,11 +3,20 @@ name: Publish
 
 # Reusable publish workflow for projects using @williamthorsen/release-kit.
 #
-# Triggered by tag pushes. Installs `@williamthorsen/release-kit` globally and
-# runs `release-kit publish` with OIDC-based npm authentication.
+# Triggered by tag pushes. Runs `pnpm install` before publishing so consumer
+# packages with build-time `prepare` hooks have their devDependencies on disk,
+# then invokes release-kit with OIDC-based npm authentication:
+#   - If the consumer lists `@williamthorsen/release-kit` in root
+#     devDependencies (workspace link or pinned version), release-kit is
+#     invoked via `pnpm exec release-kit` — the consumer's version, not
+#     `latest`.
+#   - Otherwise, the workflow falls back to
+#     `npm install --global @williamthorsen/release-kit` and invokes the
+#     global shim.
 # Pass `provenance: true` to enable npm provenance attestations (requires a public repo).
-# When running in the `williamthorsen/node-monorepo-tools` repo, release-kit is
-# built from source instead of installed from npm (auto-detected).
+# When running in the `williamthorsen/node-monorepo-tools` repo (auto-detected),
+# release-kit is additionally built from source so the workspace-linked binary
+# is ready before `pnpm exec` invokes it.
 # The calling workflow must grant `id-token: write` and `contents: read` permissions.
 #
 # Usage:
@@ -56,23 +65,32 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
-      - name: Install release-kit from npm
-        if: ${{ env.BUILD_LOCAL != 'true' }}
-        run: npm install --global @williamthorsen/release-kit
+      - name: Install dependencies
+        run: pnpm install
 
       # Build release-kit from source to avoid bootstrap problems when
       # publishing a version that introduces new CLI flags.
-      - name: Install dependencies
-        if: ${{ env.BUILD_LOCAL == 'true' }}
-        run: pnpm install --frozen-lockfile
-
       - name: Build release-kit from source
         if: ${{ env.BUILD_LOCAL == 'true' }}
         run: pnpm --filter @williamthorsen/release-kit... run prepare
 
-      - name: Link release-kit onto PATH
-        if: ${{ env.BUILD_LOCAL == 'true' }}
-        run: npm link --workspace packages/release-kit
+      - name: Detect local release-kit
+        id: detect
+        run: |
+          is_local=$(node -p "require('./package.json').devDependencies?.['@williamthorsen/release-kit'] ? 'true' : 'false'")
+          echo "local=$is_local" >> "$GITHUB_OUTPUT"
+
+      - name: Install release-kit from npm
+        if: ${{ steps.detect.outputs.local != 'true' }}
+        run: npm install --global @williamthorsen/release-kit
 
       - name: Publish
-        run: release-kit publish ${{ inputs.provenance && '--provenance' || '' }} --no-git-checks
+        env:
+          LOCAL: ${{ steps.detect.outputs.local }}
+        run: |
+          args="${{ inputs.provenance && '--provenance' || '' }} --no-git-checks"
+          if [ "$LOCAL" = "true" ]; then
+            pnpm exec release-kit publish $args
+          else
+            release-kit publish $args
+          fi


### PR DESCRIPTION
## What

Aligns the `@williamthorsen/release-kit` version used by the reusable publish workflow with whatever version a consumer tested with locally, instead of always resolving `latest` from a global install. Also unblocks publishing for packages whose `prepare` hook depends on local devDependencies (e.g., `tsx build.ts && tsc`) — the workflow now installs consumer dependencies before invoking release-kit.

## Why

Two problems motivated the change.

First, the previous workflow ran `npm install --global @williamthorsen/release-kit` for every non-workspace consumer, which always resolved `latest`. A consumer that pinned a specific release-kit version in their own `devDependencies` would still get whatever happened to be on npm when CI ran, producing hard-to-diagnose "CI ran a different release-kit than I did" drift.

Second, the workflow never ran `pnpm install` for non-workspace consumers, so any package whose `prepare` lifecycle hook needed its own devDependencies failed at publish time with a bare `node_modules/`. This was the root cause reported in #249 (`readyup-v0.17.0` publish failure).

## Details

### Features

- New `Detect local release-kit` step inspects the consumer's root `package.json` `devDependencies` via a Node one-liner and writes a boolean step output `local`. When `local=true`, the workflow skips the global install and invokes release-kit via `pnpm exec release-kit publish …`. When `local=false`, it falls back to today's behavior (`npm install --global` followed by the PATH shim).
- The `BUILD_LOCAL` auto-detect for `williamthorsen/node-monorepo-tools` is retained and now answers a separate, narrower question: "should release-kit be built from source before invocation?" The publish invocation itself uses the same `pnpm exec` path as any other detect-present case, collapsing the previous three-way conditional into an orthogonal flow.

### Fixes

- `pnpm install` now runs unconditionally before publishing, so consumer packages with build-time `prepare` hooks have their devDependencies on disk. Closes #249.

### Refactoring

- Removes the `Link release-kit onto PATH` step (`npm link --workspace packages/release-kit`) entirely; `pnpm exec release-kit` replaces it on the BUILD_LOCAL path.
- Extracts the publish argument list to a single shell variable so both branches of the local-vs-global invocation read from one source of truth, eliminating drift risk if future flags are added.
- Rewrites the workflow's header comment to describe the three invocation paths (workspace-linked, pinned-in-devDependencies, global fallback) and the narrowed role of `BUILD_LOCAL`.

Closes #249
Closes #255