### PR TITLE
#291 Replace `legacyTagPrefixes` with `legacyIdentities`

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -122,11 +122,16 @@ All fields are optional.
 interface WorkspaceOverride {
   dir: string; // Package directory name (e.g., 'arrays')
   shouldExclude?: boolean; // If true, exclude from release processing
-  legacyTagPrefixes?: string[]; // Additional tag prefixes under which historical tags exist
+  legacyIdentities?: LegacyIdentity[]; // Prior `(name, tagPrefix)` identities for this workspace
+}
+
+interface LegacyIdentity {
+  name: string; // Full scoped npm name at the time (e.g., '@scope/pkg')
+  tagPrefix: string; // Tag prefix under which historical tags were published (e.g., 'core-v')
 }
 ```
 
-`legacyTagPrefixes` lists extra tag prefixes to consult in addition to the derived prefix when release-kit searches for the most recent baseline tag and when generating changelogs. Use it when a workspace's historical tags were published under a different prefix — typically because the package was renamed or because a prior release setup derived the prefix differently. Run `release-kit show-tag-prefixes` to detect undeclared candidates and produce a paste-ready config snippet. Listing the workspace's current derived prefix is rejected as a no-op duplicate.
+`legacyIdentities` captures prior identities of a workspace as complete `(name, tagPrefix)` snapshots. The union of the current `tagPrefix` and each identity's `tagPrefix` is consulted when release-kit searches for the most recent baseline tag and when generating changelogs. Use it when a workspace's historical tags were published under a different npm name, a different tag prefix, or both — typically across a package rename. Both fields are required per identity: each entry must be a complete historical snapshot that stays valid regardless of subsequent renames. Run `release-kit show-tag-prefixes` to detect undeclared candidates and produce a paste-ready config snippet. Listing the current identity (full `(name, tagPrefix)` match) is rejected as a no-op duplicate; an identity whose `tagPrefix` matches the current but whose `name` differs is valid and documents a prior rename that reused the same tag shape.
 
 ### `VersionPatterns`
 
@@ -224,7 +229,7 @@ When `--tags` is omitted, every release tag pointing at HEAD is processed. The C
 
 ### `release-kit show-tag-prefixes`
 
-Print a per-workspace table of derived tag prefixes, tag counts, and declared legacy prefixes. Also surfaces any release-shaped tag prefix in the repo that is neither a derived prefix nor declared via `legacyTagPrefixes`, along with a copy-pasteable `workspaces: [...]` config snippet.
+Print a per-workspace table of derived tag prefixes, tag counts, and declared legacy prefixes. Also surfaces any release-shaped tag prefix in the repo that is neither a derived prefix nor declared via `legacyIdentities`, along with a copy-pasteable `workspaces: [...]` config snippet. The snippet uses a `TODO-fill-in-legacy-npm-name` placeholder for each identity's `name`; replace it with the package's prior npm name before pasting.
 
 | Flag           | Description |
 | -------------- | ----------- |
@@ -317,24 +322,31 @@ This package shells out to two external tools:
 
 ## Upgrading from v4 to v5
 
-Release-kit v5 derives each workspace's tag prefix from its unscoped `package.json` `name`, so a package at `packages/core` with `"name": "@scope/node-monorepo-core"` uses tags like `node-monorepo-core-v1.3.0`. Repos that previously tagged under the directory basename (e.g., `core-v1.3.0`) do not need to rewrite history — declare the old prefix in `legacyTagPrefixes` so release-kit recognizes historical tags under both the new and old prefixes.
+Release-kit v5 derives each workspace's tag prefix from its unscoped `package.json` `name`, so a package at `packages/core` with `"name": "@scope/node-monorepo-core"` uses tags like `node-monorepo-core-v1.3.0`. Repos that previously tagged under the directory basename (e.g., `core-v1.3.0`) do not need to rewrite history — declare the prior identity in `legacyIdentities` so release-kit recognizes historical tags under both the new and old prefixes.
 
-Minimal worked example for a repo whose pre-v5 tags were `core-v0.2.7`:
+Minimal worked example for a repo whose pre-v5 tags were `core-v0.2.7` and whose npm name has not changed:
 
 ```typescript
 // .config/release-kit.config.ts
 import type { ReleaseKitConfig } from '@williamthorsen/release-kit';
 
 const config: ReleaseKitConfig = {
-  workspaces: [{ dir: 'core', legacyTagPrefixes: ['core-v'] }],
+  workspaces: [
+    {
+      dir: 'core',
+      legacyIdentities: [{ name: '@scope/node-monorepo-core', tagPrefix: 'core-v' }],
+    },
+  ],
 };
 
 export default config;
 ```
 
-Verify with `release-kit show-tag-prefixes` — it prints the derived prefix per workspace, tag counts under each declared legacy prefix, and any undeclared release-shaped prefixes it finds in the repo (with a copy-pasteable config snippet). After declaring, `release-kit prepare` consults the union of the derived and legacy prefixes when searching for the most recent baseline tag, and changelog generation matches tags under either prefix.
+Each `legacyIdentity` is a complete `(name, tagPrefix)` snapshot of the workspace at an earlier point. In the common case — the tag-derivation rule changed but the npm name did not — the identity's `name` equals the current `name`. If an earlier publish used a different npm name, use that prior name here.
 
-See the `legacyTagPrefixes` entry in the [`WorkspaceOverride`](#workspaceoverride) section for the config shape.
+Verify with `release-kit show-tag-prefixes` — it prints the derived prefix per workspace, tag counts under each declared legacy prefix, and any undeclared release-shaped prefixes it finds in the repo (with a copy-pasteable config snippet that includes a `TODO-fill-in-legacy-npm-name` placeholder to replace with the prior npm name). After declaring, `release-kit prepare` consults the union of the current and legacy tag prefixes when searching for the most recent baseline tag, and changelog generation matches tags under either prefix.
+
+See the `legacyIdentities` entry in the [`WorkspaceOverride`](#workspaceoverride) section for the config shape.
 
 ## Using `deriveWorkspaceConfig()` for manual configuration
 
@@ -347,6 +359,7 @@ import { deriveWorkspaceConfig } from '@williamthorsen/release-kit';
 deriveWorkspaceConfig('packages/arrays');
 // => {
 //   dir: 'arrays',
+//   name: '@scope/arrays',
 //   tagPrefix: 'arrays-v',
 //   workspacePath: 'packages/arrays',
 //   packageFiles: ['packages/arrays/package.json'],

--- a/packages/release-kit/src/__tests__/buildDependencyGraph.unit.test.ts
+++ b/packages/release-kit/src/__tests__/buildDependencyGraph.unit.test.ts
@@ -12,6 +12,7 @@ import type { WorkspaceConfig } from '../types.ts';
 function makeWorkspace(dir: string, packageFile?: string): WorkspaceConfig {
   return {
     dir,
+    name: `@test/${dir}`,
     tagPrefix: `${dir}-v`,
     workspacePath: `packages/${dir}`,
     packageFiles: [packageFile ?? `packages/${dir}/package.json`],
@@ -175,6 +176,7 @@ describe(buildDependencyGraph, () => {
   it('handles workspaces with no packageFiles gracefully', () => {
     const comp: WorkspaceConfig = {
       dir: 'empty',
+      name: '@test/empty',
       tagPrefix: 'empty-v',
       workspacePath: 'packages/empty',
       packageFiles: [],

--- a/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
@@ -42,6 +42,7 @@ describe(createGithubReleaseCommand, () => {
     mockCreateGithubReleases.mockReturnValue({ created: ['v1.0.0'], skipped: [] });
     mockDeriveWorkspaceConfig.mockImplementation((workspacePath: string) => ({
       dir: workspacePath.split('/').pop(),
+      name: `@test/${workspacePath.split('/').pop()}`,
       tagPrefix: `${workspacePath.split('/').pop()}-v`,
       workspacePath,
       packageFiles: [`${workspacePath}/package.json`],

--- a/packages/release-kit/src/__tests__/deriveWorkspaceConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/deriveWorkspaceConfig.unit.test.ts
@@ -18,6 +18,7 @@ describe(deriveWorkspaceConfig, () => {
 
     expect(deriveWorkspaceConfig('packages/core')).toStrictEqual({
       dir: 'core',
+      name: '@williamthorsen/node-monorepo-core',
       tagPrefix: 'node-monorepo-core-v',
       workspacePath: 'packages/core',
       packageFiles: ['packages/core/package.json'],
@@ -31,12 +32,19 @@ describe(deriveWorkspaceConfig, () => {
 
     expect(deriveWorkspaceConfig('packages/readyup')).toStrictEqual({
       dir: 'readyup',
+      name: 'readyup',
       tagPrefix: 'readyup-v',
       workspacePath: 'packages/readyup',
       packageFiles: ['packages/readyup/package.json'],
       changelogPaths: ['packages/readyup'],
       paths: ['packages/readyup/**'],
     });
+  });
+
+  it('populates name with the full scoped name for later identity comparisons', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@scope/pkg' }));
+
+    expect(deriveWorkspaceConfig('packages/pkg').name).toBe('@scope/pkg');
   });
 
   it('preserves dir as the basename when the directory name differs from the package name', () => {

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -132,6 +132,7 @@ describe(mergeMonorepoConfig, () => {
     expect(result.workspaces).toHaveLength(2);
     expect(result.workspaces[0]).toStrictEqual({
       dir: 'arrays',
+      name: '@scope/arrays',
       tagPrefix: 'arrays-v',
       workspacePath: 'packages/arrays',
       packageFiles: ['packages/arrays/package.json'],
@@ -151,6 +152,7 @@ describe(mergeMonorepoConfig, () => {
     expect(result.workspaces).toHaveLength(2);
     expect(result.workspaces[0]).toStrictEqual({
       dir: 'core',
+      name: '@williamthorsen/node-monorepo-core',
       tagPrefix: 'node-monorepo-core-v',
       workspacePath: 'libs/core',
       packageFiles: ['libs/core/package.json'],
@@ -245,30 +247,76 @@ describe(mergeMonorepoConfig, () => {
     ).toThrow("Duplicate tag prefix 'foo-v' for workspaces: packages/a-foo, packages/b-foo");
   });
 
-  it('propagates legacyTagPrefixes from a matching workspace override', () => {
+  it('propagates legacyIdentities from a matching workspace override', () => {
     const result = mergeMonorepoConfig(discoveredPaths, {
-      workspaces: [{ dir: 'arrays', legacyTagPrefixes: ['old-arrays-v', 'legacy-v'] }],
+      workspaces: [
+        {
+          dir: 'arrays',
+          legacyIdentities: [
+            { name: '@old-scope/arrays', tagPrefix: 'old-arrays-v' },
+            { name: '@legacy-scope/arrays', tagPrefix: 'legacy-v' },
+          ],
+        },
+      ],
     });
 
     expect(result.workspaces[0]?.dir).toBe('arrays');
-    expect(result.workspaces[0]?.legacyTagPrefixes).toStrictEqual(['old-arrays-v', 'legacy-v']);
-    expect(result.workspaces[1]?.legacyTagPrefixes).toBeUndefined();
+    expect(result.workspaces[0]?.legacyIdentities).toStrictEqual([
+      { name: '@old-scope/arrays', tagPrefix: 'old-arrays-v' },
+      { name: '@legacy-scope/arrays', tagPrefix: 'legacy-v' },
+    ]);
+    expect(result.workspaces[1]?.legacyIdentities).toBeUndefined();
   });
 
-  it('leaves legacyTagPrefixes undefined when the override omits the field', () => {
+  it('shallow-clones each identity entry so mutating the override does not leak into merged workspaces', () => {
+    const identity = { name: '@old-scope/arrays', tagPrefix: 'old-arrays-v' };
+    const result = mergeMonorepoConfig(discoveredPaths, {
+      workspaces: [{ dir: 'arrays', legacyIdentities: [identity] }],
+    });
+
+    identity.tagPrefix = 'mutated-v';
+
+    expect(result.workspaces[0]?.legacyIdentities).toStrictEqual([
+      { name: '@old-scope/arrays', tagPrefix: 'old-arrays-v' },
+    ]);
+  });
+
+  it('leaves legacyIdentities undefined when the override omits the field', () => {
     const result = mergeMonorepoConfig(discoveredPaths, {
       workspaces: [{ dir: 'arrays', shouldExclude: false }],
     });
 
-    expect(result.workspaces[0]?.legacyTagPrefixes).toBeUndefined();
+    expect(result.workspaces[0]?.legacyIdentities).toBeUndefined();
   });
 
-  it('throws when legacyTagPrefixes includes the derived prefix', () => {
+  it('throws when a legacyIdentities entry matches both the current name and tagPrefix', () => {
     expect(() =>
       mergeMonorepoConfig(discoveredPaths, {
-        workspaces: [{ dir: 'arrays', legacyTagPrefixes: ['arrays-v', 'old-arrays-v'] }],
+        workspaces: [
+          {
+            dir: 'arrays',
+            legacyIdentities: [{ name: '@scope/arrays', tagPrefix: 'arrays-v' }],
+          },
+        ],
       }),
-    ).toThrow("Workspace 'arrays': legacyTagPrefixes must not include the derived prefix 'arrays-v'");
+    ).toThrow(
+      "Workspace 'arrays': legacyIdentities must not match the current identity (name='@scope/arrays', tagPrefix='arrays-v')",
+    );
+  });
+
+  it('accepts an identity whose tagPrefix matches the current but whose name differs', () => {
+    const result = mergeMonorepoConfig(discoveredPaths, {
+      workspaces: [
+        {
+          dir: 'arrays',
+          legacyIdentities: [{ name: '@old-scope/arrays', tagPrefix: 'arrays-v' }],
+        },
+      ],
+    });
+
+    expect(result.workspaces[0]?.legacyIdentities).toStrictEqual([
+      { name: '@old-scope/arrays', tagPrefix: 'arrays-v' },
+    ]);
   });
 
   it('includes every colliding workspace path when more than two collide', () => {

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -319,6 +319,21 @@ describe(mergeMonorepoConfig, () => {
     ]);
   });
 
+  it('accepts an identity whose name matches the current but whose tagPrefix differs', () => {
+    const result = mergeMonorepoConfig(discoveredPaths, {
+      workspaces: [
+        {
+          dir: 'arrays',
+          legacyIdentities: [{ name: '@scope/arrays', tagPrefix: 'old-arrays-v' }],
+        },
+      ],
+    });
+
+    expect(result.workspaces[0]?.legacyIdentities).toStrictEqual([
+      { name: '@scope/arrays', tagPrefix: 'old-arrays-v' },
+    ]);
+  });
+
   it('includes every colliding workspace path when more than two collide', () => {
     mockPackageNames({
       'packages/a-foo': '@a/foo',

--- a/packages/release-kit/src/__tests__/previewTagPrefixes.unit.test.ts
+++ b/packages/release-kit/src/__tests__/previewTagPrefixes.unit.test.ts
@@ -107,7 +107,15 @@ describe(previewTagPrefixes, () => {
   it('surfaces declared legacy prefixes with their tag counts', async () => {
     mockDiscoverWorkspaces.mockResolvedValue(['packages/core']);
     mockLoadConfig.mockResolvedValue({
-      workspaces: [{ dir: 'core', legacyTagPrefixes: ['core-v', 'old-core-v'] }],
+      workspaces: [
+        {
+          dir: 'core',
+          legacyIdentities: [
+            { name: '@old-scope/core', tagPrefix: 'core-v' },
+            { name: '@older-scope/core', tagPrefix: 'old-core-v' },
+          ],
+        },
+      ],
     });
     mockDeriveWorkspaceConfig.mockReturnValue({ tagPrefix: 'node-monorepo-core-v' });
     mockDetectUndeclared.mockReturnValue([]);
@@ -142,7 +150,7 @@ describe(previewTagPrefixes, () => {
   it('passes the union of derived and declared prefixes to detectUndeclaredTagPrefixes', async () => {
     mockDiscoverWorkspaces.mockResolvedValue(['packages/core']);
     mockLoadConfig.mockResolvedValue({
-      workspaces: [{ dir: 'core', legacyTagPrefixes: ['core-v'] }],
+      workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@old-scope/core', tagPrefix: 'core-v' }] }],
     });
     mockDeriveWorkspaceConfig.mockReturnValue({ tagPrefix: 'node-monorepo-core-v' });
     mockDetectUndeclared.mockReturnValue([]);

--- a/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
+++ b/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
@@ -8,6 +8,7 @@ import type { WorkspaceConfig } from '../types.ts';
 function makeWorkspace(dir: string): WorkspaceConfig {
   return {
     dir,
+    name: `@test/${dir}`,
     tagPrefix: `${dir}-v`,
     workspacePath: `packages/${dir}`,
     packageFiles: [`packages/${dir}/package.json`],

--- a/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
@@ -78,6 +78,7 @@ describe(publishCommand, () => {
       const dir = workspacePath.split('/').pop() ?? workspacePath;
       return {
         dir,
+        name: `@test/${dir}`,
         tagPrefix: `${dir}-v`,
         workspacePath,
         packageFiles: [`${workspacePath}/package.json`],

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -93,6 +93,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -146,6 +147,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -184,6 +186,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -192,6 +195,7 @@ describe(releasePrepareMono, () => {
         },
         {
           dir: 'strings',
+          name: '@test/strings',
           tagPrefix: 'strings-v',
           workspacePath: 'packages/strings',
           packageFiles: ['packages/strings/package.json'],
@@ -246,6 +250,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -287,6 +292,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -295,6 +301,7 @@ describe(releasePrepareMono, () => {
         },
         {
           dir: 'strings',
+          name: '@test/strings',
           tagPrefix: 'strings-v',
           workspacePath: 'packages/strings',
           packageFiles: ['packages/strings/package.json'],
@@ -331,6 +338,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -372,6 +380,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -410,6 +419,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -445,6 +455,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -481,6 +492,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -489,6 +501,7 @@ describe(releasePrepareMono, () => {
         },
         {
           dir: 'strings',
+          name: '@test/strings',
           tagPrefix: 'strings-v',
           workspacePath: 'packages/strings',
           packageFiles: ['packages/strings/package.json'],
@@ -529,6 +542,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -562,6 +576,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -593,6 +608,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -628,6 +644,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -659,6 +676,7 @@ describe(releasePrepareMono, () => {
       workspaces: [
         {
           dir: 'arrays',
+          name: '@test/arrays',
           tagPrefix: 'arrays-v',
           workspacePath: 'packages/arrays',
           packageFiles: ['packages/arrays/package.json'],
@@ -699,6 +717,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -707,6 +726,7 @@ describe(releasePrepareMono, () => {
           },
           {
             dir: 'app',
+            name: '@test/app',
             tagPrefix: 'app-v',
             workspacePath: 'packages/app',
             packageFiles: ['packages/app/package.json'],
@@ -777,6 +797,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -785,6 +806,7 @@ describe(releasePrepareMono, () => {
           },
           {
             dir: 'app',
+            name: '@test/app',
             tagPrefix: 'app-v',
             workspacePath: 'packages/app',
             packageFiles: ['packages/app/package.json'],
@@ -846,6 +868,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -874,6 +897,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -914,6 +938,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -940,6 +965,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -966,6 +992,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -997,6 +1024,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -1005,6 +1033,7 @@ describe(releasePrepareMono, () => {
           },
           {
             dir: 'app',
+            name: '@test/app',
             tagPrefix: 'app-v',
             workspacePath: 'packages/app',
             packageFiles: ['packages/app/package.json'],
@@ -1024,6 +1053,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -1032,6 +1062,7 @@ describe(releasePrepareMono, () => {
           },
           {
             dir: 'app',
+            name: '@test/app',
             tagPrefix: 'app-v',
             workspacePath: 'packages/app',
             packageFiles: ['packages/app/package.json'],
@@ -1100,11 +1131,12 @@ describe(releasePrepareMono, () => {
       mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
     }
 
-    it('emits a hint when no baseline + candidate tags exist + no legacyTagPrefixes', () => {
+    it('emits a hint when no baseline + candidate tags exist + no legacyIdentities', () => {
       const config = makeConfig({
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'node-monorepo-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -1130,17 +1162,18 @@ describe(releasePrepareMono, () => {
       errorSpy.mockRestore();
     });
 
-    it('suppresses the hint when legacyTagPrefixes is non-empty', () => {
+    it('suppresses the hint when legacyIdentities is non-empty', () => {
       const config = makeConfig({
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'node-monorepo-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
             paths: ['packages/core/**'],
-            legacyTagPrefixes: ['core-v'],
+            legacyIdentities: [{ name: '@old-scope/core', tagPrefix: 'core-v' }],
           },
         ],
       });
@@ -1161,6 +1194,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'node-monorepo-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -1190,6 +1224,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'node-monorepo-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -1198,6 +1233,7 @@ describe(releasePrepareMono, () => {
           },
           {
             dir: 'arrays',
+            name: '@test/arrays',
             tagPrefix: 'node-monorepo-arrays-v',
             workspacePath: 'packages/arrays',
             packageFiles: ['packages/arrays/package.json'],
@@ -1219,13 +1255,14 @@ describe(releasePrepareMono, () => {
       errorSpy.mockRestore();
     });
 
-    it("treats sibling workspaces' declared legacyTagPrefixes as known", () => {
+    it("treats sibling workspaces' declared legacyIdentities as known", () => {
       // Also a regression case: when a sibling workspace declares its own legacy prefixes, those
       // must not show up as undeclared candidates when another workspace has no baseline.
       const config = makeConfig({
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'node-monorepo-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -1234,12 +1271,13 @@ describe(releasePrepareMono, () => {
           },
           {
             dir: 'arrays',
+            name: '@test/arrays',
             tagPrefix: 'node-monorepo-arrays-v',
             workspacePath: 'packages/arrays',
             packageFiles: ['packages/arrays/package.json'],
             changelogPaths: ['packages/arrays'],
             paths: ['packages/arrays/**'],
-            legacyTagPrefixes: ['arrays-v'],
+            legacyIdentities: [{ name: '@old-scope/arrays', tagPrefix: 'arrays-v' }],
           },
         ],
       });
@@ -1260,6 +1298,7 @@ describe(releasePrepareMono, () => {
         workspaces: [
           {
             dir: 'core',
+            name: '@test/core',
             tagPrefix: 'node-monorepo-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
@@ -1268,6 +1307,7 @@ describe(releasePrepareMono, () => {
           },
           {
             dir: 'arrays',
+            name: '@test/arrays',
             tagPrefix: 'node-monorepo-arrays-v',
             workspacePath: 'packages/arrays',
             packageFiles: ['packages/arrays/package.json'],

--- a/packages/release-kit/src/__tests__/resolveCommandTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveCommandTags.unit.test.ts
@@ -36,6 +36,7 @@ const TAGS: ResolvedTag[] = [
 function makeWorkspace(dir: string, tagPrefix: string, workspacePath: string): WorkspaceConfig {
   return {
     dir,
+    name: `@test/${dir}`,
     tagPrefix,
     workspacePath,
     packageFiles: [`${workspacePath}/package.json`],

--- a/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
@@ -16,6 +16,7 @@ function makeWorkspace(
   const workspacePath = overrides.workspacePath ?? `packages/${dir}`;
   return {
     dir,
+    name: overrides.name ?? `@test/${dir}`,
     tagPrefix: overrides.tagPrefix,
     workspacePath,
     packageFiles: overrides.packageFiles ?? [`${workspacePath}/package.json`],

--- a/packages/release-kit/src/__tests__/showTagPrefixesCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/showTagPrefixesCommand.unit.test.ts
@@ -197,6 +197,7 @@ describe(showTagPrefixesCommand, () => {
     expect(output).toContain("'core-v'");
     expect(output).toContain('core-v0.2.7');
     expect(output).toContain("dir: 'core'");
-    expect(output).toContain("legacyTagPrefixes: ['core-v']");
+    expect(output).toContain("legacyIdentities: [{ name: 'TODO-fill-in-legacy-npm-name', tagPrefix: 'core-v' }]");
+    expect(output).toContain('TODO-fill-in-legacy-npm-name');
   });
 });

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -60,50 +60,131 @@ describe(validateConfig, () => {
       expect(errors).toContain("workspaces[0]: unknown field 'bogusField'");
     });
 
-    describe('legacyTagPrefixes', () => {
-      it('accepts a string array', () => {
+    describe('legacyIdentities', () => {
+      it('accepts an array of complete identity objects', () => {
         const { config, errors } = validateConfig({
-          workspaces: [{ dir: 'core', legacyTagPrefixes: ['core-v', 'old-core-v'] }],
+          workspaces: [
+            {
+              dir: 'core',
+              legacyIdentities: [
+                { name: '@scope/core', tagPrefix: 'core-v' },
+                { name: '@old-scope/core', tagPrefix: 'old-core-v' },
+              ],
+            },
+          ],
         });
         expect(errors).toStrictEqual([]);
-        expect(config.workspaces?.[0]?.legacyTagPrefixes).toStrictEqual(['core-v', 'old-core-v']);
+        expect(config.workspaces?.[0]?.legacyIdentities).toStrictEqual([
+          { name: '@scope/core', tagPrefix: 'core-v' },
+          { name: '@old-scope/core', tagPrefix: 'old-core-v' },
+        ]);
       });
 
       it('accepts an empty array', () => {
         const { config, errors } = validateConfig({
-          workspaces: [{ dir: 'core', legacyTagPrefixes: [] }],
+          workspaces: [{ dir: 'core', legacyIdentities: [] }],
         });
         expect(errors).toStrictEqual([]);
-        expect(config.workspaces?.[0]?.legacyTagPrefixes).toStrictEqual([]);
+        expect(config.workspaces?.[0]?.legacyIdentities).toStrictEqual([]);
       });
 
-      it('omits legacyTagPrefixes from the result when the field is not provided', () => {
+      it('omits legacyIdentities from the result when the field is not provided', () => {
         const { config, errors } = validateConfig({
           workspaces: [{ dir: 'core' }],
         });
         expect(errors).toStrictEqual([]);
-        expect(config.workspaces?.[0]?.legacyTagPrefixes).toBeUndefined();
+        expect(config.workspaces?.[0]?.legacyIdentities).toBeUndefined();
       });
 
-      it('returns an error when legacyTagPrefixes is not an array', () => {
+      it('returns an error when legacyIdentities is not an array', () => {
         const { errors } = validateConfig({
-          workspaces: [{ dir: 'core', legacyTagPrefixes: 'core-v' }],
+          workspaces: [{ dir: 'core', legacyIdentities: 'core-v' }],
         });
-        expect(errors).toContain("workspaces[0]: 'legacyTagPrefixes' must be a string array");
+        expect(errors).toContain("workspaces[0]: 'legacyIdentities' must be an array");
       });
 
-      it('returns a per-index error when an entry is not a string', () => {
+      it('returns a per-index error when an entry is not an object', () => {
         const { errors } = validateConfig({
-          workspaces: [{ dir: 'core', legacyTagPrefixes: ['core-v', 123, 'old-v'] }],
+          workspaces: [{ dir: 'core', legacyIdentities: ['core-v'] }],
         });
-        expect(errors).toContain('workspaces[0].legacyTagPrefixes[1]: must be a string');
+        expect(errors).toContain('workspaces[0].legacyIdentities[0]: must be an object');
       });
 
-      it('returns a per-index error when an entry is an empty string', () => {
+      it('returns a per-index error when name is missing', () => {
         const { errors } = validateConfig({
-          workspaces: [{ dir: 'core', legacyTagPrefixes: ['core-v', ''] }],
+          workspaces: [{ dir: 'core', legacyIdentities: [{ tagPrefix: 'core-v' }] }],
         });
-        expect(errors).toContain('workspaces[0].legacyTagPrefixes[1]: must be a non-empty string');
+        expect(errors).toContain('workspaces[0].legacyIdentities[0].name: must be a string');
+      });
+
+      it('returns a per-index error when name is an empty string', () => {
+        const { errors } = validateConfig({
+          workspaces: [{ dir: 'core', legacyIdentities: [{ name: '', tagPrefix: 'core-v' }] }],
+        });
+        expect(errors).toContain('workspaces[0].legacyIdentities[0].name: must be a non-empty string');
+      });
+
+      it('returns a per-index error when tagPrefix is missing', () => {
+        const { errors } = validateConfig({
+          workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@scope/core' }] }],
+        });
+        expect(errors).toContain('workspaces[0].legacyIdentities[0].tagPrefix: must be a string');
+      });
+
+      it('returns a per-index error when tagPrefix is an empty string', () => {
+        const { errors } = validateConfig({
+          workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@scope/core', tagPrefix: '' }] }],
+        });
+        expect(errors).toContain('workspaces[0].legacyIdentities[0].tagPrefix: must be a non-empty string');
+      });
+
+      it('returns an error on unknown identity fields', () => {
+        const { errors } = validateConfig({
+          workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@scope/core', tagPrefix: 'core-v', bogus: true }] }],
+        });
+        expect(errors).toContain("workspaces[0].legacyIdentities[0]: unknown field 'bogus'");
+      });
+
+      it('rejects full-tuple duplicates', () => {
+        const { errors } = validateConfig({
+          workspaces: [
+            {
+              dir: 'core',
+              legacyIdentities: [
+                { name: '@scope/core', tagPrefix: 'core-v' },
+                { name: '@scope/core', tagPrefix: 'core-v' },
+              ],
+            },
+          ],
+        });
+        expect(errors).toContain(
+          "workspaces[0].legacyIdentities[1]: duplicate identity (name='@scope/core', tagPrefix='core-v')",
+        );
+      });
+
+      it('accepts two entries with the same tagPrefix but different names', () => {
+        const { config, errors } = validateConfig({
+          workspaces: [
+            {
+              dir: 'core',
+              legacyIdentities: [
+                { name: '@old-scope/core', tagPrefix: 'core-v' },
+                { name: '@other-scope/core', tagPrefix: 'core-v' },
+              ],
+            },
+          ],
+        });
+        expect(errors).toStrictEqual([]);
+        expect(config.workspaces?.[0]?.legacyIdentities).toHaveLength(2);
+      });
+
+      it('emits a migration error when the removed legacyTagPrefixes field is present', () => {
+        const { errors } = validateConfig({
+          workspaces: [{ dir: 'core', legacyTagPrefixes: ['core-v'] }],
+        });
+        expect(errors).toContain(
+          "workspaces[0]: 'legacyTagPrefixes' is no longer supported; use 'legacyIdentities: [{ name, tagPrefix }, ...]' instead",
+        );
       });
     });
   });

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -186,6 +186,63 @@ describe(validateConfig, () => {
           "workspaces[0]: 'legacyTagPrefixes' is no longer supported; use 'legacyIdentities: [{ name, tagPrefix }, ...]' instead",
         );
       });
+
+      it('emits a migration error and still validates legacyIdentities when both fields coexist', () => {
+        const { config, errors } = validateConfig({
+          workspaces: [
+            {
+              dir: 'core',
+              legacyTagPrefixes: ['core-v'],
+              legacyIdentities: [{ name: '@scope/core', tagPrefix: 'old-core-v' }],
+            },
+          ],
+        });
+        expect(errors).toContain(
+          "workspaces[0]: 'legacyTagPrefixes' is no longer supported; use 'legacyIdentities: [{ name, tagPrefix }, ...]' instead",
+        );
+        expect(config.workspaces?.[0]?.legacyIdentities).toStrictEqual([
+          { name: '@scope/core', tagPrefix: 'old-core-v' },
+        ]);
+      });
+
+      it('preserves valid entries when only some entries in a multi-entry array are invalid', () => {
+        const { config, errors } = validateConfig({
+          workspaces: [
+            {
+              dir: 'core',
+              legacyIdentities: [
+                { name: '@scope/core', tagPrefix: 'core-v' },
+                'core-v',
+                { name: '@other-scope/core', tagPrefix: 'other-core-v' },
+              ],
+            },
+          ],
+        });
+        expect(errors).toContain('workspaces[0].legacyIdentities[1]: must be an object');
+        expect(config.workspaces?.[0]?.legacyIdentities).toStrictEqual([
+          { name: '@scope/core', tagPrefix: 'core-v' },
+          { name: '@other-scope/core', tagPrefix: 'other-core-v' },
+        ]);
+      });
+
+      it('accepts tuples that would have collided under a space-separator dedup key', () => {
+        const { config, errors } = validateConfig({
+          workspaces: [
+            {
+              dir: 'core',
+              legacyIdentities: [
+                { name: 'foo bar', tagPrefix: 'baz-v' },
+                { name: 'foo', tagPrefix: 'bar baz-v' },
+              ],
+            },
+          ],
+        });
+        expect(errors).toStrictEqual([]);
+        expect(config.workspaces?.[0]?.legacyIdentities).toStrictEqual([
+          { name: 'foo bar', tagPrefix: 'baz-v' },
+          { name: 'foo', tagPrefix: 'bar baz-v' },
+        ]);
+      });
     });
   });
 

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -181,7 +181,7 @@ Usage: release-kit show-tag-prefixes [options]
 
 Print a per-workspace table of derived tag prefixes, tag counts, and declared
 legacy tag prefixes. Surfaces any release-shaped tags whose prefix is neither a
-derived prefix nor declared in \`legacyTagPrefixes\`, with a copy-pasteable
+derived prefix nor declared in \`legacyIdentities\`, with a copy-pasteable
 config snippet.
 
 Options:

--- a/packages/release-kit/src/deriveWorkspaceConfig.ts
+++ b/packages/release-kit/src/deriveWorkspaceConfig.ts
@@ -33,6 +33,7 @@ export function deriveWorkspaceConfig(workspacePath: string): WorkspaceConfig {
 
   return {
     dir,
+    name,
     tagPrefix: `${unscopedName}-v`,
     workspacePath,
     packageFiles: [packageJsonPath],

--- a/packages/release-kit/src/getCommitsSinceTarget.ts
+++ b/packages/release-kit/src/getCommitsSinceTarget.ts
@@ -87,8 +87,8 @@ function parseLogOutput(logOutput: string): Commit[] {
  * are returned.
  *
  * Callers must pass at least one prefix; the single-prefix case is the common one (the
- * workspace's derived prefix). Multiple prefixes are used to include legacy tag prefixes
- * declared via `legacyTagPrefixes`.
+ * workspace's derived prefix). Multiple prefixes are used to include historical tag prefixes
+ * from `legacyIdentities`.
  *
  * @param tagPrefixes - Tag prefixes to search as a union (e.g., `['core-v', 'old-core-v']`).
  * @param paths - Optional glob patterns to filter commits by path (appended after `--` in `git log`).

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -14,6 +14,7 @@ export type {
   ChangelogJsonConfig,
   ChangelogSection,
   Commit,
+  LegacyIdentity,
   MonorepoReleaseConfig,
   ParsedCommit,
   PrepareResult,

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -11,6 +11,7 @@ import { deriveWorkspaceConfig } from './deriveWorkspaceConfig.ts';
 import { isRecord } from './typeGuards.ts';
 import type {
   ChangelogJsonConfig,
+  LegacyIdentity,
   MonorepoReleaseConfig,
   ReleaseConfig,
   ReleaseKitConfig,
@@ -85,11 +86,11 @@ export function mergeMonorepoConfig(
       })
       .map((w) => {
         const override = overrides.get(w.dir);
-        if (override?.legacyTagPrefixes === undefined) {
+        if (override?.legacyIdentities === undefined) {
           return w;
         }
-        assertLegacyTagPrefixesDoNotIncludeDerived(w.dir, w.tagPrefix, override.legacyTagPrefixes);
-        return { ...w, legacyTagPrefixes: [...override.legacyTagPrefixes] };
+        assertLegacyIdentityDoesNotMatchCurrent(w.dir, w.name, w.tagPrefix, override.legacyIdentities);
+        return { ...w, legacyIdentities: override.legacyIdentities.map((identity) => ({ ...identity })) };
       });
   }
 
@@ -191,21 +192,27 @@ function mergeChangelogJsonConfig(partial: Partial<ChangelogJsonConfig> | undefi
 }
 
 /**
- * Throw when a workspace's `legacyTagPrefixes` contains its derived tag prefix.
+ * Throw when a workspace's `legacyIdentities` contains its current identity.
  *
- * A legacy entry equal to the derived prefix is a guaranteed no-op duplicate, almost always
- * a copy-paste mistake. Rejecting it early prevents silent config drift.
+ * An identity whose full `(name, tagPrefix)` tuple equals the current workspace's
+ * `(name, tagPrefix)` is a guaranteed no-op duplicate, almost always a copy-paste mistake.
+ * An entry whose `tagPrefix` matches but whose `name` differs is valid — it documents a prior
+ * rename that reused the same tag shape.
  */
-function assertLegacyTagPrefixesDoNotIncludeDerived(
+function assertLegacyIdentityDoesNotMatchCurrent(
   dir: string,
-  derivedPrefix: string,
-  legacyTagPrefixes: readonly string[],
+  currentName: string,
+  currentTagPrefix: string,
+  legacyIdentities: readonly LegacyIdentity[],
 ): void {
-  if (legacyTagPrefixes.includes(derivedPrefix)) {
-    throw new Error(
-      `Workspace '${dir}': legacyTagPrefixes must not include the derived prefix '${derivedPrefix}'. ` +
-        'The derived prefix is always searched; listing it again is a no-op.',
-    );
+  for (const identity of legacyIdentities) {
+    if (identity.name === currentName && identity.tagPrefix === currentTagPrefix) {
+      throw new Error(
+        `Workspace '${dir}': legacyIdentities must not match the current identity ` +
+          `(name='${currentName}', tagPrefix='${currentTagPrefix}'). ` +
+          'The current identity is always searched; listing it again is a no-op.',
+      );
+    }
   }
 }
 

--- a/packages/release-kit/src/previewTagPrefixes.ts
+++ b/packages/release-kit/src/previewTagPrefixes.ts
@@ -83,27 +83,20 @@ async function loadUserConfig(): Promise<ReleaseKitConfig | undefined> {
   return errors.length === 0 ? config : undefined;
 }
 
-/** Build a `dir -> override` lookup map from a validated config, skipping entries without a `dir`. */
-function buildOverrideMap(
-  userConfig: ReleaseKitConfig | undefined,
-): Map<string, { legacyIdentities?: LegacyIdentity[] }> {
-  const map = new Map<string, { legacyIdentities?: LegacyIdentity[] }>();
+/** Build a `dir -> legacyIdentities` lookup map from a validated config. */
+function buildOverrideMap(userConfig: ReleaseKitConfig | undefined): Map<string, LegacyIdentity[]> {
+  const map = new Map<string, LegacyIdentity[]>();
   if (userConfig?.workspaces === undefined) return map;
   for (const entry of userConfig.workspaces) {
-    const override: { legacyIdentities?: LegacyIdentity[] } = {};
     if (entry.legacyIdentities !== undefined) {
-      override.legacyIdentities = entry.legacyIdentities;
+      map.set(entry.dir, entry.legacyIdentities);
     }
-    map.set(entry.dir, override);
   }
   return map;
 }
 
 /** Construct a single workspace's preview row, catching derivation failures per-workspace. */
-function buildPreviewRow(
-  workspacePath: string,
-  overridesByDir: Map<string, { legacyIdentities?: LegacyIdentity[] }>,
-): TagPrefixPreviewRow {
+function buildPreviewRow(workspacePath: string, overridesByDir: Map<string, LegacyIdentity[]>): TagPrefixPreviewRow {
   const dir = basename(workspacePath);
   let derivedPrefix: string | null = null;
   let derivationError: string | null = null;
@@ -115,7 +108,7 @@ function buildPreviewRow(
 
   const derivedTagCount = derivedPrefix === null ? 0 : countTagsMatching(derivedPrefix);
 
-  const declaredIdentities = overridesByDir.get(dir)?.legacyIdentities ?? [];
+  const declaredIdentities = overridesByDir.get(dir) ?? [];
   const legacyEntries: LegacyTagPrefixEntry[] = declaredIdentities.map((identity) => ({
     prefix: identity.tagPrefix,
     tagCount: countTagsMatching(identity.tagPrefix),

--- a/packages/release-kit/src/previewTagPrefixes.ts
+++ b/packages/release-kit/src/previewTagPrefixes.ts
@@ -6,7 +6,7 @@ import type { UndeclaredTagPrefix } from './detectUndeclaredTagPrefixes.ts';
 import { detectUndeclaredTagPrefixes } from './detectUndeclaredTagPrefixes.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
 import { loadConfig } from './loadConfig.ts';
-import type { ReleaseKitConfig } from './types.ts';
+import type { LegacyIdentity, ReleaseKitConfig } from './types.ts';
 import { validateConfig } from './validateConfig.ts';
 
 /** One workspace's preview row in the tag-prefix preview. */
@@ -84,13 +84,15 @@ async function loadUserConfig(): Promise<ReleaseKitConfig | undefined> {
 }
 
 /** Build a `dir -> override` lookup map from a validated config, skipping entries without a `dir`. */
-function buildOverrideMap(userConfig: ReleaseKitConfig | undefined): Map<string, { legacyTagPrefixes?: string[] }> {
-  const map = new Map<string, { legacyTagPrefixes?: string[] }>();
+function buildOverrideMap(
+  userConfig: ReleaseKitConfig | undefined,
+): Map<string, { legacyIdentities?: LegacyIdentity[] }> {
+  const map = new Map<string, { legacyIdentities?: LegacyIdentity[] }>();
   if (userConfig?.workspaces === undefined) return map;
   for (const entry of userConfig.workspaces) {
-    const override: { legacyTagPrefixes?: string[] } = {};
-    if (entry.legacyTagPrefixes !== undefined) {
-      override.legacyTagPrefixes = entry.legacyTagPrefixes;
+    const override: { legacyIdentities?: LegacyIdentity[] } = {};
+    if (entry.legacyIdentities !== undefined) {
+      override.legacyIdentities = entry.legacyIdentities;
     }
     map.set(entry.dir, override);
   }
@@ -100,7 +102,7 @@ function buildOverrideMap(userConfig: ReleaseKitConfig | undefined): Map<string,
 /** Construct a single workspace's preview row, catching derivation failures per-workspace. */
 function buildPreviewRow(
   workspacePath: string,
-  overridesByDir: Map<string, { legacyTagPrefixes?: string[] }>,
+  overridesByDir: Map<string, { legacyIdentities?: LegacyIdentity[] }>,
 ): TagPrefixPreviewRow {
   const dir = basename(workspacePath);
   let derivedPrefix: string | null = null;
@@ -113,10 +115,10 @@ function buildPreviewRow(
 
   const derivedTagCount = derivedPrefix === null ? 0 : countTagsMatching(derivedPrefix);
 
-  const declaredLegacyPrefixes = overridesByDir.get(dir)?.legacyTagPrefixes ?? [];
-  const legacyEntries: LegacyTagPrefixEntry[] = declaredLegacyPrefixes.map((prefix) => ({
-    prefix,
-    tagCount: countTagsMatching(prefix),
+  const declaredIdentities = overridesByDir.get(dir)?.legacyIdentities ?? [];
+  const legacyEntries: LegacyTagPrefixEntry[] = declaredIdentities.map((identity) => ({
+    prefix: identity.tagPrefix,
+    tagCount: countTagsMatching(identity.tagPrefix),
   }));
 
   return {

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -146,11 +146,17 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
   const hintState: BaselineHintState = { emitted: false };
   // Build once: the union of every workspace's derived and declared tag prefixes. Passed into
   // the baseline hint so sibling workspaces' tags aren't misclassified as undeclared candidates.
-  const knownPrefixes = config.workspaces.flatMap((w) => [w.tagPrefix, ...(w.legacyTagPrefixes ?? [])]);
+  const knownPrefixes = config.workspaces.flatMap((w) => [
+    w.tagPrefix,
+    ...(w.legacyIdentities?.map((identity) => identity.tagPrefix) ?? []),
+  ]);
 
   for (const workspace of config.workspaces) {
     const name = workspace.dir;
-    const tagPrefixes = [workspace.tagPrefix, ...(workspace.legacyTagPrefixes ?? [])];
+    const tagPrefixes = [
+      workspace.tagPrefix,
+      ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? []),
+    ];
     const { tag, commits } = getCommitsSinceTarget(tagPrefixes, workspace.paths);
     const since = tag === undefined ? '(no previous release found)' : `since ${tag}`;
 
@@ -445,7 +451,10 @@ function generateWorkspaceChangelogs(args: GenerateWorkspaceChangelogsArgs): str
     return changelogFiles;
   }
 
-  const tagPattern = buildTagPattern([workspace.tagPrefix, ...(workspace.legacyTagPrefixes ?? [])]);
+  const tagPattern = buildTagPattern([
+    workspace.tagPrefix,
+    ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? []),
+  ]);
   for (const changelogPath of workspace.changelogPaths) {
     changelogFiles.push(
       ...generateChangelog(config, changelogPath, newTag, dryRun, {
@@ -511,7 +520,7 @@ interface BaselineHintState {
 /**
  * Emit a one-line hint to stderr pointing at `release-kit show-tag-prefixes` when a workspace
  * has no baseline tag AND the repo contains candidate-shaped tags AND the workspace has no
- * declared `legacyTagPrefixes`.
+ * declared `legacyIdentities`.
  *
  * `knownPrefixes` must be the full union across all workspaces so sibling workspaces' tags
  * are not mistaken for undeclared candidates.
@@ -524,7 +533,7 @@ function maybeEmitBaselineHint(
   state: BaselineHintState,
 ): void {
   if (state.emitted) return;
-  if ((workspace.legacyTagPrefixes?.length ?? 0) > 0) return;
+  if ((workspace.legacyIdentities?.length ?? 0) > 0) return;
 
   const candidates = detectUndeclaredTagPrefixes(knownPrefixes);
   if (candidates.length === 0) return;

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -146,18 +146,11 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
   const hintState: BaselineHintState = { emitted: false };
   // Build once: the union of every workspace's derived and declared tag prefixes. Passed into
   // the baseline hint so sibling workspaces' tags aren't misclassified as undeclared candidates.
-  const knownPrefixes = config.workspaces.flatMap((w) => [
-    w.tagPrefix,
-    ...(w.legacyIdentities?.map((identity) => identity.tagPrefix) ?? []),
-  ]);
+  const knownPrefixes = config.workspaces.flatMap(getAllTagPrefixes);
 
   for (const workspace of config.workspaces) {
     const name = workspace.dir;
-    const tagPrefixes = [
-      workspace.tagPrefix,
-      ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? []),
-    ];
-    const { tag, commits } = getCommitsSinceTarget(tagPrefixes, workspace.paths);
+    const { tag, commits } = getCommitsSinceTarget(getAllTagPrefixes(workspace), workspace.paths);
     const since = tag === undefined ? '(no previous release found)' : `since ${tag}`;
 
     if (tag === undefined) {
@@ -451,10 +444,7 @@ function generateWorkspaceChangelogs(args: GenerateWorkspaceChangelogsArgs): str
     return changelogFiles;
   }
 
-  const tagPattern = buildTagPattern([
-    workspace.tagPrefix,
-    ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? []),
-  ]);
+  const tagPattern = buildTagPattern(getAllTagPrefixes(workspace));
   for (const changelogPath of workspace.changelogPaths) {
     changelogFiles.push(
       ...generateChangelog(config, changelogPath, newTag, dryRun, {
@@ -629,4 +619,9 @@ function topologicalSort(
   }
 
   return { sorted, cyclicDirs };
+}
+
+/** Return the workspace's derived tag prefix followed by each declared legacy-identity tag prefix. */
+function getAllTagPrefixes(workspace: WorkspaceConfig): string[] {
+  return [workspace.tagPrefix, ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? [])];
 }

--- a/packages/release-kit/src/showTagPrefixesCommand.ts
+++ b/packages/release-kit/src/showTagPrefixesCommand.ts
@@ -61,11 +61,11 @@ function renderMonorepo(preview: TagPrefixPreview): string {
           `  '${candidate.prefix}' — ${candidate.tagCount} tags (e.g., ${candidate.exampleTags.join(', ')})`,
       ),
       '',
-      'Suggested config snippet (adjust `dir` to match your workspace if the guess is wrong):',
+      'Suggested config snippet (adjust `dir` to match your workspace if the guess is wrong, and replace the `name` placeholder with the legacy npm name):',
       '',
       renderSuggestedSnippet(preview.undeclaredCandidates),
       '',
-      'If the suggested `dir` does not match your workspace, adjust before pasting.',
+      "If the suggested `dir` does not match your workspace, adjust before pasting. Each legacy identity requires a `name` — replace the `TODO-fill-in-legacy-npm-name` placeholder with the package's prior npm name.",
     );
   }
 
@@ -97,7 +97,10 @@ function renderWorkspaceRow(row: TagPrefixPreviewRow): string[] {
 /** Render a paste-ready `workspaces: [ ... ]` config snippet for the undeclared candidates. */
 function renderSuggestedSnippet(candidates: readonly { prefix: string; suggestedDir: string }[]): string {
   const entries = candidates
-    .map((candidate) => `    { dir: '${candidate.suggestedDir}', legacyTagPrefixes: ['${candidate.prefix}'] },`)
+    .map(
+      (candidate) =>
+        `    { dir: '${candidate.suggestedDir}', legacyIdentities: [{ name: 'TODO-fill-in-legacy-npm-name', tagPrefix: '${candidate.prefix}' }] },`,
+    )
     .join('\n');
   return `  workspaces: [\n${entries}\n  ],`;
 }

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -145,6 +145,21 @@ export interface ReleaseKitConfig {
   releaseNotes?: Partial<ReleaseNotesConfig>;
 }
 
+/**
+ * A single historical identity snapshot for a workspace.
+ *
+ * Captures what the package looked like at some earlier point: the full npm `name`
+ * (e.g., `'@williamthorsen/node-monorepo-core'`) and the `tagPrefix` under which tags
+ * were published (e.g., `'core-v'`). Both fields are required — a full tuple stays
+ * unambiguous across any number of future renames.
+ */
+export interface LegacyIdentity {
+  /** Full scoped npm name as it appeared at the time (e.g., `'@scope/pkg'`). */
+  name: string;
+  /** Tag prefix under which the workspace's historical tags were published (e.g., `'core-v'`). */
+  tagPrefix: string;
+}
+
 /** Override for a single workspace in the config file. */
 export interface WorkspaceOverride {
   /** The package directory name (e.g., 'arrays'). */
@@ -152,12 +167,13 @@ export interface WorkspaceOverride {
   /** If true, exclude this workspace from release processing. */
   shouldExclude?: boolean;
   /**
-   * Additional tag prefixes under which historical release tags for this workspace exist.
-   * Consulted (in addition to the derived prefix) when release-kit searches for the most recent
-   * baseline tag and when generating changelogs. Declaring these allows release-kit to recognize
-   * legacy tags without any tag mutation.
+   * Prior identities of this workspace, used to recognize historical tags across renames.
+   * Each entry is a complete `(name, tagPrefix)` snapshot. The union of the current `tagPrefix`
+   * and each identity's `tagPrefix` is consulted when release-kit searches for the most recent
+   * baseline tag and when generating changelogs. Declaring identities allows release-kit to
+   * recognize legacy tags without any tag mutation.
    */
-  legacyTagPrefixes?: string[];
+  legacyIdentities?: LegacyIdentity[];
 }
 
 /** A raw commit from the git log. */
@@ -188,6 +204,8 @@ export interface ParsedCommit {
 export interface WorkspaceConfig {
   /** The package directory name (e.g., 'arrays'). Used for display and `--only` matching. */
   dir: string;
+  /** The full scoped npm name from `package.json` (e.g., `'@williamthorsen/node-monorepo-core'`). */
+  name: string;
   /** The git tag prefix for this workspace (e.g., 'node-monorepo-core-v'), derived from the unscoped `package.json` name. */
   tagPrefix: string;
   /** Workspace-relative path to the package root (e.g., `packages/core`). */
@@ -199,11 +217,11 @@ export interface WorkspaceConfig {
   /** Glob patterns passed to `git log -- <paths>` for commit filtering. */
   paths: string[];
   /**
-   * Additional tag prefixes under which historical release tags for this workspace exist.
-   * Treated as the union `[tagPrefix, ...legacyTagPrefixes]` when searching for baseline tags
-   * and generating changelogs. `undefined` is equivalent to the empty array.
+   * Prior identities of this workspace. Each identity's `tagPrefix` is consulted in addition
+   * to the current `tagPrefix` when searching for baseline tags and generating changelogs.
+   * `undefined` is equivalent to the empty array.
    */
-  legacyTagPrefixes?: string[];
+  legacyIdentities?: LegacyIdentity[];
 }
 
 /** Configuration for a monorepo release workflow with multiple workspaces. */

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -1,5 +1,5 @@
 import { isRecord } from './typeGuards.ts';
-import type { ReleaseKitConfig } from './types.ts';
+import type { LegacyIdentity, ReleaseKitConfig } from './types.ts';
 
 /**
  * Validates a raw config object loaded from `.config/release-kit.config.ts`.
@@ -146,7 +146,7 @@ function validateWorkspaces(value: unknown, config: ReleaseKitConfig, errors: st
   }
 
   const workspaces: NonNullable<ReleaseKitConfig['workspaces']> = [];
-  const knownWorkspaceFields = new Set(['dir', 'shouldExclude', 'legacyTagPrefixes']);
+  const knownWorkspaceFields = new Set(['dir', 'shouldExclude', 'legacyIdentities']);
   for (const [i, entry] of value.entries()) {
     if (!isRecord(entry)) {
       errors.push(`workspaces[${i}]: must be an object`);
@@ -164,6 +164,10 @@ function validateWorkspaces(value: unknown, config: ReleaseKitConfig, errors: st
           errors.push(
             `workspaces[${i}]: 'tagPrefix' is no longer supported; remove it to use the default '${entry.dir}-v'`,
           );
+        } else if (key === 'legacyTagPrefixes') {
+          errors.push(
+            `workspaces[${i}]: 'legacyTagPrefixes' is no longer supported; use 'legacyIdentities: [{ name, tagPrefix }, ...]' instead`,
+          );
         } else {
           errors.push(`workspaces[${i}]: unknown field '${key}'`);
         }
@@ -180,10 +184,10 @@ function validateWorkspaces(value: unknown, config: ReleaseKitConfig, errors: st
       }
     }
 
-    if (entry.legacyTagPrefixes !== undefined) {
-      const legacy = validateLegacyTagPrefixes(entry.legacyTagPrefixes, i, errors);
-      if (legacy !== undefined) {
-        workspace.legacyTagPrefixes = legacy;
+    if (entry.legacyIdentities !== undefined) {
+      const identities = validateLegacyIdentities(entry.legacyIdentities, i, errors);
+      if (identities !== undefined) {
+        workspace.legacyIdentities = identities;
       }
     }
     workspaces.push(workspace);
@@ -192,34 +196,83 @@ function validateWorkspaces(value: unknown, config: ReleaseKitConfig, errors: st
 }
 
 /**
- * Validate a `legacyTagPrefixes` field on a workspace override.
+ * Validate a `legacyIdentities` field on a workspace override.
  *
- * Accepts a string array with non-empty entries. Returns the validated array, or `undefined`
- * when validation fails (with errors appended to the caller's list).
+ * Accepts an array of records, each with non-empty string `name` and `tagPrefix` fields and
+ * no unknown fields. Rejects full-tuple duplicates (two entries whose `name` and `tagPrefix`
+ * both match). Returns the validated array, or `undefined` when any entry fails validation.
  */
-function validateLegacyTagPrefixes(value: unknown, workspaceIndex: number, errors: string[]): string[] | undefined {
+function validateLegacyIdentities(
+  value: unknown,
+  workspaceIndex: number,
+  errors: string[],
+): LegacyIdentity[] | undefined {
   if (!Array.isArray(value)) {
-    errors.push(`workspaces[${workspaceIndex}]: 'legacyTagPrefixes' must be a string array`);
+    errors.push(`workspaces[${workspaceIndex}]: 'legacyIdentities' must be an array`);
     return undefined;
   }
 
-  const prefixes: string[] = [];
+  const knownIdentityFields = new Set(['name', 'tagPrefix']);
+  const identities: LegacyIdentity[] = [];
+  const seenTuples = new Set<string>();
   let valid = true;
+
   for (const [entryIndex, entry] of value.entries()) {
-    if (typeof entry !== 'string') {
-      errors.push(`workspaces[${workspaceIndex}].legacyTagPrefixes[${entryIndex}]: must be a string`);
+    if (!isRecord(entry)) {
+      errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}]: must be an object`);
       valid = false;
       continue;
     }
