### PR TITLE
#292 Add `retiredPackages` repo-level config field

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -113,6 +113,7 @@ The config file supports both `export default config` and `export const config =
 | `versionPatterns` | `VersionPatterns`                | Rules for which commit types trigger major/minor bumps                                                                        |
 | `scopeAliases`    | `Record<string, string>`         | Maps shorthand scope names to canonical names in commits                                                                      |
 | `workTypes`       | `Record<string, WorkTypeConfig>` | Work type definitions, merged with defaults by key                                                                            |
+| `retiredPackages` | `RetiredPackage[]`               | Packages that once lived in this repo but have been extracted or removed; suppresses undeclared-tag-prefix warnings           |
 
 All fields are optional.
 
@@ -131,7 +132,41 @@ interface LegacyIdentity {
 }
 ```
 
-`legacyIdentities` captures prior identities of a workspace as complete `(name, tagPrefix)` snapshots. The union of the current `tagPrefix` and each identity's `tagPrefix` is consulted when release-kit searches for the most recent baseline tag and when generating changelogs. Use it when a workspace's historical tags were published under a different npm name, a different tag prefix, or both — typically across a package rename. Both fields are required per identity: each entry must be a complete historical snapshot that stays valid regardless of subsequent renames. Run `release-kit show-tag-prefixes` to detect undeclared candidates and produce a paste-ready config snippet. Listing the current identity (full `(name, tagPrefix)` match) is rejected as a no-op duplicate; an identity whose `tagPrefix` matches the current but whose `name` differs is valid and documents a prior rename that reused the same tag shape.
+`legacyIdentities` captures prior identities of a workspace as complete `(name, tagPrefix)` snapshots. The union of the current `tagPrefix` and each identity's `tagPrefix` is consulted when release-kit searches for the most recent baseline tag and when generating changelogs. Use it when a workspace's historical tags were published under a different npm name, a different tag prefix, or both — typically across a package rename. Both fields are required per identity: each entry must be a complete historical snapshot that stays valid regardless of subsequent renames. Run `release-kit show-tag-prefixes` to detect undeclared candidates and produce a paste-ready config snippet. Listing the current identity (full `(name, tagPrefix)` match) is rejected as a no-op duplicate; an identity whose `tagPrefix` matches the current but whose `name` differs is valid and documents a prior rename that reused the same tag shape. If the workspace no longer exists in this repo at all (the package was extracted or removed), use [`retiredPackages`](#retiredpackage) instead.
+
+### `RetiredPackage`
+
+```typescript
+interface RetiredPackage {
+  name: string; // Final scoped npm name while the package lived in this repo
+  tagPrefix: string; // Tag prefix under which the package's historical tags were published
+  successor?: string; // Optional successor package name (e.g., 'readyup')
+}
+```
+
+`retiredPackages` is the repo-level complement to `legacyIdentities`. Use `legacyIdentities` when the workspace still exists in this repo under a new identity; use `retiredPackages` when no workspace for this package exists in this repo anymore — the package was extracted to another repo or removed outright. Retired entries are inert: release-kit never consults them for baseline lookup or changelog attribution. Their declared `tagPrefix` values are recognized as historical, so `show-tag-prefixes` stops flagging them under "Undeclared tag prefixes."
+
+Worked example — `preflight` was extracted from this monorepo and continues as the standalone `readyup` project. Its tags stay in this repo as historical anchors:
+
+```typescript
+import type { ReleaseKitConfig } from '@williamthorsen/release-kit';
+
+const config: ReleaseKitConfig = {
+  retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', successor: 'readyup' }],
+};
+
+export default config;
+```
+
+Validation rules:
+
+- `name` and `tagPrefix` are required per entry and must be non-empty strings.
+- `successor` is optional; if present, it must be a non-empty string.
+- Full-tuple `(name, tagPrefix)` duplicates within `retiredPackages` are rejected.
+- Two entries sharing the same `tagPrefix` but different `name`s are accepted — this documents a package renamed within the repo before being retired.
+- A `tagPrefix` that collides with an active workspace's derived prefix or any declared `workspaces[].legacyIdentities[].tagPrefix` is rejected. A retired prefix cannot also be current or legacy.
+
+`show-tag-prefixes` currently does not render a dedicated "Retired packages" section (deferred). Declaring a retired entry is verifiable by confirming that its `tagPrefix` stops appearing under "Undeclared tag prefixes" in the `show-tag-prefixes` output.
 
 ### `VersionPatterns`
 

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -334,6 +334,24 @@ describe(mergeMonorepoConfig, () => {
     ]);
   });
 
