### PR TITLE
#271 Apply pre-1.0 bump rule and add --set-version CLI escape hatch

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -176,15 +176,36 @@ Release-notes sections are rendered in the declaration order of the merged work-
 
 Run release preparation with automatic workspace discovery.
 
-| Flag                         | Description                                                      |
-| ---------------------------- | ---------------------------------------------------------------- |
-| `--dry-run`                  | Preview changes without writing files                            |
-| `--bump=major\|minor\|patch` | Override the bump type for all components                        |
-| `--force`                    | Bypass the "no commits since last tag" check (requires `--bump`) |
-| `--only=name1,name2`         | Only process the named components (monorepo only)                |
-| `--help`, `-h`               | Show help                                                        |
+| Flag                         | Description                                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `--dry-run`                  | Preview changes without writing files                                                                        |
+| `--bump=major\|minor\|patch` | Override the bump type for all components                                                                    |
+| `--set-version=X.Y.Z`        | Set an explicit canonical semver version; bypasses commit-derived bumps. Requires `--only` in monorepo mode. |
+| `--force`                    | Bypass the "no commits since last tag" check (requires `--bump`)                                             |
+| `--only=name1,name2`         | Only process the named components (monorepo only)                                                            |
+| `--help`, `-h`               | Show help                                                                                                    |
 
 Component names for `--only` match the package directory name (e.g., `arrays`, `release-kit`).
+
+#### Setting an explicit version with `--set-version`
+
+The `--set-version` flag is a first-class escape hatch for the cases where commit-derived bump logic produces the wrong version — most notably, promoting a pre-1.0 package to 1.0.0. Pre-1.0 packages collapse a `feat!` breaking change to a minor bump (matching semantic-release's `initialMajor: false` and release-please's `bump-minor-pre-major`), so a deliberate promotion to 1.0.0 must be requested explicitly.
+
+The flag validates that:
+
+- The value is canonical `N.N.N` semver (pre-release suffixes are rejected).
+- The target is strictly greater than the current version (numeric comparison on each component).
+- In monorepo mode, `--only` is set and resolves to exactly one component.
+
+`--set-version` is mutually exclusive with `--bump` and `--force`. The rest of the pipeline (changelog generation, tag creation, commit summary, propagation to dependents) runs unchanged, so dependents receive a propagated patch bump triggered by the overridden version.
+
+Promoting a pre-1.0 package to 1.0.0 in a monorepo:
+
+```sh
+release-kit prepare --only arrays --set-version 1.0.0
+```
+
+An empty changelog section is expected for a bare promotion, because the changelog is generated from commits since the last tag. To include a narrative entry, land a descriptive release commit (e.g., a `feat!` describing the stable API) before running `prepare`.
 
 ### `release-kit create-github-release`
 

--- a/packages/release-kit/src/__tests__/bumpAllVersions.unit.test.ts
+++ b/packages/release-kit/src/__tests__/bumpAllVersions.unit.test.ts
@@ -8,7 +8,7 @@ vi.mock(import('node:fs'), () => ({
   writeFileSync: mockWriteFileSync,
 }));
 
-import { bumpAllVersions } from '../bumpAllVersions.ts';
+import { bumpAllVersions, setAllVersions } from '../bumpAllVersions.ts';
 
 describe(bumpAllVersions, () => {
   afterEach(() => {
@@ -86,11 +86,59 @@ describe(bumpAllVersions, () => {
 
     const result = bumpAllVersions(['packages/a/package.json'], 'major', true);
 
-    expect(result.newVersion).toBe('1.0.0');
+    // Pre-1.0 'major' collapses to a minor bump, so 0.5.0 → 0.6.0 (not 1.0.0).
+    expect(result.newVersion).toBe('0.6.0');
     expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
 
   it('throws when no package files are specified', () => {
     expect(() => bumpAllVersions([], 'patch', false)).toThrow('No package files specified');
+  });
+});
+
+describe(setAllVersions, () => {
+  afterEach(() => {
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('writes the provided version to every file and returns the pre-write current version', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '0.5.0' }));
+
+    const result = setAllVersions(['packages/a/package.json', 'packages/b/package.json'], '1.0.0', false);
+
+    expect(result).toStrictEqual({
+      currentVersion: '0.5.0',
+      newVersion: '1.0.0',
+      files: ['packages/a/package.json', 'packages/b/package.json'],
+    });
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
+    expect(mockWriteFileSync).toHaveBeenNthCalledWith(
+      1,
+      'packages/a/package.json',
+      expect.stringContaining('"version": "1.0.0"'),
+      'utf8',
+    );
+    expect(mockWriteFileSync).toHaveBeenNthCalledWith(
+      2,
+      'packages/b/package.json',
+      expect.stringContaining('"version": "1.0.0"'),
+      'utf8',
+    );
+  });
+
+  it('does not write files in dry-run mode', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '0.5.0' }));
+
+    const result = setAllVersions(['packages/a/package.json'], '1.0.0', true);
+
+    expect(result.currentVersion).toBe('0.5.0');
+    expect(result.newVersion).toBe('1.0.0');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('throws when no package files are specified', () => {
+    expect(() => setAllVersions([], '1.0.0', false)).toThrow('No package files specified');
   });
 });