-    if (entry === '') {
-      errors.push(`workspaces[${workspaceIndex}].legacyTagPrefixes[${entryIndex}]: must be a non-empty string`);
+
+    let entryValid = true;
+    for (const key of Object.keys(entry)) {
+      if (!knownIdentityFields.has(key)) {
+        errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}]: unknown field '${key}'`);
+        entryValid = false;
+      }
+    }
+
+    const name = entry.name;
+    if (typeof name !== 'string') {
+      errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}].name: must be a string`);
+      entryValid = false;
+    } else if (name === '') {
+      errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}].name: must be a non-empty string`);
+      entryValid = false;
+    }
+
+    const tagPrefix = entry.tagPrefix;
+    if (typeof tagPrefix !== 'string') {
+      errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}].tagPrefix: must be a string`);
+      entryValid = false;
+    } else if (tagPrefix === '') {
+      errors.push(
+        `workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}].tagPrefix: must be a non-empty string`,
+      );
+      entryValid = false;
+    }
+
+    if (!entryValid) {
       valid = false;
       continue;
     }
-    prefixes.push(entry);
+
+    // Safe narrowing: both fields passed the string/non-empty checks above.
+    if (typeof name === 'string' && typeof tagPrefix === 'string') {
+      const key = `${name} ${tagPrefix}`;
+      if (seenTuples.has(key)) {
+        errors.push(
+          `workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}]: duplicate identity (name='${name}', tagPrefix='${tagPrefix}')`,
+        );
+        valid = false;
+        continue;
+      }
+      seenTuples.add(key);
+      identities.push({ name, tagPrefix });
+    }
   }
 
