### PR TITLE
#259 Derive monorepo tag prefix from unscoped `package.json` name

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -350,6 +350,27 @@ The key difference: the script-based approach requires manually listing every co
 
 ## Breaking changes
 
+### `resolveReleaseTags` takes components; `ComponentConfig` requires `workspacePath`
+
+Tag resolution is now driven by component records rather than a caller-supplied directory map, so `resolveReleaseTags` can report both the component `dir` and its `workspacePath` for every resolved tag.
+
+- `resolveReleaseTags` signature changed from `(workspaceMap?: Map<string, string>)` to `(components?: readonly ComponentConfig[])`.
+- `ComponentConfig` gained a required `workspacePath: string` field.
+
+Replace direct `Map`-based calls with `component()`, which now populates `workspacePath` for you:
+
+```diff
+-import { resolveReleaseTags } from '@williamthorsen/release-kit';
+-
+-const workspaceMap = new Map([['core', 'packages/core']]);
+-resolveReleaseTags(workspaceMap);
++import { component, resolveReleaseTags } from '@williamthorsen/release-kit';
++
++resolveReleaseTags([component('packages/core')]);
+```
+
+If you construct `ComponentConfig` objects directly, add `workspacePath` alongside the other required fields.
+
 ### `release-kit publish` and `release-kit push` replace `--only` with `--tags`
 
 The `--only=<dir>` flag on `release-kit publish` and `release-kit push` has been removed. Both commands now filter by full tag name via `--tags=<tag1>[,<tag2>...]`, matching `release-kit create-github-release`. Passing `--only=...` after upgrading produces an `Unknown option: --only` error.

--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -302,23 +302,26 @@ This package shells out to two external tools:
 
 ## Using `component()` for manual configuration
 
-If you need to build a `MonorepoReleaseConfig` manually (e.g., for the legacy script-based approach), the exported `component()` helper creates a `ComponentConfig` from a workspace-relative path:
+If you need to build a `MonorepoReleaseConfig` manually (e.g., for the legacy script-based approach), the exported `component()` helper creates a `ComponentConfig` from a workspace-relative path. It reads the workspace's `package.json` to derive the tag prefix from the package name:
 
 ```typescript
 import { component } from '@williamthorsen/release-kit';
 
-// Accepts the full workspace-relative path
+// packages/arrays/package.json contains `"name": "@scope/arrays"`
 component('packages/arrays');
 // => {
 //   dir: 'arrays',
 //   tagPrefix: 'arrays-v',
+//   workspacePath: 'packages/arrays',
 //   packageFiles: ['packages/arrays/package.json'],
 //   changelogPaths: ['packages/arrays'],
 //   paths: ['packages/arrays/**'],
 // }
 ```
 
-The `dir` field is derived from `path.basename()`, so `packages/arrays` and `libs/arrays` both produce `dir: 'arrays'`. The `tagPrefix` is always `${dir}-v` — it cannot be customized.
+`dir` is the basename of the workspace path and is the stable internal identifier used by `--only`, `ComponentOverride.dir`, and the dependency graph. `tagPrefix` is derived from the unscoped `package.json` `name` — any leading `@scope/` is stripped — so tags reflect the package identity rather than the directory layout. For example, a workspace at `packages/core` with `"name": "@williamthorsen/node-monorepo-core"` produces `tagPrefix: 'node-monorepo-core-v'`, yielding tags like `node-monorepo-core-v1.3.0`.
+
+The workspace's `package.json` must declare a non-empty `name` field; `component()` throws otherwise. If two workspaces produce the same `tagPrefix` (because their unscoped names collide), `mergeMonorepoConfig()` throws and names the colliding workspaces so you can rename one.
 
 ## Legacy script-based approach
 

--- a/packages/release-kit/src/__tests__/buildDependencyGraph.unit.test.ts
+++ b/packages/release-kit/src/__tests__/buildDependencyGraph.unit.test.ts
@@ -13,6 +13,7 @@ function makeComponent(dir: string, packageFile?: string): ComponentConfig {
   return {
     dir,
     tagPrefix: `${dir}-v`,
+    workspacePath: `packages/${dir}`,
     packageFiles: [packageFile ?? `packages/${dir}/package.json`],
     changelogPaths: [`packages/${dir}`],
     paths: [`packages/${dir}/**`],
@@ -175,6 +176,7 @@ describe(buildDependencyGraph, () => {
     const comp: ComponentConfig = {
       dir: 'empty',
       tagPrefix: 'empty-v',
+      workspacePath: 'packages/empty',
       packageFiles: [],
       changelogPaths: [],
       paths: [],

--- a/packages/release-kit/src/__tests__/component.unit.test.ts
+++ b/packages/release-kit/src/__tests__/component.unit.test.ts
@@ -73,17 +73,19 @@ describe(component, () => {
     );
   });
 
-  it('propagates the underlying error when readFileSync fails (e.g., missing file)', () => {
+  it('wraps readFileSync errors with the workspace path for context', () => {
     mockReadFileSync.mockImplementation(() => {
       throw new Error('ENOENT: no such file or directory, open packages/missing/package.json');
     });
 
-    expect(() => component('packages/missing')).toThrow('ENOENT');
+    expect(() => component('packages/missing')).toThrow(
+      'Failed to read packages/missing/package.json: ENOENT: no such file or directory, open packages/missing/package.json',
+    );
   });
 
-  it('throws a SyntaxError when package.json contents are not valid JSON', () => {
+  it('wraps JSON.parse errors with the workspace path for context', () => {
     mockReadFileSync.mockReturnValue('not json');
 
-    expect(() => component('packages/malformed')).toThrow(SyntaxError);
+    expect(() => component('packages/malformed')).toThrow(/^Failed to read packages\/malformed\/package\.json: /);
   });
 });

--- a/packages/release-kit/src/__tests__/component.unit.test.ts
+++ b/packages/release-kit/src/__tests__/component.unit.test.ts
@@ -72,4 +72,18 @@ describe(component, () => {
       "packages/invalid/package.json is missing a 'name' field (required for tag derivation).",
     );
   });
+
+  it('propagates the underlying error when readFileSync fails (e.g., missing file)', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT: no such file or directory, open packages/missing/package.json');
+    });
+
+    expect(() => component('packages/missing')).toThrow('ENOENT');
+  });
+
+  it('throws a SyntaxError when package.json contents are not valid JSON', () => {
+    mockReadFileSync.mockReturnValue('not json');
+
+    expect(() => component('packages/malformed')).toThrow(SyntaxError);
+  });
 });