--- a/packages/release-kit/src/__tests__/bumpVersion.unit.test.ts
+++ b/packages/release-kit/src/__tests__/bumpVersion.unit.test.ts
@@ -21,13 +21,35 @@ describe(bumpVersion, () => {
   it('handles version 0.0.0', () => {
     expect(bumpVersion('0.0.0', 'patch')).toBe('0.0.1');
     expect(bumpVersion('0.0.0', 'minor')).toBe('0.1.0');
-    expect(bumpVersion('0.0.0', 'major')).toBe('1.0.0');
+    // Pre-1.0: 'major' collapses to a minor bump rather than promoting to 1.0.0.
+    expect(bumpVersion('0.0.0', 'major')).toBe('0.1.0');
   });
 
   it('handles version 0.1.0', () => {
     expect(bumpVersion('0.1.0', 'patch')).toBe('0.1.1');
     expect(bumpVersion('0.1.0', 'minor')).toBe('0.2.0');
-    expect(bumpVersion('0.1.0', 'major')).toBe('1.0.0');
+    // Pre-1.0: 'major' collapses to a minor bump.
+    expect(bumpVersion('0.1.0', 'major')).toBe('0.2.0');
+  });
+
+  it('collapses major to minor at pre-1.0 for the canonical ticket case', () => {
+    expect(bumpVersion('0.3.7', 'major')).toBe('0.4.0');
+  });
+
+  it('increments the minor component decimally at pre-1.0 (not lexically)', () => {
+    expect(bumpVersion('0.9.5', 'major')).toBe('0.10.0');
+  });
+
+  it('leaves pre-1.0 minor bumps unchanged by the pre-1.0 rule', () => {
+    expect(bumpVersion('0.3.7', 'minor')).toBe('0.4.0');
+  });
+
+  it('leaves pre-1.0 patch bumps unchanged by the pre-1.0 rule', () => {
+    expect(bumpVersion('0.3.7', 'patch')).toBe('0.3.8');
+  });
+
+  it('leaves post-1.0 major bumps unchanged by the pre-1.0 rule', () => {
+    expect(bumpVersion('1.2.3', 'major')).toBe('2.0.0');
   });
 
   it('throws for an invalid version string', () => {

--- a/packages/release-kit/src/__tests__/compareVersions.unit.test.ts
+++ b/packages/release-kit/src/__tests__/compareVersions.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { isForwardVersion } from '../compareVersions.ts';
+
+describe(isForwardVersion, () => {
+  it('returns true when the target increments the major component', () => {
+    expect(isForwardVersion('0.9.9', '1.0.0')).toBe(true);
+  });
+
+  it('returns true when the target increments the minor component', () => {
+    expect(isForwardVersion('0.3.7', '0.4.0')).toBe(true);
+  });
+
+  it('returns true when the target increments the patch component', () => {
+    expect(isForwardVersion('0.3.7', '0.3.8')).toBe(true);
+  });
+
+  it('returns false when the target equals the current version', () => {
+    expect(isForwardVersion('1.0.0', '1.0.0')).toBe(false);
+  });
+
+  it('returns false when the target downgrades the major component', () => {
+    expect(isForwardVersion('2.0.0', '1.9.9')).toBe(false);
+  });
+
+  it('returns false when the target downgrades the minor component', () => {
+    expect(isForwardVersion('0.4.0', '0.3.9')).toBe(false);
+  });
+
+  it('returns false when the target downgrades the patch component', () => {
+    expect(isForwardVersion('0.3.8', '0.3.7')).toBe(false);
+  });
+
+  it('compares the minor component numerically (0.10.0 greater than 0.9.0)', () => {
+    expect(isForwardVersion('0.9.0', '0.10.0')).toBe(true);
+  });
+
+  it('compares the patch component numerically (0.0.10 greater than 0.0.9)', () => {
+    expect(isForwardVersion('0.0.9', '0.0.10')).toBe(true);
+  });
+
+  it('throws when the current version has a pre-release suffix', () => {
+    expect(() => isForwardVersion('1.0.0-alpha', '1.0.0')).toThrow("Invalid semver version: '1.0.0-alpha'");
+  });
+
+  it('throws when the target version has a pre-release suffix', () => {
+    expect(() => isForwardVersion('1.0.0', '1.0.0-beta')).toThrow("Invalid semver version: '1.0.0-beta'");
+  });
+
+  it('throws when a version is non-canonical (two-component)', () => {
+    expect(() => isForwardVersion('1.0', '1.0.1')).toThrow("Invalid semver version: '1.0'");
+  });
+
+  it('throws when a version is empty', () => {
+    expect(() => isForwardVersion('', '1.0.0')).toThrow("Invalid semver version: ''");
+  });
+});

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -387,6 +387,15 @@ describe(prepareCommand, () => {
     expect(mockReleasePrepareMono).not.toHaveBeenCalled();
   });
 
+  it('exits with the unknown-component error when --only matches zero components under --set-version', async () => {
+    // A non-matching --only name is caught by the unknown-component guard in prepareCommand
+    // (which runs before the --set-version narrowing check), so the error mentions the
+    // unknown name rather than the "exactly one component" message.
+    await expect(prepareCommand(['--only=nonexistent', '--set-version=1.0.0'])).rejects.toThrow(ExitError);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('nonexistent'));
+    expect(mockReleasePrepareMono).not.toHaveBeenCalled();
+  });
+
   it('passes setVersion to releasePrepare in single-package mode', async () => {
     mockDiscoverWorkspaces.mockResolvedValue(undefined);
 

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -363,6 +363,40 @@ describe(prepareCommand, () => {
 
     expect(mockAssertCleanWorkingTree).not.toHaveBeenCalled();
   });
+
+  it('passes setVersion to releasePrepareMono when --only matches exactly one component', async () => {
+    await prepareCommand(['--only=arrays', '--set-version=1.0.0']);
+
+    expect(mockReleasePrepareMono).toHaveBeenCalledWith(
+      expect.objectContaining({
+        components: [expect.objectContaining({ tagPrefix: 'arrays-v' })],
+      }),
+      expect.objectContaining({ setVersion: '1.0.0' }),
+    );
+  });
+
+  it('exits with an error when --set-version is used without --only in monorepo mode', async () => {
+    await expect(prepareCommand(['--set-version=1.0.0'])).rejects.toThrow(ExitError);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--set-version requires --only'));
+    expect(mockReleasePrepareMono).not.toHaveBeenCalled();
+  });
+
+  it('exits with an error when --only matches multiple components under --set-version', async () => {
+    await expect(prepareCommand(['--only=arrays,strings', '--set-version=1.0.0'])).rejects.toThrow(ExitError);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('exactly one component'));
+    expect(mockReleasePrepareMono).not.toHaveBeenCalled();
+  });
+
+  it('passes setVersion to releasePrepare in single-package mode', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue(undefined);
+
+    await prepareCommand(['--set-version=1.2.3']);
+
+    expect(mockReleasePrepare).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ setVersion: '1.2.3' }),
+    );
+  });
 });
 
 describe(parseArgs, () => {
@@ -400,6 +434,35 @@ describe(parseArgs, () => {
 
   it('throws when --only value is empty', () => {
     expect(() => parseArgs(['--only='])).toThrow('--only requires');
+  });
+
+  it('accepts a canonical semver value for --set-version', () => {
+    const result = parseArgs(['--set-version=1.0.0']);
+    expect(result.setVersion).toBe('1.0.0');
+  });
+
+  it('throws when --set-version has a pre-release suffix', () => {
+    expect(() => parseArgs(['--set-version=1.0.0-alpha'])).toThrow('Invalid --set-version');
+  });
+
+  it('throws when --set-version is not canonical N.N.N', () => {
+    expect(() => parseArgs(['--set-version=1.0'])).toThrow('Invalid --set-version');
+  });
+
+  it('throws when --set-version is empty', () => {
+    expect(() => parseArgs(['--set-version='])).toThrow('--set-version requires');
+  });
+
+  it('throws when --set-version is combined with --bump', () => {
+    expect(() => parseArgs(['--set-version=1.0.0', '--bump=minor'])).toThrow(
+      '--set-version cannot be combined with --bump',
+    );
+  });
+
+  it('throws when --set-version is combined with --force', () => {
+    expect(() => parseArgs(['--set-version=1.0.0', '--force'])).toThrow(
+      '--set-version cannot be combined with --force',
+    );
   });
 
   it('parses --no-git-checks flag', () => {

--- a/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
+++ b/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
@@ -200,4 +200,28 @@ describe(propagateBumps, () => {
     expect(result.size).toBe(1);
     expect(result.get('core')).toMatchObject({ releaseType: 'minor' });
   });
+
+  it('uses newVersionOverride for propagation metadata instead of a bump-computed version', () => {
+    const dependent = makeComponent('app');
+
+    const graph = makeGraph({ '@scope/core': 'core', '@scope/app': 'app' }, { '@scope/core': [dependent] });
+
+    // The sentinel releaseType ('patch') would compute 0.5.1 from 0.5.0, but the explicit
+    // override must win so dependents see the set-version value.
+    const directBumps = new Map<string, ReleaseEntry>([
+      ['core', { releaseType: 'patch', newVersionOverride: '1.0.0' }],
+    ]);
+
+    const currentVersions = new Map([
+      ['core', '0.5.0'],
+      ['app', '2.0.0'],
+    ]);
+
+    const result = propagateBumps(directBumps, graph, currentVersions);
+
+    expect(result.get('app')).toMatchObject({
+      releaseType: 'patch',
+      propagatedFrom: [{ packageName: '@scope/core', newVersion: '1.0.0' }],
+    });
+  });
 });

--- a/packages/release-kit/src/__tests__/readCurrentVersion.unit.test.ts
+++ b/packages/release-kit/src/__tests__/readCurrentVersion.unit.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  readFileSync: mockReadFileSync,
+}));
+
+import { readCurrentVersion } from '../readCurrentVersion.ts';
+
+describe(readCurrentVersion, () => {
+  afterEach(() => {
+    mockReadFileSync.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the version field when package.json parses successfully', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '1.2.3' }));
+
+    expect(readCurrentVersion('package.json')).toBe('1.2.3');
+  });
+
+  it('returns undefined when package.json has no version field', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg' }));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(readCurrentVersion('package.json')).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined and warns when the file cannot be read', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT: no such file');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(readCurrentVersion('missing.json')).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('missing.json'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('ENOENT'));
+  });
+
+  it('returns undefined and warns when the file is not valid JSON', () => {
+    mockReadFileSync.mockReturnValue('not json');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(readCurrentVersion('bad.json')).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('bad.json'));
+  });
+});

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -241,4 +241,109 @@ describe(releasePrepare, () => {
     expect(result.tags).toStrictEqual(['v1.1.0']);
     expect(result.dryRun).toBe(true);
   });
+
+  it('writes the explicit --set-version value, bypassing commit-derived bumps', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v0.5.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'chore: unrelated change\u001Fabc123';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '0.5.0' }));
+
+    const result = releasePrepare(makeConfig(), { dryRun: false, setVersion: '1.0.0' });
+
+    expect(result.tags).toStrictEqual(['v1.0.0']);
+    expect(result.components).toHaveLength(1);
+    expect(result.components[0]).toMatchObject({
+      status: 'released',
+      newVersion: '1.0.0',
+      currentVersion: '0.5.0',
+      tag: 'v1.0.0',
+      setVersion: '1.0.0',
+    });
+    expect(result.components[0]?.releaseType).toBeUndefined();
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      'package.json',
+      expect.stringContaining('"version": "1.0.0"'),
+      'utf8',
+    );
+  });
+
+  it('still generates a changelog when using --set-version', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v0.5.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return '';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '0.5.0' }));
+
+    const result = releasePrepare(makeConfig(), { dryRun: false, setVersion: '1.0.0' });
+
+    expect(result.components[0]?.changelogFiles).toStrictEqual(['./CHANGELOG.md']);
+    const cliffCalls = mockExecFileSync.mock.calls.filter(
+      (call: unknown[]) => call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff'),
+    );
+    expect(cliffCalls).toHaveLength(1);
+  });
+
+  it('throws when --set-version is not greater than the current version', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v0.5.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return '';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '0.5.0' }));
+
+    expect(() => releasePrepare(makeConfig(), { dryRun: false, setVersion: '0.3.0' })).toThrow(
+      '--set-version 0.3.0 is not greater than current version 0.5.0',
+    );
+  });
+
+  it('throws when --set-version equals the current version', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v0.5.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return '';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '0.5.0' }));
+
+    expect(() => releasePrepare(makeConfig(), { dryRun: false, setVersion: '0.5.0' })).toThrow(
+      '--set-version 0.5.0 is not greater than current version 0.5.0',
+    );
+  });
+
+  it('does not write files in dry-run mode with --set-version', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') {
+        return 'v0.5.0\n';
+      }
+      if (cmd === 'git' && args[0] === 'log') {
+        return '';
+      }
+      return '';
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'pkg', version: '0.5.0' }));
+
+    const result = releasePrepare(makeConfig(), { dryRun: true, setVersion: '1.0.0' });
+
+    expect(result.tags).toStrictEqual(['v1.0.0']);
+    expect(result.dryRun).toBe(true);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
 });

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -935,6 +935,61 @@ describe(releasePrepareMono, () => {
       );
     });
 