-  return valid ? prefixes : undefined;
+  return valid ? identities : undefined;
 }
 
 function validateVersionPatterns(value: unknown, config: ReleaseKitConfig, errors: string[]): void {

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -200,7 +200,9 @@ function validateWorkspaces(value: unknown, config: ReleaseKitConfig, errors: st
  *
  * Accepts an array of records, each with non-empty string `name` and `tagPrefix` fields and
  * no unknown fields. Rejects full-tuple duplicates (two entries whose `name` and `tagPrefix`
- * both match). Returns the validated array, or `undefined` when any entry fails validation.
+ * both match). Appends a per-entry error for each invalid entry and returns the array of
+ * valid entries (including partial results when some entries fail). Returns `undefined`
+ * only when the top-level value is not an array.
  */
 function validateLegacyIdentities(
   value: unknown,
@@ -215,12 +217,10 @@ function validateLegacyIdentities(
   const knownIdentityFields = new Set(['name', 'tagPrefix']);
   const identities: LegacyIdentity[] = [];
   const seenTuples = new Set<string>();
-  let valid = true;
 
   for (const [entryIndex, entry] of value.entries()) {
     if (!isRecord(entry)) {
       errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}]: must be an object`);
-      valid = false;
       continue;
     }
 
@@ -253,18 +253,18 @@ function validateLegacyIdentities(
     }
 
     if (!entryValid) {
-      valid = false;
       continue;
     }
 
     // Safe narrowing: both fields passed the string/non-empty checks above.
     if (typeof name === 'string' && typeof tagPrefix === 'string') {
-      const key = `${name} ${tagPrefix}`;
+      // Use a null-byte separator: neither npm names nor tag prefixes can contain `\0`,
+      // so distinct `(name, tagPrefix)` tuples always produce distinct keys.
+      const key = `${name}\0${tagPrefix}`;
       if (seenTuples.has(key)) {
         errors.push(
           `workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}]: duplicate identity (name='${name}', tagPrefix='${tagPrefix}')`,
         );
-        valid = false;
         continue;
       }
       seenTuples.add(key);
@@ -272,7 +272,7 @@ function validateLegacyIdentities(
     }
   }
 
-  return valid ? identities : undefined;
+  return identities;
 }
 
 function validateVersionPatterns(value: unknown, config: ReleaseKitConfig, errors: string[]): void {

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -232,7 +232,7 @@ function validateLegacyIdentities(
       }
     }
 
-    const name = entry.name;
+    const { name, tagPrefix } = entry;
     if (typeof name !== 'string') {
       errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}].name: must be a string`);
       entryValid = false;
