### PR TITLE
#303 Rename `node-monorepo-core` to `nmr-core`

### DIFF
--- a/.agents/PROJECT.md
+++ b/.agents/PROJECT.md
@@ -12,7 +12,7 @@ Packages live under `packages/`:
 
 - **`@williamthorsen/audit-deps`** — Wraps audit-ci with a richer config model, typed JSON source of truth, and a sync workflow that automates allowlist management.
 - **`@williamthorsen/nmr`** — Context-aware script runner for PNPM monorepos. Detects root vs workspace context and resolves the appropriate script registry.
-- **`@williamthorsen/node-monorepo-core`** — Shared utilities consumed by `release-kit`.
+- **`@williamthorsen/nmr-core`** — Shared utilities consumed by `release-kit`.
 - **`@williamthorsen/release-kit`** — Version-bumping and changelog-generation toolkit. Has integration tests (`vitest.integration.config.ts`).
 
 Key files:

--- a/.config/release-kit.config.ts
+++ b/.config/release-kit.config.ts
@@ -5,6 +5,9 @@ const config: ReleaseKitConfig = {
   releaseNotes: {
     shouldInjectIntoReadme: true,
   },
+  workspaces: [
+    { dir: 'core', legacyIdentities: [{ name: '@williamthorsen/node-monorepo-core', tagPrefix: 'core-v' }] },
+  ],
 };
 
 export default config;

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | ----------------------------------------------------- | ----------------------------------------------------------- |
 | [`@williamthorsen/audit-deps`](packages/audit-deps)   | Wraps audit-ci with a richer config model and sync workflow |
 | [`@williamthorsen/nmr`](packages/nmr)                 | Context-aware script runner for PNPM monorepos              |
-| [`@williamthorsen/node-monorepo-core`](packages/core) | Shared utilities for monorepo tools                         |
+| [`@williamthorsen/nmr-core`](packages/core)           | Shared utilities for monorepo tools                         |
 | [`@williamthorsen/release-kit`](packages/release-kit) | Version-bumping and changelog generation                    |
 
 ## Getting started

--- a/packages/audit-deps/package.json
+++ b/packages/audit-deps/package.json
@@ -44,7 +44,7 @@
     "test:watch": "pnpm exec vitest --config=vitest.standalone.config.ts --watch"
   },
   "dependencies": {
-    "@williamthorsen/node-monorepo-core": "workspace:*",
+    "@williamthorsen/nmr-core": "workspace:*",
     "audit-ci": "7.1.0",
     "zod": "4.3.6"
   },

--- a/packages/audit-deps/src/bin/route.ts
+++ b/packages/audit-deps/src/bin/route.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 
-import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
 
 import { auditCommand, checkCommand, extractMessage, syncCommand } from '../cli.ts';
 import { initCommand } from '../init/initCommand.ts';

--- a/packages/audit-deps/src/init/__tests__/scaffold.unit.test.ts
+++ b/packages/audit-deps/src/init/__tests__/scaffold.unit.test.ts
@@ -10,7 +10,7 @@ vi.mock(import('node:fs'), () => ({
   readFileSync: mockReadFileSync,
 }));
 
