### PR TITLE
#300 Add release-notes preview generator to `release-kit prepare`

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -228,9 +228,31 @@ Run release preparation with automatic workspace discovery.
 | `--set-version=X.Y.Z`        | Set an explicit canonical semver version; bypasses commit-derived bumps. Requires `--only` in monorepo mode. |
 | `--force`                    | Bypass the "no commits since last tag" check (requires `--bump`)                                             |
 | `--only=name1,name2`         | Only process the named workspaces (monorepo only)                                                            |
+| `--with-release-notes`       | Write per-workspace release-notes previews under `{workspacePath}/docs/`                                     |
 | `--help`, `-h`               | Show help                                                                                                    |
 
 Workspace names for `--only` match the package directory name (e.g., `arrays`, `release-kit`).
+
+#### Previewing release notes with `--with-release-notes`
+
+`--with-release-notes` writes two versioned files per workspace after each workspace's `changelog.json` is produced:
+
+- `{workspacePath}/docs/README.v{version}.md` — the workspace `README.md` with release notes injected at the `<!-- section:release-notes -->` marker.
+- `{workspacePath}/docs/RELEASE_NOTES.v{version}.md` — the standalone release notes for this version.
+
+The publish-time inject-and-revert lifecycle is unchanged; previews are additive, deterministic, and safe to regenerate. When `changelogJson.enabled` is `false`, the flag logs a warning and skips preview generation. In dry-run mode, planned writes are logged and no files are created.
+
+Because preview filenames are versioned, committing them will accumulate files over time. The recommended `.gitignore` entry for monorepos is:
+
+```gitignore
+packages/*/docs/*.v*.md
+```
+
+For single-package repos:
+
+```gitignore
+docs/*.v*.md
+```
 
 #### Setting an explicit version with `--set-version`
 

--- a/packages/release-kit/src/__tests__/injectReleaseNotesIntoReadme.unit.test.ts
+++ b/packages/release-kit/src/__tests__/injectReleaseNotesIntoReadme.unit.test.ts
@@ -182,9 +182,10 @@ describe(renderInjectedReadme, () => {
     const result = renderInjectedReadme(readme, '/pkg/.meta/changelog.json', 'v1.2.3');
 
     expect(result).toBeDefined();
+    expect(result?.injectedReadme).toContain('## Release notes — v1.2.3 (2024-01-01)');
     expect(result?.injectedReadme).toContain('### Features');
     expect(result?.injectedReadme).toContain('## Installation');
-    expect(result?.releaseNotesMarkdown).toBe('### Features\n\n- Add widget');
+    expect(result?.releaseNotesMarkdown).toBe('## Release notes — v1.2.3 (2024-01-01)\n\n### Features\n\n- Add widget');
     // The wrapper does not write; neither does the pure renderer.
     expect(mockWriteFileSync).not.toHaveBeenCalled();
   });

--- a/packages/release-kit/src/__tests__/injectReleaseNotesIntoReadme.unit.test.ts
+++ b/packages/release-kit/src/__tests__/injectReleaseNotesIntoReadme.unit.test.ts
@@ -24,7 +24,11 @@ vi.mock('../renderReleaseNotes.ts', () => ({
   renderReleaseNotesSingle: mockRenderReleaseNotesSingle,
 }));
 