@@ -241,7 +241,6 @@ function validateLegacyIdentities(
       entryValid = false;
     }
 
-    const tagPrefix = entry.tagPrefix;
     if (typeof tagPrefix !== 'string') {
       errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}].tagPrefix: must be a string`);
       entryValid = false;
@@ -252,24 +251,21 @@ function validateLegacyIdentities(
       entryValid = false;
     }
 
-    if (!entryValid) {
+    if (!entryValid || typeof name !== 'string' || typeof tagPrefix !== 'string') {
       continue;
     }
 
-    // Safe narrowing: both fields passed the string/non-empty checks above.
-    if (typeof name === 'string' && typeof tagPrefix === 'string') {
-      // Use a null-byte separator: neither npm names nor tag prefixes can contain `\0`,
-      // so distinct `(name, tagPrefix)` tuples always produce distinct keys.
-      const key = `${name}\0${tagPrefix}`;
-      if (seenTuples.has(key)) {
-        errors.push(
-          `workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}]: duplicate identity (name='${name}', tagPrefix='${tagPrefix}')`,
-        );
-        continue;
-      }
-      seenTuples.add(key);
-      identities.push({ name, tagPrefix });
+    // Use a null-byte separator: neither npm names nor tag prefixes can contain `\0`,
+    // so distinct `(name, tagPrefix)` tuples always produce distinct keys.
+    const key = `${name}\0${tagPrefix}`;
+    if (seenTuples.has(key)) {
+      errors.push(
+        `workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}]: duplicate identity (name='${name}', tagPrefix='${tagPrefix}')`,
+      );
+      continue;
     }
+    seenTuples.add(key);
+    identities.push({ name, tagPrefix });
   }
 
   return identities;


### PR DESCRIPTION
## What

Replaces the per-workspace `legacyTagPrefixes: string[]` field with `legacyIdentities: LegacyIdentity[]`, a structured array of complete `(name, tagPrefix)` historical snapshots. Each legacy identity is now a self-consistent record of what a workspace used to be called and how its tags used to be prefixed, so a workspace that has been renamed (npm name change, tag-prefix change, or both) carries one entry per prior identity. Exports the new `LegacyIdentity` type from the public API, adds a required `name: string` to `WorkspaceConfig` populated from `package.json`, and surfaces the new shape in validation, merge, consumers, CLI help, the `show-tag-prefixes` snippet, and the README (including the v4→v5 upgrade example).

Because v5.0 landed on `main` but has not yet been published to npm, this is a **single pre-publish breaking change** — `legacyTagPrefixes` is removed without a deprecation cycle. Configs using the old field receive a migration-friendly validation error pointing at the new shape.

## Why

v5.0 introduced `legacyTagPrefixes: string[]` to capture prior tag prefixes across a rename, but the field covers only the tag-prefix dimension of a rename and entirely misses the npm-name dimension. Parallel arrays (`legacyTagPrefixes` + a hypothetical `legacyNames`) would force the reader to mentally zip entries to reconstruct each historical state, and the implicit pairing would degrade as additional renames accumulated. Structurally grouped records avoid the zip problem, stay self-consistent across any number of future renames, and extend naturally if additional legacy dimensions ever emerge.

Fixing the shape before v5.0.0 ships to npm avoids either breaking consumers within one minor cycle (deprecate → remove) or carrying the imperfect shape forward as permanent public API.

## Details

### Features

- Adds exported `LegacyIdentity` type (`{ name: string; tagPrefix: string }`).
- `WorkspaceOverride.legacyIdentities?: LegacyIdentity[]` replaces `legacyTagPrefixes`.
- `WorkspaceConfig` gains a required `name: string` (full scoped npm name) and `legacyIdentities?: LegacyIdentity[]`; `deriveWorkspaceConfig` populates `name` from `package.json`.
- Validation (`validateLegacyIdentities`) enforces per-entry shape with per-index error messages, rejects unknown fields on identity entries, uses full-tuple `(name, tagPrefix)` dedup (two entries with the same `tagPrefix` but different `name` are allowed), and emits a migration error when the removed `legacyTagPrefixes` field still appears. Valid entries are preserved when siblings fail, matching the workspace-validation accumulation pattern.
- Merge-time guard renamed from `assertLegacyTagPrefixesDoNotIncludeDerived` to `assertLegacyIdentityDoesNotMatchCurrent`. Semantics shifted from prefix-only to full-tuple equality — an entry whose `tagPrefix` matches the current prefix but whose `name` differs is now accepted, documenting a prior rename that happened to reuse the same tag shape.
- CLI help and the `show-tag-prefixes` paste-ready snippet render the new shape with a `TODO-fill-in-legacy-npm-name` placeholder; the instructional line calls out both `dir` (may need remapping) and the `name` placeholder.

### Refactoring

- All three tag-prefix union sites in `releasePrepareMono.ts` (known-prefix aggregation, per-workspace baseline search, changelog tag pattern) and the `maybeEmitBaselineHint` gate now derive from `legacyIdentities` via a new `getAllTagPrefixes(workspace)` helper — one function replaces three inline copies of `[workspace.tagPrefix, ...(workspace.legacyIdentities?.map(i => i.tagPrefix) ?? [])]`.
- `previewTagPrefixes.buildOverrideMap` now stores `LegacyIdentity[]` directly (previously a `{ legacyTagPrefixes?: string[] }` wrapper). `buildPreviewRow` derives the existing `LegacyTagPrefixEntry[]` shape from identity `tagPrefix` values — identity-aware per-workspace rendering is deliberately deferred per the ticket's out-of-scope list.
- Dedup key in `validateLegacyIdentities` uses `\0` as the separator (previously a space) to prevent collisions when `name` or `tagPrefix` contains a space.

### Tests

- All 992 release-kit tests pass.
- Three behavioral-gap tests added: combined `legacyTagPrefixes` + `legacyIdentities` on the same override (migration error plus explicit contract on the resulting field), multi-entry array with a middle-index invalid entry (valid entries preserved, per-index error reported), and the merge guard's "name matches current, tagPrefix differs" accepted path.
- Fixture sweep: 23 `WorkspaceConfig` fixtures across 11 test files updated for the new required `name` field.
- Regression test for the dedup-separator fix uses the exact `{ name: 'foo bar', tagPrefix: 'baz-v' }` / `{ name: 'foo', tagPrefix: 'bar baz-v' }` collision case.

### Documentation

- README `WorkspaceOverride`, `show-tag-prefixes`, and v4→v5 upgrade sections updated to reference `legacyIdentities` and describe the complete-historical-snapshot requirement.

Closes #291