--- a/packages/release-kit/src/__tests__/component.unit.test.ts
+++ b/packages/release-kit/src/__tests__/component.unit.test.ts
@@ -1,25 +1,75 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  readFileSync: mockReadFileSync,
+}));
 
 import { component } from '../component.ts';
 
 describe(component, () => {
-  it('derives all fields from the workspace path', () => {
-    expect(component('packages/basic')).toStrictEqual({
-      dir: 'basic',
-      tagPrefix: 'basic-v',
-      packageFiles: ['packages/basic/package.json'],
-      changelogPaths: ['packages/basic'],
-      paths: ['packages/basic/**'],
+  afterEach(() => {
+    mockReadFileSync.mockReset();
+  });
+
+  it('strips the @scope/ prefix from package name to derive tagPrefix', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@williamthorsen/node-monorepo-core' }));
+
+    expect(component('packages/core')).toStrictEqual({
+      dir: 'core',
+      tagPrefix: 'node-monorepo-core-v',
+      workspacePath: 'packages/core',
+      packageFiles: ['packages/core/package.json'],
+      changelogPaths: ['packages/core'],
+      paths: ['packages/core/**'],
     });
   });
 
-  it('works with non-standard workspace paths', () => {
-    expect(component('libs/core')).toStrictEqual({
-      dir: 'core',
-      tagPrefix: 'core-v',
-      packageFiles: ['libs/core/package.json'],
-      changelogPaths: ['libs/core'],
-      paths: ['libs/core/**'],
+  it('uses unscoped package name verbatim when no scope is present', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'readyup' }));
+
+    expect(component('packages/readyup')).toStrictEqual({
+      dir: 'readyup',
+      tagPrefix: 'readyup-v',
+      workspacePath: 'packages/readyup',
+      packageFiles: ['packages/readyup/package.json'],
+      changelogPaths: ['packages/readyup'],
+      paths: ['packages/readyup/**'],
     });
+  });
+
+  it('preserves dir as the basename when the directory name differs from the package name', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@williamthorsen/node-monorepo-core' }));
+
+    const result = component('libs/core');
+
+    expect(result.dir).toBe('core');
+    expect(result.tagPrefix).toBe('node-monorepo-core-v');
+    expect(result.workspacePath).toBe('libs/core');
+  });
+
+  it('throws a descriptive error when package.json has no name field', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+    expect(() => component('packages/bad')).toThrow(
+      "packages/bad/package.json is missing a 'name' field (required for tag derivation).",
+    );
+  });
+
+  it('throws when package.json name field is an empty string', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '' }));
+
+    expect(() => component('packages/empty')).toThrow(
+      "packages/empty/package.json is missing a 'name' field (required for tag derivation).",
+    );
+  });
+
+  it('throws when package.json name field is not a string', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 123 }));
+
+    expect(() => component('packages/invalid')).toThrow(
+      "packages/invalid/package.json is missing a 'name' field (required for tag derivation).",
+    );
   });
 });

--- a/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
@@ -4,6 +4,7 @@ const mockDiscoverWorkspaces = vi.hoisted(() => vi.fn());
 const mockResolveReleaseTags = vi.hoisted(() => vi.fn());
 const mockCreateGithubReleases = vi.hoisted(() => vi.fn());
 const mockResolveReleaseNotesConfig = vi.hoisted(() => vi.fn());