+    it('does not write files in dry-run mode with --set-version', () => {
+      const config = makeConfig({
+        components: [
+          {
+            dir: 'core',
+            tagPrefix: 'core-v',
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'core-v0.5.0\n';
+        if (cmd === 'git' && args[0] === 'log') return '';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/core', version: '0.5.0' }));
+      mockExistsSync.mockReturnValue(false);
+
+      const result = releasePrepareMono(config, { dryRun: true, setVersion: '1.0.0' });
+
+      expect(result.tags).toStrictEqual(['core-v1.0.0']);
+      expect(result.dryRun).toBe(true);
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('throws when --set-version is used with more than one component', () => {
+      // Explicit guard in `determineDirectBumps` enforces the single-component contract for
+      // --set-version even if a caller bypasses the CLI layer that normally narrows via --only.
+      const config = makeConfig({
+        components: [
+          {
+            dir: 'core',
+            tagPrefix: 'core-v',
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+          {
+            dir: 'app',
+            tagPrefix: 'app-v',
+            packageFiles: ['packages/app/package.json'],
+            changelogPaths: ['packages/app'],
+            paths: ['packages/app/**'],
+          },
+        ],
+      });
+
+      expect(() => releasePrepareMono(config, { dryRun: false, setVersion: '1.0.0' })).toThrow(
+        '--set-version requires exactly one component',
+      );
+    });
+
     it('preserves a direct higher bump when propagation would add a patch', () => {
       const config = makeConfig({
         components: [

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -846,6 +846,95 @@ describe(releasePrepareMono, () => {
       expect(result.components).toHaveLength(1);
     });
 
+    it('writes the explicit --set-version value in monorepo mode', () => {
+      const config = makeConfig({
+        components: [
+          {
+            dir: 'core',
+            tagPrefix: 'core-v',
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'core-v0.5.0\n';
+        if (cmd === 'git' && args[0] === 'log') return '';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/core', version: '0.5.0' }));
+      mockExistsSync.mockReturnValue(false);
+
+      const result = releasePrepareMono(config, { dryRun: false, setVersion: '1.0.0' });
+
+      const coreResult = result.components.find((c) => c.name === 'core');
+      expect(coreResult).toMatchObject({
+        status: 'released',
+        newVersion: '1.0.0',
+        currentVersion: '0.5.0',
+        setVersion: '1.0.0',
+      });
+      expect(coreResult?.releaseType).toBeUndefined();
+      expect(result.tags).toStrictEqual(['core-v1.0.0']);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        'packages/core/package.json',
+        expect.stringContaining('"version": "1.0.0"'),
+        'utf8',
+      );
+    });
+
+    it('throws when --set-version is not greater than the current version', () => {
+      const config = makeConfig({
+        components: [
+          {
+            dir: 'core',
+            tagPrefix: 'core-v',
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'core-v0.5.0\n';
+        if (cmd === 'git' && args[0] === 'log') return '';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/core', version: '0.5.0' }));
+
+      expect(() => releasePrepareMono(config, { dryRun: false, setVersion: '0.3.0' })).toThrow(
+        '--set-version 0.3.0 is not greater than current version 0.5.0',
+      );
+    });
+
+    it('throws when --set-version equals the current version', () => {
+      const config = makeConfig({
+        components: [
+          {
+            dir: 'core',
+            tagPrefix: 'core-v',
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'core-v0.5.0\n';
+        if (cmd === 'git' && args[0] === 'log') return '';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/core', version: '0.5.0' }));
+
+      expect(() => releasePrepareMono(config, { dryRun: false, setVersion: '0.5.0' })).toThrow(
+        '--set-version 0.5.0 is not greater than current version 0.5.0',
+      );
+    });
+
     it('preserves a direct higher bump when propagation would add a patch', () => {
       const config = makeConfig({
         components: [

--- a/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
@@ -146,6 +146,32 @@ describe(reportPrepare, () => {
       expect(output).toContain('Using bump override: major');
     });
 
+    it('renders "version override" labels when setVersion is present on a component', () => {
+      const result: PrepareResult = {
+        components: [
+          {
+            status: 'released',
+            previousTag: 'v0.5.0',
+            commitCount: 0,
+            currentVersion: '0.5.0',
+            newVersion: '1.0.0',
+            tag: 'v1.0.0',
+            bumpedFiles: ['package.json'],
+            changelogFiles: ['./CHANGELOG.md'],
+            setVersion: '1.0.0',
+          },
+        ],
+        tags: ['v1.0.0'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('Using version override: 1.0.0');
+      expect(output).toContain(`📦 0.5.0 → ${bold('1.0.0')} (version override)`);
+      expect(output).not.toContain('Using bump override:');
+    });
+
     it('shows unparseable commit warning when all commits are unparseable (patch floor)', () => {
       const result: PrepareResult = {
         components: [
@@ -381,6 +407,74 @@ describe(reportPrepare, () => {
       expect(output).toContain(sectionHeader('strings'));
       expect(output).toContain('  ⏭️  No changes for strings since strings-v2.0.0. Skipping.');
       expect(output).toContain('✅ Release preparation complete.');
+    });
+
+    it('renders "version override" labels for a setVersion component in monorepo mode', () => {
+      const result: PrepareResult = {
+        components: [
+          {
+            name: 'arrays',
+            status: 'released',
+            previousTag: 'arrays-v0.5.0',
+            commitCount: 0,
+            currentVersion: '0.5.0',
+            newVersion: '1.0.0',
+            tag: 'arrays-v1.0.0',
+            bumpedFiles: ['packages/arrays/package.json'],
+            changelogFiles: ['packages/arrays/CHANGELOG.md'],
+            setVersion: '1.0.0',
+          },
+        ],
+        tags: ['arrays-v1.0.0'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('Using version override: 1.0.0');
+      expect(output).toContain(`  📦 0.5.0 → ${bold('1.0.0')} (version override)`);
+    });
+
+    it('leaves propagated dependents of a setVersion component with a normal release-type label', () => {
+      const result: PrepareResult = {
+        components: [
+          {
+            name: 'core',
+            status: 'released',
+            previousTag: 'core-v0.5.0',
+            commitCount: 0,
+            currentVersion: '0.5.0',
+            newVersion: '1.0.0',
+            tag: 'core-v1.0.0',
+            bumpedFiles: ['packages/core/package.json'],
+            changelogFiles: ['packages/core/CHANGELOG.md'],
+            setVersion: '1.0.0',
+          },
+          {
+            name: 'app',
+            status: 'released',
+            previousTag: 'app-v2.0.0',
+            commitCount: 0,
+            releaseType: 'patch',
+            currentVersion: '2.0.0',
+            newVersion: '2.0.1',
+            tag: 'app-v2.0.1',
+            bumpedFiles: ['packages/app/package.json'],
+            changelogFiles: ['packages/app/CHANGELOG.md'],
+            propagatedFrom: [{ packageName: '@test/core', newVersion: '1.0.0' }],
+          },
+        ],
+        tags: ['core-v1.0.0', 'app-v2.0.1'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      // core shows the version-override label.
+      expect(output).toContain('Using version override: 1.0.0');
+      expect(output).toContain(`  📦 0.5.0 → ${bold('1.0.0')} (version override)`);
+      // app shows the normal dependency-propagation label.
+      expect(output).toContain(`  📦 2.0.0 → ${bold('2.0.1')} (patch, dependency: @test/core)`);
     });
 
     it('formats a full skip in monorepo mode', () => {

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -112,6 +112,7 @@ Run release preparation with automatic workspace discovery.
 Options:
   --dry-run             Run without modifying any files
   --bump=major|minor|patch  Override the bump type for all components
+  --set-version=X.Y.Z   Set an explicit version; bypasses commit-derived bumps. Requires --only in monorepo mode.
   --no-git-checks, -n   Skip the clean-working-tree check
   --only=name1,name2    Only process the named components (comma-separated, monorepo only)
   --help, -h            Show this help message

--- a/packages/release-kit/src/bumpAllVersions.ts
+++ b/packages/release-kit/src/bumpAllVersions.ts
@@ -33,6 +33,40 @@ export function bumpAllVersions(
   const currentVersion = firstPkg.version;
   const newVersion = bumpVersion(currentVersion, releaseType);
 
+  writeVersionToAllFiles(packageFiles, firstFile, firstPkg, newVersion, dryRun);
+
+  return { currentVersion, newVersion, files: [...packageFiles] };
+}
+
+/**
+ * Write an explicit version string to all specified package.json files, bypassing
+ * commit-derived bump logic.
+ *
+ * Reads the first file to capture the pre-write `currentVersion`, then writes `newVersion`
+ * to every file in `packageFiles`. Used by the `--set-version` CLI flag.
+ */
+export function setAllVersions(packageFiles: readonly string[], newVersion: string, dryRun: boolean): BumpResult {
+  const firstFile = packageFiles[0];
+  if (firstFile === undefined) {
+    throw new Error('No package files specified');
+  }
+
+  const firstPkg = readPackageJson(firstFile);
+  const currentVersion = firstPkg.version;
+
+  writeVersionToAllFiles(packageFiles, firstFile, firstPkg, newVersion, dryRun);
+
+  return { currentVersion, newVersion, files: [...packageFiles] };
+}
+
+/** Write `newVersion` to every file in `packageFiles`, reusing `firstPkg` for the first file. */
+function writeVersionToAllFiles(
+  packageFiles: readonly string[],
+  firstFile: string,
+  firstPkg: PackageJson,
+  newVersion: string,
+  dryRun: boolean,
+): void {
   for (const filePath of packageFiles) {
     if (dryRun) {
       continue;
@@ -47,8 +81,6 @@ export function bumpAllVersions(
       throw new Error(`Failed to write ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
-
-  return { currentVersion, newVersion, files: [...packageFiles] };
 }
 
 /**

--- a/packages/release-kit/src/bumpVersion.ts
+++ b/packages/release-kit/src/bumpVersion.ts
@@ -28,6 +28,11 @@ export function bumpVersion(version: string, releaseType: ReleaseType): string {
 
   switch (releaseType) {
     case 'major':
+      // Pre-1.0 packages are in "initial development" per semver; a breaking change
+      // should not implicitly promote to 1.0.0. Collapse to a minor bump instead.
+      if (majorNum === 0) {
+        return `0.${minorNum + 1}.0`;
+      }
       return `${majorNum + 1}.0.0`;
     case 'minor':
       return `${majorNum}.${minorNum + 1}.0`;

--- a/packages/release-kit/src/compareVersions.ts
+++ b/packages/release-kit/src/compareVersions.ts
@@ -1,0 +1,55 @@
+/** Canonical semver regex used to validate `N.N.N` strings (no pre-release or build metadata). */
+const CANONICAL_SEMVER_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/;
+
+/** Parsed canonical semver components. */
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/**
+ * Parse a canonical semver version string into its numeric components.
+ *
+ * @throws If the version string is not canonical `N.N.N` semver (pre-release or build metadata is rejected).
+ */
+function parseCanonicalSemver(version: string): ParsedVersion {
+  const match = version.match(CANONICAL_SEMVER_PATTERN);
+  if (!match) {
+    throw new Error(`Invalid semver version: '${version}'`);
+  }
+
+  const major = match[1];
+  const minor = match[2];
+  const patch = match[3];
+
+  if (major === undefined || minor === undefined || patch === undefined) {
+    throw new Error(`Invalid semver version: '${version}'`);
+  }
+
+  return {
+    major: Number.parseInt(major, 10),
+    minor: Number.parseInt(minor, 10),
+    patch: Number.parseInt(patch, 10),
+  };
+}
+
+/**
+ * Return true when `target` is strictly greater than `current`, comparing major, minor, then patch.
+ *
+ * Equal versions return false. Comparison is numeric (not lexical), so `0.10.0` is greater than `0.9.0`.
+ *
+ * @throws If either version is not canonical `N.N.N` semver.
+ */
+export function isForwardVersion(current: string, target: string): boolean {
+  const currentParsed = parseCanonicalSemver(current);
+  const targetParsed = parseCanonicalSemver(target);
+
+  if (targetParsed.major !== currentParsed.major) {
+    return targetParsed.major > currentParsed.major;
+  }
+  if (targetParsed.minor !== currentParsed.minor) {
+    return targetParsed.minor > currentParsed.minor;
+  }
+  return targetParsed.patch > currentParsed.patch;
+}

--- a/packages/release-kit/src/compareVersions.ts
+++ b/packages/release-kit/src/compareVersions.ts
@@ -19,13 +19,11 @@ function parseCanonicalSemver(version: string): ParsedVersion {
     throw new Error(`Invalid semver version: '${version}'`);
   }
 
-  const major = match[1];
-  const minor = match[2];
-  const patch = match[3];
-
-  if (major === undefined || minor === undefined || patch === undefined) {
-    throw new Error(`Invalid semver version: '${version}'`);
-  }
+  // The pattern has exactly three capture groups, so a successful match always yields
+  // defined strings in positions 1..3. Fallback empty strings make the destructuring
+  // type-safe without adding a redundant runtime guard; `Number.parseInt('', 10)` is `NaN`,
+  // which is unreachable given the `!match` early exit above.
+  const [, major = '', minor = '', patch = ''] = match;
 
   return {
     major: Number.parseInt(major, 10),

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -33,6 +33,9 @@ export const RELEASE_SUMMARY_FILE = 'tmp/.release-summary';
 
 const VALID_BUMP_TYPES: readonly string[] = ['major', 'minor', 'patch'];
 
+/** Canonical `N.N.N` semver pattern for validating `--set-version` input. */
+const CANONICAL_SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+
 function isReleaseType(value: string): value is ReleaseType {
   return VALID_BUMP_TYPES.includes(value);
 }
@@ -45,6 +48,7 @@ Usage: npx @williamthorsen/release-kit prepare [options]
 Options:
   --dry-run             Run without modifying any files
   --bump=major|minor|patch  Override the bump type for all components
+  --set-version=X.Y.Z   Set an explicit version; bypasses commit-derived bumps. Requires --only in monorepo mode.
   --force               Force a release even when there are no commits since the last tag (requires --bump)
   --no-git-checks, -n   Skip the clean-working-tree check
   --only=name1,name2    Only process the named components (comma-separated, monorepo only)
@@ -61,6 +65,7 @@ const prepareFlagSchema = {
     short: '-n',
   },
   bump: { long: '--bump', type: 'string' as const },
+  setVersion: { long: '--set-version', type: 'string' as const },
   only: { long: '--only', type: 'string' as const },
   help: { long: '--help', type: 'boolean' as const, short: '-h' },
 };
@@ -72,6 +77,7 @@ export function parseArgs(argv: string[]): {
   noGitChecks: boolean;
   bumpOverride: ReleaseType | undefined;
   only: string[] | undefined;
+  setVersion: string | undefined;
 } {
   let parsed;
   try {
@@ -95,9 +101,27 @@ export function parseArgs(argv: string[]): {
     bumpOverride = flags.bump;
   }
 
+  let setVersion: string | undefined;
+  if (flags.setVersion !== undefined) {
+    if (!CANONICAL_SEMVER_PATTERN.test(flags.setVersion)) {
+      throw new Error(
+        `Invalid --set-version value "${flags.setVersion}". Must be canonical semver (N.N.N, no pre-release suffix).`,
+      );
+    }
+    setVersion = flags.setVersion;
+  }
+
   let only: string[] | undefined;
   if (flags.only !== undefined) {
     only = flags.only.split(',');
+  }
+
+  if (setVersion !== undefined && bumpOverride !== undefined) {
+    throw new Error('--set-version cannot be combined with --bump');
+  }
+
+  if (setVersion !== undefined && flags.force) {
+    throw new Error('--set-version cannot be combined with --force');
   }
 
   if (flags.force && bumpOverride === undefined) {
@@ -110,6 +134,7 @@ export function parseArgs(argv: string[]): {
     noGitChecks: flags.noGitChecks,
     bumpOverride,
     only,
+    setVersion,
   };
 }
 
@@ -144,8 +169,9 @@ export async function prepareCommand(argv: string[]): Promise<void> {
   let noGitChecks: boolean;
   let bumpOverride: ReleaseType | undefined;
   let only: string[] | undefined;
+  let setVersion: string | undefined;
   try {
-    ({ dryRun, force, noGitChecks, bumpOverride, only } = parseArgs(argv));
+    ({ dryRun, force, noGitChecks, bumpOverride, only, setVersion } = parseArgs(argv));
   } catch (error: unknown) {
     console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
@@ -154,6 +180,7 @@ export async function prepareCommand(argv: string[]): Promise<void> {
     dryRun,
     force,
     ...(bumpOverride === undefined ? {} : { bumpOverride }),
+    ...(setVersion === undefined ? {} : { setVersion }),
   };
 
   if (dryRun) {
@@ -207,6 +234,20 @@ export async function prepareCommand(argv: string[]): Promise<void> {
       }
 
       config.components = config.components.filter((c) => only.includes(c.dir));
+    }
+
+    // --set-version requires exactly one target component in monorepo mode.
+    if (setVersion !== undefined) {
+      if (only === undefined) {
+        console.error('Error: --set-version requires --only in monorepo mode');
+        process.exit(1);
+      }
+      if (config.components.length !== 1) {
+        console.error(
+          `Error: --set-version requires --only to match exactly one component; matched ${config.components.length}`,
+        );
+        process.exit(1);
+      }
     }
 
     runAndReport(() => releasePrepareMono(config, options), dryRun);

--- a/packages/release-kit/src/propagateBumps.ts
+++ b/packages/release-kit/src/propagateBumps.ts
@@ -7,6 +7,12 @@ export interface ReleaseEntry {
   releaseType: ReleaseType;
   /** Present when this component was bumped (wholly or partly) due to a dependency update. */
   propagatedFrom?: PropagationSource[];
+  /**
+   * Explicit new version override used for propagation metadata. When set, dependents see this
+   * value in their `propagatedFrom.newVersion` entry instead of a version computed from `releaseType`.
+   * Used by the `--set-version` CLI path so propagation reflects the overridden version.
+   */
+  newVersionOverride?: string;
 }
 
 /** Map from component `dir` to its current version string (read from package.json). */
@@ -58,7 +64,8 @@ export function propagateBumps(
     if (currentVersion === undefined || entry === undefined) {
       continue;
     }
-    const newVersion = bumpVersion(currentVersion, entry.releaseType);
+    // Prefer the explicit override (--set-version) when present; otherwise compute from releaseType.
+    const newVersion = entry.newVersionOverride ?? bumpVersion(currentVersion, entry.releaseType);
 
     // Find dependents and propagate.
     const dependents = graph.dependentsOf.get(packageName);

--- a/packages/release-kit/src/readCurrentVersion.ts
+++ b/packages/release-kit/src/readCurrentVersion.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+
+/** Type guard asserting that `value` is an object with a string `version` field. */
+function hasVersionField(value: unknown): value is { version: string } {
+  return typeof value === 'object' && value !== null && 'version' in value && typeof value.version === 'string';
+}
+
+/** Read the `version` field from a package.json file. Returns undefined if the file can't be read or parsed. */
+export function readCurrentVersion(filePath: string): string | undefined {
+  try {
+    const content = readFileSync(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+    if (hasVersionField(parsed)) {
+      return parsed.version;
+    }
+  } catch {
+    // Return undefined if the file can't be read or parsed.
+  }
+  return undefined;
+}

--- a/packages/release-kit/src/readCurrentVersion.ts
+++ b/packages/release-kit/src/readCurrentVersion.ts
@@ -13,8 +13,12 @@ export function readCurrentVersion(filePath: string): string | undefined {
     if (hasVersionField(parsed)) {
       return parsed.version;
     }
-  } catch {
-    // Return undefined if the file can't be read or parsed.
+  } catch (error: unknown) {
+    // Return undefined so benign callers degrade gracefully, but surface the failure so
+    // operators get a signal when --set-version or similar paths depend on this value.
+    console.warn(
+      `Failed to read current version from ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
   return undefined;
 }

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -1,13 +1,15 @@
 import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
-import { bumpAllVersions } from './bumpAllVersions.ts';
+import { bumpAllVersions, setAllVersions } from './bumpAllVersions.ts';
+import { isForwardVersion } from './compareVersions.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpFromCommits } from './determineBumpFromCommits.ts';
 import { generateChangelogJson } from './generateChangelogJson.ts';
 import { generateChangelogs } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
-import type { Commit, PrepareResult, ReleaseConfig, ReleaseType } from './types.ts';
+import type { BumpResult, Commit, PrepareResult, ReleaseConfig, ReleaseType } from './types.ts';
 
 /** Options for the release preparation workflow. */
 export interface ReleasePrepareOptions {
@@ -17,6 +19,12 @@ export interface ReleasePrepareOptions {
   force?: boolean;
   /** Override the bump type instead of determining it from commits. */
   bumpOverride?: ReleaseType;
+  /**
+   * Explicit target version (canonical `N.N.N`) that bypasses commit-derived bump logic.
+   * Mutually exclusive with `bumpOverride`. In monorepo mode the caller must narrow
+   * `config.components` to a single component before invoking.
+   */
+  setVersion?: string;
 }
 
 /**
@@ -31,48 +39,67 @@ export interface ReleasePrepareOptions {
  * Returns a structured `PrepareResult` with all data needed for presentation.
  */
 export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOptions): PrepareResult {
-  const { dryRun, bumpOverride } = options;
+  const { dryRun, bumpOverride, setVersion } = options;
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
 
   // 1. Get commits since last tag
   const { tag, commits } = getCommitsSinceTarget(config.tagPrefix);
 
-  // 2. Determine bump type
+  // 2. Determine bump type (or use the explicit setVersion bypass)
   let releaseType: ReleaseType | undefined;
   let parsedCommitCount: number | undefined;
   let unparseableCommits: Commit[] | undefined;
+  let bump: BumpResult;
 
-  if (bumpOverride === undefined) {
-    const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.scopeAliases);
-    parsedCommitCount = determination.parsedCommitCount;
-    unparseableCommits = determination.unparseableCommits;
-    releaseType = determination.releaseType;
+  if (setVersion !== undefined) {
+    // Bypass commit-derived bump logic. Read the current version directly from the primary
+    // package file so validation runs once, then perform a single write honouring `dryRun`.
+    const primaryPackageFile = config.packageFiles[0];
+    if (primaryPackageFile === undefined) {
+      throw new Error('No package files specified');
+    }
+    const currentVersion = readCurrentVersion(primaryPackageFile);
+    if (currentVersion === undefined) {
+      throw new Error(`Cannot validate --set-version: failed to read current version from ${primaryPackageFile}`);
+    }
+    if (!isForwardVersion(currentVersion, setVersion)) {
+      throw new Error(`--set-version ${setVersion} is not greater than current version ${currentVersion}`);
+    }
+    bump = setAllVersions(config.packageFiles, setVersion, dryRun);
   } else {
-    releaseType = bumpOverride;
+    if (bumpOverride === undefined) {
+      const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.scopeAliases);
+      parsedCommitCount = determination.parsedCommitCount;
+      unparseableCommits = determination.unparseableCommits;
+      releaseType = determination.releaseType;
+    } else {
+      releaseType = bumpOverride;
+    }
+
+    if (releaseType === undefined) {
+      return {
+        components: [
+          {
+            status: 'skipped',
+            previousTag: tag,
+            commitCount: commits.length,
+            parsedCommitCount,
+            unparseableCommits,
+            bumpedFiles: [],
+            changelogFiles: [],
+            skipReason: 'No release-worthy changes found. Skipping.',
+          },
+        ],
+        tags: [],
+        dryRun,
+      };
+    }
+
+    // 3. Bump all versions
+    bump = bumpAllVersions(config.packageFiles, releaseType, dryRun);
   }
 
-  if (releaseType === undefined) {
-    return {
-      components: [
-        {
-          status: 'skipped',
-          previousTag: tag,
-          commitCount: commits.length,
-          parsedCommitCount,
-          unparseableCommits,
-          bumpedFiles: [],
-          changelogFiles: [],
-          skipReason: 'No release-worthy changes found. Skipping.',
-        },
-      ],
-      tags: [],
-      dryRun,
-    };
-  }
-
-  // 3. Bump all versions
-  const bump = bumpAllVersions(config.packageFiles, releaseType, dryRun);
   const newTag = `${config.tagPrefix}${bump.newVersion}`;
 
   // 4. Generate changelogs
@@ -127,10 +154,29 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
         changelogFiles,
         commits,
         unparseableCommits,
+        ...(setVersion === undefined ? {} : { setVersion }),
       },
     ],
     tags: [newTag],
     formatCommand,
     dryRun,
   };
+}
+
+function hasVersionField(value: unknown): value is { version: string } {
+  return typeof value === 'object' && value !== null && 'version' in value && typeof value.version === 'string';
+}
+
+/** Read the `version` field from a package.json file. Returns undefined if the file can't be read or parsed. */
+function readCurrentVersion(filePath: string): string | undefined {
+  try {
+    const content = readFileSync(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+    if (hasVersionField(parsed)) {
+      return parsed.version;
+    }
+  } catch {
+    // Return undefined if the file can't be read or parsed.
+  }
+  return undefined;
 }

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -1,5 +1,4 @@
 import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
 
 import { bumpAllVersions, setAllVersions } from './bumpAllVersions.ts';
 import { isForwardVersion } from './compareVersions.ts';
@@ -9,6 +8,7 @@ import { generateChangelogJson } from './generateChangelogJson.ts';
 import { generateChangelogs } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
+import { readCurrentVersion } from './readCurrentVersion.ts';
 import type { BumpResult, Commit, PrepareResult, ReleaseConfig, ReleaseType } from './types.ts';
 
 /** Options for the release preparation workflow. */
@@ -161,22 +161,4 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
     formatCommand,
     dryRun,
   };
-}
-
-function hasVersionField(value: unknown): value is { version: string } {
-  return typeof value === 'object' && value !== null && 'version' in value && typeof value.version === 'string';
-}
-
-/** Read the `version` field from a package.json file. Returns undefined if the file can't be read or parsed. */
-function readCurrentVersion(filePath: string): string | undefined {
-  try {
-    const content = readFileSync(filePath, 'utf8');
-    const parsed: unknown = JSON.parse(content);
-    if (hasVersionField(parsed)) {
-      return parsed.version;
-    }
-  } catch {
-    // Return undefined if the file can't be read or parsed.
-  }
-  return undefined;
 }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -1,5 +1,4 @@
 import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
 
 import type { DependencyGraph } from './buildDependencyGraph.ts';
 import { buildDependencyGraph } from './buildDependencyGraph.ts';
@@ -13,6 +12,7 @@ import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
 import type { CurrentVersions, ReleaseEntry } from './propagateBumps.ts';
 import { propagateBumps } from './propagateBumps.ts';
+import { readCurrentVersion } from './readCurrentVersion.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
 import type {
   Commit,
@@ -482,24 +482,6 @@ function runFormatCommand(
 /** Find a component by its `dir` in the components array. */
 function findComponent(components: readonly ComponentConfig[], dir: string): ComponentConfig | undefined {
   return components.find((c) => c.dir === dir);
-}
-
-function hasVersionField(value: unknown): value is { version: string } {
-  return typeof value === 'object' && value !== null && 'version' in value && typeof value.version === 'string';
-}
-
-/** Read the `version` field from a package.json file. */
-function readCurrentVersion(filePath: string): string | undefined {
-  try {
-    const content = readFileSync(filePath, 'utf8');
-    const parsed: unknown = JSON.parse(content);
-    if (hasVersionField(parsed)) {
-      return parsed.version;
-    }
-  } catch {
-    // Return undefined if the file can't be read or parsed.
-  }
-  return undefined;
 }
 
 /**

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -127,6 +127,14 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
 /** Determine direct bumps from commits for each component. */
 function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePrepareOptions): Phase1Result {
   const { force, bumpOverride, setVersion } = options;
+
+  // Enforce the `--set-version` contract at the orchestration layer. The CLI layer
+  // (`prepareCommand`) normally narrows to a single component before calling, but this
+  // guard protects against programmatic misuse.
+  if (setVersion !== undefined && config.components.length !== 1) {
+    throw new Error(`--set-version requires exactly one component; received ${config.components.length}`);
+  }
+
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
 

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -155,7 +155,12 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
     // Validation that only one component is targeted runs in `prepareCommand` before this function.
     if (setVersion !== undefined) {
       const currentVersion = currentVersions.get(component.dir);
-      if (currentVersion !== undefined && !isForwardVersion(currentVersion, setVersion)) {
+      if (currentVersion === undefined) {
+        throw new Error(
+          `Cannot validate --set-version: failed to read current version from ${primaryPackageFile ?? '(no package file)'}`,
+        );
+      }
+      if (!isForwardVersion(currentVersion, setVersion)) {
         throw new Error(`--set-version ${setVersion} is not greater than current version ${currentVersion}`);
       }
 

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -3,7 +3,8 @@ import { readFileSync } from 'node:fs';
 
 import type { DependencyGraph } from './buildDependencyGraph.ts';
 import { buildDependencyGraph } from './buildDependencyGraph.ts';
-import { bumpAllVersions } from './bumpAllVersions.ts';
+import { bumpAllVersions, setAllVersions } from './bumpAllVersions.ts';
+import { isForwardVersion } from './compareVersions.ts';
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpFromCommits } from './determineBumpFromCommits.ts';
 import { generateChangelogJson, generateSyntheticChangelogJson } from './generateChangelogJson.ts';
@@ -28,9 +29,12 @@ interface DirectBumpResult {
   component: ComponentConfig;
   tag: string | undefined;
   commits: Commit[];
-  releaseType: ReleaseType;
+  /** Release type determined from commits (or the override). Undefined when `setVersion` is used. */
+  releaseType: ReleaseType | undefined;
   parsedCommitCount: number | undefined;
   unparseableCommits: Commit[] | undefined;
+  /** Explicit version from `--set-version`, present only for the overridden component. */
+  setVersion?: string;
 }
 
 /** Intermediate result for a skipped component. */
@@ -122,7 +126,7 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
 
 /** Determine direct bumps from commits for each component. */
 function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePrepareOptions): Phase1Result {
-  const { force, bumpOverride } = options;
+  const { force, bumpOverride, setVersion } = options;
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
 
@@ -137,12 +141,37 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
     const since = tag === undefined ? '(no previous release found)' : `since ${tag}`;
 
     // Read current version from the first package file.
+    // Important: this read must occur BEFORE any bypass branch so propagation sees the
+    // pre-write current version.
     const primaryPackageFile = component.packageFiles[0];
     if (primaryPackageFile !== undefined) {
       const currentVersion = readCurrentVersion(primaryPackageFile);
       if (currentVersion !== undefined) {
         currentVersions.set(component.dir, currentVersion);
       }
+    }
+
+    // --set-version bypass: skip commit-derived bump logic for the overridden component.
+    // Validation that only one component is targeted runs in `prepareCommand` before this function.
+    if (setVersion !== undefined) {
+      const currentVersion = currentVersions.get(component.dir);
+      if (currentVersion !== undefined && !isForwardVersion(currentVersion, setVersion)) {
+        throw new Error(`--set-version ${setVersion} is not greater than current version ${currentVersion}`);
+      }
+
+      // The releaseType in the ReleaseEntry is a sentinel value; `newVersionOverride` takes
+      // precedence when propagation computes dependent versions.
+      directBumps.set(component.dir, { releaseType: 'patch', newVersionOverride: setVersion });
+      directResults.set(component.dir, {
+        component,
+        tag,
+        commits,
+        releaseType: undefined,
+        parsedCommitCount: undefined,
+        unparseableCommits: undefined,
+        setVersion,
+      });
+      continue;
     }
 
     // Skip components with no changes unless --force is set.
@@ -248,85 +277,171 @@ function executeReleaseSet(
       continue;
     }
 
-    // Bump all versions for this component.
-    const bump = bumpAllVersions(component.packageFiles, releaseEntry.releaseType, dryRun);
-    const newTag = `${component.tagPrefix}${bump.newVersion}`;
-    tags.push(newTag);
-    modifiedFiles.push(...component.packageFiles, ...component.changelogPaths.map((p) => `${p}/CHANGELOG.md`));
-
-    // Generate changelogs: git-cliff for direct bumps, synthetic for propagation-only.
-    const changelogFiles: string[] = [];
-    const directResult = directResults.get(dir);
-    const isPropagationOnly = directResult === undefined;
-
-    if (isPropagationOnly && releaseEntry.propagatedFrom !== undefined) {
-      for (const changelogPath of component.changelogPaths) {
-        changelogFiles.push(
-          writeSyntheticChangelog({
-            changelogPath,
-            newVersion: bump.newVersion,
-            date: today,
-            propagatedFrom: releaseEntry.propagatedFrom,
-            dryRun,
-          }),
-        );
-      }
-
-      // Generate synthetic changelog JSON for propagation-only bumps.
-      if (config.changelogJson.enabled) {
-        for (const changelogPath of component.changelogPaths) {
-          const jsonFiles = generateSyntheticChangelogJson(
-            config,
-            changelogPath,
-            bump.newVersion,
-            today,
-            releaseEntry.propagatedFrom,
-            dryRun,
-          );
-          modifiedFiles.push(...jsonFiles);
-        }
-      }
-    } else {
-      for (const changelogPath of component.changelogPaths) {
-        changelogFiles.push(
-          ...generateChangelog(config, changelogPath, newTag, dryRun, {
-            tagPattern: buildTagPattern(component.tagPrefix),
-            includePaths: component.paths,
-          }),
-        );
-      }
-
-      // Generate changelog JSON for direct bumps.
-      if (config.changelogJson.enabled) {
-        for (const changelogPath of component.changelogPaths) {
-          const jsonFiles = generateChangelogJson(config, changelogPath, newTag, dryRun, {
-            tagPattern: buildTagPattern(component.tagPrefix),
-            includePaths: component.paths,
-          });
-          modifiedFiles.push(...jsonFiles);
-        }
-      }
-    }
-
-    components.push({
-      name: dir,
-      status: 'released',
-      previousTag: directResult?.tag ?? previousTags.get(dir),
-      commitCount: directResult?.commits.length ?? 0,
-      parsedCommitCount: directResult?.parsedCommitCount,
-      releaseType: releaseEntry.releaseType,
-      currentVersion: bump.currentVersion,
-      newVersion: bump.newVersion,
-      tag: newTag,
-      bumpedFiles: bump.files,
-      changelogFiles,
-      commits: directResult?.commits,
-      unparseableCommits: directResult?.unparseableCommits,
-      propagatedFrom: releaseEntry.propagatedFrom,
+    executeComponentRelease({
+      dir,
+      component,
+      releaseEntry,
+      directResult: directResults.get(dir),
+      previousTags,
+      config,
+      dryRun,
+      today,
+      tags,
+      modifiedFiles,
+      components,
     });
   }
 
   return { tags, modifiedFiles };
+}
+
+/** Arguments for executing a single component's bump + changelog generation. */
+interface ExecuteComponentReleaseArgs {
+  dir: string;
+  component: ComponentConfig;
+  releaseEntry: ReleaseEntry;
+  directResult: DirectBumpResult | undefined;
+  previousTags: Map<string, string | undefined>;
+  config: MonorepoReleaseConfig;
+  dryRun: boolean;
+  today: string;
+  tags: string[];
+  modifiedFiles: string[];
+  components: ComponentPrepareResult[];
+}
+
+/** Bump, generate changelogs, and append the component result for one entry in the release set. */
+function executeComponentRelease(args: ExecuteComponentReleaseArgs): void {
+  const {
+    dir,
+    component,
+    releaseEntry,
+    directResult,
+    previousTags,
+    config,
+    dryRun,
+    today,
+    tags,
+    modifiedFiles,
+    components,
+  } = args;
+
+  // Bump all versions for this component. For --set-version components, write the explicit
+  // version directly; otherwise compute the bump from the release type.
+  const setVersionTarget = directResult?.setVersion;
+  const bump =
+    setVersionTarget === undefined
+      ? bumpAllVersions(component.packageFiles, releaseEntry.releaseType, dryRun)
+      : setAllVersions(component.packageFiles, setVersionTarget, dryRun);
+  const newTag = `${component.tagPrefix}${bump.newVersion}`;
+  tags.push(newTag);
+  modifiedFiles.push(...component.packageFiles, ...component.changelogPaths.map((p) => `${p}/CHANGELOG.md`));
+
+  const isPropagationOnly = directResult === undefined;
+  const changelogFiles = generateComponentChangelogs({
+    component,
+    releaseEntry,
+    newTag,
+    newVersion: bump.newVersion,
+    isPropagationOnly,
+    config,
+    dryRun,
+    today,
+    modifiedFiles,
+  });
+
+  components.push({
+    name: dir,
+    status: 'released',
+    previousTag: directResult?.tag ?? previousTags.get(dir),
+    commitCount: directResult?.commits.length ?? 0,
+    parsedCommitCount: directResult?.parsedCommitCount,
+    // For --set-version components releaseType is left undefined so reporting can branch
+    // on the override case without conflating it with a bump type.
+    releaseType: setVersionTarget === undefined ? releaseEntry.releaseType : undefined,
+    currentVersion: bump.currentVersion,
+    newVersion: bump.newVersion,
+    tag: newTag,
+    bumpedFiles: bump.files,
+    changelogFiles,
+    commits: directResult?.commits,
+    unparseableCommits: directResult?.unparseableCommits,
+    propagatedFrom: releaseEntry.propagatedFrom,
+    ...(setVersionTarget === undefined ? {} : { setVersion: setVersionTarget }),
+  });
+}
+
+/** Arguments for generating changelog files for a single component. */
+interface GenerateComponentChangelogsArgs {
+  component: ComponentConfig;
+  releaseEntry: ReleaseEntry;
+  newTag: string;
+  newVersion: string;
+  isPropagationOnly: boolean;
+  config: MonorepoReleaseConfig;
+  dryRun: boolean;
+  today: string;
+  modifiedFiles: string[];
+}
+
+/**
+ * Generate changelogs for a component: synthetic entries for propagation-only bumps, git-cliff
+ * output for direct bumps (including `--set-version`). Returns the list of changelog files written.
+ * Additional changelog JSON files are appended to `modifiedFiles` when the feature is enabled.
+ */
+function generateComponentChangelogs(args: GenerateComponentChangelogsArgs): string[] {
+  const { component, releaseEntry, newTag, newVersion, isPropagationOnly, config, dryRun, today, modifiedFiles } = args;
+  const changelogFiles: string[] = [];
+
+  if (isPropagationOnly && releaseEntry.propagatedFrom !== undefined) {
+    for (const changelogPath of component.changelogPaths) {
+      changelogFiles.push(
+        writeSyntheticChangelog({
+          changelogPath,
+          newVersion,
+          date: today,
+          propagatedFrom: releaseEntry.propagatedFrom,
+          dryRun,
+        }),
+      );
+    }
+
+    if (config.changelogJson.enabled) {
+      for (const changelogPath of component.changelogPaths) {
+        const jsonFiles = generateSyntheticChangelogJson(
+          config,
+          changelogPath,
+          newVersion,
+          today,
+          releaseEntry.propagatedFrom,
+          dryRun,
+        );
+        modifiedFiles.push(...jsonFiles);
+      }
+    }
+    return changelogFiles;
+  }
+
+  for (const changelogPath of component.changelogPaths) {
+    changelogFiles.push(
+      ...generateChangelog(config, changelogPath, newTag, dryRun, {
+        tagPattern: buildTagPattern(component.tagPrefix),
+        includePaths: component.paths,
+      }),
+    );
+  }
+
+  if (config.changelogJson.enabled) {
+    for (const changelogPath of component.changelogPaths) {
+      const jsonFiles = generateChangelogJson(config, changelogPath, newTag, dryRun, {
+        tagPattern: buildTagPattern(component.tagPrefix),
+        includePaths: component.paths,
+      });
+      modifiedFiles.push(...jsonFiles);
+    }
+  }
+
+  return changelogFiles;
 }
 
 /** Run the format command on modified files, if configured. */

--- a/packages/release-kit/src/reportPrepare.ts
+++ b/packages/release-kit/src/reportPrepare.ts
@@ -42,22 +42,27 @@ function formatSingleComponent(result: PrepareResult): string {
     return lines.join('\n');
   }
 
-  // Bump override message (no parsedCommitCount means bump override was used)
-  if (component.parsedCommitCount === undefined && component.releaseType !== undefined) {
+  // --set-version: render an explicit version-override message instead of a bump label.
+  if (component.setVersion !== undefined) {
+    lines.push(`  Using version override: ${component.setVersion}`);
+  } else if (component.parsedCommitCount === undefined && component.releaseType !== undefined) {
+    // Bump override message (no parsedCommitCount means bump override was used)
     lines.push(`  Using bump override: ${component.releaseType}`);
   }
 
   // Bump info
   if (component.releaseType !== undefined) {
     lines.push(dim(`Bumping versions (${component.releaseType})...`));
+  } else if (component.setVersion !== undefined) {
+    lines.push(dim(`Bumping versions (version override)...`));
   }
 
-  if (
-    component.currentVersion !== undefined &&
-    component.newVersion !== undefined &&
-    component.releaseType !== undefined
-  ) {
-    lines.push(`📦 ${component.currentVersion} → ${bold(component.newVersion)} (${component.releaseType})`);
+  if (component.currentVersion !== undefined && component.newVersion !== undefined) {
+    if (component.setVersion !== undefined) {
+      lines.push(`📦 ${component.currentVersion} → ${bold(component.newVersion)} (version override)`);
+    } else if (component.releaseType !== undefined) {
+      lines.push(`📦 ${component.currentVersion} → ${bold(component.newVersion)} (${component.releaseType})`);
+    }
   }
 
   // Bump file details
@@ -84,58 +89,7 @@ function formatMultiComponent(result: PrepareResult): string {
   const lines: string[] = [];
 
   for (const component of result.components) {
-    if (component.name !== undefined) {
-      lines.push(`\n${sectionHeader(component.name)}`);
-    }
-
-    const since =
-      component.previousTag === undefined ? '(no previous release found)' : `since ${component.previousTag}`;
-
-    lines.push(dim(`  Found ${component.commitCount} commits ${since}`));
-
-    if (component.status === 'skipped') {
-      lines.push(`  ⏭️  ${component.skipReason ?? 'Skipped'}`);
-      continue;
-    }
-
-    const { propagatedFrom } = component;
-    const isPropagatedOnly = propagatedFrom !== undefined && component.commitCount === 0;
-
-    if (isPropagatedOnly) {
-      const depNames = propagatedFrom.map((p) => p.packageName).join(', ');
-      lines.push(dim(`  0 commits (bumped via dependency: ${depNames})`));
-    } else if (component.parsedCommitCount !== undefined) {
-      lines.push(dim(`  Parsed ${component.parsedCommitCount} typed commits`));
-    }
-
-    formatUnparseableWarning(lines, component, '  ');
-
-    if (component.parsedCommitCount === undefined && component.releaseType !== undefined && !isPropagatedOnly) {
-      lines.push(`  Using bump override: ${component.releaseType}`);
-    }
-
-    if (component.releaseType !== undefined) {
-      lines.push(dim(`  Bumping versions (${component.releaseType})...`));
-    }
-
-    if (
-      component.currentVersion !== undefined &&
-      component.newVersion !== undefined &&
-      component.releaseType !== undefined
-    ) {
-      const suffix = isPropagatedOnly ? formatPropagationSuffix(propagatedFrom) : '';
-      lines.push(
-        `  📦 ${component.currentVersion} → ${bold(component.newVersion)} (${component.releaseType}${suffix})`,
-      );
-    }
-
-    formatBumpFiles(lines, component, result.dryRun, '  ');
-    lines.push(dim('  Generating changelogs...'));
-    formatChangelogFiles(lines, component, result.dryRun, '  ');
-
-    if (component.tag !== undefined) {
-      lines.push(`  🏷️  ${bold(component.tag)}`);
-    }
+    formatComponentSection(lines, component, result.dryRun);
   }
 
   // Format command
@@ -155,6 +109,86 @@ function formatMultiComponent(result: PrepareResult): string {
   }
 
   return lines.join('\n');
+}
+
+/** Render a single component's section within multi-component output. */
+function formatComponentSection(lines: string[], component: ComponentPrepareResult, dryRun: boolean): void {
+  if (component.name !== undefined) {
+    lines.push(`\n${sectionHeader(component.name)}`);
+  }
+
+  const since = component.previousTag === undefined ? '(no previous release found)' : `since ${component.previousTag}`;
+  lines.push(dim(`  Found ${component.commitCount} commits ${since}`));
+
+  if (component.status === 'skipped') {
+    lines.push(`  ⏭️  ${component.skipReason ?? 'Skipped'}`);
+    return;
+  }
+
+  const { propagatedFrom } = component;
+  const isPropagatedOnly = propagatedFrom !== undefined && component.commitCount === 0;
+
+  formatCommitSummary(lines, component, propagatedFrom, isPropagatedOnly);
+  formatUnparseableWarning(lines, component, '  ');
+  formatBumpLabels(lines, component, isPropagatedOnly);
+  formatVersionLine(lines, component, propagatedFrom, isPropagatedOnly);
+
+  formatBumpFiles(lines, component, dryRun, '  ');
+  lines.push(dim('  Generating changelogs...'));
+  formatChangelogFiles(lines, component, dryRun, '  ');
+
+  if (component.tag !== undefined) {
+    lines.push(`  🏷️  ${bold(component.tag)}`);
+  }
+}
+
+/** Append the commit-count summary line for a component (propagation-only or parsed counts). */
+function formatCommitSummary(
+  lines: string[],
+  component: ComponentPrepareResult,
+  propagatedFrom: PropagationSource[] | undefined,
+  isPropagatedOnly: boolean,
+): void {
+  if (isPropagatedOnly && propagatedFrom !== undefined) {
+    const depNames = propagatedFrom.map((p) => p.packageName).join(', ');
+    lines.push(dim(`  0 commits (bumped via dependency: ${depNames})`));
+  } else if (component.parsedCommitCount !== undefined) {
+    lines.push(dim(`  Parsed ${component.parsedCommitCount} typed commits`));
+  }
+}
+
+/** Append the bump-override / set-version label and the "Bumping versions..." line. */
+function formatBumpLabels(lines: string[], component: ComponentPrepareResult, isPropagatedOnly: boolean): void {
+  if (component.setVersion !== undefined) {
+    lines.push(`  Using version override: ${component.setVersion}`);
+  } else if (component.parsedCommitCount === undefined && component.releaseType !== undefined && !isPropagatedOnly) {
+    lines.push(`  Using bump override: ${component.releaseType}`);
+  }
+
+  if (component.releaseType !== undefined) {
+    lines.push(dim(`  Bumping versions (${component.releaseType})...`));
+  } else if (component.setVersion !== undefined) {
+    lines.push(dim(`  Bumping versions (version override)...`));
+  }
+}
+
+/** Append the `currentVersion → newVersion` line with the appropriate suffix. */
+function formatVersionLine(
+  lines: string[],
+  component: ComponentPrepareResult,
+  propagatedFrom: PropagationSource[] | undefined,
+  isPropagatedOnly: boolean,
+): void {
+  if (component.currentVersion === undefined || component.newVersion === undefined) {
+    return;
+  }
+
+  if (component.setVersion !== undefined) {
+    lines.push(`  📦 ${component.currentVersion} → ${bold(component.newVersion)} (version override)`);
+  } else if (component.releaseType !== undefined) {
+    const suffix = isPropagatedOnly ? formatPropagationSuffix(propagatedFrom) : '';
+    lines.push(`  📦 ${component.currentVersion} → ${bold(component.newVersion)} (${component.releaseType}${suffix})`);
+  }
 }
 
 /** Append bump file detail lines. */

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -71,6 +71,8 @@ export interface ComponentPrepareResult {
   /** Dependencies that triggered a propagated bump (present for propagated or mixed components). */
   propagatedFrom?: PropagationSource[] | undefined;
   skipReason?: string | undefined;
+  /** Present when this component was written via `--set-version`; the explicit version that was applied. */
+  setVersion?: string | undefined;
 }
 
 /** Aggregate result of the prepare workflow for both single-package and monorepo modes. */


### PR DESCRIPTION
## What

Fixes an issue where a `feat!` commit on a pre-1.0 package would accidentally promote it to `1.0.0`. At pre-1.0 (`0.y.z`), a `'major'` release type now collapses to a minor bump (so `0.3.7` + major → `0.4.0`), preserving the semver convention that `0.y.z` is "initial development" where breaking changes are expected without a 1.0 commitment. Post-1.0 behavior is unchanged.

Adds a validated `--set-version <semver>` CLI flag on `release-kit prepare` that bypasses commit-derived bump logic and writes a specific version. The rest of the pipeline (changelog from commits since last tag, commit, tag, push, propagation to dependents) runs normally. In monorepo mode, `--only` must narrow to exactly one component; `--set-version` rejects non-canonical semver, downgrades, equal versions, and mutually-exclusive combinations with `--bump` or `--force`. Propagation to dependents uses the overridden version. Documented in `packages/release-kit/README.md` and CLI help text with a 0.x → 1.0 promotion example.

## Why

release-kit previously had no first-class way to intentionally promote a package to `1.0.0`. The only path was hand-editing every affected `package.json`, creating tags manually, and commiting outside the tool's normal flow — error-prone in a monorepo and bypassing the commit/tag/push/changelog pipeline release-kit otherwise manages. Meanwhile, the implicit major-bump behavior was a trap: a `feat!` commit on a pre-1.0 package would declare API stability the maintainer never intended. This change fixes the bug and provides the escape hatch together, so maintainers can intentionally promote through the standard pipeline.

## Details

### Features

- `--set-version <semver>`: accepts canonical `N.N.N` (same regex as `bumpVersion`); rejects pre-release suffixes; validates strictly greater than the current version via a new `isForwardVersion` helper; monorepo mode requires `--only` narrowing to exactly one component (enforced both in `prepareCommand` and via an explicit guard in `determineDirectBumps`); mutually exclusive with `--bump` and `--force`; works with `--dry-run`.
- New `ReleasePrepareOptions.setVersion` and `ComponentPrepareResult.setVersion` discriminator: reporting renders `📦 {current} → {new} (version override)` and `Using version override: {setVersion}` for overridden components; propagated dependents retain their standard release-type labels (e.g., `(patch, dependency: core)`).
- `ReleaseEntry.newVersionOverride`: propagation to dependents uses the override value so each dependent's `propagatedFrom.newVersion` reflects the intended version rather than a bump-computed value.
- README: new "Promoting to 1.0.0" subsection under `prepare` with a worked `--only arrays --set-version 1.0.0` example and a note explaining empty changelogs for bare promotions.

### Fixes

- `bumpVersion`: pre-1.0 `major` collapses to minor (`0.3.7` + major → `0.4.0`; `0.0.0` + major → `0.1.0`; `0.9.5` + major → `0.10.0`). `'minor'` and `'patch'` paths unchanged. Post-1.0 unchanged (`1.2.3` + major → `2.0.0`).
- `bumpAllVersions` dry-run test updated to `'0.6.0'` (was `'1.0.0'`) to reflect the new rule.
- Explicit throw (rather than silent short-circuit) when `readCurrentVersion` fails during a `--set-version` run, so misconfigured `package.json` files surface a clear error instead of silently bypassing forward-version validation.

### Refactoring

- New shared helper `parseCanonicalSemver` in `bumpVersion.ts` used by both `bumpVersion` and the new `compareVersions.ts`.
- New shared internal module `readCurrentVersion.ts` used by both `releasePrepare.ts` and `releasePrepareMono.ts` (extracted during simplifier pass, after the second consumer arrived).
- New `setAllVersions` in `bumpAllVersions.ts`: writes an explicit version instead of computing one from a release type. Single-responsibility sibling of `bumpAllVersions`.
- `reportPrepare.formatMultiComponent` decomposed into `formatComponentSection`, `formatCommitSummary`, `formatBumpLabels`, and `formatVersionLine` to stay under the eslint complexity threshold after `--set-version` branching.
- `releasePrepareMono.executeReleaseSet` decomposed into `executeComponentRelease` and `generateComponentChangelogs` for the same reason.
- `readCurrentVersion` now emits `console.warn` on file/parse failures so operators can diagnose misconfigured components; behavior (returning `undefined`) is unchanged.

### Tests

- New `compareVersions.unit.test.ts`: covers forward/equal/downgrade in all three positions, decimal (not lexical) comparison (`0.9.0` → `0.10.0`), and invalid-input throws.
- `bumpVersion.unit.test.ts`: updated pre-1.0 `major` assertions; added `0.3.7` + major, `0.9.5` + major, and explicit pre-1.0 `'minor'`/`'patch'` invariance cases.
- `propagateBumps.unit.test.ts`: new direct-coverage test for `newVersionOverride` asserting dependent's `propagatedFrom.newVersion` reflects the override.
- `prepareCommand.unit.test.ts`: `--set-version` argument parsing, format validation, mutual-exclusion, monorepo `--only` narrowing, and a zero-component `--only` rejection case.
- `releasePrepare.unit.test.ts` and `releasePrepareMono.unit.test.ts`: `--set-version` writes, downgrade rejection, equal-version rejection (error message shape), dry-run no-write behavior, and the monorepo single-component guard.
- `reportPrepare.unit.test.ts`: `(version override)` suffix on the 📦 line and `Using version override:` label; propagated dependents retain their standard release-type labels.

Closes #271