+  it('throws when a retiredPackages entry tagPrefix matches an active workspace derived prefix', () => {
+    expect(() =>
+      mergeMonorepoConfig(discoveredPaths, {
+        retiredPackages: [{ name: '@old-scope/arrays', tagPrefix: 'arrays-v' }],
+      }),
+    ).toThrow(
+      "retiredPackages: tagPrefix 'arrays-v' collides with active workspace 'arrays' (derived prefix 'arrays-v'). A retired package's tagPrefix cannot belong to an active workspace.",
+    );
+  });
+
+  it('accepts retiredPackages whose tagPrefix does not match any active workspace', () => {
+    expect(() =>
+      mergeMonorepoConfig(discoveredPaths, {
+        retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', successor: 'readyup' }],
+      }),
+    ).not.toThrow();
+  });
+
   it('includes every colliding workspace path when more than two collide', () => {
     mockPackageNames({
       'packages/a-foo': '@a/foo',

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -352,6 +352,17 @@ describe(mergeMonorepoConfig, () => {
     ).not.toThrow();
   });
 
+  it('accepts an empty retiredPackages array', () => {
+    // The guard in `mergeMonorepoConfig` calls `assertRetiredPackagesDoNotCollideWithActive`
+    // for any non-undefined value; exercising the empty-iterable path ensures the call does
+    // not throw when the user declares `retiredPackages: []` explicitly.
+    expect(() =>
+      mergeMonorepoConfig(discoveredPaths, {
+        retiredPackages: [],
+      }),
+    ).not.toThrow();
+  });
+
   it('includes every colliding workspace path when more than two collide', () => {
     mockPackageNames({
       'packages/a-foo': '@a/foo',

--- a/packages/release-kit/src/__tests__/previewTagPrefixes.unit.test.ts
+++ b/packages/release-kit/src/__tests__/previewTagPrefixes.unit.test.ts
@@ -175,4 +175,51 @@ describe(previewTagPrefixes, () => {
       { prefix: 'orphan-v', tagCount: 1, exampleTags: ['orphan-v1.0.0'], suggestedDir: 'orphan' },
     ]);
   });
+
+  it('returns declared retired packages with their tag counts and preserves successor when present', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue([]);
+    mockLoadConfig.mockResolvedValue({
+      retiredPackages: [
+        { name: '@scope/preflight', tagPrefix: 'preflight-v', successor: 'readyup' },
+        { name: '@scope/dead', tagPrefix: 'dead-v' },
+      ],
+    });
+    mockDetectUndeclared.mockReturnValue([]);
+    setupTagCounts({
+      'preflight-v': ['preflight-v1.0.0', 'preflight-v1.1.0', 'preflight-v2.0.0'],
+      'dead-v': [],
+    });
+
+    const result = await previewTagPrefixes();
+
+    expect(result.retiredPackages).toStrictEqual([
+      { name: '@scope/preflight', tagPrefix: 'preflight-v', successor: 'readyup', tagCount: 3 },
+      { name: '@scope/dead', tagPrefix: 'dead-v', tagCount: 0 },
+    ]);
+  });
+
+  it('passes retired tagPrefixes to detectUndeclaredTagPrefixes as known', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue(['packages/core']);
+    mockLoadConfig.mockResolvedValue({
+      retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v' }],
+    });
+    mockDeriveWorkspaceConfig.mockReturnValue({ tagPrefix: 'node-monorepo-core-v' });
+    mockDetectUndeclared.mockReturnValue([]);
+    setupTagCounts({});
+
+    await previewTagPrefixes();
+
+    expect(mockDetectUndeclared).toHaveBeenCalledWith(expect.arrayContaining(['node-monorepo-core-v', 'preflight-v']));
+  });
+
+  it('returns an empty retiredPackages array when the config omits the field', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue([]);
+    mockLoadConfig.mockResolvedValue({});
+    mockDetectUndeclared.mockReturnValue([]);
+    setupTagCounts({});
+
+    const result = await previewTagPrefixes();
+
+    expect(result.retiredPackages).toStrictEqual([]);
+  });
 });

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -246,6 +246,143 @@ describe(validateConfig, () => {
     });
   });
 