-vi.mock(import('@williamthorsen/node-monorepo-core'), () => ({
+vi.mock(import('@williamthorsen/nmr-core'), () => ({
   findPackageRoot: mockFindPackageRoot,
   writeFileWithCheck: mockWriteFileWithCheck,
 }));

--- a/packages/audit-deps/src/init/initCommand.ts
+++ b/packages/audit-deps/src/init/initCommand.ts
@@ -1,4 +1,4 @@
-import { printError, printStep, reportWriteResult } from '@williamthorsen/node-monorepo-core';
+import { printError, printStep, reportWriteResult } from '@williamthorsen/nmr-core';
 
 import { extractMessage } from '../cli.ts';
 import { scaffoldFiles } from './scaffold.ts';

--- a/packages/audit-deps/src/init/scaffold.ts
+++ b/packages/audit-deps/src/init/scaffold.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import type { WriteResult } from '@williamthorsen/node-monorepo-core';
-import { findPackageRoot, writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
+import type { WriteResult } from '@williamthorsen/nmr-core';
+import { findPackageRoot, writeFileWithCheck } from '@williamthorsen/nmr-core';
 
 import { auditDepsConfigTemplate } from './templates.ts';
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# @williamthorsen/node-monorepo-core
+# @williamthorsen/nmr-core
 
 Shared utilities for node-monorepo-tools packages.
 
@@ -9,5 +9,5 @@ This package serves as the shared library foundation for the monorepo. For the n
 ## Installation
 
 ```bash
-pnpm add -D @williamthorsen/node-monorepo-core
+pnpm add -D @williamthorsen/nmr-core
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@williamthorsen/node-monorepo-core",
+  "name": "@williamthorsen/nmr-core",
   "version": "0.2.7",
   "private": false,
   "description": "Shared utilities for node-monorepo-tools packages",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 // Placeholder — shared utilities will be added here as the monorepo grows.
-export const PACKAGE_NAME = '@williamthorsen/node-monorepo-core';
+export const PACKAGE_NAME = '@williamthorsen/nmr-core';
 export { findPackageRoot } from './findPackageRoot.js';
 export type { FlagDefinition, FlagSchema, ParsedArgs, ParsedFlags } from './parseArgs.js';
 export { parseArgs, translateParseError } from './parseArgs.js';

--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -381,7 +381,7 @@ This package shells out to two external tools:
 
 ## Upgrading from v4 to v5
 
-Release-kit v5 derives each workspace's tag prefix from its unscoped `package.json` `name`, so a package at `packages/core` with `"name": "@scope/node-monorepo-core"` uses tags like `node-monorepo-core-v1.3.0`. Repos that previously tagged under the directory basename (e.g., `core-v1.3.0`) do not need to rewrite history — declare the prior identity in `legacyIdentities` so release-kit recognizes historical tags under both the new and old prefixes.
+Release-kit v5 derives each workspace's tag prefix from its unscoped `package.json` `name`, so a package at `packages/core` with `"name": "@scope/nmr-core"` uses tags like `nmr-core-v1.3.0`. Repos that previously tagged under the directory basename (e.g., `core-v1.3.0`) do not need to rewrite history — declare the prior identity in `legacyIdentities` so release-kit recognizes historical tags under both the new and old prefixes.
 
 Minimal worked example for a repo whose pre-v5 tags were `core-v0.2.7` and whose npm name has not changed:
 
@@ -393,7 +393,7 @@ const config: ReleaseKitConfig = {
   workspaces: [
     {
       dir: 'core',
-      legacyIdentities: [{ name: '@scope/node-monorepo-core', tagPrefix: 'core-v' }],
+      legacyIdentities: [{ name: '@scope/nmr-core', tagPrefix: 'core-v' }],
     },
   ],
 };
@@ -427,7 +427,7 @@ deriveWorkspaceConfig('packages/arrays');
 // }
 ```
 
-`dir` is the basename of the workspace path and is the stable internal identifier used by `--only`, `WorkspaceOverride.dir`, and the dependency graph. `tagPrefix` is derived from the unscoped `package.json` `name` — any leading `@scope/` is stripped — so tags reflect the package identity rather than the directory layout. For example, a workspace at `packages/core` with `"name": "@williamthorsen/node-monorepo-core"` produces `tagPrefix: 'node-monorepo-core-v'`, yielding tags like `node-monorepo-core-v1.3.0`.
+`dir` is the basename of the workspace path and is the stable internal identifier used by `--only`, `WorkspaceOverride.dir`, and the dependency graph. `tagPrefix` is derived from the unscoped `package.json` `name` — any leading `@scope/` is stripped — so tags reflect the package identity rather than the directory layout. For example, a workspace at `packages/core` with `"name": "@williamthorsen/nmr-core"` produces `tagPrefix: 'nmr-core-v'`, yielding tags like `nmr-core-v1.3.0`.
 
 The workspace's `package.json` must declare a non-empty `name` field; `deriveWorkspaceConfig()` throws otherwise. If two workspaces produce the same `tagPrefix` (because their unscoped names collide), `mergeMonorepoConfig()` throws and names the colliding workspaces so you can rename one.
 

--- a/packages/release-kit/package.json
+++ b/packages/release-kit/package.json
@@ -39,7 +39,7 @@
     "test:watch": "pnpm exec vitest --config=vitest.standalone.config.ts --watch"
   },
   "dependencies": {
-    "@williamthorsen/node-monorepo-core": "workspace:*",
+    "@williamthorsen/nmr-core": "workspace:*",
     "glob": "13.0.6",
     "jiti": "2.6.1",
     "js-yaml": "4.1.1",

--- a/packages/release-kit/src/__tests__/deriveWorkspaceConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/deriveWorkspaceConfig.unit.test.ts
@@ -14,12 +14,12 @@ describe(deriveWorkspaceConfig, () => {
   });
 
   it('strips the @scope/ prefix from package name to derive tagPrefix', () => {
-    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@williamthorsen/node-monorepo-core' }));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@williamthorsen/nmr-core' }));
 
     expect(deriveWorkspaceConfig('packages/core')).toStrictEqual({
       dir: 'core',
-      name: '@williamthorsen/node-monorepo-core',
-      tagPrefix: 'node-monorepo-core-v',
+      name: '@williamthorsen/nmr-core',
+      tagPrefix: 'nmr-core-v',
       workspacePath: 'packages/core',
       packageFiles: ['packages/core/package.json'],
       changelogPaths: ['packages/core'],
@@ -48,12 +48,12 @@ describe(deriveWorkspaceConfig, () => {
   });
 
   it('preserves dir as the basename when the directory name differs from the package name', () => {
-    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@williamthorsen/node-monorepo-core' }));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@williamthorsen/nmr-core' }));
 
     const result = deriveWorkspaceConfig('libs/core');
 
     expect(result.dir).toBe('core');
-    expect(result.tagPrefix).toBe('node-monorepo-core-v');
+    expect(result.tagPrefix).toBe('nmr-core-v');
     expect(result.workspacePath).toBe('libs/core');
   });
 

--- a/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
@@ -33,7 +33,7 @@ describe(buildTagPattern, () => {
   });
 
   it('builds an alternation group when given multiple prefixes', () => {
-    expect(buildTagPattern(['node-monorepo-core-v', 'core-v'])).toBe('(node-monorepo-core-v|core-v)[0-9].*');
+    expect(buildTagPattern(['nmr-core-v', 'core-v'])).toBe('(nmr-core-v|core-v)[0-9].*');
   });
 
   it('escapes regex metacharacters in prefix entries', () => {

--- a/packages/release-kit/src/__tests__/getCommitsSinceTarget.unit.test.ts
+++ b/packages/release-kit/src/__tests__/getCommitsSinceTarget.unit.test.ts
@@ -174,13 +174,13 @@ describe(getCommitsSinceTarget, () => {
     it('passes one --match flag per prefix to git describe', () => {
       setupDescribeMock('core-v0.2.7');
 
-      getCommitsSinceTarget(['node-monorepo-core-v', 'core-v']);
+      getCommitsSinceTarget(['nmr-core-v', 'core-v']);
 
       expect(findDescribeCallArgs()).toStrictEqual([
         'describe',
         '--tags',
         '--abbrev=0',
-        '--match=node-monorepo-core-v*',
+        '--match=nmr-core-v*',
         '--match=core-v*',
       ]);
     });
@@ -192,7 +192,7 @@ describe(getCommitsSinceTarget, () => {
         return 'feat: addabc123';
       });
 
-      const result = getCommitsSinceTarget(['node-monorepo-core-v', 'core-v']);
+      const result = getCommitsSinceTarget(['nmr-core-v', 'core-v']);
 
       expect(result.tag).toBe('core-v0.2.7');
       expect(result.commits).toStrictEqual([{ message: 'feat: add', hash: 'abc123' }]);

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -143,7 +143,7 @@ describe(mergeMonorepoConfig, () => {
 
   it('derives tagPrefix from unscoped pkg.name when directory basename differs', () => {
     mockPackageNames({
-      'libs/core': '@williamthorsen/node-monorepo-core',
+      'libs/core': '@williamthorsen/nmr-core',
       'apps/web': 'web-app',
     });
 
@@ -152,8 +152,8 @@ describe(mergeMonorepoConfig, () => {
     expect(result.workspaces).toHaveLength(2);
     expect(result.workspaces[0]).toStrictEqual({
       dir: 'core',
-      name: '@williamthorsen/node-monorepo-core',
-      tagPrefix: 'node-monorepo-core-v',
+      name: '@williamthorsen/nmr-core',
+      tagPrefix: 'nmr-core-v',
       workspacePath: 'libs/core',
       packageFiles: ['libs/core/package.json'],
       changelogPaths: ['libs/core'],

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -41,7 +41,7 @@ vi.mock('../releasePrepare.ts', () => ({
   releasePrepare: mockReleasePrepare,
 }));
 
-vi.mock(import('@williamthorsen/node-monorepo-core'), async (importOriginal) => {
+vi.mock(import('@williamthorsen/nmr-core'), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/packages/release-kit/src/__tests__/previewTagPrefixes.unit.test.ts
+++ b/packages/release-kit/src/__tests__/previewTagPrefixes.unit.test.ts
@@ -52,13 +52,13 @@ describe(previewTagPrefixes, () => {
     mockDiscoverWorkspaces.mockResolvedValue(['packages/core', 'packages/arrays']);
     mockLoadConfig.mockResolvedValue(undefined);
     mockDeriveWorkspaceConfig.mockImplementation((path: string) => {
-      if (path === 'packages/core') return { tagPrefix: 'node-monorepo-core-v' };
+      if (path === 'packages/core') return { tagPrefix: 'nmr-core-v' };
       if (path === 'packages/arrays') return { tagPrefix: 'arrays-v' };
       throw new Error(`unexpected path: ${path}`);
     });
     mockDetectUndeclared.mockReturnValue([]);
     setupTagCounts({
-      'node-monorepo-core-v': ['node-monorepo-core-v1.0.0', 'node-monorepo-core-v1.1.0'],
+      'nmr-core-v': ['nmr-core-v1.0.0', 'nmr-core-v1.1.0'],
       'arrays-v': ['arrays-v0.1.0'],
     });
 
@@ -68,7 +68,7 @@ describe(previewTagPrefixes, () => {
       {
         workspacePath: 'packages/core',
         dir: 'core',
-        derivedPrefix: 'node-monorepo-core-v',
+        derivedPrefix: 'nmr-core-v',
         derivationError: null,
         derivedTagCount: 2,
         legacyEntries: [],
@@ -117,10 +117,10 @@ describe(previewTagPrefixes, () => {
         },
       ],
     });
-    mockDeriveWorkspaceConfig.mockReturnValue({ tagPrefix: 'node-monorepo-core-v' });
+    mockDeriveWorkspaceConfig.mockReturnValue({ tagPrefix: 'nmr-core-v' });
     mockDetectUndeclared.mockReturnValue([]);
     setupTagCounts({
-      'node-monorepo-core-v': [],
+      'nmr-core-v': [],
       'core-v': ['core-v0.2.7', 'core-v0.2.8'],
       'old-core-v': [],
     });
@@ -152,13 +152,13 @@ describe(previewTagPrefixes, () => {
     mockLoadConfig.mockResolvedValue({
       workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@old-scope/core', tagPrefix: 'core-v' }] }],
     });
-    mockDeriveWorkspaceConfig.mockReturnValue({ tagPrefix: 'node-monorepo-core-v' });
+    mockDeriveWorkspaceConfig.mockReturnValue({ tagPrefix: 'nmr-core-v' });
     mockDetectUndeclared.mockReturnValue([]);
     setupTagCounts({});
 
     await previewTagPrefixes();
 
-    expect(mockDetectUndeclared).toHaveBeenCalledWith(expect.arrayContaining(['node-monorepo-core-v', 'core-v']));
+    expect(mockDetectUndeclared).toHaveBeenCalledWith(expect.arrayContaining(['nmr-core-v', 'core-v']));
   });
 
   it('returns detection results as undeclaredCandidates in the preview', async () => {
@@ -203,13 +203,13 @@ describe(previewTagPrefixes, () => {
     mockLoadConfig.mockResolvedValue({
       retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v' }],
     });
-    mockDeriveWorkspaceConfig.mockReturnValue({ tagPrefix: 'node-monorepo-core-v' });
+    mockDeriveWorkspaceConfig.mockReturnValue({ tagPrefix: 'nmr-core-v' });
     mockDetectUndeclared.mockReturnValue([]);
     setupTagCounts({});
 
     await previewTagPrefixes();
 
-    expect(mockDetectUndeclared).toHaveBeenCalledWith(expect.arrayContaining(['node-monorepo-core-v', 'preflight-v']));
+    expect(mockDetectUndeclared).toHaveBeenCalledWith(expect.arrayContaining(['nmr-core-v', 'preflight-v']));
   });
 
   it('returns an empty retiredPackages array when the config omits the field', async () => {

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -1167,7 +1167,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             name: '@test/core',
-            tagPrefix: 'node-monorepo-core-v',
+            tagPrefix: 'nmr-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
@@ -1185,7 +1185,7 @@ describe(releasePrepareMono, () => {
 
       expect(messages).toHaveLength(1);
       const message = messages[0] ?? '';
-      expect(message).toContain("no baseline tag found for core under 'node-monorepo-core-v'");
+      expect(message).toContain("no baseline tag found for core under 'nmr-core-v'");
       expect(message).toContain('candidate-shaped tags');
       expect(message).toContain('core-v0.2.7');
       expect(message).toContain('show-tag-prefixes');
@@ -1198,7 +1198,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             name: '@test/core',
-            tagPrefix: 'node-monorepo-core-v',
+            tagPrefix: 'nmr-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
@@ -1225,7 +1225,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             name: '@test/core',
-            tagPrefix: 'node-monorepo-core-v',
+            tagPrefix: 'nmr-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
@@ -1255,7 +1255,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             name: '@test/core',
-            tagPrefix: 'node-monorepo-core-v',
+            tagPrefix: 'nmr-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
@@ -1293,7 +1293,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             name: '@test/core',
-            tagPrefix: 'node-monorepo-core-v',
+            tagPrefix: 'nmr-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],
@@ -1329,7 +1329,7 @@ describe(releasePrepareMono, () => {
           {
             dir: 'core',
             name: '@test/core',
-            tagPrefix: 'node-monorepo-core-v',
+            tagPrefix: 'nmr-core-v',
             workspacePath: 'packages/core',
             packageFiles: ['packages/core/package.json'],
             changelogPaths: ['packages/core'],

--- a/packages/release-kit/src/__tests__/resolveCliffConfigPath.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveCliffConfigPath.unit.test.ts
@@ -7,7 +7,7 @@ vi.mock(import('node:fs'), () => ({
   existsSync: mockExistsSync,
 }));
 
-vi.mock(import('@williamthorsen/node-monorepo-core'), () => ({
+vi.mock(import('@williamthorsen/nmr-core'), () => ({
   findPackageRoot: mockFindPackageRoot,
 }));
 

--- a/packages/release-kit/src/__tests__/resolveCommandTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveCommandTags.unit.test.ts
@@ -28,7 +28,7 @@ class ExitError extends Error {
 }
 
 const TAGS: ResolvedTag[] = [
-  { tag: 'node-monorepo-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+  { tag: 'nmr-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
   { tag: 'cli-v0.5.0', dir: 'cli', workspacePath: 'packages/cli' },
   { tag: 'release-kit-v2.1.0', dir: 'release-kit', workspacePath: 'packages/release-kit' },
 ];
@@ -51,7 +51,7 @@ describe(resolveCommandTags, () => {
     mockResolveReleaseTags.mockReturnValue(TAGS);
     mockDeriveWorkspaceConfig.mockImplementation((workspacePath: string) => {
       if (workspacePath === 'packages/core') {
-        return makeWorkspace('core', 'node-monorepo-core-v', 'packages/core');
+        return makeWorkspace('core', 'nmr-core-v', 'packages/core');
       }
       if (workspacePath === 'packages/cli') {
         return makeWorkspace('cli', 'cli-v', 'packages/cli');
@@ -84,7 +84,7 @@ describe(resolveCommandTags, () => {
     await resolveCommandTags(undefined);
 
     expect(mockResolveReleaseTags).toHaveBeenCalledWith([
-      makeWorkspace('core', 'node-monorepo-core-v', 'packages/core'),
+      makeWorkspace('core', 'nmr-core-v', 'packages/core'),
       makeWorkspace('cli', 'cli-v', 'packages/cli'),
       makeWorkspace('release-kit', 'release-kit-v', 'packages/release-kit'),
     ]);
@@ -100,16 +100,16 @@ describe(resolveCommandTags, () => {
   });
 
   it('returns only the filtered tag when a single-tag filter is provided', async () => {
-    const result = await resolveCommandTags(['node-monorepo-core-v1.3.0']);
+    const result = await resolveCommandTags(['nmr-core-v1.3.0']);
 
-    expect(result).toStrictEqual([{ tag: 'node-monorepo-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' }]);
+    expect(result).toStrictEqual([{ tag: 'nmr-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' }]);
   });
 
   it('returns only the filtered subset when a multi-tag filter is provided', async () => {
-    const result = await resolveCommandTags(['node-monorepo-core-v1.3.0', 'release-kit-v2.1.0']);
+    const result = await resolveCommandTags(['nmr-core-v1.3.0', 'release-kit-v2.1.0']);
 
     expect(result).toStrictEqual([
-      { tag: 'node-monorepo-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+      { tag: 'nmr-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
       { tag: 'release-kit-v2.1.0', dir: 'release-kit', workspacePath: 'packages/release-kit' },
     ]);
   });
@@ -117,7 +117,7 @@ describe(resolveCommandTags, () => {
   it('exits with code 1 when the first tag in the filter is unknown', async () => {
     let thrown: ExitError | undefined;
     try {
-      await resolveCommandTags(['missing-v9.9.9', 'node-monorepo-core-v1.3.0']);
+      await resolveCommandTags(['missing-v9.9.9', 'nmr-core-v1.3.0']);
     } catch (error: unknown) {
       if (error instanceof ExitError) {
         thrown = error;
@@ -127,14 +127,14 @@ describe(resolveCommandTags, () => {
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
     expect(console.error).toHaveBeenCalledWith(
-      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: node-monorepo-core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0',
+      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: nmr-core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0',
     );
   });
 
   it('exits with code 1 when the second tag in the filter is unknown', async () => {
     let thrown: ExitError | undefined;
     try {
-      await resolveCommandTags(['node-monorepo-core-v1.3.0', 'missing-v9.9.9']);
+      await resolveCommandTags(['nmr-core-v1.3.0', 'missing-v9.9.9']);
     } catch (error: unknown) {
       if (error instanceof ExitError) {
         thrown = error;
@@ -144,7 +144,7 @@ describe(resolveCommandTags, () => {
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
     expect(console.error).toHaveBeenCalledWith(
-      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: node-monorepo-core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0',
+      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: nmr-core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0',
     );
   });
 

--- a/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveReleaseTags.unit.test.ts
@@ -54,26 +54,24 @@ describe(resolveReleaseTags, () => {
   });
 
   it('resolves monorepo tags whose tagPrefix matches a workspace', () => {
-    mockExecFileSync.mockReturnValue('node-monorepo-core-v1.3.0\nrelease-kit-v2.1.0\n');
+    mockExecFileSync.mockReturnValue('nmr-core-v1.3.0\nrelease-kit-v2.1.0\n');
     const workspaces = [
-      makeWorkspace({ dir: 'core', tagPrefix: 'node-monorepo-core-v', workspacePath: 'packages/core' }),
+      makeWorkspace({ dir: 'core', tagPrefix: 'nmr-core-v', workspacePath: 'packages/core' }),
       makeWorkspace({ dir: 'release-kit', tagPrefix: 'release-kit-v', workspacePath: 'packages/release-kit' }),
     ];
 
     expect(resolveReleaseTags(workspaces)).toStrictEqual([
-      { tag: 'node-monorepo-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+      { tag: 'nmr-core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
       { tag: 'release-kit-v2.1.0', dir: 'release-kit', workspacePath: 'packages/release-kit' },
     ]);
   });
 
   it('reports dir from workspace.dir, not the tagPrefix, when directory differs from package name', () => {
-    mockExecFileSync.mockReturnValue('node-monorepo-core-v0.2.8\n');
-    const workspaces = [
-      makeWorkspace({ dir: 'core', tagPrefix: 'node-monorepo-core-v', workspacePath: 'packages/core' }),
-    ];
+    mockExecFileSync.mockReturnValue('nmr-core-v0.2.8\n');
+    const workspaces = [makeWorkspace({ dir: 'core', tagPrefix: 'nmr-core-v', workspacePath: 'packages/core' })];
 
     expect(resolveReleaseTags(workspaces)).toStrictEqual([
-      { tag: 'node-monorepo-core-v0.2.8', dir: 'core', workspacePath: 'packages/core' },
+      { tag: 'nmr-core-v0.2.8', dir: 'core', workspacePath: 'packages/core' },
     ]);
   });
 

--- a/packages/release-kit/src/__tests__/showTagPrefixesCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/showTagPrefixesCommand.unit.test.ts
@@ -58,7 +58,7 @@ describe(showTagPrefixesCommand, () => {
         {
           workspacePath: 'packages/core',
           dir: 'core',
-          derivedPrefix: 'node-monorepo-core-v',
+          derivedPrefix: 'nmr-core-v',
           derivationError: null,
           derivedTagCount: 2,
           legacyEntries: [],
@@ -72,7 +72,7 @@ describe(showTagPrefixesCommand, () => {
 
     expect(exitCode).toBe(0);
     expect(output).toContain('packages/core');
-    expect(output).toContain("derived prefix 'node-monorepo-core-v'");
+    expect(output).toContain("derived prefix 'nmr-core-v'");
     expect(output).toContain('2 tags');
   });
 
@@ -82,7 +82,7 @@ describe(showTagPrefixesCommand, () => {
         {
           workspacePath: 'packages/core',
           dir: 'core',
-          derivedPrefix: 'node-monorepo-core-v',
+          derivedPrefix: 'nmr-core-v',
           derivationError: null,
           derivedTagCount: 0,
           legacyEntries: [{ prefix: 'core-v', tagCount: 3 }],
@@ -178,7 +178,7 @@ describe(showTagPrefixesCommand, () => {
         {
           workspacePath: 'packages/core',
           dir: 'core',
-          derivedPrefix: 'node-monorepo-core-v',
+          derivedPrefix: 'nmr-core-v',
           derivationError: null,
           derivedTagCount: 1,
           legacyEntries: [],

--- a/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
+++ b/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
@@ -11,7 +11,7 @@ vi.mock('node:fs', () => ({
   readFileSync: mockReadFileSync,
 }));
 
-vi.mock('@williamthorsen/node-monorepo-core', () => ({
+vi.mock('@williamthorsen/nmr-core', () => ({
   writeFileWithCheck: mockWriteFileWithCheck,
 }));
 

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -2,7 +2,7 @@
 /* eslint n/hashbang: off, n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
 
 import { commitCommand } from '../commitCommand.ts';
 import { createGithubReleaseCommand } from '../createGithubReleaseCommand.ts';

--- a/packages/release-kit/src/commitCommand.ts
+++ b/packages/release-kit/src/commitCommand.ts
@@ -4,7 +4,7 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
-import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
 
 import { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from './prepareCommand.ts';
 

--- a/packages/release-kit/src/createGithubReleaseCommand.ts
+++ b/packages/release-kit/src/createGithubReleaseCommand.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
 
 import { createGithubReleases } from './createGithubRelease.ts';
 import { parseRequestedTags } from './parseRequestedTags.ts';

--- a/packages/release-kit/src/init/__tests__/initCommand.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/initCommand.unit.test.ts
@@ -25,7 +25,7 @@ vi.mock(import('../scaffold.ts'), () => ({
   scaffoldFiles: mockScaffoldFiles,
 }));
 
-vi.mock(import('@williamthorsen/node-monorepo-core'), () => ({
+vi.mock(import('@williamthorsen/nmr-core'), () => ({
   printError: mockPrintError,
   printSkip: mockPrintSkip,
   printStep: mockPrintStep,

--- a/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
+++ b/packages/release-kit/src/init/__tests__/scaffold.unit.test.ts
@@ -10,7 +10,7 @@ vi.mock(import('node:fs'), () => ({
   readFileSync: mockReadFileSync,
 }));
 
-vi.mock(import('@williamthorsen/node-monorepo-core'), () => ({
+vi.mock(import('@williamthorsen/nmr-core'), () => ({
   findPackageRoot: mockFindPackageRoot,
   writeFileWithCheck: mockWriteFileWithCheck,
 }));

--- a/packages/release-kit/src/init/initCommand.ts
+++ b/packages/release-kit/src/init/initCommand.ts
@@ -1,5 +1,5 @@
-import type { WriteResult } from '@williamthorsen/node-monorepo-core';
-import { printError, printStep, printSuccess, reportWriteResult } from '@williamthorsen/node-monorepo-core';
+import type { WriteResult } from '@williamthorsen/nmr-core';
+import { printError, printStep, printSuccess, reportWriteResult } from '@williamthorsen/nmr-core';
 
 import type { CheckResult } from './checks.ts';
 import { hasPackageJson, isGitRepo, usesPnpm } from './checks.ts';

--- a/packages/release-kit/src/init/scaffold.ts
+++ b/packages/release-kit/src/init/scaffold.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import type { WriteResult } from '@williamthorsen/node-monorepo-core';
-import { findPackageRoot, writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
+import type { WriteResult } from '@williamthorsen/nmr-core';
+import { findPackageRoot, writeFileWithCheck } from '@williamthorsen/nmr-core';
 
 import type { RepoType } from './detectRepoType.ts';
 import { createGithubReleaseWorkflow, publishWorkflow, releaseConfigScript, releaseWorkflow } from './templates.ts';

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -1,12 +1,8 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import type { WriteResult } from '@williamthorsen/node-monorepo-core';
-import {
-  parseArgs as coreParseArgs,
-  translateParseError,
-  writeFileWithCheck,
-} from '@williamthorsen/node-monorepo-core';
+import type { WriteResult } from '@williamthorsen/nmr-core';
+import { parseArgs as coreParseArgs, translateParseError, writeFileWithCheck } from '@williamthorsen/nmr-core';
 
 import { assertCleanWorkingTree } from './assertCleanWorkingTree.ts';
 import { buildReleaseSummary } from './buildReleaseSummary.ts';

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -4,7 +4,7 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
 
 import { detectPackageManager } from './detectPackageManager.ts';
 import { injectReleaseNotesIntoReadme, resolveReadmePath } from './injectReleaseNotesIntoReadme.ts';

--- a/packages/release-kit/src/pushCommand.ts
+++ b/packages/release-kit/src/pushCommand.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
 
 import { parseRequestedTags } from './parseRequestedTags.ts';
 import { pushRelease } from './pushRelease.ts';

--- a/packages/release-kit/src/resolveCliffConfigPath.ts
+++ b/packages/release-kit/src/resolveCliffConfigPath.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import { findPackageRoot } from '@williamthorsen/node-monorepo-core';
+import { findPackageRoot } from '@williamthorsen/nmr-core';
 
 /**
  * Resolve the git-cliff configuration file path.

--- a/packages/release-kit/src/resolveCommandTags.ts
+++ b/packages/release-kit/src/resolveCommandTags.ts
@@ -9,7 +9,7 @@ import type { WorkspaceConfig } from './types.ts';
 
 /**
  * Discover workspaces, resolve release tags from HEAD, validate `--tags` names against the
- * full resolved tag names (e.g., `node-monorepo-core-v1.3.0`), and return the filtered tag list.
+ * full resolved tag names (e.g., `nmr-core-v1.3.0`), and return the filtered tag list.
  * Works in both single-package and monorepo modes. Exits with an error message on any validation
  * failure — including `deriveWorkspaceConfig()` throws for workspaces missing a `package.json` `name` field.
  */

--- a/packages/release-kit/src/sync-labels/__tests__/initCommand.test.ts
+++ b/packages/release-kit/src/sync-labels/__tests__/initCommand.test.ts
@@ -15,7 +15,7 @@ vi.mock(import('../generateCommand.ts'), async (importOriginal) => {
 
 const mockReportWriteResult = vi.hoisted(() => vi.fn());
 
-vi.mock(import('@williamthorsen/node-monorepo-core'), () => ({
+vi.mock(import('@williamthorsen/nmr-core'), () => ({
   reportWriteResult: mockReportWriteResult,
   writeFileWithCheck: mockWriteFileWithCheck,
 }));

--- a/packages/release-kit/src/sync-labels/__tests__/presets.test.ts
+++ b/packages/release-kit/src/sync-labels/__tests__/presets.test.ts
@@ -9,7 +9,7 @@ vi.mock(import('node:fs'), () => ({
   readFileSync: mockReadFileSync,
 }));
 
-vi.mock(import('@williamthorsen/node-monorepo-core'), () => ({
+vi.mock(import('@williamthorsen/nmr-core'), () => ({
   findPackageRoot: mockFindPackageRoot,
 }));
 

--- a/packages/release-kit/src/sync-labels/initCommand.ts
+++ b/packages/release-kit/src/sync-labels/initCommand.ts
@@ -1,4 +1,4 @@
-import { reportWriteResult, writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
+import { reportWriteResult, writeFileWithCheck } from '@williamthorsen/nmr-core';
 
 import { discoverWorkspaces } from '../discoverWorkspaces.ts';
 import { generateCommand, LABELS_OUTPUT_PATH } from './generateCommand.ts';

--- a/packages/release-kit/src/sync-labels/presets.ts
+++ b/packages/release-kit/src/sync-labels/presets.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import { findPackageRoot } from '@williamthorsen/node-monorepo-core';
+import { findPackageRoot } from '@williamthorsen/nmr-core';
 import { load } from 'js-yaml';
 
 import { isRecord } from '../typeGuards.ts';

--- a/packages/release-kit/src/tagCommand.ts
+++ b/packages/release-kit/src/tagCommand.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs, translateParseError } from '@williamthorsen/node-monorepo-core';
+import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
 
 import { createTags } from './createTags.ts';
 

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -160,7 +160,7 @@ export interface ReleaseKitConfig {
  * A single historical identity snapshot for a workspace.
  *
  * Captures what the package looked like at some earlier point: the full npm `name`
- * (e.g., `'@williamthorsen/node-monorepo-core'`) and the `tagPrefix` under which tags
+ * (e.g., `'@williamthorsen/nmr-core'`) and the `tagPrefix` under which tags
  * were published (e.g., `'core-v'`). Both fields are required — a full tuple stays
  * unambiguous across any number of future renames.
  */
@@ -233,9 +233,9 @@ export interface ParsedCommit {
 export interface WorkspaceConfig {
   /** The package directory name (e.g., 'arrays'). Used for display and `--only` matching. */
   dir: string;
-  /** The full scoped npm name from `package.json` (e.g., `'@williamthorsen/node-monorepo-core'`). */
+  /** The full scoped npm name from `package.json` (e.g., `'@williamthorsen/nmr-core'`). */
   name: string;
-  /** The git tag prefix for this workspace (e.g., 'node-monorepo-core-v'), derived from the unscoped `package.json` name. */
+  /** The git tag prefix for this workspace (e.g., 'nmr-core-v'), derived from the unscoped `package.json` name. */
   tagPrefix: string;
   /** Workspace-relative path to the package root (e.g., `packages/core`). */
   workspacePath: string;

--- a/packages/release-kit/src/writeReleaseNotesPreviews.ts
+++ b/packages/release-kit/src/writeReleaseNotesPreviews.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { writeFileWithCheck } from '@williamthorsen/node-monorepo-core';
+import { writeFileWithCheck } from '@williamthorsen/nmr-core';
 
 import { extractVersion } from './changelogJsonUtils.ts';
 import { dim } from './format.ts';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
 
   packages/audit-deps:
     dependencies:
-      '@williamthorsen/node-monorepo-core':
+      '@williamthorsen/nmr-core':
         specifier: workspace:*
         version: link:../core
       audit-ci:
@@ -115,7 +115,7 @@ importers:
 
   packages/release-kit:
     dependencies:
-      '@williamthorsen/node-monorepo-core':
+      '@williamthorsen/nmr-core':
         specifier: workspace:*
         version: link:../core
       glob:


### PR DESCRIPTION
## What

Renames the shared-utilities package from `@williamthorsen/node-monorepo-core` to `@williamthorsen/nmr-core`, aligning it with the repository's `nmr-*` naming convention. The package's functionality and version are unchanged; only the published name differs.

External consumers depending on `@williamthorsen/node-monorepo-core` must update their `package.json` entries and imports to `@williamthorsen/nmr-core`. Historical git tags (`core-v*`) are preserved and continue to be recognized by release-kit via a `legacyIdentities` declaration, so release continuity for this workspace is unaffected.

## Why

The old name was verbose and inconsistent with the rest of the monorepo, which uses the shorter `nmr-*` prefix for user-facing packages. Adopting `nmr-core` brings the shared-utilities package into line with that convention before any broader public adoption cements the longer name.

## Details

### Refactoring

- Renames `@williamthorsen/node-monorepo-core` to `@williamthorsen/nmr-core` in `packages/core/package.json`, the package's `README.md`, and the `PACKAGE_NAME` constant in `packages/core/src/index.ts`.
- Updates `devDependencies` in `packages/audit-deps/package.json` and `packages/release-kit/package.json`, plus every `import` and `vi.mock(...)` specifier in those packages' sources and tests.
- Refreshes documentation and JSDoc examples referencing the old name: top-level `README.md`, `.agents/PROJECT.md`, `packages/release-kit/README.md` (v4→v5 upgrade docs and the derivation example), and `packages/release-kit/src/types.ts`.
- Updates test-fixture example data that used the old name, including expected derived tag prefixes (`node-monorepo-core-v` → `nmr-core-v`) in `deriveWorkspaceConfig`, `loadConfig`, `previewTagPrefixes`, `showTagPrefixesCommand`, `resolveCommandTags`, `resolveReleaseTags`, `releasePrepareMono`, `generateChangelog`, and `getCommitsSinceTarget` tests.
- Adds a `legacyIdentities` entry to `.config/release-kit.config.ts` for the `core` workspace, declaring that the prior identity `@williamthorsen/node-monorepo-core` used the `core-v` tag prefix. This preserves release-kit's ability to locate historical baseline tags.
- Regenerates `pnpm-lock.yaml` to reflect the new package name.

`CHANGELOG.md` files are intentionally untouched; they are historical records.

Closes #303