-import { injectReleaseNotesIntoReadme, resolveReadmePath } from '../injectReleaseNotesIntoReadme.ts';
+import {
+  injectReleaseNotesIntoReadme,
+  renderInjectedReadme,
+  resolveReadmePath,
+} from '../injectReleaseNotesIntoReadme.ts';
 
 describe(injectReleaseNotesIntoReadme, () => {
   beforeEach(() => {
@@ -135,6 +139,123 @@ describe(injectReleaseNotesIntoReadme, () => {
     setupInjectionMocks();
 
     injectReleaseNotesIntoReadme('/pkg/README.md', '/pkg/.meta/changelog.json', 'v1.0.0');
+
+    const renderOptions = mockRenderReleaseNotesSingle.mock.calls[0]?.[1];
+    expect(renderOptions).not.toHaveProperty('sectionOrder');
+  });
+});
+
+describe(renderInjectedReadme, () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
+    mockExtractVersion.mockReset();
+    mockReadChangelogEntries.mockReset();
+    mockMatchesAudience.mockReset();
+    mockRenderReleaseNotesSingle.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  function setupRenderMocks(): void {
+    mockExistsSync.mockReturnValue(true);
+    mockExtractVersion.mockReturnValue('1.2.3');
+    mockReadChangelogEntries.mockReturnValue([
+      {
+        version: '1.2.3',
+        date: '2024-01-01',
+        sections: [{ title: 'Features', audience: 'all', items: [{ description: 'Add widget' }] }],
+      },
+    ]);
+    mockMatchesAudience.mockReturnValue(() => true);
+    mockRenderReleaseNotesSingle.mockReturnValue('### Features\n\n- Add widget\n');
+  }
+
+  it('returns both injected README and standalone release notes when markers are present', () => {
+    setupRenderMocks();
+
+    const readme = '# Package\n\n<!-- section:release-notes --><!-- /section:release-notes -->\n\n## Installation\n';
+    const result = renderInjectedReadme(readme, '/pkg/.meta/changelog.json', 'v1.2.3');
+
+    expect(result).toBeDefined();
+    expect(result?.injectedReadme).toContain('### Features');
+    expect(result?.injectedReadme).toContain('## Installation');
+    expect(result?.releaseNotesMarkdown).toBe('### Features\n\n- Add widget');
+    // The wrapper does not write; neither does the pure renderer.
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('prepends a release-notes section when markers are absent', () => {
+    setupRenderMocks();
+
+    const readme = '# Package\n\n## Installation\n';
+    const result = renderInjectedReadme(readme, '/pkg/.meta/changelog.json', 'v1.2.3');
+
+    expect(result).toBeDefined();
+    expect(result?.injectedReadme.startsWith('<!-- section:release-notes -->')).toBe(true);
+    expect(result?.injectedReadme).toContain('# Package');
+  });
+
+  it('returns undefined when changelog.json does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const result = renderInjectedReadme('# README\n', '/pkg/.meta/changelog.json', 'v1.2.3');
+
+    expect(result).toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('not found; skipping README injection'));
+  });
+
+  it('returns undefined when changelog.json is unparseable', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExtractVersion.mockReturnValue('1.2.3');
+    mockReadChangelogEntries.mockReturnValue(undefined);
+
+    const result = renderInjectedReadme('# README\n', '/pkg/.meta/changelog.json', 'v1.2.3');
+
+    expect(result).toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('could not parse'));
+  });
+
+  it('returns undefined when no changelog entry matches the version', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExtractVersion.mockReturnValue('9.9.9');
+    mockReadChangelogEntries.mockReturnValue([{ version: '1.0.0', date: '2024-01-01', sections: [] }]);
+
+    const result = renderInjectedReadme('# README\n', '/pkg/.meta/changelog.json', 'v9.9.9');
+
+    expect(result).toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no changelog entry for version 9.9.9'));
+  });
+
+  it('returns undefined when all sections are dev-only', () => {
+    setupRenderMocks();
+    mockRenderReleaseNotesSingle.mockReturnValue('');
+
+    const result = renderInjectedReadme('# README\n', '/pkg/.meta/changelog.json', 'v1.2.3');
+
+    expect(result).toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no user-facing release notes'));
+  });
+
+  it('forwards sectionOrder to the renderer when provided', () => {
+    setupRenderMocks();
+
+    renderInjectedReadme('# README\n', '/pkg/.meta/changelog.json', 'v1.2.3', ['Bug fixes', 'Features']);
+
+    expect(mockRenderReleaseNotesSingle).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sectionOrder: ['Bug fixes', 'Features'] }),
+    );
+  });
+
+  it('omits sectionOrder from render options when not provided', () => {
+    setupRenderMocks();
+
+    renderInjectedReadme('# README\n', '/pkg/.meta/changelog.json', 'v1.2.3');
 
     const renderOptions = mockRenderReleaseNotesSingle.mock.calls[0]?.[1];
     expect(renderOptions).not.toHaveProperty('sectionOrder');

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -421,6 +421,33 @@ describe(prepareCommand, () => {
       expect.objectContaining({ setVersion: '1.2.3' }),
     );
   });
+
+  it('forwards withReleaseNotes to releasePrepareMono when --with-release-notes is set', async () => {
+    await prepareCommand(['--with-release-notes']);
+
+    expect(mockReleasePrepareMono).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ withReleaseNotes: true }),
+    );
+  });
+
+  it('forwards withReleaseNotes to releasePrepare in single-package mode', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue(undefined);
+
+    await prepareCommand(['--with-release-notes']);
+
+    expect(mockReleasePrepare).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ withReleaseNotes: true }),
+    );
+  });
+
+  it('omits withReleaseNotes from options when the flag is not set', async () => {
+    await prepareCommand([]);
+
+    const callArgs = mockReleasePrepareMono.mock.calls[0]?.[1];
+    expect(callArgs).not.toHaveProperty('withReleaseNotes');
+  });
 });
 
 describe(parseArgs, () => {
@@ -502,6 +529,21 @@ describe(parseArgs, () => {
   it('defaults noGitChecks to false', () => {
     const result = parseArgs([]);
     expect(result.noGitChecks).toBe(false);
+  });
+
+  it('parses --with-release-notes flag', () => {
+    const result = parseArgs(['--with-release-notes']);
+    expect(result.withReleaseNotes).toBe(true);
+  });
+
+  it('defaults withReleaseNotes to false', () => {
+    const result = parseArgs([]);
+    expect(result.withReleaseNotes).toBe(false);
+  });
+
+  it('documents --with-release-notes in --help output', () => {
+    expect(() => parseArgs(['--help'])).toThrow(ExitError);
+    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('--with-release-notes'));
   });
 });
 

--- a/packages/release-kit/src/__tests__/prepareWithReleaseNotes.int.test.ts
+++ b/packages/release-kit/src/__tests__/prepareWithReleaseNotes.int.test.ts
@@ -1,0 +1,181 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { writeReleaseNotesPreviews } from '../writeReleaseNotesPreviews.ts';
+
+/** Minimal changelog.json fixture with a public feature section and a dev-only internal section. */
+const changelogJsonFixture = [
+  {
+    version: '2.4.0',
+    date: '2026-04-23',
+    sections: [
+      {
+        title: 'Features',
+        audience: 'all',
+        items: [{ description: 'Add release-notes preview generator', body: 'Adds the `--with-release-notes` flag.' }],
+      },
+      {
+        title: 'Internal',
+        audience: 'dev',
+        items: [{ description: 'Refactor internal helper' }],
+      },
+    ],
+  },
+];
+
+const readmeWithMarker = `# @scope/pkg
+
+Short description.
+
+<!-- section:release-notes --><!-- /section:release-notes -->
+
+## Installation
+
+\`\`\`sh
+npm install @scope/pkg
+\`\`\`
+`;
+
+describe('writeReleaseNotesPreviews (integration)', () => {
+  let tempDir: string;
+  let changelogJsonPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'prepare-with-release-notes-'));
+    writeFileSync(join(tempDir, 'README.md'), readmeWithMarker, 'utf8');
+    mkdirSync(join(tempDir, '.meta'), { recursive: true });
+    changelogJsonPath = join(tempDir, '.meta', 'changelog.json');
+    writeFileSync(changelogJsonPath, JSON.stringify(changelogJsonFixture), 'utf8');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes both preview files under docs/ with correct content for a pending release', () => {
+    const result = writeReleaseNotesPreviews({
+      workspacePath: tempDir,
+      tag: 'pkg-v2.4.0',
+      changelogJsonPath,
+      sectionOrder: ['Features', 'Bug fixes'],
+      dryRun: false,
+    });
+
+    expect(result.renderSkipped).toBe(false);
+
+    const readmePreviewPath = join(tempDir, 'docs', 'README.v2.4.0.md');
+    const releaseNotesPreviewPath = join(tempDir, 'docs', 'RELEASE_NOTES.v2.4.0.md');
+
+    expect(existsSync(readmePreviewPath)).toBe(true);
+    expect(existsSync(releaseNotesPreviewPath)).toBe(true);
+
+    const readmePreview = readFileSync(readmePreviewPath, 'utf8');
+    expect(readmePreview).toContain('# @scope/pkg');
+    expect(readmePreview).toContain('## Installation');
+    expect(readmePreview).toContain('### Features');
+    expect(readmePreview).toContain('Add release-notes preview generator');
+    // Dev-only sections must not leak into the public README preview.
+    expect(readmePreview).not.toContain('Internal');
+
+    const releaseNotesPreview = readFileSync(releaseNotesPreviewPath, 'utf8');
+    expect(releaseNotesPreview).toContain('### Features');
+    expect(releaseNotesPreview).toContain('Add release-notes preview generator');
+    expect(releaseNotesPreview).not.toContain('Internal');
+    expect(releaseNotesPreview.endsWith('\n')).toBe(true);
+  });
+
+  it('overwrites existing preview files on re-run with the same version', () => {
+    // First pass.
+    writeReleaseNotesPreviews({
+      workspacePath: tempDir,
+      tag: 'pkg-v2.4.0',
+      changelogJsonPath,
+      sectionOrder: ['Features'],
+      dryRun: false,
+    });
+
+    const readmePreviewPath = join(tempDir, 'docs', 'README.v2.4.0.md');
+    // Mutate the existing file to something clearly stale.
+    writeFileSync(readmePreviewPath, 'STALE CONTENT', 'utf8');
+    expect(readFileSync(readmePreviewPath, 'utf8')).toBe('STALE CONTENT');
+
+    // Second pass with the same tag should overwrite.
+    const result = writeReleaseNotesPreviews({
+      workspacePath: tempDir,
+      tag: 'pkg-v2.4.0',
+      changelogJsonPath,
+      sectionOrder: ['Features'],
+      dryRun: false,
+    });
+
+    expect(result.renderSkipped).toBe(false);
+    expect(result.injectedReadme?.outcome).toBe('overwritten');
+    expect(readFileSync(readmePreviewPath, 'utf8')).toContain('### Features');
+  });
+
+  it('creates the docs/ directory when it does not already exist', () => {
+    const docsDir = join(tempDir, 'docs');
+    expect(existsSync(docsDir)).toBe(false);
+
+    writeReleaseNotesPreviews({
+      workspacePath: tempDir,
+      tag: 'pkg-v2.4.0',
+      changelogJsonPath,
+      sectionOrder: ['Features'],
+      dryRun: false,
+    });
+
+    expect(existsSync(docsDir)).toBe(true);
+    expect(existsSync(join(docsDir, 'README.v2.4.0.md'))).toBe(true);
+    expect(existsSync(join(docsDir, 'RELEASE_NOTES.v2.4.0.md'))).toBe(true);
+  });
+
+  it('skips the injected-README preview when the workspace has no README.md but still writes the standalone release notes', () => {
+    // Remove the fixture README to simulate a workspace without one.
+    rmSync(join(tempDir, 'README.md'));
+
+    const result = writeReleaseNotesPreviews({
+      workspacePath: tempDir,
+      tag: 'pkg-v2.4.0',
+      changelogJsonPath,
+      sectionOrder: ['Features'],
+      dryRun: false,
+    });
+
+    expect(result.renderSkipped).toBe(false);
+    expect(result.injectedReadme?.outcome).toBe('skipped-no-readme');
+    expect(existsSync(join(tempDir, 'docs', 'README.v2.4.0.md'))).toBe(false);
+    expect(existsSync(join(tempDir, 'docs', 'RELEASE_NOTES.v2.4.0.md'))).toBe(true);
+  });
+
+  it('writes no files and reports renderSkipped when no changelog entry matches the tag', () => {
+    const result = writeReleaseNotesPreviews({
+      workspacePath: tempDir,
+      tag: 'pkg-v9.9.9',
+      changelogJsonPath,
+      sectionOrder: ['Features'],
+      dryRun: false,
+    });
+
+    expect(result.renderSkipped).toBe(true);
+    expect(existsSync(join(tempDir, 'docs'))).toBe(false);
+  });
+
+  it('writes no files in dry-run mode', () => {
+    const result = writeReleaseNotesPreviews({
+      workspacePath: tempDir,
+      tag: 'pkg-v2.4.0',
+      changelogJsonPath,
+      sectionOrder: ['Features'],
+      dryRun: true,
+    });
+
+    expect(result.renderSkipped).toBe(false);
+    expect(result.injectedReadme?.outcome).toBe('dry-run');
+    expect(result.releaseNotes?.outcome).toBe('dry-run');
+    expect(existsSync(join(tempDir, 'docs'))).toBe(false);
+  });
+});

--- a/packages/release-kit/src/__tests__/prepareWithReleaseNotes.int.test.ts
+++ b/packages/release-kit/src/__tests__/prepareWithReleaseNotes.int.test.ts
@@ -75,12 +75,15 @@ describe('writeReleaseNotesPreviews (integration)', () => {
     const readmePreview = readFileSync(readmePreviewPath, 'utf8');
     expect(readmePreview).toContain('# @scope/pkg');
     expect(readmePreview).toContain('## Installation');
+    // Labeled heading anchors the injected content to a version.
+    expect(readmePreview).toContain('## Release notes — v2.4.0 (2026-04-23)');
     expect(readmePreview).toContain('### Features');
     expect(readmePreview).toContain('Add release-notes preview generator');
     // Dev-only sections must not leak into the public README preview.
     expect(readmePreview).not.toContain('Internal');
 
     const releaseNotesPreview = readFileSync(releaseNotesPreviewPath, 'utf8');
+    expect(releaseNotesPreview).toContain('## Release notes — v2.4.0 (2026-04-23)');
     expect(releaseNotesPreview).toContain('### Features');
     expect(releaseNotesPreview).toContain('Add release-notes preview generator');
     expect(releaseNotesPreview).not.toContain('Internal');

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockExecFileSync = vi.hoisted(() => vi.fn());
 const mockExecSync = vi.hoisted(() => vi.fn());
 const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
 const mockHasPrettierConfig = vi.hoisted(() => vi.fn());
+const mockWriteReleaseNotesPreviews = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,
@@ -22,6 +23,18 @@ vi.mock('../resolveCliffConfigPath.ts', () => ({
 
 vi.mock('../hasPrettierConfig.ts', () => ({
   hasPrettierConfig: mockHasPrettierConfig,
+}));
+
+vi.mock('../writeReleaseNotesPreviews.ts', () => ({
+  writeReleaseNotesPreviews: mockWriteReleaseNotesPreviews,
+}));
+
+// Stub generateChangelogJson when tests exercise the enabled path, so no git-cliff invocation
+// or filesystem access is required.
+const mockGenerateChangelogJson = vi.hoisted(() => vi.fn());
+
+vi.mock('../generateChangelogJson.ts', () => ({
+  generateChangelogJson: mockGenerateChangelogJson,
 }));
 
 import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG } from '../defaults.ts';
@@ -60,12 +73,20 @@ function setupFeatCommit(): void {
 }
 
 describe(releasePrepare, () => {
+  beforeEach(() => {
+    mockGenerateChangelogJson.mockImplementation((_config, changelogPath: string) => [
+      `${changelogPath}/.meta/changelog.json`,
+    ]);
+  });
+
   afterEach(() => {
     mockExecFileSync.mockReset();
     mockExecSync.mockReset();
     mockReadFileSync.mockReset();
     mockWriteFileSync.mockReset();
     mockHasPrettierConfig.mockReset();
+    mockWriteReleaseNotesPreviews.mockReset();
+    mockGenerateChangelogJson.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -326,6 +347,59 @@ describe(releasePrepare, () => {
     expect(() => releasePrepare(makeConfig(), { dryRun: false, setVersion: '0.5.0' })).toThrow(
       '--set-version 0.5.0 is not greater than current version 0.5.0',
     );
+  });
+
+  it('calls writeReleaseNotesPreviews when --with-release-notes is set and changelogJson is enabled', () => {
+    setupFeatCommit();
+    vi.spyOn(process, 'cwd').mockReturnValue('/single-pkg');
+
+    releasePrepare(makeConfig({ changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true } }), {
+      dryRun: false,
+      withReleaseNotes: true,
+    });
+
+    expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledTimes(1);
+    expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspacePath: '/single-pkg',
+        tag: 'v1.1.0',
+        dryRun: false,
+        sectionOrder: expect.any(Array),
+      }),
+    );
+  });
+
+  it('warns and skips preview generation when --with-release-notes is set but changelogJson is disabled', () => {
+    setupFeatCommit();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    releasePrepare(makeConfig(), { dryRun: false, withReleaseNotes: true });
+
+    expect(mockWriteReleaseNotesPreviews).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('--with-release-notes requires changelogJson.enabled'),
+    );
+  });
+
+  it('does not call writeReleaseNotesPreviews when --with-release-notes is not set', () => {
+    setupFeatCommit();
+
+    releasePrepare(makeConfig({ changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true } }), {
+      dryRun: false,
+    });
+
+    expect(mockWriteReleaseNotesPreviews).not.toHaveBeenCalled();
+  });
+
+  it('propagates dryRun to writeReleaseNotesPreviews', () => {
+    setupFeatCommit();
+
+    releasePrepare(makeConfig({ changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true } }), {
+      dryRun: true,
+      withReleaseNotes: true,
+    });
+
+    expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
   });
 
   it('does not write files in dry-run mode with --set-version', () => {

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -365,6 +365,7 @@ describe(releasePrepare, () => {
         tag: 'v1.1.0',
         dryRun: false,
         sectionOrder: expect.any(Array),
+        changelogJsonPath: './.meta/changelog.json',
       }),
     );
   });

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -1485,5 +1485,71 @@ describe(releasePrepareMono, () => {
 
       expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
     });