+  describe('retiredPackages', () => {
+    it('accepts an array of complete retired-package objects', () => {
+      const { config, errors } = validateConfig({
+        retiredPackages: [
+          { name: '@scope/preflight', tagPrefix: 'preflight-v', successor: 'readyup' },
+          { name: '@scope/dead', tagPrefix: 'dead-v' },
+        ],
+      });
+      expect(errors).toStrictEqual([]);
+      expect(config.retiredPackages).toStrictEqual([
+        { name: '@scope/preflight', tagPrefix: 'preflight-v', successor: 'readyup' },
+        { name: '@scope/dead', tagPrefix: 'dead-v' },
+      ]);
+    });
+
+    it('accepts an empty array', () => {
+      const { config, errors } = validateConfig({ retiredPackages: [] });
+      expect(errors).toStrictEqual([]);
+      expect(config.retiredPackages).toStrictEqual([]);
+    });
+
+    it('omits retiredPackages from the result when the field is not provided', () => {
+      const { config, errors } = validateConfig({});
+      expect(errors).toStrictEqual([]);
+      expect(config.retiredPackages).toBeUndefined();
+    });
+
+    it('returns an error when retiredPackages is not an array', () => {
+      const { errors } = validateConfig({ retiredPackages: 'preflight-v' });
+      expect(errors).toContain("'retiredPackages' must be an array");
+    });
+
+    it('returns a per-index error when an entry is not an object', () => {
+      const { errors } = validateConfig({ retiredPackages: ['preflight-v'] });
+      expect(errors).toContain('retiredPackages[0]: must be an object');
+    });
+
+    it('returns a per-index error when name is missing', () => {
+      const { errors } = validateConfig({ retiredPackages: [{ tagPrefix: 'preflight-v' }] });
+      expect(errors).toContain('retiredPackages[0].name: must be a string');
+    });
+
+    it('returns a per-index error when name is an empty string', () => {
+      const { errors } = validateConfig({ retiredPackages: [{ name: '', tagPrefix: 'preflight-v' }] });
+      expect(errors).toContain('retiredPackages[0].name: must be a non-empty string');
+    });
+
+    it('returns a per-index error when tagPrefix is missing', () => {
+      const { errors } = validateConfig({ retiredPackages: [{ name: '@scope/preflight' }] });
+      expect(errors).toContain('retiredPackages[0].tagPrefix: must be a string');
+    });
+
+    it('returns a per-index error when tagPrefix is an empty string', () => {
+      const { errors } = validateConfig({ retiredPackages: [{ name: '@scope/preflight', tagPrefix: '' }] });
+      expect(errors).toContain('retiredPackages[0].tagPrefix: must be a non-empty string');
+    });
+
+    it('returns a per-index error when successor is not a string', () => {
+      const { errors } = validateConfig({
+        retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', successor: 42 }],
+      });
+      expect(errors).toContain('retiredPackages[0].successor: must be a string');
+    });
+
+    it('returns a per-index error when successor is an empty string', () => {
+      const { errors } = validateConfig({
+        retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', successor: '' }],
+      });
+      expect(errors).toContain('retiredPackages[0].successor: must be a non-empty string');
+    });
+
+    it('returns an error on unknown retired-package fields', () => {
+      const { errors } = validateConfig({
+        retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', bogus: true }],
+      });
+      expect(errors).toContain("retiredPackages[0]: unknown field 'bogus'");
+    });
+
+    it('rejects full-tuple duplicates', () => {
+      const { errors } = validateConfig({
+        retiredPackages: [
+          { name: '@scope/preflight', tagPrefix: 'preflight-v' },
+          { name: '@scope/preflight', tagPrefix: 'preflight-v' },
+        ],
+      });
+      expect(errors).toContain(
+        "retiredPackages[1]: duplicate package (name='@scope/preflight', tagPrefix='preflight-v')",
+      );
+    });
+
+    it('accepts two entries with the same tagPrefix but different names', () => {
+      const { config, errors } = validateConfig({
+        retiredPackages: [
+          { name: '@old-scope/preflight', tagPrefix: 'preflight-v' },
+          { name: '@new-scope/preflight', tagPrefix: 'preflight-v' },
+        ],
+      });
+      expect(errors).toStrictEqual([]);
+      expect(config.retiredPackages).toHaveLength(2);
+    });
+
+    it('rejects a tagPrefix colliding with a declared legacyIdentities[].tagPrefix', () => {
+      const { errors } = validateConfig({
+        workspaces: [
+          {
+            dir: 'core',
+            legacyIdentities: [{ name: '@old-scope/core', tagPrefix: 'old-core-v' }],
+          },
+        ],
+        retiredPackages: [{ name: '@scope/retired', tagPrefix: 'old-core-v' }],
+      });
+      expect(errors).toContain(
+        "retiredPackages[0]: tagPrefix 'old-core-v' collides with a declared legacyIdentities[].tagPrefix on workspace 'core'",
+      );
+    });
+
+    it('records the collision when retired and legacy tagPrefixes match across workspaces', () => {
+      const { errors } = validateConfig({
+        workspaces: [
+          {
+            dir: 'arrays',
+            legacyIdentities: [{ name: '@old-scope/arrays', tagPrefix: 'shared-v' }],
+          },
+          {
+            dir: 'strings',
+            legacyIdentities: [{ name: '@old-scope/strings', tagPrefix: 'shared-v' }],
+          },
+        ],
+        retiredPackages: [{ name: '@scope/retired', tagPrefix: 'shared-v' }],
+      });
+      // Preserves the first declaring workspace in the error.
+      expect(errors).toContain(
+        "retiredPackages[0]: tagPrefix 'shared-v' collides with a declared legacyIdentities[].tagPrefix on workspace 'arrays'",
+      );
+    });
+  });
+
   describe('versionPatterns', () => {
     it('validates a valid versionPatterns object', () => {
       const { config, errors } = validateConfig({

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -348,7 +348,7 @@ describe(validateConfig, () => {
     });
 
     it('rejects a tagPrefix colliding with a declared legacyIdentities[].tagPrefix', () => {
-      const { errors } = validateConfig({
+      const { config, errors } = validateConfig({
         workspaces: [
           {
             dir: 'core',
@@ -360,10 +360,14 @@ describe(validateConfig, () => {
       expect(errors).toContain(
         "retiredPackages[0]: tagPrefix 'old-core-v' collides with a declared legacyIdentities[].tagPrefix on workspace 'core'",
       );
+      // The colliding entry is still written to `config.retiredPackages` — the returned config
+      // is not guaranteed to be internally consistent when `errors` is non-empty. Callers must
+      // check `errors` before trusting `config`.
+      expect(config.retiredPackages).toStrictEqual([{ name: '@scope/retired', tagPrefix: 'old-core-v' }]);
     });
 
     it('records the collision when retired and legacy tagPrefixes match across workspaces', () => {
-      const { errors } = validateConfig({
+      const { config, errors } = validateConfig({
         workspaces: [
           {
             dir: 'arrays',
@@ -379,6 +383,44 @@ describe(validateConfig, () => {
       // Preserves the first declaring workspace in the error.
       expect(errors).toContain(
         "retiredPackages[0]: tagPrefix 'shared-v' collides with a declared legacyIdentities[].tagPrefix on workspace 'arrays'",
+      );
+      // The colliding entry is still present in `config.retiredPackages` under the current
+      // contract (mirrors `validateWorkspaces` behavior).
+      expect(config.retiredPackages).toStrictEqual([{ name: '@scope/retired', tagPrefix: 'shared-v' }]);
+    });
+
+    it('preserves valid entries when only some entries in a multi-entry array are invalid', () => {
+      const { config, errors } = validateConfig({
+        retiredPackages: [
+          { name: '@scope/preflight', tagPrefix: 'preflight-v' },
+          'not-an-object',
+          { name: '@scope/dead', tagPrefix: 'dead-v', successor: 'alive' },
+        ],
+      });
+      expect(errors).toContain('retiredPackages[1]: must be an object');
+      expect(config.retiredPackages).toStrictEqual([
+        { name: '@scope/preflight', tagPrefix: 'preflight-v' },
+        { name: '@scope/dead', tagPrefix: 'dead-v', successor: 'alive' },
+      ]);
+    });
+
+    it('reports the user-supplied index in the collision error when an earlier entry was rejected', () => {
+      const { errors } = validateConfig({
+        workspaces: [
+          {
+            dir: 'core',
+            legacyIdentities: [{ name: '@old-scope/core', tagPrefix: 'old-core-v' }],
+          },
+        ],
+        retiredPackages: [
+          // Structurally invalid: bare string, rejected during per-entry validation.
+          'not-an-object',
+          // Valid entry whose tagPrefix collides with the legacy identity above.
+          { name: '@scope/retired', tagPrefix: 'old-core-v' },
+        ],
+      });
+      expect(errors).toContain(
+        "retiredPackages[1]: tagPrefix 'old-core-v' collides with a declared legacyIdentities[].tagPrefix on workspace 'core'",
       );
     });
   });

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -2,6 +2,7 @@
 export type { CreateTagsOptions } from './createTags.ts';
 export type { PackageManager } from './detectPackageManager.ts';
 export type { GenerateChangelogOptions } from './generateChangelogs.ts';
+export type { RetiredPackagePreviewEntry } from './previewTagPrefixes.ts';
 export type { PublishOptions } from './publish.ts';
 export type { ReleasePrepareOptions } from './releasePrepare.ts';
 export type { ResolvedTag } from './resolveReleaseTags.ts';

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -22,6 +22,7 @@ export type {
   ReleaseKitConfig,
   ReleaseNotesConfig,
   ReleaseType,
+  RetiredPackage,
   VersionPatterns,
   WorkspaceConfig,
   WorkspaceOverride,

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -16,6 +16,7 @@ import type {
   ReleaseConfig,
   ReleaseKitConfig,
   ReleaseNotesConfig,
+  RetiredPackage,
   WorkspaceConfig,
   WorkTypeConfig,
 } from './types.ts';
@@ -92,6 +93,10 @@ export function mergeMonorepoConfig(
         assertLegacyIdentityDoesNotMatchCurrent(w.dir, w.name, w.tagPrefix, override.legacyIdentities);
         return { ...w, legacyIdentities: override.legacyIdentities.map((identity) => ({ ...identity })) };
       });
+  }
+
+  if (userConfig?.retiredPackages !== undefined) {
+    assertRetiredPackagesDoNotCollideWithActive(workspaces, userConfig.retiredPackages);
   }
 
   // Merge workTypes
@@ -211,6 +216,34 @@ function assertLegacyIdentityDoesNotMatchCurrent(
         `Workspace '${dir}': legacyIdentities must not match the current identity ` +
           `(name='${currentName}', tagPrefix='${currentTagPrefix}'). ` +
           'The current identity is always searched; listing it again is a no-op.',
+      );
+    }
+  }
+}
+
+/**
+ * Throw when a retired package's `tagPrefix` matches an active workspace's derived prefix.
+ *
+ * A retired package is, by definition, no longer hosted by any active workspace in this repo.
+ * If its declared `tagPrefix` equals an active workspace's derived prefix, new tags from that
+ * workspace would collide with the retired package's historical tags — and the retired entry
+ * would be a misstatement of reality. Reject at load time with a workspace-naming error.
+ */
+function assertRetiredPackagesDoNotCollideWithActive(
+  workspaces: readonly WorkspaceConfig[],
+  retiredPackages: readonly RetiredPackage[],
+): void {
+  const workspaceByDerivedPrefix = new Map<string, WorkspaceConfig>();
+  for (const workspace of workspaces) {
+    workspaceByDerivedPrefix.set(workspace.tagPrefix, workspace);
+  }
+
+  for (const retired of retiredPackages) {
+    const active = workspaceByDerivedPrefix.get(retired.tagPrefix);
+    if (active !== undefined) {
+      throw new Error(
+        `retiredPackages: tagPrefix '${retired.tagPrefix}' collides with active workspace '${active.dir}' ` +
+          `(derived prefix '${active.tagPrefix}'). A retired package's tagPrefix cannot belong to an active workspace.`,
       );
     }
   }

--- a/packages/release-kit/src/previewTagPrefixes.ts
+++ b/packages/release-kit/src/previewTagPrefixes.ts
@@ -6,7 +6,7 @@ import type { UndeclaredTagPrefix } from './detectUndeclaredTagPrefixes.ts';
 import { detectUndeclaredTagPrefixes } from './detectUndeclaredTagPrefixes.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
 import { loadConfig } from './loadConfig.ts';
-import type { LegacyIdentity, ReleaseKitConfig } from './types.ts';
+import type { LegacyIdentity, ReleaseKitConfig, RetiredPackage } from './types.ts';
 import { validateConfig } from './validateConfig.ts';
 
 /** One workspace's preview row in the tag-prefix preview. */
@@ -31,6 +31,14 @@ export interface LegacyTagPrefixEntry {
   tagCount: number;
 }
 
+/** A declared retired package plus its current tag count. */
+export interface RetiredPackagePreviewEntry {
+  name: string;
+  tagPrefix: string;
+  successor?: string;
+  tagCount: number;
+}
+
 /** A tag-prefix collision between two or more workspaces. */
 export interface TagPrefixCollision {
   tagPrefix: string;
@@ -42,6 +50,7 @@ export interface TagPrefixPreview {
   workspaces: TagPrefixPreviewRow[];
   collisions: TagPrefixCollision[];
   undeclaredCandidates: UndeclaredTagPrefix[];
+  retiredPackages: RetiredPackagePreviewEntry[];
 }
 
 /**
@@ -63,11 +72,13 @@ export async function previewTagPrefixes(): Promise<TagPrefixPreview> {
     workspaces.push(buildPreviewRow(workspacePath, overridesByDir));
   }
 
+  const retiredPackages = buildRetiredPreviewEntries(userConfig?.retiredPackages ?? []);
+
   const collisions = detectCollisions(workspaces);
-  const knownPrefixes = collectKnownPrefixes(workspaces);
+  const knownPrefixes = collectKnownPrefixes(workspaces, retiredPackages);
   const undeclaredCandidates = detectUndeclaredTagPrefixes(knownPrefixes);
 
-  return { workspaces, collisions, undeclaredCandidates };
+  return { workspaces, collisions, undeclaredCandidates, retiredPackages };
 }
 
 /** Load and validate `.config/release-kit.config.ts`, returning undefined on absent/invalid. */
@@ -159,8 +170,11 @@ function detectCollisions(rows: readonly TagPrefixPreviewRow[]): TagPrefixCollis
   return collisions;
 }
 
-/** Collect the union of successfully-derived prefixes and declared legacy prefixes. */
-function collectKnownPrefixes(rows: readonly TagPrefixPreviewRow[]): string[] {
+/** Collect the union of successfully-derived prefixes, declared legacy prefixes, and retired prefixes. */
+function collectKnownPrefixes(
+  rows: readonly TagPrefixPreviewRow[],
+  retiredPackages: readonly RetiredPackagePreviewEntry[],
+): string[] {
   const known = new Set<string>();
   for (const row of rows) {
     if (row.derivedPrefix !== null) known.add(row.derivedPrefix);
@@ -168,5 +182,23 @@ function collectKnownPrefixes(rows: readonly TagPrefixPreviewRow[]): string[] {
       known.add(entry.prefix);
     }
   }
+  for (const retired of retiredPackages) {
+    known.add(retired.tagPrefix);
+  }
   return [...known];
+}
+
+/** Build preview entries for each declared retired package, attaching current tag counts. */
+function buildRetiredPreviewEntries(retiredPackages: readonly RetiredPackage[]): RetiredPackagePreviewEntry[] {
+  return retiredPackages.map((retired) => {
+    const entry: RetiredPackagePreviewEntry = {
+      name: retired.name,
+      tagPrefix: retired.tagPrefix,
+      tagCount: countTagsMatching(retired.tagPrefix),
+    };
+    if (retired.successor !== undefined) {
+      entry.successor = retired.successor;
+    }
+    return entry;
+  });
 }

--- a/packages/release-kit/src/previewTagPrefixes.ts
+++ b/packages/release-kit/src/previewTagPrefixes.ts
@@ -190,15 +190,10 @@ function collectKnownPrefixes(
 
 /** Build preview entries for each declared retired package, attaching current tag counts. */
 function buildRetiredPreviewEntries(retiredPackages: readonly RetiredPackage[]): RetiredPackagePreviewEntry[] {
-  return retiredPackages.map((retired) => {
-    const entry: RetiredPackagePreviewEntry = {
-      name: retired.name,
-      tagPrefix: retired.tagPrefix,
-      tagCount: countTagsMatching(retired.tagPrefix),
-    };
-    if (retired.successor !== undefined) {
-      entry.successor = retired.successor;
-    }
-    return entry;
-  });
+  return retiredPackages.map((retired) => ({
+    name: retired.name,
+    tagPrefix: retired.tagPrefix,
+    tagCount: countTagsMatching(retired.tagPrefix),
+    ...(retired.successor !== undefined ? { successor: retired.successor } : {}),
+  }));
 }

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -143,6 +143,17 @@ export interface ReleaseKitConfig {
   changelogJson?: Partial<ChangelogJsonConfig>;
   /** Controls release notes consumption (README injection). */
   releaseNotes?: Partial<ReleaseNotesConfig>;
+  /**
+   * Packages that once lived in this repo but have since been extracted or removed.
+   *
+   * Complements the per-workspace `workspaces[].legacyIdentities` field. Use
+   * `legacyIdentities` when the workspace still exists under a new identity; use
+   * `retiredPackages` when no workspace for this package exists in this repo anymore.
+   * Retired packages are never consulted for baseline lookup or changelog attribution —
+   * their declared `tagPrefix` values are treated as known so `show-tag-prefixes` does
+   * not flag them as undeclared candidates.
+   */
+  retiredPackages?: RetiredPackage[];
 }
 
 /**
@@ -158,6 +169,24 @@ export interface LegacyIdentity {
   name: string;
   /** Tag prefix under which the workspace's historical tags were published (e.g., `'core-v'`). */
   tagPrefix: string;
+}
+
+/**
+ * A package that once lived in this repo but has since been extracted or removed.
+ *
+ * Unlike `LegacyIdentity`, retired packages are never consulted for baseline lookup or
+ * changelog attribution — they exist purely to acknowledge historical tag prefixes and
+ * suppress undeclared-candidate warnings. Use `legacyIdentities` when the workspace
+ * still exists under a new identity; use `retiredPackages` when no workspace for this
+ * package exists anymore.
+ */
+export interface RetiredPackage {
+  /** The package's final npm name while it lived in this repo. */
+  name: string;
+  /** The tag prefix under which the package's tags were published (e.g., `'preflight-v'`). */
+  tagPrefix: string;
+  /** Optional successor package name, for packages that were renamed/extracted rather than deleted. */
+  successor?: string;
 }
 
 /** Override for a single workspace in the config file. */

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -294,6 +294,7 @@ function validateRetiredPackages(value: unknown, config: ReleaseKitConfig, error
   }
 
   const retiredPackages: RetiredPackage[] = [];
+  const retiredPackagesWithRawIndex: Array<{ entry: RetiredPackage; rawIndex: number }> = [];
   const seenTuples = new Set<string>();
 
   for (const [i, entry] of value.entries()) {
@@ -310,9 +311,10 @@ function validateRetiredPackages(value: unknown, config: ReleaseKitConfig, error
     }
     seenTuples.add(key);
     retiredPackages.push(retired);
+    retiredPackagesWithRawIndex.push({ entry: retired, rawIndex: i });
   }
 
-  detectRetiredVsLegacyCollisions(retiredPackages, config, errors);
+  detectRetiredVsLegacyCollisions(retiredPackagesWithRawIndex, config, errors);
 
   config.retiredPackages = retiredPackages;
 }
@@ -361,10 +363,13 @@ function validateRetiredPackageEntry(entry: unknown, i: number, errors: string[]
 
 /**
  * Append errors when a `retiredPackages` entry's `tagPrefix` matches any workspace's declared
- * `legacyIdentities[].tagPrefix`. The first declaring workspace is named in the error.
+ * `legacyIdentities[].tagPrefix`. The first declaring workspace is named in the error. Each
+ * entry carries its `rawIndex` (the position in the user-supplied `retiredPackages` array) so
+ * error messages point at the entry the user actually wrote, not the position in the filtered
+ * valid-entries array.
  */
 function detectRetiredVsLegacyCollisions(
-  retiredPackages: readonly RetiredPackage[],
+  retiredPackages: readonly { entry: RetiredPackage; rawIndex: number }[],
   config: ReleaseKitConfig,
   errors: string[],
 ): void {
@@ -380,11 +385,11 @@ function detectRetiredVsLegacyCollisions(
     }
   }
 
-  for (const [i, retired] of retiredPackages.entries()) {
+  for (const { entry: retired, rawIndex } of retiredPackages) {
     const collidingDir = legacyPrefixToWorkspace.get(retired.tagPrefix);
     if (collidingDir !== undefined) {
       errors.push(
-        `retiredPackages[${i}]: tagPrefix '${retired.tagPrefix}' collides with a declared legacyIdentities[].tagPrefix on workspace '${collidingDir}'`,
+        `retiredPackages[${rawIndex}]: tagPrefix '${retired.tagPrefix}' collides with a declared legacyIdentities[].tagPrefix on workspace '${collidingDir}'`,
       );
     }
   }

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -1,5 +1,5 @@
 import { isRecord } from './typeGuards.ts';
-import type { LegacyIdentity, ReleaseKitConfig } from './types.ts';
+import type { LegacyIdentity, ReleaseKitConfig, RetiredPackage } from './types.ts';
 
 /**
  * Validates a raw config object loaded from `.config/release-kit.config.ts`.
@@ -22,6 +22,7 @@ export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors
     'cliffConfigPath',
     'formatCommand',
     'releaseNotes',
+    'retiredPackages',
     'scopeAliases',
     'versionPatterns',
     'workspaces',
@@ -42,6 +43,7 @@ export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors
   validateStringField('formatCommand', raw.formatCommand, config, errors);
   validateStringField('cliffConfigPath', raw.cliffConfigPath, config, errors);
   validateScopeAliases(raw.scopeAliases, config, errors);
+  validateRetiredPackages(raw.retiredPackages, config, errors);
 
   // Cross-field warnings: releaseNotes features require changelogJson to be enabled.
   const warnings: string[] = [];
@@ -269,6 +271,139 @@ function validateLegacyIdentities(
   }
 
   return identities;
+}
+
+/**
+ * Validate a top-level `retiredPackages` field.
+ *
+ * Accepts an array of records, each with non-empty string `name` and `tagPrefix` and an
+ * optional non-empty string `successor`. Rejects full-tuple `(name, tagPrefix)` duplicates
+ * within the array (two entries sharing the same `tagPrefix` but different `name`s are
+ * allowed — this documents a package renamed before retirement). After per-entry validation,
+ * rejects any `tagPrefix` that collides with a declared `workspaces[].legacyIdentities[].tagPrefix`.
+ *
+ * Collisions with an active workspace's *derived* `tagPrefix` are not checked here — that
+ * check requires reading each workspace's `package.json` and belongs in `loadConfig`.
+ */
+function validateRetiredPackages(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
+  if (value === undefined) return;
+
+  if (!Array.isArray(value)) {
+    errors.push("'retiredPackages' must be an array");
+    return;
+  }
+
+  const retiredPackages: RetiredPackage[] = [];
+  const seenTuples = new Set<string>();
+
+  for (const [i, entry] of value.entries()) {
+    const retired = validateRetiredPackageEntry(entry, i, errors);
+    if (retired === undefined) continue;
+
+    // Null-byte separator: neither npm names nor tag prefixes can contain `\0`.
+    const key = `${retired.name}\0${retired.tagPrefix}`;
+    if (seenTuples.has(key)) {
+      errors.push(
+        `retiredPackages[${i}]: duplicate package (name='${retired.name}', tagPrefix='${retired.tagPrefix}')`,
+      );
+      continue;
+    }
+    seenTuples.add(key);
+    retiredPackages.push(retired);
+  }
+
+  detectRetiredVsLegacyCollisions(retiredPackages, config, errors);
+
+  config.retiredPackages = retiredPackages;
+}
+
+/**
+ * Validate a single `retiredPackages[i]` entry. Returns the parsed entry when every required
+ * field is a valid non-empty string (and `successor`, if present, is too). Appends any errors
+ * encountered and returns `undefined` for otherwise-invalid entries.
+ */
+function validateRetiredPackageEntry(entry: unknown, i: number, errors: string[]): RetiredPackage | undefined {
+  if (!isRecord(entry)) {
+    errors.push(`retiredPackages[${i}]: must be an object`);
+    return undefined;
+  }
+
+  const knownRetiredFields = new Set(['name', 'tagPrefix', 'successor']);
+  let entryValid = true;
+  for (const key of Object.keys(entry)) {
+    if (!knownRetiredFields.has(key)) {
+      errors.push(`retiredPackages[${i}]: unknown field '${key}'`);
+      entryValid = false;
+    }
+  }
+
+  const { name, tagPrefix, successor } = entry;
+  if (!validateNonEmptyString(name, `retiredPackages[${i}].name`, errors)) {
+    entryValid = false;
+  }
+  if (!validateNonEmptyString(tagPrefix, `retiredPackages[${i}].tagPrefix`, errors)) {
+    entryValid = false;
+  }
+  if (successor !== undefined && !validateNonEmptyString(successor, `retiredPackages[${i}].successor`, errors)) {
+    entryValid = false;
+  }
+
+  if (!entryValid || typeof name !== 'string' || typeof tagPrefix !== 'string') {
+    return undefined;
+  }
+
+  const retired: RetiredPackage = { name, tagPrefix };
+  if (typeof successor === 'string' && successor !== '') {
+    retired.successor = successor;
+  }
+  return retired;
+}
+
+/**
+ * Append errors when a `retiredPackages` entry's `tagPrefix` matches any workspace's declared
+ * `legacyIdentities[].tagPrefix`. The first declaring workspace is named in the error.
+ */
+function detectRetiredVsLegacyCollisions(
+  retiredPackages: readonly RetiredPackage[],
+  config: ReleaseKitConfig,
+  errors: string[],
+): void {
+  if (config.workspaces === undefined) return;
+
+  const legacyPrefixToWorkspace = new Map<string, string>();
+  for (const workspace of config.workspaces) {
+    if (workspace.legacyIdentities === undefined) continue;
+    for (const identity of workspace.legacyIdentities) {
+      if (!legacyPrefixToWorkspace.has(identity.tagPrefix)) {
+        legacyPrefixToWorkspace.set(identity.tagPrefix, workspace.dir);
+      }
+    }
+  }
+
+  for (const [i, retired] of retiredPackages.entries()) {
+    const collidingDir = legacyPrefixToWorkspace.get(retired.tagPrefix);
+    if (collidingDir !== undefined) {
+      errors.push(
+        `retiredPackages[${i}]: tagPrefix '${retired.tagPrefix}' collides with a declared legacyIdentities[].tagPrefix on workspace '${collidingDir}'`,
+      );
+    }
+  }
+}
+
+/**
+ * Append a typed error when `value` is not a non-empty string under `fieldPath`. Returns `true`
+ * when the value passes, `false` when any error was appended.
+ */
+function validateNonEmptyString(value: unknown, fieldPath: string, errors: string[]): boolean {
+  if (typeof value !== 'string') {
+    errors.push(`${fieldPath}: must be a string`);
+    return false;
+  }
+  if (value === '') {
+    errors.push(`${fieldPath}: must be a non-empty string`);
+    return false;
+  }
+  return true;
 }
 
 function validateVersionPatterns(value: unknown, config: ReleaseKitConfig, errors: string[]): void {

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -293,8 +293,7 @@ function validateRetiredPackages(value: unknown, config: ReleaseKitConfig, error
     return;
   }
 
-  const retiredPackages: RetiredPackage[] = [];
-  const retiredPackagesWithRawIndex: Array<{ entry: RetiredPackage; rawIndex: number }> = [];
+  const validEntries: Array<{ entry: RetiredPackage; rawIndex: number }> = [];
   const seenTuples = new Set<string>();
 
   for (const [i, entry] of value.entries()) {
@@ -310,13 +309,12 @@ function validateRetiredPackages(value: unknown, config: ReleaseKitConfig, error
       continue;
     }
     seenTuples.add(key);
-    retiredPackages.push(retired);
-    retiredPackagesWithRawIndex.push({ entry: retired, rawIndex: i });
+    validEntries.push({ entry: retired, rawIndex: i });
   }
 
-  detectRetiredVsLegacyCollisions(retiredPackagesWithRawIndex, config, errors);
+  detectRetiredVsLegacyCollisions(validEntries, config, errors);
 
-  config.retiredPackages = retiredPackages;
+  config.retiredPackages = validEntries.map(({ entry }) => entry);
 }
 
 /**


### PR DESCRIPTION
## What

Adds support for declaring packages that once lived in this repo but have been extracted or removed, so their historical tag prefixes (e.g., `preflight-v*` from the extracted `readyup` project) no longer surface as "Undeclared tag prefixes" in `release-kit show-tag-prefixes`. Declared retired packages are acknowledged as real history but never consulted for baseline lookup or changelog attribution — they complement `workspaces[].legacyIdentities`, which is used when a workspace still exists under a new identity.

## Why

Tags for packages that have left the repo currently have no configuration home. The only ways to silence the "undeclared" warning were to fake a workspace entry (cruft that risks downstream pipelines acting on it) or to tolerate the warning indefinitely (cries-wolf signal dilution, defeating the point of flagging undeclared candidates). The tags themselves can't be deleted — they anchor historical GitHub Releases, enable `git log <prefix>-vX..Y` archaeology, and back CHANGELOG regeneration for that era. `retiredPackages` provides an inert, structured home for this provenance.

## Details

### Features

- New `RetiredPackage` type (`{ name, tagPrefix, successor? }`) and optional `ReleaseKitConfig.retiredPackages?: RetiredPackage[]` field.
- `validateConfig` enforces per-entry shape, full-tuple duplicate rejection, and `tagPrefix` collision detection against declared `workspaces[].legacyIdentities[].tagPrefix`; multiple entries sharing a `tagPrefix` with different `name`s are explicitly allowed (documents a package renamed within this repo before being retired).
- `loadConfig` additionally rejects `tagPrefix` collisions against active workspaces' derived prefixes (post-derivation invariant check, adjacent to the existing `legacyIdentities`-vs-current-identity check).
- `TagPrefixPreview` gains a `retiredPackages: RetiredPackagePreviewEntry[]` field with per-entry `tagCount`, surfaced for consumption by a future `show-tag-prefixes` renderer. Retired prefixes are also unioned into the known-prefix set that `detectUndeclaredTagPrefixes` consults, so declared retired prefixes no longer appear under "Undeclared tag prefixes."
- `RetiredPackage` and `RetiredPackagePreviewEntry` are re-exported from `@williamthorsen/release-kit`.
- README gains a self-contained `RetiredPackage` subsection with the semantic distinction from `legacyIdentities` ("workspace still exists under a new identity" vs. "no workspace exists anymore"), the preflight → readyup worked example, and a note that CLI rendering of a retired section is deferred to a follow-up ticket.

### Fixes

- Collision error messages for `retiredPackages[].tagPrefix` now cite the user-supplied array index rather than the index in the internally-filtered valid-entries array (`f4f9cc4`). When a prior entry was rejected as invalid or as a duplicate, the surviving entries were being renumbered from zero, so an error on what the user wrote as `retiredPackages[2]` could be reported as `retiredPackages[0]`. Mirrors the pattern used by `validateLegacyIdentities`.

### Refactoring

- Collapsed parallel arrays in `validateRetiredPackages` into a single `Array<{ entry, rawIndex }>`; `buildRetiredPreviewEntries` uses a single object literal with conditional spread rather than a mutable intermediate (`5d3dc62`).

### Tests

- New dedicated tests in `validateConfig.unit.test.ts`, `loadConfig.unit.test.ts`, and `previewTagPrefixes.unit.test.ts` covering: per-entry shape rejection, full-tuple duplicate rejection, same-`tagPrefix`-different-`name` acceptance, retired-vs-legacy and retired-vs-active-derived collisions, empty-array handling, mixed-validity partial-results behavior, user-supplied-index reporting regression, retired entries surfacing with `tagCount`, and undeclared-candidate filtering.

### Documentation

- README Config reference gains a `RetiredPackage` subsection with the type shape, the decision criterion ("legacyIdentities = workspace still exists under a new identity; retiredPackages = no workspace for this package exists anymore"), a worked example, and a cross-reference from the existing `legacyIdentities` paragraph. The `ReleaseKitConfig` field table includes the new `retiredPackages` row. The "Upgrading from v4 to v5" section is unchanged (out of scope per the ticket).

### Follow-up

- #298 carves out the pre-existing silent catch in `loadUserConfig` whose blast radius became materially larger with this feature (silent config-load failures now cause declared retired prefixes to re-appear as "undeclared" with no diagnostic). Fix deferred because it requires a design decision about error-surfacing semantics for the preview flow, independent of this feature.

Closes #292