+const mockComponent = vi.hoisted(() => vi.fn());
 
 vi.mock('../discoverWorkspaces.ts', () => ({
   discoverWorkspaces: mockDiscoverWorkspaces,
@@ -21,6 +22,10 @@ vi.mock('../resolveReleaseNotesConfig.ts', () => ({
   resolveReleaseNotesConfig: mockResolveReleaseNotesConfig,
 }));
 
+vi.mock('../component.ts', () => ({
+  component: mockComponent,
+}));
+
 import { createGithubReleaseCommand } from '../createGithubReleaseCommand.ts';
 
 /** Sentinel error thrown by the mocked process.exit. */
@@ -35,6 +40,14 @@ describe(createGithubReleaseCommand, () => {
     mockDiscoverWorkspaces.mockResolvedValue(undefined);
     mockResolveReleaseTags.mockReturnValue([{ tag: 'v1.0.0', dir: '.', workspacePath: '.' }]);
     mockCreateGithubReleases.mockReturnValue({ created: ['v1.0.0'], skipped: [] });
+    mockComponent.mockImplementation((workspacePath: string) => ({
+      dir: workspacePath.split('/').pop(),
+      tagPrefix: `${workspacePath.split('/').pop()}-v`,
+      workspacePath,
+      packageFiles: [`${workspacePath}/package.json`],
+      changelogPaths: [workspacePath],
+      paths: [`${workspacePath}/**`],
+    }));
     mockResolveReleaseNotesConfig.mockResolvedValue({
       releaseNotes: { shouldInjectIntoReadme: false },
       changelogJsonOutputPath: '.meta/changelog.json',

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -1,12 +1,14 @@
 import path from 'node:path';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockJitiImport = vi.hoisted(() => vi.fn());
 
 vi.mock(import('node:fs'), () => ({
   existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
 }));
 
 vi.mock('jiti', () => ({
@@ -16,9 +18,25 @@ vi.mock('jiti', () => ({
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from '../defaults.ts';
 import { CONFIG_FILE_PATH, loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig } from '../loadConfig.ts';
 
+/**
+ * Configure `mockReadFileSync` to return a `package.json` with the given `name` per workspace
+ * path. Any path not in the map triggers a test failure rather than a silent default.
+ */
+function mockPackageNames(namesByPath: Record<string, string>): void {
+  mockReadFileSync.mockImplementation((filePath: string) => {
+    for (const [workspacePath, name] of Object.entries(namesByPath)) {
+      if (filePath === `${workspacePath}/package.json`) {
+        return JSON.stringify({ name });
+      }
+    }
+    throw new Error(`Unexpected readFileSync call for path: ${filePath}`);
+  });
+}
+
 describe(loadConfig, () => {
   afterEach(() => {
     mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
     mockJitiImport.mockReset();
   });
 
@@ -97,30 +115,49 @@ describe(loadConfig, () => {
 describe(mergeMonorepoConfig, () => {
   const discoveredPaths = ['packages/arrays', 'packages/strings'];
 
-  it('builds default components from discovered paths', () => {
+  beforeEach(() => {
+    mockPackageNames({
+      'packages/arrays': '@scope/arrays',
+      'packages/strings': '@scope/strings',
+    });
+  });
+
+  afterEach(() => {
+    mockReadFileSync.mockReset();
+  });
+
+  it('builds default components from discovered paths using pkg.name for tagPrefix', () => {
     const result = mergeMonorepoConfig(discoveredPaths, undefined);
 
     expect(result.components).toHaveLength(2);
     expect(result.components[0]).toStrictEqual({
       dir: 'arrays',
       tagPrefix: 'arrays-v',
+      workspacePath: 'packages/arrays',
       packageFiles: ['packages/arrays/package.json'],
       changelogPaths: ['packages/arrays'],
       paths: ['packages/arrays/**'],
     });
   });
 
-  it('builds components from non-standard workspace paths', () => {
+  it('derives tagPrefix from unscoped pkg.name when directory basename differs', () => {
+    mockPackageNames({
+      'libs/core': '@williamthorsen/node-monorepo-core',
+      'apps/web': 'web-app',
+    });
+
     const result = mergeMonorepoConfig(['libs/core', 'apps/web'], undefined);
 
     expect(result.components).toHaveLength(2);
     expect(result.components[0]).toStrictEqual({
       dir: 'core',
-      tagPrefix: 'core-v',
+      tagPrefix: 'node-monorepo-core-v',
+      workspacePath: 'libs/core',
       packageFiles: ['libs/core/package.json'],
       changelogPaths: ['libs/core'],
       paths: ['libs/core/**'],
     });
+    expect(result.components[1]?.tagPrefix).toBe('web-app-v');
   });
 
   it('uses default workTypes when no config is provided', () => {
@@ -182,6 +219,42 @@ describe(mergeMonorepoConfig, () => {
     });
 
     expect(result.scopeAliases).toStrictEqual({ api: 'backend-api' });
+  });
+
+  it('throws when two workspaces produce the same tagPrefix', () => {
+    mockPackageNames({
+      'packages/a-foo': '@a/foo',
+      'packages/b-foo': '@b/foo',
+    });
+
+    expect(() => mergeMonorepoConfig(['packages/a-foo', 'packages/b-foo'], undefined)).toThrow(
+      "Duplicate tag prefix 'foo-v' for workspaces: packages/a-foo, packages/b-foo",
+    );
+  });
+
+  it('throws on duplicate tagPrefix even when one colliding workspace is excluded', () => {
+    mockPackageNames({
+      'packages/a-foo': '@a/foo',
+      'packages/b-foo': '@b/foo',
+    });
+
+    expect(() =>
+      mergeMonorepoConfig(['packages/a-foo', 'packages/b-foo'], {
+        components: [{ dir: 'b-foo', shouldExclude: true }],
+      }),
+    ).toThrow("Duplicate tag prefix 'foo-v' for workspaces: packages/a-foo, packages/b-foo");
+  });
+
+  it('includes every colliding workspace path when more than two collide', () => {
+    mockPackageNames({
+      'packages/a-foo': '@a/foo',
+      'packages/b-foo': '@b/foo',
+      'packages/c-foo': '@c/foo',
+    });
+
+    expect(() => mergeMonorepoConfig(['packages/a-foo', 'packages/b-foo', 'packages/c-foo'], undefined)).toThrow(
+      "Duplicate tag prefix 'foo-v' for workspaces: packages/a-foo, packages/b-foo, packages/c-foo",
+    );
   });
 });
 

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -4,9 +4,18 @@ const mockAssertCleanWorkingTree = vi.hoisted(() => vi.fn());
 const mockBuildReleaseSummary = vi.hoisted(() => vi.fn());
 const mockDiscoverWorkspaces = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockReleasePrepareMono = vi.hoisted(() => vi.fn());
 const mockReleasePrepare = vi.hoisted(() => vi.fn());
 const mockWriteFileWithCheck = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    readFileSync: mockReadFileSync,
+  };
+});
 
 vi.mock('../assertCleanWorkingTree.ts', () => ({
   assertCleanWorkingTree: mockAssertCleanWorkingTree,
@@ -69,6 +78,15 @@ describe(prepareCommand, () => {
     mockBuildReleaseSummary.mockReturnValue('');
     mockDiscoverWorkspaces.mockResolvedValue(['packages/arrays', 'packages/strings']);
     mockLoadConfig.mockResolvedValue(undefined);
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath === 'packages/arrays/package.json') {
+        return JSON.stringify({ name: '@scope/arrays' });
+      }
+      if (filePath === 'packages/strings/package.json') {
+        return JSON.stringify({ name: '@scope/strings' });
+      }
+      throw new Error(`Unexpected readFileSync call for path: ${filePath}`);
+    });
     mockReleasePrepareMono.mockReturnValue(makePrepareResult());
     mockReleasePrepare.mockReturnValue(makePrepareResult());
     mockWriteFileWithCheck.mockReturnValue({ filePath: RELEASE_TAGS_FILE, outcome: 'created' });
@@ -85,6 +103,7 @@ describe(prepareCommand, () => {
     mockBuildReleaseSummary.mockReset();
     mockDiscoverWorkspaces.mockReset();
     mockLoadConfig.mockReset();
+    mockReadFileSync.mockReset();
     mockReleasePrepareMono.mockReset();
     mockReleasePrepare.mockReset();
     mockWriteFileWithCheck.mockReset();

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -9,13 +9,9 @@ const mockReleasePrepareMono = vi.hoisted(() => vi.fn());
 const mockReleasePrepare = vi.hoisted(() => vi.fn());
 const mockWriteFileWithCheck = vi.hoisted(() => vi.fn());
 
-vi.mock(import('node:fs'), async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    readFileSync: mockReadFileSync,
-  };
-});
+vi.mock('node:fs', () => ({
+  readFileSync: mockReadFileSync,
+}));
 
 vi.mock('../assertCleanWorkingTree.ts', () => ({
   assertCleanWorkingTree: mockAssertCleanWorkingTree,

--- a/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
+++ b/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
@@ -9,6 +9,7 @@ function makeComponent(dir: string): ComponentConfig {
   return {
     dir,
     tagPrefix: `${dir}-v`,
+    workspacePath: `packages/${dir}`,
     packageFiles: [`packages/${dir}/package.json`],
     changelogPaths: [`packages/${dir}`],
     paths: [`packages/${dir}/**`],

--- a/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
@@ -10,6 +10,7 @@ const mockCreateGithubReleases = vi.hoisted(() => vi.fn());
 const mockInjectReleaseNotesIntoReadme = vi.hoisted(() => vi.fn());
 const mockResolveReadmePath = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockComponent = vi.hoisted(() => vi.fn());
 
 vi.mock('node:fs', () => ({
   writeFileSync: mockWriteFileSync,
@@ -21,6 +22,10 @@ vi.mock('../discoverWorkspaces.ts', () => ({
 
 vi.mock('../resolveReleaseTags.ts', () => ({
   resolveReleaseTags: mockResolveReleaseTags,
+}));
+
+vi.mock('../component.ts', () => ({
+  component: mockComponent,
 }));
 
 vi.mock('../detectPackageManager.ts', () => ({
@@ -69,6 +74,17 @@ describe(publishCommand, () => {
     mockLoadConfig.mockResolvedValue(undefined);
     mockValidateConfig.mockReturnValue({ config: {}, errors: [], warnings: [] });
     mockResolveReadmePath.mockReturnValue(undefined);
+    mockComponent.mockImplementation((workspacePath: string) => {
+      const dir = workspacePath.split('/').pop() ?? workspacePath;
+      return {
+        dir,
+        tagPrefix: `${dir}-v`,
+        workspacePath,
+        packageFiles: [`${workspacePath}/package.json`],
+        changelogPaths: [workspacePath],
+        paths: [`${workspacePath}/**`],
+      };
+    });
     vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
@@ -88,6 +104,7 @@ describe(publishCommand, () => {
     mockInjectReleaseNotesIntoReadme.mockReset();
     mockResolveReadmePath.mockReset();
     mockWriteFileSync.mockReset();
+    mockComponent.mockReset();
     vi.restoreAllMocks();
   });
 

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -875,6 +875,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
             paths: ['packages/core/**'],
@@ -914,6 +915,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
             paths: ['packages/core/**'],
@@ -939,6 +941,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
             paths: ['packages/core/**'],
@@ -964,6 +967,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
             paths: ['packages/core/**'],
@@ -994,6 +998,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
             paths: ['packages/core/**'],
@@ -1001,6 +1006,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'app',
             tagPrefix: 'app-v',
+            workspacePath: 'packages/app',
             packageFiles: ['packages/app/package.json'],
             changelogPaths: ['packages/app'],
             paths: ['packages/app/**'],

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -94,6 +94,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -146,6 +147,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -183,6 +185,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -190,6 +193,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'strings',
           tagPrefix: 'strings-v',
+          workspacePath: 'packages/strings',
           packageFiles: ['packages/strings/package.json'],
           changelogPaths: ['packages/strings'],
           paths: ['packages/strings/**'],
@@ -243,6 +247,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -283,6 +288,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -290,6 +296,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'strings',
           tagPrefix: 'strings-v',
+          workspacePath: 'packages/strings',
           packageFiles: ['packages/strings/package.json'],
           changelogPaths: ['packages/strings'],
           paths: ['packages/strings/**'],
@@ -325,6 +332,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -365,6 +373,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -402,6 +411,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -436,6 +446,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -471,6 +482,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -478,6 +490,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'strings',
           tagPrefix: 'strings-v',
+          workspacePath: 'packages/strings',
           packageFiles: ['packages/strings/package.json'],
           changelogPaths: ['packages/strings'],
           paths: ['packages/strings/**'],
@@ -517,6 +530,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -549,6 +563,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -579,6 +594,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -613,6 +629,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays'],
           paths: ['packages/arrays/**'],
@@ -643,6 +660,7 @@ describe(releasePrepareMono, () => {
         {
           dir: 'arrays',
           tagPrefix: 'arrays-v',
+          workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
           changelogPaths: ['packages/arrays', 'packages/arrays/docs'],
           paths: ['packages/arrays/**'],
@@ -682,6 +700,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
             paths: ['packages/core/**'],
@@ -689,6 +708,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'app',
             tagPrefix: 'app-v',
+            workspacePath: 'packages/app',
             packageFiles: ['packages/app/package.json'],
             changelogPaths: ['packages/app'],
             paths: ['packages/app/**'],
@@ -758,6 +778,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
             paths: ['packages/core/**'],
@@ -765,6 +786,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'app',
             tagPrefix: 'app-v',
+            workspacePath: 'packages/app',
             packageFiles: ['packages/app/package.json'],
             changelogPaths: ['packages/app'],
             paths: ['packages/app/**'],
@@ -825,6 +847,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
             paths: ['packages/core/**'],
@@ -996,6 +1019,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
             paths: ['packages/core/**'],
@@ -1003,6 +1027,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'app',
             tagPrefix: 'app-v',
+            workspacePath: 'packages/app',
             packageFiles: ['packages/app/package.json'],
             changelogPaths: ['packages/app'],
             paths: ['packages/app/**'],

--- a/packages/release-kit/src/__tests__/resolveCommandTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveCommandTags.unit.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockDiscoverWorkspaces = vi.hoisted(() => vi.fn());
 const mockResolveReleaseTags = vi.hoisted(() => vi.fn());
+const mockComponent = vi.hoisted(() => vi.fn());
 
 vi.mock('../discoverWorkspaces.ts', () => ({
   discoverWorkspaces: mockDiscoverWorkspaces,
@@ -11,8 +12,13 @@ vi.mock('../resolveReleaseTags.ts', () => ({
   resolveReleaseTags: mockResolveReleaseTags,
 }));
 
+vi.mock('../component.ts', () => ({
+  component: mockComponent,
+}));
+
 import { resolveCommandTags } from '../resolveCommandTags.ts';
 import type { ResolvedTag } from '../resolveReleaseTags.ts';
+import type { ComponentConfig } from '../types.ts';
 
 /** Sentinel error thrown by the mocked process.exit. */
 class ExitError extends Error {
@@ -22,15 +28,38 @@ class ExitError extends Error {
 }
 
 const TAGS: ResolvedTag[] = [
-  { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+  { tag: 'node-monorepo-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
   { tag: 'cli-v0.5.0', dir: 'cli', workspacePath: 'packages/cli' },
   { tag: 'release-kit-v2.1.0', dir: 'release-kit', workspacePath: 'packages/release-kit' },
 ];
+
+function makeComponent(dir: string, tagPrefix: string, workspacePath: string): ComponentConfig {
+  return {
+    dir,
+    tagPrefix,
+    workspacePath,
+    packageFiles: [`${workspacePath}/package.json`],
+    changelogPaths: [workspacePath],
+    paths: [`${workspacePath}/**`],
+  };
+}
 
 describe(resolveCommandTags, () => {
   beforeEach(() => {
     mockDiscoverWorkspaces.mockResolvedValue(['packages/core', 'packages/cli', 'packages/release-kit']);
     mockResolveReleaseTags.mockReturnValue(TAGS);
+    mockComponent.mockImplementation((workspacePath: string) => {
+      if (workspacePath === 'packages/core') {
+        return makeComponent('core', 'node-monorepo-core-v', 'packages/core');
+      }
+      if (workspacePath === 'packages/cli') {
+        return makeComponent('cli', 'cli-v', 'packages/cli');
+      }
+      if (workspacePath === 'packages/release-kit') {
+        return makeComponent('release-kit', 'release-kit-v', 'packages/release-kit');
+      }
+      throw new Error(`Unexpected workspace path: ${workspacePath}`);
+    });
     vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
@@ -40,6 +69,7 @@ describe(resolveCommandTags, () => {
   afterEach(() => {
     mockDiscoverWorkspaces.mockReset();
     mockResolveReleaseTags.mockReset();
+    mockComponent.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -49,17 +79,36 @@ describe(resolveCommandTags, () => {
     expect(result).toStrictEqual(TAGS);
   });
 
-  it('returns only the filtered tag when a single-tag filter is provided', async () => {
-    const result = await resolveCommandTags(['core-v1.3.0']);
+  it('passes resolved components to resolveReleaseTags in monorepo mode', async () => {
+    await resolveCommandTags(undefined);
 
-    expect(result).toStrictEqual([{ tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' }]);
+    expect(mockResolveReleaseTags).toHaveBeenCalledWith([
+      makeComponent('core', 'node-monorepo-core-v', 'packages/core'),
+      makeComponent('cli', 'cli-v', 'packages/cli'),
+      makeComponent('release-kit', 'release-kit-v', 'packages/release-kit'),
+    ]);
+  });
+
+  it('passes undefined to resolveReleaseTags in single-package mode', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue(undefined);
+
+    await resolveCommandTags(undefined);
+
+    expect(mockResolveReleaseTags).toHaveBeenCalledWith(undefined);
+    expect(mockComponent).not.toHaveBeenCalled();
+  });
+
+  it('returns only the filtered tag when a single-tag filter is provided', async () => {
+    const result = await resolveCommandTags(['node-monorepo-core-v1.3.0']);
+
+    expect(result).toStrictEqual([{ tag: 'node-monorepo-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' }]);
   });
 
   it('returns only the filtered subset when a multi-tag filter is provided', async () => {
-    const result = await resolveCommandTags(['core-v1.3.0', 'release-kit-v2.1.0']);
+    const result = await resolveCommandTags(['node-monorepo-core-v1.3.0', 'release-kit-v2.1.0']);
 
     expect(result).toStrictEqual([
-      { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+      { tag: 'node-monorepo-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
       { tag: 'release-kit-v2.1.0', dir: 'release-kit', workspacePath: 'packages/release-kit' },
     ]);
   });
@@ -67,7 +116,7 @@ describe(resolveCommandTags, () => {
   it('exits with code 1 when the first tag in the filter is unknown', async () => {
     let thrown: ExitError | undefined;
     try {
-      await resolveCommandTags(['missing-v9.9.9', 'core-v1.3.0']);
+      await resolveCommandTags(['missing-v9.9.9', 'node-monorepo-core-v1.3.0']);
     } catch (error: unknown) {
       if (error instanceof ExitError) {
         thrown = error;
@@ -77,14 +126,14 @@ describe(resolveCommandTags, () => {
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
     expect(console.error).toHaveBeenCalledWith(
-      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0',
+      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: node-monorepo-core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0',
     );
   });
 
   it('exits with code 1 when the second tag in the filter is unknown', async () => {
     let thrown: ExitError | undefined;
     try {
-      await resolveCommandTags(['core-v1.3.0', 'missing-v9.9.9']);
+      await resolveCommandTags(['node-monorepo-core-v1.3.0', 'missing-v9.9.9']);
     } catch (error: unknown) {
       if (error instanceof ExitError) {
         thrown = error;
@@ -94,7 +143,7 @@ describe(resolveCommandTags, () => {
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
     expect(console.error).toHaveBeenCalledWith(
-      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0',
+      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: node-monorepo-core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0',
     );
   });
 
@@ -132,6 +181,28 @@ describe(resolveCommandTags, () => {
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
     expect(console.error).toHaveBeenCalledWith('Error discovering workspaces: workspace read failure');
+    expect(mockResolveReleaseTags).not.toHaveBeenCalled();
+  });
+
+  it('exits with code 1 when component() throws for a missing package name', async () => {
+    mockComponent.mockImplementation((workspacePath: string) => {
+      throw new Error(`${workspacePath}/package.json is missing a 'name' field (required for tag derivation).`);
+    });
+
+    let thrown: ExitError | undefined;
+    try {
+      await resolveCommandTags(undefined);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
+    expect(console.error).toHaveBeenCalledWith(
+      "Error resolving workspace components: packages/core/package.json is missing a 'name' field (required for tag derivation).",
+    );
     expect(mockResolveReleaseTags).not.toHaveBeenCalled();
   });
 });

--- a/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
@@ -7,6 +7,22 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { resolveReleaseTags } from '../resolveReleaseTags.ts';
+import type { ComponentConfig } from '../types.ts';
+
+function makeComponent(
+  overrides: Partial<ComponentConfig> & Pick<ComponentConfig, 'dir' | 'tagPrefix'>,
+): ComponentConfig {
+  const dir = overrides.dir;
+  const workspacePath = overrides.workspacePath ?? `packages/${dir}`;
+  return {
+    dir,
+    tagPrefix: overrides.tagPrefix,
+    workspacePath,
+    packageFiles: overrides.packageFiles ?? [`${workspacePath}/package.json`],
+    changelogPaths: overrides.changelogPaths ?? [workspacePath],
+    paths: overrides.paths ?? [`${workspacePath}/**`],
+  };
+}
 
 describe(resolveReleaseTags, () => {
   beforeEach(() => {
@@ -36,51 +52,77 @@ describe(resolveReleaseTags, () => {
     expect(resolveReleaseTags()).toStrictEqual([{ tag: 'v1.2.3', dir: '.', workspacePath: '.' }]);
   });
 
-  it('resolves monorepo tags against the workspace map', () => {
-    mockExecFileSync.mockReturnValue('core-v1.3.0\nrelease-kit-v2.1.0\n');
-    const workspaceMap = new Map([
-      ['core', 'packages/core'],
-      ['release-kit', 'packages/release-kit'],
-    ]);
+  it('resolves monorepo tags whose tagPrefix matches a component', () => {
+    mockExecFileSync.mockReturnValue('node-monorepo-core-v1.3.0\nrelease-kit-v2.1.0\n');
+    const components = [
+      makeComponent({ dir: 'core', tagPrefix: 'node-monorepo-core-v', workspacePath: 'packages/core' }),
+      makeComponent({ dir: 'release-kit', tagPrefix: 'release-kit-v', workspacePath: 'packages/release-kit' }),
+    ];
 
-    expect(resolveReleaseTags(workspaceMap)).toStrictEqual([
-      { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+    expect(resolveReleaseTags(components)).toStrictEqual([
+      { tag: 'node-monorepo-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
       { tag: 'release-kit-v2.1.0', dir: 'release-kit', workspacePath: 'packages/release-kit' },
     ]);
   });
 
-  it('ignores monorepo tags with unrecognized directory names', () => {
-    mockExecFileSync.mockReturnValue('unknown-v1.0.0\ncore-v1.3.0\n');
-    const workspaceMap = new Map([['core', 'packages/core']]);
+  it('reports dir from component.dir, not the tagPrefix, when directory differs from package name', () => {
+    mockExecFileSync.mockReturnValue('node-monorepo-core-v0.2.8\n');
+    const components = [
+      makeComponent({ dir: 'core', tagPrefix: 'node-monorepo-core-v', workspacePath: 'packages/core' }),
+    ];
 
-    expect(resolveReleaseTags(workspaceMap)).toStrictEqual([
+    expect(resolveReleaseTags(components)).toStrictEqual([
+      { tag: 'node-monorepo-core-v0.2.8', dir: 'core', workspacePath: 'packages/core' },
+    ]);
+  });
+
+  it('ignores monorepo tags with unrecognized prefixes', () => {
+    mockExecFileSync.mockReturnValue('unknown-v1.0.0\ncore-v1.3.0\n');
+    const components = [makeComponent({ dir: 'core', tagPrefix: 'core-v' })];
+
+    expect(resolveReleaseTags(components)).toStrictEqual([
       { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
     ]);
   });
 
   it('ignores non-release tags in monorepo mode', () => {
     mockExecFileSync.mockReturnValue('core-v1.3.0\nsome-random-tag\n');
-    const workspaceMap = new Map([['core', 'packages/core']]);
+    const components = [makeComponent({ dir: 'core', tagPrefix: 'core-v' })];
 
-    expect(resolveReleaseTags(workspaceMap)).toStrictEqual([
+    expect(resolveReleaseTags(components)).toStrictEqual([
       { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
     ]);
   });
 
-  it('handles tags with multiple hyphens in the directory name', () => {
+  it('handles tags with multiple hyphens in the package name', () => {
     mockExecFileSync.mockReturnValue('my-cool-lib-v3.0.0\n');
-    const workspaceMap = new Map([['my-cool-lib', 'packages/my-cool-lib']]);
+    const components = [
+      makeComponent({ dir: 'my-cool-lib', tagPrefix: 'my-cool-lib-v', workspacePath: 'packages/my-cool-lib' }),
+    ];
 
-    expect(resolveReleaseTags(workspaceMap)).toStrictEqual([
+    expect(resolveReleaseTags(components)).toStrictEqual([
       { tag: 'my-cool-lib-v3.0.0', dir: 'my-cool-lib', workspacePath: 'packages/my-cool-lib' },
+    ]);
+  });
+
+  it('prefers the longest matching prefix when two prefixes nest', () => {
+    mockExecFileSync.mockReturnValue('foo-bar-v1.0.0\nfoo-v2.0.0\n');
+    const components = [
+      makeComponent({ dir: 'foo', tagPrefix: 'foo-v' }),
+      makeComponent({ dir: 'foo-bar', tagPrefix: 'foo-bar-v' }),
+    ];
+
+    expect(resolveReleaseTags(components)).toStrictEqual([
+      { tag: 'foo-bar-v1.0.0', dir: 'foo-bar', workspacePath: 'packages/foo-bar' },
+      { tag: 'foo-v2.0.0', dir: 'foo', workspacePath: 'packages/foo' },
     ]);
   });
 
   it('returns an empty array when no tags match in monorepo mode', () => {
     mockExecFileSync.mockReturnValue('unrelated-tag\n');
-    const workspaceMap = new Map([['core', 'packages/core']]);
+    const components = [makeComponent({ dir: 'core', tagPrefix: 'core-v' })];
 
-    expect(resolveReleaseTags(workspaceMap)).toStrictEqual([]);
+    expect(resolveReleaseTags(components)).toStrictEqual([]);
   });
 
   it('warns and returns only the first tag when multiple single-package version tags exist', () => {

--- a/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
@@ -94,6 +94,15 @@ describe(resolveReleaseTags, () => {
     ]);
   });
 
+  it('resolves pre-release monorepo tags like core-v1.0.0-beta.1', () => {
+    mockExecFileSync.mockReturnValue('core-v1.0.0-beta.1\n');
+    const components = [makeComponent({ dir: 'core', tagPrefix: 'core-v' })];
+
+    expect(resolveReleaseTags(components)).toStrictEqual([
+      { tag: 'core-v1.0.0-beta.1', dir: 'core', workspacePath: 'packages/core' },
+    ]);
+  });
+
   it('handles tags with multiple hyphens in the package name', () => {
     mockExecFileSync.mockReturnValue('my-cool-lib-v3.0.0\n');
     const components = [

--- a/packages/release-kit/src/component.ts
+++ b/packages/release-kit/src/component.ts
@@ -1,21 +1,59 @@
+import { readFileSync } from 'node:fs';
 import { basename } from 'node:path';
 
+import { isRecord } from './typeGuards.ts';
 import type { ComponentConfig } from './types.ts';
 
 /**
  * Creates a component configuration from a workspace-relative path.
  *
- * Derives all fields from the workspace path so that the same rule governs both
- * tag creation and tag lookup. The `dir` field is the basename of the path; the
- * `tagPrefix` is always `${dir}-v`.
+ * Reads `package.json` at the workspace path to derive the tag identifier from the
+ * package's `name` field (with any leading `@scope/` stripped). The `dir` field remains
+ * the basename of the path — it is the stable internal identifier used for `--only`,
+ * config overrides, and dependency-graph lookups. The `tagPrefix` is `${unscopedName}-v`,
+ * so tags reflect the package identity rather than the directory layout.
  */
 export function component(workspacePath: string): ComponentConfig {
   const dir = basename(workspacePath);
+  const packageJsonPath = `${workspacePath}/package.json`;
+  const packageJsonContent = readFileSync(packageJsonPath, 'utf8');
+  const parsed: unknown = JSON.parse(packageJsonContent);
+  const name = extractName(parsed);
+
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error(`${packageJsonPath} is missing a 'name' field (required for tag derivation).`);
+  }
+
+  const unscopedName = stripNpmScope(name);
+
   return {
     dir,
-    tagPrefix: `${dir}-v`,
-    packageFiles: [`${workspacePath}/package.json`],
+    tagPrefix: `${unscopedName}-v`,
+    workspacePath,
+    packageFiles: [packageJsonPath],
     changelogPaths: [workspacePath],
     paths: [`${workspacePath}/**`],
   };
+}
+
+/**
+ * Strip a leading `@scope/` from an npm package name.
+ *
+ * Npm package names cannot contain `/` outside the scope separator, so splitting on
+ * the first `/` is safe. Intentionally scoped to this module because the concept is
+ * distinct from the commit-scope stripping performed by `stripScope.ts`.
+ */
+function stripNpmScope(name: string): string {
+  if (name.startsWith('@') && name.includes('/')) {
+    return name.slice(name.indexOf('/') + 1);
+  }
+  return name;
+}
+
+/** Read the `name` field from a parsed `package.json` value without assuming its shape. */
+function extractName(parsed: unknown): unknown {
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+  return parsed.name;
 }

--- a/packages/release-kit/src/component.ts
+++ b/packages/release-kit/src/component.ts
@@ -16,9 +16,14 @@ import type { ComponentConfig } from './types.ts';
 export function component(workspacePath: string): ComponentConfig {
   const dir = basename(workspacePath);
   const packageJsonPath = `${workspacePath}/package.json`;
-  const packageJsonContent = readFileSync(packageJsonPath, 'utf8');
-  const parsed: unknown = JSON.parse(packageJsonContent);
-  const name = extractName(parsed);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read ${packageJsonPath}: ${message}`);
+  }
+  const name = isRecord(parsed) ? parsed.name : undefined;
 
   if (typeof name !== 'string' || name.length === 0) {
     throw new Error(`${packageJsonPath} is missing a 'name' field (required for tag derivation).`);
@@ -48,12 +53,4 @@ function stripNpmScope(name: string): string {
     return name.slice(name.indexOf('/') + 1);
   }
   return name;
-}
-
-/** Read the `name` field from a parsed `package.json` value without assuming its shape. */
-function extractName(parsed: unknown): unknown {
-  if (!isRecord(parsed)) {
-    return undefined;
-  }
-  return parsed.name;
 }

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -71,6 +71,9 @@ export function mergeMonorepoConfig(
   // Build default components from discovered paths
   let components: ComponentConfig[] = discoveredPaths.map((workspacePath) => component(workspacePath));
 
+  // Detect duplicate tagPrefix values before filtering so exclusions cannot hide collisions.
+  assertUniqueTagPrefixes(components);
+
   // Apply component overrides from user config
   if (userConfig?.components !== undefined) {
     const overrides = new Map(userConfig.components.map((c) => [c.dir, c]));
@@ -176,6 +179,31 @@ function mergeChangelogJsonConfig(partial: Partial<ChangelogJsonConfig> | undefi
     outputPath: partial.outputPath ?? DEFAULT_CHANGELOG_JSON_CONFIG.outputPath,
     devOnlySections: partial.devOnlySections ?? [...DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections],
   };
+}
+
+/**
+ * Throw when two or more components share the same `tagPrefix`.
+ *
+ * A collision means two workspaces would produce indistinguishable tags, breaking both tag
+ * creation and tag resolution. The error lists every colliding workspace path so the author
+ * can rename one of the conflicting `package.json` `name` fields.
+ */
+function assertUniqueTagPrefixes(components: readonly ComponentConfig[]): void {
+  const pathsByPrefix = new Map<string, string[]>();
+  for (const component of components) {
+    const existing = pathsByPrefix.get(component.tagPrefix);
+    if (existing === undefined) {
+      pathsByPrefix.set(component.tagPrefix, [component.workspacePath]);
+    } else {
+      existing.push(component.workspacePath);
+    }
+  }
+
+  for (const [prefix, paths] of pathsByPrefix) {
+    if (paths.length > 1) {
+      throw new Error(`Duplicate tag prefix '${prefix}' for workspaces: ${paths.join(', ')}`);
+    }
+  }
 }
 
 /** Merge user-provided release notes config with defaults. */

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -16,7 +16,7 @@ import { loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig } from './loa
 import { releasePrepare } from './releasePrepare.ts';
 import { releasePrepareMono } from './releasePrepareMono.ts';
 import { reportPrepare } from './reportPrepare.ts';
-import type { PrepareResult, ReleaseKitConfig, ReleaseType } from './types.ts';
+import type { MonorepoReleaseConfig, PrepareResult, ReleaseKitConfig, ReleaseType } from './types.ts';
 import { validateConfig } from './validateConfig.ts';
 
 /**
@@ -220,7 +220,13 @@ export async function prepareCommand(argv: string[]): Promise<void> {
     runAndReport(() => releasePrepare(config, options), dryRun);
   } else {
     // Monorepo mode
-    const config = mergeMonorepoConfig(discoveredPaths, userConfig);
+    let config: MonorepoReleaseConfig;
+    try {
+      config = mergeMonorepoConfig(discoveredPaths, userConfig);
+    } catch (error: unknown) {
+      console.error(`Error resolving workspace components: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
 
     if (only !== undefined) {
       const knownNames = config.components.map((c) => c.dir);

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -210,54 +210,79 @@ export async function prepareCommand(argv: string[]): Promise<void> {
 
   // 4. Determine mode, merge config, and run
   if (discoveredPaths === undefined) {
-    // Single-package mode
-    if (only !== undefined) {
-      console.error('Error: --only is only supported for monorepo configurations');
-      process.exit(1);
-    }
-
-    const config = mergeSinglePackageConfig(userConfig);
-    runAndReport(() => releasePrepare(config, options), dryRun);
+    runSinglePackageMode(userConfig, options, only, dryRun);
   } else {
-    // Monorepo mode
-    let config: MonorepoReleaseConfig;
-    try {
-      config = mergeMonorepoConfig(discoveredPaths, userConfig);
-    } catch (error: unknown) {
-      console.error(`Error resolving workspace components: ${error instanceof Error ? error.message : String(error)}`);
+    runMonorepoMode(discoveredPaths, userConfig, options, only, setVersion, dryRun);
+  }
+}
+
+function runSinglePackageMode(
+  userConfig: ReleaseKitConfig | undefined,
+  options: PrepareOptions,
+  only: string[] | undefined,
+  dryRun: boolean,
+): void {
+  if (only !== undefined) {
+    console.error('Error: --only is only supported for monorepo configurations');
+    process.exit(1);
+  }
+
+  const config = mergeSinglePackageConfig(userConfig);
+  runAndReport(() => releasePrepare(config, options), dryRun);
+}
+
+function runMonorepoMode(
+  discoveredPaths: string[],
+  userConfig: ReleaseKitConfig | undefined,
+  options: PrepareOptions,
+  only: string[] | undefined,
+  setVersion: string | undefined,
+  dryRun: boolean,
+): void {
+  let config: MonorepoReleaseConfig;
+  try {
+    config = mergeMonorepoConfig(discoveredPaths, userConfig);
+  } catch (error: unknown) {
+    console.error(`Error resolving workspace components: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  if (only !== undefined) {
+    const knownNames = config.components.map((c) => c.dir);
+
+    // Validate all names before mutating config
+    for (const name of only) {
+      if (!knownNames.includes(name)) {
+        console.error(`Error: Unknown component "${name}". Known components: ${knownNames.join(', ')}`);
+        process.exit(1);
+      }
+    }
+
+    config.components = config.components.filter((c) => only.includes(c.dir));
+  }
+
+  // --set-version requires exactly one target component in monorepo mode.
+  if (setVersion !== undefined) {
+    if (only === undefined) {
+      console.error('Error: --set-version requires --only in monorepo mode');
       process.exit(1);
     }
-
-    if (only !== undefined) {
-      const knownNames = config.components.map((c) => c.dir);
-
-      // Validate all names before mutating config
-      for (const name of only) {
-        if (!knownNames.includes(name)) {
-          console.error(`Error: Unknown component "${name}". Known components: ${knownNames.join(', ')}`);
-          process.exit(1);
-        }
-      }
-
-      config.components = config.components.filter((c) => only.includes(c.dir));
+    if (config.components.length !== 1) {
+      console.error(
+        `Error: --set-version requires --only to match exactly one component; matched ${config.components.length}`,
+      );
+      process.exit(1);
     }
-
-    // --set-version requires exactly one target component in monorepo mode.
-    if (setVersion !== undefined) {
-      if (only === undefined) {
-        console.error('Error: --set-version requires --only in monorepo mode');
-        process.exit(1);
-      }
-      if (config.components.length !== 1) {
-        console.error(
-          `Error: --set-version requires --only to match exactly one component; matched ${config.components.length}`,
-        );
-        process.exit(1);
-      }
-    }
-
-    runAndReport(() => releasePrepareMono(config, options), dryRun);
   }
+
+  runAndReport(() => releasePrepareMono(config, options), dryRun);
+}
+
+interface PrepareOptions {
+  dryRun: boolean;
+  force: boolean;
+  bumpOverride?: ReleaseType;
+  setVersion?: string;
 }
 
 /** Loads and validate the release-kit config file, exiting on errors. */

--- a/packages/release-kit/src/resolveCommandTags.ts
+++ b/packages/release-kit/src/resolveCommandTags.ts
@@ -1,16 +1,17 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { basename } from 'node:path';
-
+import { component } from './component.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
 import type { ResolvedTag } from './resolveReleaseTags.ts';
 import { resolveReleaseTags } from './resolveReleaseTags.ts';
+import type { ComponentConfig } from './types.ts';
 
 /**
  * Discover workspaces, resolve release tags from HEAD, validate `--tags` names against the
- * full resolved tag names (e.g., `core-v1.3.0`), and return the filtered tag list. Works in
- * both single-package and monorepo modes. Exits with an error message on any validation failure.
+ * full resolved tag names (e.g., `node-monorepo-core-v1.3.0`), and return the filtered tag list.
+ * Works in both single-package and monorepo modes. Exits with an error message on any validation
+ * failure — including `component()` throws for workspaces missing a `package.json` `name` field.
  */
 export async function resolveCommandTags(tags: string[] | undefined): Promise<ResolvedTag[]> {
   // Discover workspaces to determine single-package vs monorepo mode.
@@ -22,12 +23,19 @@ export async function resolveCommandTags(tags: string[] | undefined): Promise<Re
     process.exit(1);
   }
 
-  // Build workspace map: dir (basename) -> workspace path.
-  const workspaceMap =
-    discoveredPaths === undefined ? undefined : new Map(discoveredPaths.map((p) => [basename(p), p]));
+  // Build component list so resolveReleaseTags can match tags by tagPrefix (derived from pkg.name).
+  let components: ComponentConfig[] | undefined;
+  if (discoveredPaths !== undefined) {
+    try {
+      components = discoveredPaths.map((workspacePath) => component(workspacePath));
+    } catch (error: unknown) {
+      console.error(`Error resolving workspace components: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  }
 
   // Resolve tags from HEAD.
-  let resolvedTags = resolveReleaseTags(workspaceMap);
+  let resolvedTags = resolveReleaseTags(components);
 
   if (resolvedTags.length === 0) {
     console.error('Error: No release tags found on HEAD. Create tags with `release-kit tag` first.');

--- a/packages/release-kit/src/resolveReleaseTags.ts
+++ b/packages/release-kit/src/resolveReleaseTags.ts
@@ -8,8 +8,11 @@ export interface ResolvedTag {
   workspacePath: string;
 }
 
-/** Pattern matching a version suffix like `v1.2.3` or `v0.10.0-beta.1`. */
+/** Pattern matching a single-package tag like `v1.2.3` or `v0.10.0-beta.1`. */
 const VERSION_PATTERN = /^v\d+\.\d+\.\d+/;
+
+/** Pattern matching a bare semver suffix like `1.2.3` or `0.10.0-beta.1` (no leading `v`). */
+const SEMVER_SUFFIX_PATTERN = /^\d+\.\d+\.\d+/;
 
 /**
  * Resolve release tags pointing at HEAD into publishable package descriptors.
@@ -74,10 +77,10 @@ function resolveMonorepoTags(tags: string[], components: readonly ComponentConfi
 
 /**
  * Return the component whose `tagPrefix` the tag starts with and whose version suffix matches
- * `VERSION_PATTERN`. Expects `sortedComponents` to be ordered longest-prefix first.
+ * `SEMVER_SUFFIX_PATTERN`. Expects `sortedComponents` to be ordered longest-prefix first.
  *
  * `tagPrefix` ends with `v` (e.g., `core-v`), so `tag.slice(c.tagPrefix.length)` yields a bare
- * semver without a leading `v`. Prepending `'v'` re-forms the pattern's expected shape.
+ * semver without a leading `v` — matched directly by `SEMVER_SUFFIX_PATTERN`.
  */
 function findMatchingComponent(tag: string, sortedComponents: readonly ComponentConfig[]): ComponentConfig | undefined {
   for (const component of sortedComponents) {
@@ -85,7 +88,7 @@ function findMatchingComponent(tag: string, sortedComponents: readonly Component
       continue;
     }
     const versionSuffix = tag.slice(component.tagPrefix.length);
-    if (VERSION_PATTERN.test(`v${versionSuffix}`)) {
+    if (SEMVER_SUFFIX_PATTERN.test(versionSuffix)) {
       return component;
     }
   }

--- a/packages/release-kit/src/resolveReleaseTags.ts
+++ b/packages/release-kit/src/resolveReleaseTags.ts
@@ -1,5 +1,7 @@
 import { execFileSync } from 'node:child_process';
 
+import type { ComponentConfig } from './types.ts';
+
 export interface ResolvedTag {
   tag: string;
   dir: string;
@@ -12,10 +14,12 @@ const VERSION_PATTERN = /^v\d+\.\d+\.\d+/;
 /**
  * Resolve release tags pointing at HEAD into publishable package descriptors.
  *
- * In single-package mode (no `workspaceMap`), match tags like `v1.2.3`.
- * In monorepo mode, match `{dir}-v{semver}` tags against the provided workspace map.
+ * In single-package mode (no `components`), match tags like `v1.2.3`.
+ * In monorepo mode, match each tag against the component whose `tagPrefix` the tag
+ * starts with. Because `tagPrefix` is derived from `component()` (the same source that
+ * produced the tag), encoding and decoding stay colocated.
  */
-export function resolveReleaseTags(workspaceMap?: Map<string, string>): ResolvedTag[] {
+export function resolveReleaseTags(components?: readonly ComponentConfig[]): ResolvedTag[] {
   const output = execFileSync('git', ['tag', '--points-at', 'HEAD'], { encoding: 'utf8' });
 
   const tags = output
@@ -23,11 +27,11 @@ export function resolveReleaseTags(workspaceMap?: Map<string, string>): Resolved
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 
-  if (workspaceMap === undefined) {
+  if (components === undefined) {
     return resolveSinglePackageTags(tags);
   }
 
-  return resolveMonorepoTags(tags, workspaceMap);
+  return resolveMonorepoTags(tags, components);
 }
 
 /** Match single-package tags of the form `v{semver}`, warning if multiple are found. */
@@ -45,28 +49,45 @@ function resolveSinglePackageTags(tags: string[]): ResolvedTag[] {
   return matched.map((tag) => ({ tag, dir: '.', workspacePath: '.' }));
 }
 
-/** Match monorepo tags of the form `{dir}-v{semver}` against the workspace map. */
-function resolveMonorepoTags(tags: string[], workspaceMap: Map<string, string>): ResolvedTag[] {
+/**
+ * Match monorepo tags by scanning components for a matching `tagPrefix`.
+ *
+ * When two prefixes nest (e.g., `foo-v` and `foo-bar-v`), prefer the longest match so
+ * `foo-bar-v1.0.0` does not bind to `foo-v`.
+ */
+function resolveMonorepoTags(tags: string[], components: readonly ComponentConfig[]): ResolvedTag[] {
+  // Sort components by tagPrefix length descending so the longest match wins on nested prefixes.
+  // eslint-disable-next-line unicorn/no-array-sort -- toSorted requires Node 20+; engine target is >=18.17.0
+  const sortedComponents = [...components].sort((a, b) => b.tagPrefix.length - a.tagPrefix.length);
+
   const resolved: ResolvedTag[] = [];
 
   for (const tag of tags) {
-    const dashV = tag.lastIndexOf('-v');
-    if (dashV === -1) {
-      continue;
-    }
-
-    const dir = tag.slice(0, dashV);
-    const versionPart = tag.slice(dashV + 1);
-
-    if (!VERSION_PATTERN.test(versionPart)) {
-      continue;
-    }
-
-    const workspacePath = workspaceMap.get(dir);
-    if (workspacePath !== undefined) {
-      resolved.push({ tag, dir, workspacePath });
+    const match = findMatchingComponent(tag, sortedComponents);
+    if (match !== undefined) {
+      resolved.push({ tag, dir: match.dir, workspacePath: match.workspacePath });
     }
   }
 
   return resolved;
+}
+
+/**
+ * Return the component whose `tagPrefix` the tag starts with and whose version suffix matches
+ * `VERSION_PATTERN`. Expects `sortedComponents` to be ordered longest-prefix first.
+ *
+ * `tagPrefix` ends with `v` (e.g., `core-v`), so `tag.slice(c.tagPrefix.length)` yields a bare
+ * semver without a leading `v`. Prepending `'v'` re-forms the pattern's expected shape.
+ */
+function findMatchingComponent(tag: string, sortedComponents: readonly ComponentConfig[]): ComponentConfig | undefined {
+  for (const component of sortedComponents) {
+    if (!tag.startsWith(component.tagPrefix)) {
+      continue;
+    }
+    const versionSuffix = tag.slice(component.tagPrefix.length);
+    if (VERSION_PATTERN.test(`v${versionSuffix}`)) {
+      return component;
+    }
+  }
+  return undefined;
 }

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -181,8 +181,10 @@ export interface ParsedCommit {
 export interface ComponentConfig {
   /** The package directory name (e.g., 'arrays'). Used for display and `--only` matching. */
   dir: string;
-  /** The git tag prefix for this component (e.g., 'arrays-v'). */
+  /** The git tag prefix for this component (e.g., 'node-monorepo-core-v'), derived from the unscoped `package.json` name. */
   tagPrefix: string;
+  /** Workspace-relative path to the package root (e.g., `packages/core`). */
+  workspacePath: string;
   /** Paths to package.json files to bump. */
   packageFiles: string[];
   /** Directories in which to generate changelogs. */


### PR DESCRIPTION
## What

Fixes a long-standing mismatch between a monorepo workspace's directory basename and its publishable package identity: `release-kit` now derives `tagPrefix` from the unscoped `package.json` `name` (e.g., `@williamthorsen/node-monorepo-core` → `node-monorepo-core-v`), so GitHub Release tags describe the package rather than the directory. `ComponentConfig.dir` continues to be the directory basename, which downstream consumers rely on as a stable internal identifier for `--tags`, config overrides, and the dependency graph.

If two workspaces resolve to the same unscoped name, `mergeMonorepoConfig()` now refuses to load the config and names all colliding workspace paths, so the collision is caught immediately instead of producing indistinguishable tags at release time. `component()`'s filesystem errors (missing file, unparseable JSON, missing `name`) all surface with the workspace path for context, and `prepareCommand` translates them into the same clean `Error resolving workspace components: …` / `process.exit(1)` pattern already used by `resolveCommandTags`.

Legacy-tag aliasing (re-pointing historical `core-v0.2.x` tags at their new `node-monorepo-core-v0.2.x` equivalents) is tracked separately in #276 and ships in the same release.

## Why

The directory-basename-derived tag was ambiguous on a GitHub Releases page and not searchable on npm: users browsing releases saw `core-v0.2.7` with no indication of which `core` package it referred to, and a tag derived from `@williamthorsen/node-monorepo-core` would have matched the npm package name. The fix had to split two concerns that the old code conflated — the workspace's internal identifier (unchanged) versus the public artifact identifier on tags and releases (now derived from `package.json`).

## Details

### Fixes

- **`component()` now reads `package.json`.** Validates that `name` is a non-empty string, strips a leading `@scope/`, and returns `tagPrefix: ${unscopedName}-v`. Throws a contextual error (`Failed to read ${path}: …`) on filesystem or JSON errors, and a distinct `missing a 'name' field` error when `name` is absent or empty.
- **`ComponentConfig` gains `workspacePath: string`** so `ResolvedTag` can report the path without deriving it from `packageFiles[0]`.
- **`resolveReleaseTags()` signature changes** from `(workspaceMap?: Map<string, string>)` to `(components?: readonly ComponentConfig[])`. Tag matching walks components sorted by `tagPrefix` length descending, so nested prefixes (`foo-v` vs. `foo-bar-v`) bind to the longest match. A dedicated `SEMVER_SUFFIX_PATTERN` tests the bare version suffix directly, keeping `VERSION_PATTERN` responsible only for single-package tags.
- **`resolveCommandTags()`** builds the `ComponentConfig[]` via `component()` and passes it through.
- **`mergeMonorepoConfig()`** detects duplicate `tagPrefix` values across workspaces (pre-filter) and throws, naming all colliding workspace paths.
- **`prepareCommand`** wraps `mergeMonorepoConfig()` in a try/catch matching the `resolveCommandTags` pattern, so `component()` errors surface as clean command-line output rather than raw stack traces.

### Tests

- Added cases in `component.unit.test.ts` covering scoped-name stripping, unscoped names, missing/empty/non-string `name`, `readFileSync` errors, and malformed JSON.
- Added cases in `resolveReleaseTags.unit.test.ts` covering longest-match prefix resolution, pre-release version suffixes (`core-v1.0.0-beta.1`), and the new `ComponentConfig[]`-driven signature.
- Added cases in `loadConfig.unit.test.ts` covering duplicate-prefix detection across workspaces (pair, exclusion-before-detection ordering, three-way collision).
- Updated 7 pre-existing tests across the suite to add `readFileSync` to their `node:fs` mocks, since `mergeMonorepoConfig` now transitively invokes `component()`.

### Refactoring

- Scope-stripping logic is inlined in `component.ts` (not reused from `stripScope.ts`, which concerns commit-message scopes — a separate concept).
- `prepareCommand.unit.test.ts` adopts the wholesale `vi.mock('node:fs', …)` pattern used elsewhere in the suite, replacing the prior `importOriginal` + spread form.

Closes #259