+
+    it('invokes writeReleaseNotesPreviews for both direct-bumped and propagation-only workspaces', () => {
+      // Mirrors the `dependency propagation` setup: core is bumped directly (feat commit), and
+      // app is bumped only through propagation. Both branches of `generateWorkspaceChangelogs`
+      // must reach `maybeWritePreviews` so previews are written for each workspace.
+      const config = makeConfig({
+        workspaces: [
+          {
+            dir: 'core',
+            name: '@test/core',
+            tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+          {
+            dir: 'app',
+            name: '@test/app',
+            tagPrefix: 'app-v',
+            workspacePath: 'packages/app',
+            packageFiles: ['packages/app/package.json'],
+            changelogPaths: ['packages/app'],
+            paths: ['packages/app/**'],
+          },
+        ],
+        changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true },
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          const matchArg = args.find((a: string) => a.startsWith('--match='));
+          if (matchArg?.includes('core-v')) return 'core-v1.0.0\n';
+          if (matchArg?.includes('app-v')) return 'app-v2.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          const hasCorePath = args.includes('packages/core/**');
+          if (hasCorePath) return 'feat: add utilityabc123';
+          return '';
+        }
+        // git-cliff context output (used when changelogJson.enabled is true)
+        return '[]';
+      });
+      mockReadFileSync.mockImplementation((filePath: string) => {
+        if (typeof filePath === 'string' && filePath.includes('core')) {
+          return JSON.stringify({ name: '@test/core', version: '1.0.0' });
+        }
+        return JSON.stringify({
+          name: '@test/app',
+          version: '2.0.0',
+          dependencies: { '@test/core': 'workspace:*' },
+        });
+      });
+      mockExistsSync.mockReturnValue(false);
+
+      releasePrepareMono(config, { dryRun: false, withReleaseNotes: true });
+
+      expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledTimes(2);
+      // Confirm each workspace received a preview call with the correct workspacePath and tag.
+      expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledWith(
+        expect.objectContaining({ workspacePath: 'packages/core', tag: 'core-v1.1.0' }),
+      );
+      expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledWith(
+        expect.objectContaining({ workspacePath: 'packages/app', tag: 'app-v2.0.1' }),
+      );
+    });
   });
 });

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockExecFileSync = vi.hoisted(() => vi.fn());
 const mockExecSync = vi.hoisted(() => vi.fn());
@@ -6,6 +6,7 @@ const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
 const mockHasPrettierConfig = vi.hoisted(() => vi.fn());
+const mockWriteReleaseNotesPreviews = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,
@@ -24,6 +25,21 @@ vi.mock('../resolveCliffConfigPath.ts', () => ({
 
 vi.mock('../hasPrettierConfig.ts', () => ({
   hasPrettierConfig: mockHasPrettierConfig,
+}));
+
+vi.mock('../writeReleaseNotesPreviews.ts', () => ({
+  writeReleaseNotesPreviews: mockWriteReleaseNotesPreviews,
+}));
+
+// Stub out the real `generateChangelogJson*` helpers for tests in this file that exercise
+// the `changelogJson.enabled: true` path. The default stub returns a deterministic file path
+// without invoking git-cliff or touching the filesystem.
+const mockGenerateChangelogJson = vi.hoisted(() => vi.fn());
+const mockGenerateSyntheticChangelogJson = vi.hoisted(() => vi.fn());
+
+vi.mock('../generateChangelogJson.ts', () => ({
+  generateChangelogJson: mockGenerateChangelogJson,
+  generateSyntheticChangelogJson: mockGenerateSyntheticChangelogJson,
 }));
 
 import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG } from '../defaults.ts';
@@ -79,6 +95,17 @@ function findAllCliffOutputPaths(): string[] {
 }
 
 describe(releasePrepareMono, () => {
+  beforeEach(() => {
+    // Default: pretend each call produced a single changelog.json path derived from the
+    // changelog directory. Individual tests can override if needed.
+    mockGenerateChangelogJson.mockImplementation((_config, changelogPath: string) => [
+      `${changelogPath}/.meta/changelog.json`,
+    ]);
+    mockGenerateSyntheticChangelogJson.mockImplementation((_config, changelogPath: string) => [
+      `${changelogPath}/.meta/changelog.json`,
+    ]);
+  });
+
   afterEach(() => {
     mockExecFileSync.mockReset();
     mockExecSync.mockReset();
@@ -86,6 +113,9 @@ describe(releasePrepareMono, () => {
     mockReadFileSync.mockReset();
     mockWriteFileSync.mockReset();
     mockHasPrettierConfig.mockReset();
+    mockWriteReleaseNotesPreviews.mockReset();
+    mockGenerateChangelogJson.mockReset();
+    mockGenerateSyntheticChangelogJson.mockReset();
   });
 
   it('processes a workspace that has commits', () => {
@@ -1326,6 +1356,134 @@ describe(releasePrepareMono, () => {
 
       expect(messages).toHaveLength(1);
       errorSpy.mockRestore();
+    });
+  });
+
+  describe('--with-release-notes flag', () => {
+    function setupArraysWithFeat(): MonorepoReleaseConfig {
+      const config = makeConfig({
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+        ],
+        changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true },
+      });
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          return 'arrays-v1.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          return 'feat: add utilityabc123';
+        }
+        // git-cliff context output (used when changelogJson.enabled is true)
+        return '[]';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+      return config;
+    }
+
+    it('invokes writeReleaseNotesPreviews for each released workspace when enabled', () => {
+      const config = setupArraysWithFeat();
+
+      releasePrepareMono(config, { dryRun: false, withReleaseNotes: true });
+
+      expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledTimes(1);
+      expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspacePath: 'packages/arrays',
+          tag: 'arrays-v1.1.0',
+          dryRun: false,
+          sectionOrder: expect.any(Array),
+        }),
+      );
+    });
+
+    it('does not invoke writeReleaseNotesPreviews when the flag is not set', () => {
+      const config = setupArraysWithFeat();
+
+      releasePrepareMono(config, { dryRun: false });
+
+      expect(mockWriteReleaseNotesPreviews).not.toHaveBeenCalled();
+    });
+
+    it('warns and skips when --with-release-notes is set but changelogJson.enabled is false', () => {
+      const config = makeConfig({
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+        ],
+      });
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          return 'arrays-v1.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          return 'feat: add utilityabc123';
+        }
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      releasePrepareMono(config, { dryRun: false, withReleaseNotes: true });
+
+      expect(mockWriteReleaseNotesPreviews).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--with-release-notes requires changelogJson.enabled'),
+      );
+    });
+
+    it('does not invoke previews for skipped workspaces', () => {
+      const config = makeConfig({
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+        ],
+        changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true },
+      });
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          return 'arrays-v1.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          return '';
+        }
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/arrays', version: '1.0.0' }));
+
+      releasePrepareMono(config, { dryRun: false, withReleaseNotes: true });
+
+      expect(mockWriteReleaseNotesPreviews).not.toHaveBeenCalled();
+    });
+
+    it('propagates dryRun through to writeReleaseNotesPreviews', () => {
+      const config = setupArraysWithFeat();
+
+      releasePrepareMono(config, { dryRun: true, withReleaseNotes: true });
+
+      expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
     });
   });
 });

--- a/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
+++ b/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
@@ -223,6 +223,64 @@ describe(writeReleaseNotesPreviews, () => {
     expect(standaloneCall?.[1]).toBe('### Features\n\n- X\n');
   });
 
+  it('treats the README as unreadable when readFileSync throws and skips only the injected preview', () => {
+    mockExtractVersion.mockReturnValue('1.2.3');
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+    mockRenderInjectedReadme.mockReturnValue({
+      injectedReadme: '<!-- section:release-notes -->\n### Features\n\n- X\n<!-- /section:release-notes -->\n',
+      releaseNotesMarkdown: '### Features\n\n- X',
+    });
+    mockWriteFileWithCheck.mockReturnValue({ filePath: '', outcome: 'created' });
+
+    const result = writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: [],
+      dryRun: false,
+    });
+
+    expect(result.renderSkipped).toBe(false);
+    expect(result.injectedReadme?.outcome).toBe('skipped-no-readme');
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('failed to read'));
+    // Suppresses the generic "not found" warning when the file existed but was unreadable.
+    expect(console.warn).not.toHaveBeenCalledWith(expect.stringContaining('not found'));
+    // Only the standalone file is written.
+    expect(mockWriteFileWithCheck).toHaveBeenCalledTimes(1);
+    expect(mockWriteFileWithCheck.mock.calls[0]?.[0]).toBe('/ws/docs/RELEASE_NOTES.v1.2.3.md');
+  });
+
+  it('handles dry-run + missing README: writes nothing, logs dry-run for standalone, warns about missing README', () => {
+    mockExtractVersion.mockReturnValue('1.2.3');
+    mockExistsSync.mockReturnValue(false);
+    mockRenderInjectedReadme.mockReturnValue({
+      injectedReadme: '<!-- section:release-notes -->\n### Features\n\n- X\n<!-- /section:release-notes -->\n',
+      releaseNotesMarkdown: '### Features\n\n- X',
+    });
+
+    const result = writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: [],
+      dryRun: true,
+    });
+
+    expect(mockWriteFileWithCheck).not.toHaveBeenCalled();
+    expect(result.injectedReadme?.outcome).toBe('skipped-no-readme');
+    expect(result.releaseNotes?.outcome).toBe('dry-run');
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('not found; skipping injected-README preview'));
+    expect(console.info).toHaveBeenCalledWith(
+      expect.stringContaining('[dry-run] Would write /ws/docs/RELEASE_NOTES.v1.2.3.md'),
+    );
+    expect(console.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('[dry-run] Would write /ws/docs/README.v1.2.3.md'),
+    );
+  });
+
   it('records a failure outcome and logs an error when writeFileWithCheck fails', () => {
     setupRenderOk();
     mockWriteFileWithCheck.mockReturnValue({ filePath: '', outcome: 'failed', error: 'EACCES' });

--- a/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
+++ b/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileWithCheck = vi.hoisted(() => vi.fn());
+const mockRenderInjectedReadme = vi.hoisted(() => vi.fn());
+const mockExtractVersion = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+}));
+
+vi.mock('@williamthorsen/node-monorepo-core', () => ({
+  writeFileWithCheck: mockWriteFileWithCheck,
+}));
+
+vi.mock('../injectReleaseNotesIntoReadme.ts', () => ({
+  renderInjectedReadme: mockRenderInjectedReadme,
+}));
+
+vi.mock('../changelogJsonUtils.ts', () => ({
+  extractVersion: mockExtractVersion,
+}));
+
+import { writeReleaseNotesPreviews } from '../writeReleaseNotesPreviews.ts';
+
+describe(writeReleaseNotesPreviews, () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
+    mockWriteFileWithCheck.mockReset();
+    mockRenderInjectedReadme.mockReset();
+    mockExtractVersion.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  function setupRenderOk(): void {
+    mockExtractVersion.mockReturnValue('1.2.3');
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('# Pkg\n<!-- section:release-notes --><!-- /section:release-notes -->\n');
+    mockRenderInjectedReadme.mockReturnValue({
+      injectedReadme: '# Pkg\n<!-- section:release-notes -->\n### Features\n\n- X\n<!-- /section:release-notes -->\n',
+      releaseNotesMarkdown: '### Features\n\n- X',
+    });
+    mockWriteFileWithCheck.mockReturnValue({ filePath: '', outcome: 'created' });
+  }
+
+  it('writes both preview files under docs/ with versioned names', () => {
+    setupRenderOk();
+
+    const result = writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: ['Features'],
+      dryRun: false,
+    });
+
+    expect(result.renderSkipped).toBe(false);
+    expect(mockWriteFileWithCheck).toHaveBeenCalledTimes(2);
+    const calls = mockWriteFileWithCheck.mock.calls;
+    const firstPath = calls[0]?.[0];
+    const secondPath = calls[1]?.[0];
+    expect(firstPath).toBe('/ws/docs/README.v1.2.3.md');
+    expect(secondPath).toBe('/ws/docs/RELEASE_NOTES.v1.2.3.md');
+    expect(result.injectedReadme?.outcome).toBe('created');
+    expect(result.releaseNotes?.outcome).toBe('created');
+  });
+
+  it('passes overwrite:true so existing files are replaced', () => {
+    setupRenderOk();
+    mockWriteFileWithCheck.mockReturnValue({ filePath: '', outcome: 'overwritten' });
+
+    const result = writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: [],
+      dryRun: false,
+    });
+
+    expect(result.injectedReadme?.outcome).toBe('overwritten');
+    expect(result.releaseNotes?.outcome).toBe('overwritten');
+    for (const call of mockWriteFileWithCheck.mock.calls) {
+      expect(call[2]).toEqual({ dryRun: false, overwrite: true });
+    }
+  });
+
+  it('skips the injected README preview when the workspace has no README.md but still writes the standalone file', () => {
+    mockExtractVersion.mockReturnValue('1.2.3');
+    // README.md does not exist; nothing else calls existsSync in this flow.
+    mockExistsSync.mockReturnValue(false);
+    mockRenderInjectedReadme.mockReturnValue({
+      injectedReadme: '<!-- section:release-notes -->\n### Features\n\n- X\n<!-- /section:release-notes -->\n\n',
+      releaseNotesMarkdown: '### Features\n\n- X',
+    });
+    mockWriteFileWithCheck.mockReturnValue({ filePath: '', outcome: 'created' });
+
+    const result = writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: [],
+      dryRun: false,
+    });
+
+    expect(result.renderSkipped).toBe(false);
+    expect(result.injectedReadme?.outcome).toBe('skipped-no-readme');
+    // Only the release-notes file is written.
+    expect(mockWriteFileWithCheck).toHaveBeenCalledTimes(1);
+    expect(mockWriteFileWithCheck.mock.calls[0]?.[0]).toBe('/ws/docs/RELEASE_NOTES.v1.2.3.md');
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it('passes an empty-string readme to the renderer when README.md is missing', () => {
+    mockExtractVersion.mockReturnValue('1.2.3');
+    mockExistsSync.mockReturnValue(false);
+    mockRenderInjectedReadme.mockReturnValue({
+      injectedReadme: '<!-- section:release-notes -->\n### Features\n\n- X\n<!-- /section:release-notes -->\n\n',
+      releaseNotesMarkdown: '### Features\n\n- X',
+    });
+    mockWriteFileWithCheck.mockReturnValue({ filePath: '', outcome: 'created' });
+
+    writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: [],
+      dryRun: false,
+    });
+
+    const call = mockRenderInjectedReadme.mock.calls[0];
+    expect(call?.[0]).toBe('');
+  });
+
+  it('writes nothing and returns renderSkipped when the renderer returns undefined', () => {
+    mockExtractVersion.mockReturnValue('1.2.3');
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('# Pkg\n');
+    mockRenderInjectedReadme.mockReturnValue(undefined);
+
+    const result = writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: [],
+      dryRun: false,
+    });
+
+    expect(result.renderSkipped).toBe(true);
+    expect(result.injectedReadme).toBeUndefined();
+    expect(result.releaseNotes).toBeUndefined();
+    expect(mockWriteFileWithCheck).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('skipping release-notes previews'));
+  });
+
+  it('logs planned writes in dry-run mode and creates no files', () => {
+    setupRenderOk();
+
+    const result = writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: [],
+      dryRun: true,
+    });
+
+    expect(mockWriteFileWithCheck).not.toHaveBeenCalled();
+    expect(result.injectedReadme?.outcome).toBe('dry-run');
+    expect(result.releaseNotes?.outcome).toBe('dry-run');
+    expect(console.info).toHaveBeenCalledWith(
+      expect.stringContaining('[dry-run] Would write /ws/docs/README.v1.2.3.md'),
+    );
+    expect(console.info).toHaveBeenCalledWith(
+      expect.stringContaining('[dry-run] Would write /ws/docs/RELEASE_NOTES.v1.2.3.md'),
+    );
+  });
+
+  it('forwards sectionOrder to the renderer', () => {
+    setupRenderOk();
+
+    writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: ['Bug fixes', 'Features'],
+      dryRun: false,
+    });
+
+    const call = mockRenderInjectedReadme.mock.calls[0];
+    expect(call?.[3]).toEqual(['Bug fixes', 'Features']);
+  });
+
+  it('writes the standalone file with a trailing newline even when the rendered notes lack one', () => {
+    setupRenderOk();
+    // Rendered notes have no trailing newline (as produced by the trimmed renderer output).
+    mockRenderInjectedReadme.mockReturnValue({
+      injectedReadme: '# Pkg\n',
+      releaseNotesMarkdown: '### Features\n\n- X',
+    });
+
+    writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: [],
+      dryRun: false,
+    });
+
+    const standaloneCall = mockWriteFileWithCheck.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].endsWith('RELEASE_NOTES.v1.2.3.md'),
+    );
+    expect(standaloneCall).toBeDefined();
+    expect(standaloneCall?.[1]).toBe('### Features\n\n- X\n');
+  });
+
+  it('records a failure outcome and logs an error when writeFileWithCheck fails', () => {
+    setupRenderOk();
+    mockWriteFileWithCheck.mockReturnValue({ filePath: '', outcome: 'failed', error: 'EACCES' });
+
+    const result = writeReleaseNotesPreviews({
+      workspacePath: '/ws',
+      tag: 'pkg-v1.2.3',
+      changelogJsonPath: '/ws/.meta/changelog.json',
+      sectionOrder: [],
+      dryRun: false,
+    });
+
+    expect(result.injectedReadme?.outcome).toBe('failed');
+    expect(result.injectedReadme?.error).toBe('EACCES');
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error writing'));
+  });
+});

--- a/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
+++ b/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
@@ -158,7 +158,9 @@ describe(writeReleaseNotesPreviews, () => {
     expect(result.injectedReadme).toBeUndefined();
     expect(result.releaseNotes).toBeUndefined();
     expect(mockWriteFileWithCheck).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('skipping release-notes previews'));
+    // `renderInjectedReadme` emits its own specific skip reason; `writeReleaseNotesPreviews`
+    // no longer emits a redundant outer warning.
+    expect(console.warn).not.toHaveBeenCalledWith(expect.stringContaining('skipping release-notes previews'));
   });
 
   it('logs planned writes in dry-run mode and creates no files', () => {

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -117,6 +117,9 @@ Options:
   --set-version=X.Y.Z   Set an explicit version; bypasses commit-derived bumps. Requires --only in monorepo mode.
   --no-git-checks, -n   Skip the clean-working-tree check
   --only=name1,name2    Only process the named workspaces (comma-separated, monorepo only)
+  --with-release-notes  Also write per-workspace release-notes previews under {workspacePath}/docs/
+                         (docs/README.v{version}.md and docs/RELEASE_NOTES.v{version}.md).
+                         Recommended .gitignore entry: packages/*/docs/*.v*.md (or docs/*.v*.md).
   --help, -h            Show this help message
 `);
 }

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -55,7 +55,12 @@ export { discoverWorkspaces } from './discoverWorkspaces.ts';
 export { generateChangelogJson, generateSyntheticChangelogJson } from './generateChangelogJson.ts';
 export { generateChangelog, generateChangelogs } from './generateChangelogs.ts';
 export { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
-export { injectReleaseNotesIntoReadme, resolveReadmePath } from './injectReleaseNotesIntoReadme.ts';
+export type { RenderedInjectedReadme } from './injectReleaseNotesIntoReadme.ts';
+export {
+  injectReleaseNotesIntoReadme,
+  renderInjectedReadme,
+  resolveReadmePath,
+} from './injectReleaseNotesIntoReadme.ts';
 export { injectSection } from './injectSection.ts';
 export { COMMIT_PREPROCESSOR_PATTERNS, parseCommitMessage } from './parseCommitMessage.ts';
 export { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE, writeReleaseTags } from './prepareCommand.ts';
@@ -70,3 +75,9 @@ export { reportPrepare } from './reportPrepare.ts';
 export { resolveCommandTags } from './resolveCommandTags.ts';
 export { resolveReleaseTags } from './resolveReleaseTags.ts';
 export { stripScope } from './stripScope.ts';
+export type {
+  PreviewFileResult,
+  WriteReleaseNotesPreviewsOptions,
+  WriteReleaseNotesPreviewsResult,
+} from './writeReleaseNotesPreviews.ts';
+export { writeReleaseNotesPreviews } from './writeReleaseNotesPreviews.ts';

--- a/packages/release-kit/src/injectReleaseNotesIntoReadme.ts
+++ b/packages/release-kit/src/injectReleaseNotesIntoReadme.ts
@@ -9,7 +9,11 @@ import { matchesAudience, renderReleaseNotesSingle } from './renderReleaseNotes.
 export interface RenderedInjectedReadme {
   /** The README with the release-notes section injected at the marker position. */
   injectedReadme: string;
-  /** The standalone release-notes markdown for the target version (trimmed). */
+  /**
+   * The standalone release-notes markdown for the target version (trimmed), prefixed with a
+   * labeled `## Release notes — v{version} ({date})` heading so the file is self-identifying.
+   * The GitHub-release body is rendered separately (without this heading) by `createGithubRelease`.
+   */
   releaseNotesMarkdown: string;
 }
 
@@ -48,21 +52,26 @@ export function renderInjectedReadme(
     return undefined;
   }
 
-  const releaseNotesMarkdown = renderReleaseNotesSingle(entry, {
+  const renderedSections = renderReleaseNotesSingle(entry, {
     filter: matchesAudience('all'),
     includeHeading: false,
     ...(sectionOrder === undefined ? {} : { sectionOrder }),
   });
 
-  if (releaseNotesMarkdown.trimEnd().length === 0) {
+  if (renderedSections.trimEnd().length === 0) {
     console.warn(`Warning: no user-facing release notes for version ${version}; skipping README injection`);
     return undefined;
   }
 
-  const trimmedReleaseNotes = releaseNotesMarkdown.trimEnd();
-  const injectedReadme = injectSection(readme, 'release-notes', trimmedReleaseNotes);
+  // Prepend a labeled heading so readers can see both that the content is release notes
+  // and which version they describe. The README-injected form and the standalone preview
+  // share this heading; the GitHub-release body (rendered elsewhere) omits it because the
+  // release page already shows the tag and date.
+  const labeledHeading = `## Release notes — v${version} (${entry.date})`;
+  const releaseNotesMarkdown = `${labeledHeading}\n\n${renderedSections.trimEnd()}`;
+  const injectedReadme = injectSection(readme, 'release-notes', releaseNotesMarkdown);
 
-  return { injectedReadme, releaseNotesMarkdown: trimmedReleaseNotes };
+  return { injectedReadme, releaseNotesMarkdown };
 }
 
 /**

--- a/packages/release-kit/src/injectReleaseNotesIntoReadme.ts
+++ b/packages/release-kit/src/injectReleaseNotesIntoReadme.ts
@@ -76,12 +76,6 @@ export function injectReleaseNotesIntoReadme(
   tag: string,
   sectionOrder?: string[],
 ): string | undefined {
-  // Short-circuit when the changelog JSON is missing so the README file isn't read needlessly.
-  if (!existsSync(changelogJsonPath)) {
-    console.warn(`Warning: ${changelogJsonPath} not found; skipping README injection`);
-    return undefined;
-  }
-
   const originalReadme = readFileSync(readmePath, 'utf8');
 
   const rendered = renderInjectedReadme(originalReadme, changelogJsonPath, tag, sectionOrder);

--- a/packages/release-kit/src/injectReleaseNotesIntoReadme.ts
+++ b/packages/release-kit/src/injectReleaseNotesIntoReadme.ts
@@ -5,23 +5,35 @@ import { extractVersion, readChangelogEntries } from './changelogJsonUtils.ts';
 import { injectSection } from './injectSection.ts';
 import { matchesAudience, renderReleaseNotesSingle } from './renderReleaseNotes.ts';
 
+/** Rendered artifacts produced by `renderInjectedReadme`. */
+export interface RenderedInjectedReadme {
+  /** The README with the release-notes section injected at the marker position. */
+  injectedReadme: string;
+  /** The standalone release-notes markdown for the target version (trimmed). */
+  releaseNotesMarkdown: string;
+}
+
 /**
- * Inject release notes into a README and return the original content for restoration.
+ * Render a README with release notes injected at the marker position, and the standalone
+ * release-notes markdown, from an already-loaded README string and a changelog JSON path.
  *
- * Returns the original README content, or `undefined` if injection was skipped.
+ * This is the pure rendering core shared by both the publish-time injection flow and the
+ * `--with-release-notes` preview flow. It performs no file writes; callers decide whether to
+ * persist the artifacts.
+ *
+ * Returns `undefined` when any skip condition applies (missing or unparseable changelog, no
+ * entry for the version, or no public-audience sections).
  */
-export function injectReleaseNotesIntoReadme(
-  readmePath: string,
+export function renderInjectedReadme(
+  readme: string,
   changelogJsonPath: string,
   tag: string,
   sectionOrder?: string[],
-): string | undefined {
+): RenderedInjectedReadme | undefined {
   if (!existsSync(changelogJsonPath)) {
     console.warn(`Warning: ${changelogJsonPath} not found; skipping README injection`);
     return undefined;
   }
-
-  const originalReadme = readFileSync(readmePath, 'utf8');
 
   const version = extractVersion(tag);
   const entries = readChangelogEntries(changelogJsonPath);
@@ -47,9 +59,37 @@ export function injectReleaseNotesIntoReadme(
     return undefined;
   }
 
-  const injected = injectSection(originalReadme, 'release-notes', releaseNotesMarkdown.trimEnd());
-  writeFileSync(readmePath, injected, 'utf8');
+  const trimmedReleaseNotes = releaseNotesMarkdown.trimEnd();
+  const injectedReadme = injectSection(readme, 'release-notes', trimmedReleaseNotes);
 
+  return { injectedReadme, releaseNotesMarkdown: trimmedReleaseNotes };
+}
+
+/**
+ * Inject release notes into a README and return the original content for restoration.
+ *
+ * Returns the original README content, or `undefined` if injection was skipped.
+ */
+export function injectReleaseNotesIntoReadme(
+  readmePath: string,
+  changelogJsonPath: string,
+  tag: string,
+  sectionOrder?: string[],
+): string | undefined {
+  // Short-circuit when the changelog JSON is missing so the README file isn't read needlessly.
+  if (!existsSync(changelogJsonPath)) {
+    console.warn(`Warning: ${changelogJsonPath} not found; skipping README injection`);
+    return undefined;
+  }
+
+  const originalReadme = readFileSync(readmePath, 'utf8');
+
+  const rendered = renderInjectedReadme(originalReadme, changelogJsonPath, tag, sectionOrder);
+  if (rendered === undefined) {
+    return undefined;
+  }
+
+  writeFileSync(readmePath, rendered.injectedReadme, 'utf8');
   return originalReadme;
 }
 

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -52,6 +52,9 @@ Options:
   --force               Force a release even when there are no commits since the last tag (requires --bump)
   --no-git-checks, -n   Skip the clean-working-tree check
   --only=name1,name2    Only process the named workspaces (comma-separated, monorepo only)
+  --with-release-notes  Also write per-workspace release-notes previews under {workspacePath}/docs/
+                         (docs/README.v{version}.md and docs/RELEASE_NOTES.v{version}.md).
+                         Recommended .gitignore entry: packages/*/docs/*.v*.md (or docs/*.v*.md).
   --help                Show this help message
 `);
 }
@@ -67,6 +70,7 @@ const prepareFlagSchema = {
   bump: { long: '--bump', type: 'string' as const },
   setVersion: { long: '--set-version', type: 'string' as const },
   only: { long: '--only', type: 'string' as const },
+  withReleaseNotes: { long: '--with-release-notes', type: 'boolean' as const },
   help: { long: '--help', type: 'boolean' as const, short: '-h' },
 };
 
@@ -78,6 +82,7 @@ export function parseArgs(argv: string[]): {
   bumpOverride: ReleaseType | undefined;
   only: string[] | undefined;
   setVersion: string | undefined;
+  withReleaseNotes: boolean;
 } {
   let parsed;
   try {
@@ -135,6 +140,7 @@ export function parseArgs(argv: string[]): {
     bumpOverride,
     only,
     setVersion,
+    withReleaseNotes: flags.withReleaseNotes,
   };
 }
 
@@ -170,8 +176,9 @@ export async function prepareCommand(argv: string[]): Promise<void> {
   let bumpOverride: ReleaseType | undefined;
   let only: string[] | undefined;
   let setVersion: string | undefined;
+  let withReleaseNotes: boolean;
   try {
-    ({ dryRun, force, noGitChecks, bumpOverride, only, setVersion } = parseArgs(argv));
+    ({ dryRun, force, noGitChecks, bumpOverride, only, setVersion, withReleaseNotes } = parseArgs(argv));
   } catch (error: unknown) {
     console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
@@ -181,6 +188,7 @@ export async function prepareCommand(argv: string[]): Promise<void> {
     force,
     ...(bumpOverride === undefined ? {} : { bumpOverride }),
     ...(setVersion === undefined ? {} : { setVersion }),
+    ...(withReleaseNotes ? { withReleaseNotes: true } : {}),
   };
 
   if (dryRun) {
@@ -283,6 +291,7 @@ interface PrepareOptions {
   force: boolean;
   bumpOverride?: ReleaseType;
   setVersion?: string;
+  withReleaseNotes?: boolean;
 }
 
 /** Loads and validate the release-kit config file, exiting on errors. */

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -8,8 +8,11 @@ import { generateChangelogJson } from './generateChangelogJson.ts';
 import { generateChangelogs } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
+import { resolveWorkTypes } from './loadConfig.ts';
 import { readCurrentVersion } from './readCurrentVersion.ts';
+import { deriveSectionOrder } from './resolveReleaseNotesConfig.ts';
 import type { BumpResult, Commit, PrepareResult, ReleaseConfig, ReleaseType } from './types.ts';
+import { writeReleaseNotesPreviews } from './writeReleaseNotesPreviews.ts';
 
 /** Options for the release preparation workflow. */
 export interface ReleasePrepareOptions {
@@ -25,6 +28,13 @@ export interface ReleasePrepareOptions {
    * `config.workspaces` to a single workspace before invoking.
    */
   setVersion?: string;
+  /**
+   * If true, write per-workspace release-notes previews under `{workspacePath}/docs/`
+   * (`README.v{version}.md` and `RELEASE_NOTES.v{version}.md`) after each workspace's
+   * `changelog.json` is produced. Requires `config.changelogJson.enabled`; when disabled,
+   * a warning is logged and no previews are generated.
+   */
+  withReleaseNotes?: boolean;
 }
 
 /**
@@ -39,7 +49,7 @@ export interface ReleasePrepareOptions {
  * Returns a structured `PrepareResult` with all data needed for presentation.
  */
 export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOptions): PrepareResult {
-  const { dryRun, bumpOverride, setVersion } = options;
+  const { dryRun, bumpOverride, setVersion, withReleaseNotes } = options;
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
 
@@ -113,6 +123,9 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
     }
   }
 
+  // 4c. Write release-notes previews (optional, opt-in via --with-release-notes)
+  maybeWriteSinglePackagePreviews(withReleaseNotes === true, config, newTag, changelogJsonFiles[0], dryRun);
+
   // 5. Run format command, appending modified file paths
   const formatCommandStr = config.formatCommand ?? (hasPrettierConfig() ? 'npx prettier --write' : undefined);
   let formatCommand: PrepareResult['formatCommand'];
@@ -161,4 +174,35 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
     formatCommand,
     dryRun,
   };
+}
+
+/**
+ * Invoke `writeReleaseNotesPreviews` for a single-package workspace when the user requested
+ * previews. Warns and returns when `changelogJson.enabled` is false; silently returns when no
+ * changelog JSON file was produced (e.g., no changelog paths configured).
+ */
+function maybeWriteSinglePackagePreviews(
+  withReleaseNotes: boolean,
+  config: ReleaseConfig,
+  newTag: string,
+  changelogJsonPath: string | undefined,
+  dryRun: boolean,
+): void {
+  if (!withReleaseNotes) {
+    return;
+  }
+  if (!config.changelogJson.enabled) {
+    console.warn('Warning: --with-release-notes requires changelogJson.enabled; skipping preview generation');
+    return;
+  }
+  if (changelogJsonPath === undefined) {
+    return;
+  }
+  writeReleaseNotesPreviews({
+    workspacePath: process.cwd(),
+    tag: newTag,
+    changelogJsonPath,
+    sectionOrder: deriveSectionOrder(resolveWorkTypes(config.workTypes)),
+    dryRun,
+  });
 }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -11,10 +11,12 @@ import { generateChangelogJson, generateSyntheticChangelogJson } from './generat
 import { buildTagPattern, generateChangelog } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
+import { resolveWorkTypes } from './loadConfig.ts';
 import type { CurrentVersions, ReleaseEntry } from './propagateBumps.ts';
 import { propagateBumps } from './propagateBumps.ts';
 import { readCurrentVersion } from './readCurrentVersion.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
+import { deriveSectionOrder } from './resolveReleaseNotesConfig.ts';
 import type {
   Commit,
   MonorepoReleaseConfig,
@@ -23,6 +25,7 @@ import type {
   WorkspaceConfig,
   WorkspacePrepareResult,
 } from './types.ts';
+import { writeReleaseNotesPreviews } from './writeReleaseNotesPreviews.ts';
 import { writeSyntheticChangelog } from './writeSyntheticChangelog.ts';
 
 /** Intermediate result from Phase 1 (determine direct bumps). */
@@ -65,7 +68,14 @@ interface Phase1Result {
  * Phase 3: Execute bumps and generate changelogs in dependency order.
  */
 export function releasePrepareMono(config: MonorepoReleaseConfig, options: ReleasePrepareOptions): PrepareResult {
-  const { dryRun } = options;
+  const { dryRun, withReleaseNotes } = options;
+
+  if (withReleaseNotes === true && !config.changelogJson.enabled) {
+    console.warn('Warning: --with-release-notes requires changelogJson.enabled; skipping preview generation');
+  }
+
+  // Derive section order once for all preview writes; the same value feeds every workspace.
+  const sectionOrder = deriveSectionOrder(resolveWorkTypes(config.workTypes));
 
   // === Phase 1: Determine direct bumps ===
   const { directBumps, directResults, skippedResults, currentVersions } = determineDirectBumps(config, options);
@@ -95,6 +105,10 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
 
   // === Phase 3: Execute bumps and generate changelogs ===
   const workspaces = collectSkippedWorkspaces(skippedResults, fullReleaseSet);
+  const previewOptions: PreviewOptions = {
+    enabled: withReleaseNotes === true && config.changelogJson.enabled,
+    sectionOrder,
+  };
   const { tags, modifiedFiles } = executeReleaseSet(
     sortedDirs,
     fullReleaseSet,
@@ -103,6 +117,7 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     previousTags,
     dryRun,
     workspaces,
+    previewOptions,
   );
 
   // Reorder workspaces to match original config order.
@@ -274,6 +289,14 @@ function collectSkippedWorkspaces(
   return workspaces;
 }
 
+/** Shared parameters for generating release-notes previews per workspace. */
+interface PreviewOptions {
+  /** True when `--with-release-notes` is set and `changelogJson.enabled` is true. */
+  enabled: boolean;
+  /** Section titles in priority order, derived once per run from `resolveWorkTypes(config.workTypes)`. */
+  sectionOrder: string[];
+}
+
 /** Execute bumps and generate changelogs for each workspace in dependency order. */
 function executeReleaseSet(
   sortedDirs: string[],
@@ -283,6 +306,7 @@ function executeReleaseSet(
   previousTags: Map<string, string | undefined>,
   dryRun: boolean,
   workspaces: WorkspacePrepareResult[],
+  previewOptions: PreviewOptions,
 ): { tags: string[]; modifiedFiles: string[] } {
   const tags: string[] = [];
   const modifiedFiles: string[] = [];
@@ -311,6 +335,7 @@ function executeReleaseSet(
       tags,
       modifiedFiles,
       workspaces,
+      previewOptions,
     });
   }
 
@@ -330,6 +355,7 @@ interface ExecuteWorkspaceReleaseArgs {
   tags: string[];
   modifiedFiles: string[];
   workspaces: WorkspacePrepareResult[];
+  previewOptions: PreviewOptions;
 }
 
 /** Bump, generate changelogs, and append the workspace result for one entry in the release set. */
@@ -346,6 +372,7 @@ function executeWorkspaceRelease(args: ExecuteWorkspaceReleaseArgs): void {
     tags,
     modifiedFiles,
     workspaces,
+    previewOptions,
   } = args;
 
   // Bump all versions for this workspace. For --set-version workspaces, write the explicit
@@ -370,6 +397,7 @@ function executeWorkspaceRelease(args: ExecuteWorkspaceReleaseArgs): void {
     dryRun,
     today,
     modifiedFiles,
+    previewOptions,
   });
 
   workspaces.push({
@@ -404,6 +432,7 @@ interface GenerateWorkspaceChangelogsArgs {
   dryRun: boolean;
   today: string;
   modifiedFiles: string[];
+  previewOptions: PreviewOptions;
 }
 
 /**
@@ -412,8 +441,22 @@ interface GenerateWorkspaceChangelogsArgs {
  * Additional changelog JSON files are appended to `modifiedFiles` when the feature is enabled.
  */
 function generateWorkspaceChangelogs(args: GenerateWorkspaceChangelogsArgs): string[] {
-  const { workspace, releaseEntry, newTag, newVersion, isPropagationOnly, config, dryRun, today, modifiedFiles } = args;
+  const {
+    workspace,
+    releaseEntry,
+    newTag,
+    newVersion,
+    isPropagationOnly,
+    config,
+    dryRun,
+    today,
+    modifiedFiles,
+    previewOptions,
+  } = args;
   const changelogFiles: string[] = [];
+  // Track the first changelog.json path written for this workspace so the preview writer can
+  // read the same data that `publish` and `create-github-release` will consume later.
+  let firstChangelogJsonPath: string | undefined;
 
   if (isPropagationOnly && releaseEntry.propagatedFrom !== undefined) {
     for (const changelogPath of workspace.changelogPaths) {
@@ -439,8 +482,10 @@ function generateWorkspaceChangelogs(args: GenerateWorkspaceChangelogsArgs): str
           dryRun,
         );
         modifiedFiles.push(...jsonFiles);
+        firstChangelogJsonPath ??= jsonFiles[0];
       }
     }
+    maybeWritePreviews(workspace, newTag, firstChangelogJsonPath, previewOptions, dryRun);
     return changelogFiles;
   }
 
@@ -461,10 +506,32 @@ function generateWorkspaceChangelogs(args: GenerateWorkspaceChangelogsArgs): str
         includePaths: workspace.paths,
       });
       modifiedFiles.push(...jsonFiles);
+      firstChangelogJsonPath ??= jsonFiles[0];
     }
   }
 
+  maybeWritePreviews(workspace, newTag, firstChangelogJsonPath, previewOptions, dryRun);
   return changelogFiles;
+}
+
+/** Invoke `writeReleaseNotesPreviews` for a workspace when previews are enabled and a changelog JSON path is known. */
+function maybeWritePreviews(
+  workspace: WorkspaceConfig,
+  newTag: string,
+  changelogJsonPath: string | undefined,
+  previewOptions: PreviewOptions,
+  dryRun: boolean,
+): void {
+  if (!previewOptions.enabled || changelogJsonPath === undefined) {
+    return;
+  }
+  writeReleaseNotesPreviews({
+    workspacePath: workspace.workspacePath,
+    tag: newTag,
+    changelogJsonPath,
+    sectionOrder: previewOptions.sectionOrder,
+    dryRun,
+  });
 }
 
 /** Run the format command on modified files, if configured. */

--- a/packages/release-kit/src/resolveReleaseNotesConfig.ts
+++ b/packages/release-kit/src/resolveReleaseNotesConfig.ts
@@ -73,6 +73,6 @@ export async function resolveReleaseNotesConfig(
 }
 
 /** Extract section headers in declaration order from a merged workTypes record. */
-function deriveSectionOrder(workTypes: Record<string, { header: string }>): string[] {
+export function deriveSectionOrder(workTypes: Record<string, { header: string }>): string[] {
   return Object.values(workTypes).map((entry) => entry.header);
 }

--- a/packages/release-kit/src/writeReleaseNotesPreviews.ts
+++ b/packages/release-kit/src/writeReleaseNotesPreviews.ts
@@ -71,14 +71,14 @@ export function writeReleaseNotesPreviews(options: WriteReleaseNotesPreviewsOpti
   const readmePreviewPath = path.join(docsDir, `README.v${version}.md`);
   const releaseNotesPreviewPath = path.join(docsDir, `RELEASE_NOTES.v${version}.md`);
 
-  const injectedReadme = readmeExists
-    ? writePreviewFile(readmePreviewPath, rendered.injectedReadme, dryRun)
-    : { filePath: readmePreviewPath, outcome: 'skipped-no-readme' as const };
-
-  if (!readmeExists) {
+  let injectedReadme: PreviewFileResult;
+  if (readmeExists) {
+    injectedReadme = writePreviewFile(readmePreviewPath, rendered.injectedReadme, dryRun);
+  } else {
     console.warn(
       `Warning: ${readmePath} not found; skipping injected-README preview but still writing standalone release notes`,
     );
+    injectedReadme = { filePath: readmePreviewPath, outcome: 'skipped-no-readme' };
   }
 
   // The standalone preview should end with a trailing newline for consistency with markdown files.

--- a/packages/release-kit/src/writeReleaseNotesPreviews.ts
+++ b/packages/release-kit/src/writeReleaseNotesPreviews.ts
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
+
+import { extractVersion } from './changelogJsonUtils.ts';
+import { dim } from './format.ts';
+import { renderInjectedReadme } from './injectReleaseNotesIntoReadme.ts';
+
+/** Options for `writeReleaseNotesPreviews`. */
+export interface WriteReleaseNotesPreviewsOptions {
+  /** Workspace root directory beneath which `docs/` is created. */
+  workspacePath: string;
+  /** Full release tag (e.g., `release-kit-v1.0.0`); used to extract the version for filenames. */
+  tag: string;
+  /** Path to the workspace's `changelog.json` file. */
+  changelogJsonPath: string;
+  /** Section titles in priority order, typically derived from `resolveWorkTypes(config.workTypes)`. */
+  sectionOrder: string[];
+  /** When `true`, logs planned writes without creating any files. */
+  dryRun: boolean;
+}
+
+/** Result of a single preview write attempt. */
+export interface PreviewFileResult {
+  filePath: string;
+  outcome: 'created' | 'overwritten' | 'skipped-no-readme' | 'failed' | 'dry-run';
+  error?: string;
+}
+
+/** Aggregate result of `writeReleaseNotesPreviews`. */
+export interface WriteReleaseNotesPreviewsResult {
+  /** Outcome for the injected README preview (undefined when the whole render was skipped). */
+  injectedReadme?: PreviewFileResult;
+  /** Outcome for the standalone release-notes preview (undefined when the whole render was skipped). */
+  releaseNotes?: PreviewFileResult;
+  /** True when `renderInjectedReadme` returned `undefined`, causing both writes to be skipped. */
+  renderSkipped: boolean;
+}
+
+/**
+ * Generate per-workspace release-notes previews under `{workspacePath}/docs/`:
+ *
+ * - `docs/README.v{version}.md` — the workspace README with release notes injected at the marker.
+ * - `docs/RELEASE_NOTES.v{version}.md` — the standalone release notes for this version.
+ *
+ * The injected README file is skipped (but the standalone file is still written) when the
+ * workspace has no `README.md`. If the renderer reports no content for this version
+ * (no changelog entry, all sections dev-only, etc.), no files are written and a warning is
+ * logged. Existing files at the same paths are overwritten.
+ *
+ * In dry-run mode, logs planned writes and returns without creating any files.
+ */
+export function writeReleaseNotesPreviews(options: WriteReleaseNotesPreviewsOptions): WriteReleaseNotesPreviewsResult {
+  const { workspacePath, tag, changelogJsonPath, sectionOrder, dryRun } = options;
+
+  const version = extractVersion(tag);
+  const readmePath = path.join(workspacePath, 'README.md');
+  const readmeExists = existsSync(readmePath);
+  // Use an empty string when no README exists so the pure renderer can still produce the
+  // standalone release notes. The injected-README output is discarded in that case.
+  const readmeContent = readmeExists ? readFileSync(readmePath, 'utf8') : '';
+
+  const rendered = renderInjectedReadme(readmeContent, changelogJsonPath, tag, sectionOrder);
+  if (rendered === undefined) {
+    console.warn(`Warning: skipping release-notes previews for ${tag}; no renderable content`);
+    return { renderSkipped: true };
+  }
+
+  const docsDir = path.join(workspacePath, 'docs');
+  const readmePreviewPath = path.join(docsDir, `README.v${version}.md`);
+  const releaseNotesPreviewPath = path.join(docsDir, `RELEASE_NOTES.v${version}.md`);
+
+  const injectedReadme = readmeExists
+    ? writePreviewFile(readmePreviewPath, rendered.injectedReadme, dryRun)
+    : { filePath: readmePreviewPath, outcome: 'skipped-no-readme' as const };
+
+  if (!readmeExists) {
+    console.warn(
+      `Warning: ${readmePath} not found; skipping injected-README preview but still writing standalone release notes`,
+    );
+  }
+
+  // The standalone preview should end with a trailing newline for consistency with markdown files.
+  const releaseNotesContent = rendered.releaseNotesMarkdown.endsWith('\n')
+    ? rendered.releaseNotesMarkdown
+    : `${rendered.releaseNotesMarkdown}\n`;
+  const releaseNotes = writePreviewFile(releaseNotesPreviewPath, releaseNotesContent, dryRun);
+
+  return { injectedReadme, releaseNotes, renderSkipped: false };
+}
+
+/** Write a preview file via `writeFileWithCheck` and log its outcome in the prepare-command style. */
+function writePreviewFile(filePath: string, content: string, dryRun: boolean): PreviewFileResult {
+  if (dryRun) {
+    console.info(dim(`  [dry-run] Would write ${filePath}`));
+    return { filePath, outcome: 'dry-run' };
+  }
+
+  const result = writeFileWithCheck(filePath, content, { dryRun: false, overwrite: true });
+
+  if (result.outcome === 'failed') {
+    console.error(`Error writing ${filePath}: ${result.error ?? 'unknown error'}`);
+    return { filePath, outcome: 'failed', ...(result.error === undefined ? {} : { error: result.error }) };
+  }
+
+  // `writeFileWithCheck` with `overwrite: true` only returns 'created' or 'overwritten' on success.
+  if (result.outcome === 'created' || result.outcome === 'overwritten') {
+    console.info(dim(`  Wrote ${filePath}`));
+    return { filePath, outcome: result.outcome };
+  }
+
+  // Defensive fallback — unreachable under the current `writeFileWithCheck` contract.
+  return { filePath, outcome: 'failed', error: `unexpected outcome: ${result.outcome}` };
+}

--- a/packages/release-kit/src/writeReleaseNotesPreviews.ts
+++ b/packages/release-kit/src/writeReleaseNotesPreviews.ts
@@ -61,9 +61,11 @@ export function writeReleaseNotesPreviews(options: WriteReleaseNotesPreviewsOpti
   // standalone release notes. The injected-README output is discarded in that case.
   const readmeContent = readmeExists ? readFileSync(readmePath, 'utf8') : '';
 
+  // `renderInjectedReadme` logs its own specific skip reason (missing file, parse failure, no
+  // matching version, or no public-audience sections) when it returns `undefined`. No additional
+  // outer warning is emitted here to avoid two messages per skip event.
   const rendered = renderInjectedReadme(readmeContent, changelogJsonPath, tag, sectionOrder);
   if (rendered === undefined) {
-    console.warn(`Warning: skipping release-notes previews for ${tag}; no renderable content`);
     return { renderSkipped: true };
   }
 

--- a/packages/release-kit/src/writeReleaseNotesPreviews.ts
+++ b/packages/release-kit/src/writeReleaseNotesPreviews.ts
@@ -56,10 +56,23 @@ export function writeReleaseNotesPreviews(options: WriteReleaseNotesPreviewsOpti
 
   const version = extractVersion(tag);
   const readmePath = path.join(workspacePath, 'README.md');
-  const readmeExists = existsSync(readmePath);
-  // Use an empty string when no README exists so the pure renderer can still produce the
-  // standalone release notes. The injected-README output is discarded in that case.
-  const readmeContent = readmeExists ? readFileSync(readmePath, 'utf8') : '';
+  // `readmeExists` tracks whether the injected-README preview should be written. The read may
+  // succeed or fail independently of `existsSync` (race, permission error), so we treat an
+  // unreadable file the same as a missing one but log a specific warning. An empty string lets
+  // the pure renderer still produce the standalone release notes.
+  let readmeExists = existsSync(readmePath);
+  let readmeUnreadable = false;
+  let readmeContent = '';
+  if (readmeExists) {
+    try {
+      readmeContent = readFileSync(readmePath, 'utf8');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Warning: failed to read ${readmePath}: ${message}; skipping injected-README preview`);
+      readmeExists = false;
+      readmeUnreadable = true;
+    }
+  }
 
   // `renderInjectedReadme` logs its own specific skip reason (missing file, parse failure, no
   // matching version, or no public-audience sections) when it returns `undefined`. No additional
@@ -77,9 +90,12 @@ export function writeReleaseNotesPreviews(options: WriteReleaseNotesPreviewsOpti
   if (readmeExists) {
     injectedReadme = writePreviewFile(readmePreviewPath, rendered.injectedReadme, dryRun);
   } else {
-    console.warn(
-      `Warning: ${readmePath} not found; skipping injected-README preview but still writing standalone release notes`,
-    );
+    if (!readmeUnreadable) {
+      console.warn(
+        `Warning: ${readmePath} not found; skipping injected-README preview but still writing standalone release notes`,
+      );
+    }
+    // When unreadable, the specific read-failure warning was already logged above.
     injectedReadme = { filePath: readmePreviewPath, outcome: 'skipped-no-readme' };
   }
 


### PR DESCRIPTION
## What

Adds a `--with-release-notes` flag to `release-kit prepare` that generates per-workspace preview files so authors can verify release-note injection before publishing. Each workspace with a pending release receives two files under `{workspacePath}/docs/`: `README.v{version}.md` (the workspace README with release notes injected between the `<!-- section:release-notes -->` markers) and `RELEASE_NOTES.v{version}.md` (the release notes as a standalone file). The publish-time inject-and-revert lifecycle is untouched.

Injected release notes are now prefixed with a `## Release notes — v{version} ({date})` heading so readers see both what the content is and which release it describes. This improves the rendering in every README where release notes are injected (publish-time as well as preview).

When `--with-release-notes` is set but `config.changelogJson.enabled` is false, the command warns and continues without generating previews rather than failing. Single-package mode places `docs/` at the project root (via `process.cwd()`); monorepo mode places it at each workspace's `workspacePath`.

## Why

The release-notes injection logic for `publishCommand` has no way to be exercised locally before `publish` runs end-to-end. Authors couldn't verify that the `<!-- section:release-notes -->` marker injection produced the expected content, that the audience filter worked, or that the correct changelog entry was selected — they had to trust it and find out at publish time. The preview flag closes that loop.

Running the preview against a real workspace also surfaced that the injected content had no version heading, leaving readers with a cold `### Features` section and no way to tell which release the notes described. That gap is fixed in the same PR.

## Details

### Features

- `renderInjectedReadme(readme, changelogJsonPath, tag, sectionOrder?)` is extracted as the pure rendering core, shared by both the publish path and the new preview path. Returns `{ injectedReadme, releaseNotesMarkdown } | undefined`, with `undefined` signalling skip conditions (no changelog entry, no public-audience sections, unreadable `changelog.json`).
- `writeReleaseNotesPreviews(options)` owns the preview file layout: creates `docs/` on demand, overwrites existing files, honours dry-run (logs `[dry-run] Would write ...`), skips the injected file when `README.md` is absent but still writes the standalone file, and uses `writeFileWithCheck` for consistency with other prepare outputs. Unreadable `README.md` (race or permission error on `readFileSync`) is treated the same as a missing one with a specific warning.
- `deriveSectionOrder` is exported from `resolveReleaseNotesConfig.ts` so the prepare functions can derive section order via `deriveSectionOrder(resolveWorkTypes(config.workTypes))` — the same pattern the resolver uses internally. No new async boundary and no new config field beyond `withReleaseNotes` on `ReleasePrepareOptions`.
- CLI: `--with-release-notes` flag added to `prepareCommand`, both `showHelp()` and `bin/release-kit.ts:showPrepareHelp()` updated; `release-kit/README.md` documents the flag, preview file layout, and recommended `.gitignore` patterns for both monorepo and single-package layouts.
- README markers: `packages/audit-deps/README.md`, `packages/core/README.md`, `packages/nmr/README.md`, and `packages/release-kit/README.md` all carry the `<!-- section:release-notes --><!-- /section:release-notes -->` marker at the canonical position between the intro and the next heading.

### Fixes

- Injected release notes now lead with `## Release notes — v{version} ({date})` so readers can anchor the content to a specific release. Applies to both the publish-time inject-and-revert and the new preview path. `createGithubRelease` still renders the GitHub release body without this heading (the release page provides its own title).

### Refactoring

- `injectReleaseNotesIntoReadme` is now a thin file-I/O wrapper around the pure `renderInjectedReadme`; `publishCommand` calls the wrapper unchanged.
- The dry-run guard inside `writePreviewFile`, the conditional README existence check, and the redundant outer render-skip warning were tightened during review to avoid double warnings and duplicate `existsSync` guards.

### Tests

- `renderInjectedReadme` unit tests cover markers present, markers absent (prepends), unreadable `changelog.json`, no matching version, no public-audience sections, successful render, and `sectionOrder` forwarding.
- `writeReleaseNotesPreviews` unit tests cover file creation with versioned names, overwrite, missing `docs/` directory, missing README (injected skipped, standalone still written), unreadable README (same treatment, specific warning), dry-run, dry-run + missing README, render skip (no files written, no redundant outer warning), `writeFileWithCheck` failure, and section-order forwarding.
- `prepareCommand` unit tests cover the flag plumbing through `parseArgs` and both mode delegators.
- `releasePrepare` unit tests assert `writeReleaseNotesPreviews` is called with the correct `workspacePath`, `tag`, `dryRun`, `sectionOrder`, and `changelogJsonPath`; also cover the `changelogJson.enabled: false` warn-and-skip path.
- `releasePrepareMono` unit tests cover both the direct-bump path and the dependency-propagation path (regression guard for the symmetric `maybeWritePreviews` calls).
- `prepareWithReleaseNotes.int.test.ts` is a new integration test that exercises real filesystem writes against a temp-dir fixture — successful write, overwrite, docs-dir auto-creation, standalone-only when README is missing, no-op for unreleased versions, dry-run, and the labeled-heading content.

Closes #302