### PR TITLE
#307 Skip publish.yaml checks for non-publishing repos

### DIFF
--- a/.readyup/kits/__tests__/release-kit-checks.test.ts
+++ b/.readyup/kits/__tests__/release-kit-checks.test.ts
@@ -1,132 +1,36 @@
+import type { Workspace } from 'readyup';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-// Minimal Dirent-shape covering the fields the kit reads. Using a structural
-// type avoids importing Dirent and casting through `unknown`, which the
-// repo's lint rules disallow.
-interface DirentLike {
-  name: string;
-  isDirectory(): boolean;
-  isFile(): boolean;
-}
-
-const { mockedExistsSync, mockedReaddirSync, mockedReadFile } = vi.hoisted(() => ({
-  mockedExistsSync: vi.fn<(path: string) => boolean>(),
-  mockedReaddirSync: vi.fn<(path: string, options: { withFileTypes: true }) => DirentLike[]>(),
+const { mockedDiscoverWorkspaces, mockedReadFile } = vi.hoisted(() => ({
+  mockedDiscoverWorkspaces: vi.fn<() => Workspace[]>(),
   mockedReadFile: vi.fn<(path: string) => string | undefined>(),
 }));
-
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>();
-  return {
-    ...actual,
-    default: { ...actual, existsSync: mockedExistsSync, readdirSync: mockedReaddirSync },
-    existsSync: mockedExistsSync,
-    readdirSync: mockedReaddirSync,
-  };
-});
 
 vi.mock('readyup', async (importOriginal) => {
   const actual = await importOriginal<typeof import('readyup')>();
   return {
     ...actual,
+    discoverWorkspaces: mockedDiscoverWorkspaces,
     readFile: mockedReadFile,
   };
 });
 
-import {
-  getPublishablePackages,
-  readmeHasReleaseNotesMarkers,
-  readmesHaveReleaseNotesMarkers,
-} from '../release-kit.ts';
+import { readmeHasReleaseNotesMarkers, readmesHaveReleaseNotesMarkers } from '../release-kit.ts';
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/** Build a minimal Dirent-shaped object for a directory entry. */
-function dirEntry(name: string): DirentLike {
-  return { name, isDirectory: () => true, isFile: () => false };
+/** Build a minimal Workspace-shaped fixture for tests. */
+function workspaceAt(dir: string): Workspace {
+  return {
+    dir,
+    absolutePath: `/abs/${dir}`,
+    name: dir === '.' ? 'consumer' : dir.replace(/^packages\//, ''),
+    isPackage: true,
+    packageJson: {},
+  };
 }
-
-/** Build a Dirent-shaped object for a non-directory entry. */
-function fileEntry(name: string): DirentLike {
-  return { name, isDirectory: () => false, isFile: () => true };
-}
-
-describe(getPublishablePackages, () => {
-  it('returns [] when packages/ does not exist', () => {
-    mockedExistsSync.mockReturnValue(false);
-
-    expect(getPublishablePackages()).toEqual([]);
-    expect(mockedReaddirSync).not.toHaveBeenCalled();
-  });
-
-  it('returns all packages whose package.json is not marked private', () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('beta'), dirEntry('gamma')]);
-    mockedReadFile.mockImplementation((path) => {
-      if (path === 'packages/alpha/package.json') return JSON.stringify({ name: '@scope/alpha' });
-      if (path === 'packages/beta/package.json') return JSON.stringify({ name: '@scope/beta', private: false });
-      if (path === 'packages/gamma/package.json') return JSON.stringify({ name: '@scope/gamma' });
-      return undefined;
-    });
-
-    expect(getPublishablePackages()).toEqual([
-      { dir: 'packages/alpha' },
-      { dir: 'packages/beta' },
-      { dir: 'packages/gamma' },
-    ]);
-  });
-
-  it('excludes packages with "private": true', () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('hidden')]);
-    mockedReadFile.mockImplementation((path) => {
-      if (path === 'packages/alpha/package.json') return JSON.stringify({ name: '@scope/alpha' });
-      if (path === 'packages/hidden/package.json') return JSON.stringify({ name: '@scope/hidden', private: true });
-      return undefined;
-    });
-
-    expect(getPublishablePackages()).toEqual([{ dir: 'packages/alpha' }]);
-  });
-
-  it('skips entries that are not directories', () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReaddirSync.mockReturnValue([dirEntry('alpha'), fileEntry('README.md')]);
-    mockedReadFile.mockReturnValue(JSON.stringify({ name: '@scope/alpha' }));
-
-    expect(getPublishablePackages()).toEqual([{ dir: 'packages/alpha' }]);
-  });
-
-  it('skips directories without a package.json', () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('orphan')]);
-    mockedReadFile.mockImplementation((path) => {
-      if (path === 'packages/alpha/package.json') return JSON.stringify({ name: '@scope/alpha' });
-      return undefined;
-    });
-
-    expect(getPublishablePackages()).toEqual([{ dir: 'packages/alpha' }]);
-  });
-
-  it('treats unparseable package.json as non-private (publishable)', () => {
-    // parseJsonRecord returns undefined for invalid JSON; we treat that as
-    // "no private field" so the package is included rather than silently dropped.
-    mockedExistsSync.mockReturnValue(true);
-    mockedReaddirSync.mockReturnValue([dirEntry('garbled')]);
-    mockedReadFile.mockReturnValue('not valid JSON');
-
-    expect(getPublishablePackages()).toEqual([{ dir: 'packages/garbled' }]);
-  });
-
-  it('does not treat string "true" as private', () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReaddirSync.mockReturnValue([dirEntry('alpha')]);
-    mockedReadFile.mockReturnValue(JSON.stringify({ private: 'true' }));
-
-    expect(getPublishablePackages()).toEqual([{ dir: 'packages/alpha' }]);
-  });
-});
 
 describe(readmeHasReleaseNotesMarkers, () => {
   it('returns true when both opening and closing markers are present', () => {
@@ -155,9 +59,8 @@ describe(readmeHasReleaseNotesMarkers, () => {
 describe(readmesHaveReleaseNotesMarkers, () => {
   describe('single-package mode', () => {
     it('returns true when root README contains both markers', () => {
-      mockedExistsSync.mockReturnValue(false); // pnpm-workspace.yaml absent
+      mockedDiscoverWorkspaces.mockReturnValue([workspaceAt('.')]);
       mockedReadFile.mockImplementation((path) => {
-        if (path === 'package.json') return JSON.stringify({ name: 'consumer' });
         if (path === 'README.md') return '<!-- section:release-notes -->\n<!-- /section:release-notes -->';
         return undefined;
       });
@@ -165,35 +68,34 @@ describe(readmesHaveReleaseNotesMarkers, () => {
       expect(readmesHaveReleaseNotesMarkers()).toBe(true);
     });
 
-    it('returns false when root README is missing', () => {
-      mockedExistsSync.mockReturnValue(false);
-      mockedReadFile.mockImplementation((path) => {
-        if (path === 'package.json') return JSON.stringify({ name: 'consumer' });
-        return undefined;
-      });
+    it('reports the missing root README in CheckOutcome.detail', () => {
+      mockedDiscoverWorkspaces.mockReturnValue([workspaceAt('.')]);
+      mockedReadFile.mockReturnValue(undefined);
 
-      expect(readmesHaveReleaseNotesMarkers()).toBe(false);
+      expect(readmesHaveReleaseNotesMarkers()).toEqual({
+        ok: false,
+        detail: 'missing markers or README: README.md',
+      });
     });
 
-    it('returns false when root README lacks markers', () => {
-      mockedExistsSync.mockReturnValue(false);
+    it('reports the root README path when markers are missing', () => {
+      mockedDiscoverWorkspaces.mockReturnValue([workspaceAt('.')]);
       mockedReadFile.mockImplementation((path) => {
-        if (path === 'package.json') return JSON.stringify({ name: 'consumer' });
         if (path === 'README.md') return '# Plain README';
         return undefined;
       });
 
-      expect(readmesHaveReleaseNotesMarkers()).toBe(false);
+      expect(readmesHaveReleaseNotesMarkers()).toEqual({
+        ok: false,
+        detail: 'missing markers or README: README.md',
+      });
     });
   });
 
   describe('monorepo mode', () => {
-    it('returns true when every publishable package README has both markers', () => {
-      mockedExistsSync.mockReturnValue(true); // pnpm-workspace.yaml present → monorepo
-      mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('beta')]);
+    it('returns true when every workspace package README has both markers', () => {
+      mockedDiscoverWorkspaces.mockReturnValue([workspaceAt('packages/alpha'), workspaceAt('packages/beta')]);
       mockedReadFile.mockImplementation((path) => {
-        if (path === 'packages/alpha/package.json') return JSON.stringify({ name: 'alpha' });
-        if (path === 'packages/beta/package.json') return JSON.stringify({ name: 'beta' });
         if (path === 'packages/alpha/README.md')
           return '<!-- section:release-notes -->\n<!-- /section:release-notes -->';
         if (path === 'packages/beta/README.md')
@@ -205,12 +107,12 @@ describe(readmesHaveReleaseNotesMarkers, () => {
     });
 
     it('aggregates failing packages into CheckOutcome.detail', () => {
-      mockedExistsSync.mockReturnValue(true);
-      mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('beta'), dirEntry('gamma')]);
+      mockedDiscoverWorkspaces.mockReturnValue([
+        workspaceAt('packages/alpha'),
+        workspaceAt('packages/beta'),
+        workspaceAt('packages/gamma'),
+      ]);
       mockedReadFile.mockImplementation((path) => {
-        if (path === 'packages/alpha/package.json') return JSON.stringify({ name: 'alpha' });
-        if (path === 'packages/beta/package.json') return JSON.stringify({ name: 'beta' });
-        if (path === 'packages/gamma/package.json') return JSON.stringify({ name: 'gamma' });
         if (path === 'packages/alpha/README.md')
           return '<!-- section:release-notes -->\n<!-- /section:release-notes -->';
         if (path === 'packages/beta/README.md') return '# Plain README, no markers';
@@ -224,24 +126,8 @@ describe(readmesHaveReleaseNotesMarkers, () => {
       });
     });
 
-    it('skips packages marked private', () => {
-      mockedExistsSync.mockReturnValue(true);
-      mockedReaddirSync.mockReturnValue([dirEntry('alpha'), dirEntry('hidden')]);
-      mockedReadFile.mockImplementation((path) => {
-        if (path === 'packages/alpha/package.json') return JSON.stringify({ name: 'alpha' });
-        if (path === 'packages/hidden/package.json') return JSON.stringify({ name: 'hidden', private: true });
-        if (path === 'packages/alpha/README.md')
-          return '<!-- section:release-notes -->\n<!-- /section:release-notes -->';
-        // hidden has no README — would fail if not filtered out
-        return undefined;
-      });
-
-      expect(readmesHaveReleaseNotesMarkers()).toBe(true);
-    });
-
     it('returns true when there are no publishable packages', () => {
-      mockedExistsSync.mockReturnValue(true);
-      mockedReaddirSync.mockReturnValue([]);
+      mockedDiscoverWorkspaces.mockReturnValue([]);
 
       expect(readmesHaveReleaseNotesMarkers()).toBe(true);
     });

--- a/.readyup/kits/release-kit.js
+++ b/.readyup/kits/release-kit.js
@@ -1,10 +1,1781 @@
 /** @noformat — @generated. Do not edit. Compiled by rdy. */
 /* eslint-disable */
 
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
 
-// .readyup/kits/release-kit.ts
-import { existsSync as existsSync3, readdirSync } from "node:fs";
-import { join as join2 } from "node:path";
+// node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/lib/constants.js
+var require_constants = __commonJS({
+  "node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/lib/constants.js"(exports, module) {
+    "use strict";
+    var WIN_SLASH = "\\\\/";
+    var WIN_NO_SLASH = `[^${WIN_SLASH}]`;
+    var DEFAULT_MAX_EXTGLOB_RECURSION = 0;
+    var DOT_LITERAL = "\\.";
+    var PLUS_LITERAL = "\\+";
+    var QMARK_LITERAL = "\\?";
+    var SLASH_LITERAL = "\\/";
+    var ONE_CHAR = "(?=.)";
+    var QMARK = "[^/]";
+    var END_ANCHOR = `(?:${SLASH_LITERAL}|$)`;
+    var START_ANCHOR = `(?:^|${SLASH_LITERAL})`;
+    var DOTS_SLASH = `${DOT_LITERAL}{1,2}${END_ANCHOR}`;
+    var NO_DOT = `(?!${DOT_LITERAL})`;
+    var NO_DOTS = `(?!${START_ANCHOR}${DOTS_SLASH})`;
+    var NO_DOT_SLASH = `(?!${DOT_LITERAL}{0,1}${END_ANCHOR})`;
+    var NO_DOTS_SLASH = `(?!${DOTS_SLASH})`;
+    var QMARK_NO_DOT = `[^.${SLASH_LITERAL}]`;
+    var STAR = `${QMARK}*?`;
+    var SEP = "/";
+    var POSIX_CHARS = {
+      DOT_LITERAL,
+      PLUS_LITERAL,
+      QMARK_LITERAL,
+      SLASH_LITERAL,
+      ONE_CHAR,
+      QMARK,
+      END_ANCHOR,
+      DOTS_SLASH,
+      NO_DOT,
+      NO_DOTS,
+      NO_DOT_SLASH,
+      NO_DOTS_SLASH,
+      QMARK_NO_DOT,
+      STAR,
+      START_ANCHOR,
+      SEP
+    };
+    var WINDOWS_CHARS = {
+      ...POSIX_CHARS,
+      SLASH_LITERAL: `[${WIN_SLASH}]`,
+      QMARK: WIN_NO_SLASH,
+      STAR: `${WIN_NO_SLASH}*?`,
+      DOTS_SLASH: `${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$)`,
+      NO_DOT: `(?!${DOT_LITERAL})`,
+      NO_DOTS: `(?!(?:^|[${WIN_SLASH}])${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$))`,
+      NO_DOT_SLASH: `(?!${DOT_LITERAL}{0,1}(?:[${WIN_SLASH}]|$))`,
+      NO_DOTS_SLASH: `(?!${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$))`,
+      QMARK_NO_DOT: `[^.${WIN_SLASH}]`,
+      START_ANCHOR: `(?:^|[${WIN_SLASH}])`,
+      END_ANCHOR: `(?:[${WIN_SLASH}]|$)`,
+      SEP: "\\"
+    };
+    var POSIX_REGEX_SOURCE = {
+      __proto__: null,
+      alnum: "a-zA-Z0-9",
+      alpha: "a-zA-Z",
+      ascii: "\\x00-\\x7F",
+      blank: " \\t",
+      cntrl: "\\x00-\\x1F\\x7F",
+      digit: "0-9",
+      graph: "\\x21-\\x7E",
+      lower: "a-z",
+      print: "\\x20-\\x7E ",
+      punct: "\\-!\"#$%&'()\\*+,./:;<=>?@[\\]^_`{|}~",
+      space: " \\t\\r\\n\\v\\f",
+      upper: "A-Z",
+      word: "A-Za-z0-9_",
+      xdigit: "A-Fa-f0-9"
+    };
+    module.exports = {
+      DEFAULT_MAX_EXTGLOB_RECURSION,
+      MAX_LENGTH: 1024 * 64,
+      POSIX_REGEX_SOURCE,
+      // regular expressions
+      REGEX_BACKSLASH: /\\(?![*+?^${}(|)[\]])/g,
+      REGEX_NON_SPECIAL_CHARS: /^[^@![\].,$*+?^{}()|\\/]+/,
+      REGEX_SPECIAL_CHARS: /[-*+?.^${}(|)[\]]/,
+      REGEX_SPECIAL_CHARS_BACKREF: /(\\?)((\W)(\3*))/g,
+      REGEX_SPECIAL_CHARS_GLOBAL: /([-*+?.^${}(|)[\]])/g,
+      REGEX_REMOVE_BACKSLASH: /(?:\[.*?[^\\]\]|\\(?=.))/g,
+      // Replace globs with equivalent patterns to reduce parsing time.
+      REPLACEMENTS: {
+        __proto__: null,
+        "***": "*",
+        "**/**": "**",
+        "**/**/**": "**"
+      },
+      // Digits
+      CHAR_0: 48,
+      /* 0 */
+      CHAR_9: 57,
+      /* 9 */
+      // Alphabet chars.
+      CHAR_UPPERCASE_A: 65,
+      /* A */
+      CHAR_LOWERCASE_A: 97,
+      /* a */
+      CHAR_UPPERCASE_Z: 90,
+      /* Z */
+      CHAR_LOWERCASE_Z: 122,
+      /* z */
+      CHAR_LEFT_PARENTHESES: 40,
+      /* ( */
+      CHAR_RIGHT_PARENTHESES: 41,
+      /* ) */
+      CHAR_ASTERISK: 42,
+      /* * */
+      // Non-alphabetic chars.
+      CHAR_AMPERSAND: 38,
+      /* & */
+      CHAR_AT: 64,
+      /* @ */
+      CHAR_BACKWARD_SLASH: 92,
+      /* \ */
+      CHAR_CARRIAGE_RETURN: 13,
+      /* \r */
+      CHAR_CIRCUMFLEX_ACCENT: 94,
+      /* ^ */
+      CHAR_COLON: 58,
+      /* : */
+      CHAR_COMMA: 44,
+      /* , */
+      CHAR_DOT: 46,
+      /* . */
+      CHAR_DOUBLE_QUOTE: 34,
+      /* " */
+      CHAR_EQUAL: 61,
+      /* = */
+      CHAR_EXCLAMATION_MARK: 33,
+      /* ! */
+      CHAR_FORM_FEED: 12,
+      /* \f */
+      CHAR_FORWARD_SLASH: 47,
+      /* / */
+      CHAR_GRAVE_ACCENT: 96,
+      /* ` */
+      CHAR_HASH: 35,
+      /* # */
+      CHAR_HYPHEN_MINUS: 45,
+      /* - */
+      CHAR_LEFT_ANGLE_BRACKET: 60,
+      /* < */
+      CHAR_LEFT_CURLY_BRACE: 123,
+      /* { */
+      CHAR_LEFT_SQUARE_BRACKET: 91,
+      /* [ */
+      CHAR_LINE_FEED: 10,
+      /* \n */
+      CHAR_NO_BREAK_SPACE: 160,
+      /* \u00A0 */
+      CHAR_PERCENT: 37,
+      /* % */
+      CHAR_PLUS: 43,
+      /* + */
+      CHAR_QUESTION_MARK: 63,
+      /* ? */
+      CHAR_RIGHT_ANGLE_BRACKET: 62,
+      /* > */
+      CHAR_RIGHT_CURLY_BRACE: 125,
+      /* } */
+      CHAR_RIGHT_SQUARE_BRACKET: 93,
+      /* ] */
+      CHAR_SEMICOLON: 59,
+      /* ; */
+      CHAR_SINGLE_QUOTE: 39,
+      /* ' */
+      CHAR_SPACE: 32,
+      /*   */
+      CHAR_TAB: 9,
+      /* \t */
+      CHAR_UNDERSCORE: 95,
+      /* _ */
+      CHAR_VERTICAL_LINE: 124,
+      /* | */
+      CHAR_ZERO_WIDTH_NOBREAK_SPACE: 65279,
+      /* \uFEFF */
+      /**
+       * Create EXTGLOB_CHARS
+       */
+      extglobChars(chars) {
+        return {
+          "!": { type: "negate", open: "(?:(?!(?:", close: `))${chars.STAR})` },
+          "?": { type: "qmark", open: "(?:", close: ")?" },
+          "+": { type: "plus", open: "(?:", close: ")+" },
+          "*": { type: "star", open: "(?:", close: ")*" },
+          "@": { type: "at", open: "(?:", close: ")" }
+        };
+      },
+      /**
+       * Create GLOB_CHARS
+       */
+      globChars(win32) {
+        return win32 === true ? WINDOWS_CHARS : POSIX_CHARS;
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/lib/utils.js
+var require_utils = __commonJS({
+  "node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/lib/utils.js"(exports) {
+    "use strict";
+    var {
+      REGEX_BACKSLASH,
+      REGEX_REMOVE_BACKSLASH,
+      REGEX_SPECIAL_CHARS,
+      REGEX_SPECIAL_CHARS_GLOBAL
+    } = require_constants();
+    exports.isObject = (val) => val !== null && typeof val === "object" && !Array.isArray(val);
+    exports.hasRegexChars = (str) => REGEX_SPECIAL_CHARS.test(str);
+    exports.isRegexChar = (str) => str.length === 1 && exports.hasRegexChars(str);
+    exports.escapeRegex = (str) => str.replace(REGEX_SPECIAL_CHARS_GLOBAL, "\\$1");
+    exports.toPosixSlashes = (str) => str.replace(REGEX_BACKSLASH, "/");
+    exports.isWindows = () => {
+      if (typeof navigator !== "undefined" && navigator.platform) {
+        const platform = navigator.platform.toLowerCase();
+        return platform === "win32" || platform === "windows";
+      }
+      if (typeof process !== "undefined" && process.platform) {
+        return process.platform === "win32";
+      }
+      return false;
+    };
+    exports.removeBackslashes = (str) => {
+      return str.replace(REGEX_REMOVE_BACKSLASH, (match) => {
+        return match === "\\" ? "" : match;
+      });
+    };
+    exports.escapeLast = (input, char, lastIdx) => {
+      const idx = input.lastIndexOf(char, lastIdx);
+      if (idx === -1) return input;
+      if (input[idx - 1] === "\\") return exports.escapeLast(input, char, idx - 1);
+      return `${input.slice(0, idx)}\\${input.slice(idx)}`;
+    };
+    exports.removePrefix = (input, state = {}) => {
+      let output = input;
+      if (output.startsWith("./")) {
+        output = output.slice(2);
+        state.prefix = "./";
+      }
+      return output;
+    };
+    exports.wrapOutput = (input, state = {}, options = {}) => {
+      const prepend = options.contains ? "" : "^";
+      const append = options.contains ? "" : "$";
+      let output = `${prepend}(?:${input})${append}`;
+      if (state.negated === true) {
+        output = `(?:^(?!${output}).*$)`;
+      }
+      return output;
+    };
+    exports.basename = (path, { windows } = {}) => {
+      const segs = path.split(windows ? /[\\/]/ : "/");
+      const last = segs[segs.length - 1];
+      if (last === "") {
+        return segs[segs.length - 2];
+      }
+      return last;
+    };
+  }
+});
+
+// node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/lib/scan.js
+var require_scan = __commonJS({
+  "node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/lib/scan.js"(exports, module) {
+    "use strict";
+    var utils = require_utils();
+    var {
+      CHAR_ASTERISK,
+      /* * */
+      CHAR_AT,
+      /* @ */
+      CHAR_BACKWARD_SLASH,
+      /* \ */
+      CHAR_COMMA,
+      /* , */
+      CHAR_DOT,
+      /* . */
+      CHAR_EXCLAMATION_MARK,
+      /* ! */
+      CHAR_FORWARD_SLASH,
+      /* / */
+      CHAR_LEFT_CURLY_BRACE,
+      /* { */
+      CHAR_LEFT_PARENTHESES,
+      /* ( */
+      CHAR_LEFT_SQUARE_BRACKET,
+      /* [ */
+      CHAR_PLUS,
+      /* + */
+      CHAR_QUESTION_MARK,
+      /* ? */
+      CHAR_RIGHT_CURLY_BRACE,
+      /* } */
+      CHAR_RIGHT_PARENTHESES,
+      /* ) */
+      CHAR_RIGHT_SQUARE_BRACKET
+      /* ] */
+    } = require_constants();
+    var isPathSeparator = (code) => {
+      return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+    };
+    var depth = (token) => {
+      if (token.isPrefix !== true) {
+        token.depth = token.isGlobstar ? Infinity : 1;
+      }
+    };
+    var scan = (input, options) => {
+      const opts = options || {};
+      const length = input.length - 1;
+      const scanToEnd = opts.parts === true || opts.scanToEnd === true;
+      const slashes = [];
+      const tokens = [];
+      const parts = [];
+      let str = input;
+      let index = -1;
+      let start = 0;
+      let lastIndex = 0;
+      let isBrace = false;
+      let isBracket = false;
+      let isGlob = false;
+      let isExtglob = false;
+      let isGlobstar = false;
+      let braceEscaped = false;
+      let backslashes = false;
+      let negated = false;
+      let negatedExtglob = false;
+      let finished = false;
+      let braces = 0;
+      let prev;
+      let code;
+      let token = { value: "", depth: 0, isGlob: false };
+      const eos = () => index >= length;
+      const peek = () => str.charCodeAt(index + 1);
+      const advance = () => {
+        prev = code;
+        return str.charCodeAt(++index);
+      };
+      while (index < length) {
+        code = advance();
+        let next;
+        if (code === CHAR_BACKWARD_SLASH) {
+          backslashes = token.backslashes = true;
+          code = advance();
+          if (code === CHAR_LEFT_CURLY_BRACE) {
+            braceEscaped = true;
+          }
+          continue;
+        }
+        if (braceEscaped === true || code === CHAR_LEFT_CURLY_BRACE) {
+          braces++;
+          while (eos() !== true && (code = advance())) {
+            if (code === CHAR_BACKWARD_SLASH) {
+              backslashes = token.backslashes = true;
+              advance();
+              continue;
+            }
+            if (code === CHAR_LEFT_CURLY_BRACE) {
+              braces++;
+              continue;
+            }
+            if (braceEscaped !== true && code === CHAR_DOT && (code = advance()) === CHAR_DOT) {
+              isBrace = token.isBrace = true;
+              isGlob = token.isGlob = true;
+              finished = true;
+              if (scanToEnd === true) {
+                continue;
+              }
+              break;
+            }
+            if (braceEscaped !== true && code === CHAR_COMMA) {
+              isBrace = token.isBrace = true;
+              isGlob = token.isGlob = true;
+              finished = true;
+              if (scanToEnd === true) {
+                continue;
+              }
+              break;
+            }
+            if (code === CHAR_RIGHT_CURLY_BRACE) {
+              braces--;
+              if (braces === 0) {
+                braceEscaped = false;
+                isBrace = token.isBrace = true;
+                finished = true;
+                break;
+              }
+            }
+          }
+          if (scanToEnd === true) {
+            continue;
+          }
+          break;
+        }
+        if (code === CHAR_FORWARD_SLASH) {
+          slashes.push(index);
+          tokens.push(token);
+          token = { value: "", depth: 0, isGlob: false };
+          if (finished === true) continue;
+          if (prev === CHAR_DOT && index === start + 1) {
+            start += 2;
+            continue;
+          }
+          lastIndex = index + 1;
+          continue;
+        }
+        if (opts.noext !== true) {
+          const isExtglobChar = code === CHAR_PLUS || code === CHAR_AT || code === CHAR_ASTERISK || code === CHAR_QUESTION_MARK || code === CHAR_EXCLAMATION_MARK;
+          if (isExtglobChar === true && peek() === CHAR_LEFT_PARENTHESES) {
+            isGlob = token.isGlob = true;
+            isExtglob = token.isExtglob = true;
+            finished = true;
+            if (code === CHAR_EXCLAMATION_MARK && index === start) {
+              negatedExtglob = true;
+            }
+            if (scanToEnd === true) {
+              while (eos() !== true && (code = advance())) {
+                if (code === CHAR_BACKWARD_SLASH) {
+                  backslashes = token.backslashes = true;
+                  code = advance();
+                  continue;
+                }
+                if (code === CHAR_RIGHT_PARENTHESES) {
+                  isGlob = token.isGlob = true;
+                  finished = true;
+                  break;
+                }
+              }
+              continue;
+            }
+            break;
+          }
+        }
+        if (code === CHAR_ASTERISK) {
+          if (prev === CHAR_ASTERISK) isGlobstar = token.isGlobstar = true;
+          isGlob = token.isGlob = true;
+          finished = true;
+          if (scanToEnd === true) {
+            continue;
+          }
+          break;
+        }
+        if (code === CHAR_QUESTION_MARK) {
+          isGlob = token.isGlob = true;
+          finished = true;
+          if (scanToEnd === true) {
+            continue;
+          }
+          break;
+        }
+        if (code === CHAR_LEFT_SQUARE_BRACKET) {
+          while (eos() !== true && (next = advance())) {
+            if (next === CHAR_BACKWARD_SLASH) {
+              backslashes = token.backslashes = true;
+              advance();
+              continue;
+            }
+            if (next === CHAR_RIGHT_SQUARE_BRACKET) {
+              isBracket = token.isBracket = true;
+              isGlob = token.isGlob = true;
+              finished = true;
+              break;
+            }
+          }
+          if (scanToEnd === true) {
+            continue;
+          }
+          break;
+        }
+        if (opts.nonegate !== true && code === CHAR_EXCLAMATION_MARK && index === start) {
+          negated = token.negated = true;
+          start++;
+          continue;
+        }
+        if (opts.noparen !== true && code === CHAR_LEFT_PARENTHESES) {
+          isGlob = token.isGlob = true;
+          if (scanToEnd === true) {
+            while (eos() !== true && (code = advance())) {
+              if (code === CHAR_LEFT_PARENTHESES) {
+                backslashes = token.backslashes = true;
+                code = advance();
+                continue;
+              }
+              if (code === CHAR_RIGHT_PARENTHESES) {
+                finished = true;
+                break;
+              }
+            }
+            continue;
+          }
+          break;
+        }
+        if (isGlob === true) {
+          finished = true;
+          if (scanToEnd === true) {
+            continue;
+          }
+          break;
+        }
+      }
+      if (opts.noext === true) {
+        isExtglob = false;
+        isGlob = false;
+      }
+      let base = str;
+      let prefix = "";
+      let glob = "";
+      if (start > 0) {
+        prefix = str.slice(0, start);
+        str = str.slice(start);
+        lastIndex -= start;
+      }
+      if (base && isGlob === true && lastIndex > 0) {
+        base = str.slice(0, lastIndex);
+        glob = str.slice(lastIndex);
+      } else if (isGlob === true) {
+        base = "";
+        glob = str;
+      } else {
+        base = str;
+      }
+      if (base && base !== "" && base !== "/" && base !== str) {
+        if (isPathSeparator(base.charCodeAt(base.length - 1))) {
+          base = base.slice(0, -1);
+        }
+      }
+      if (opts.unescape === true) {
+        if (glob) glob = utils.removeBackslashes(glob);
+        if (base && backslashes === true) {
+          base = utils.removeBackslashes(base);
+        }
+      }
+      const state = {
+        prefix,
+        input,
+        start,
+        base,
+        glob,
+        isBrace,
+        isBracket,
+        isGlob,
+        isExtglob,
+        isGlobstar,
+        negated,
+        negatedExtglob
+      };
+      if (opts.tokens === true) {
+        state.maxDepth = 0;
+        if (!isPathSeparator(code)) {
+          tokens.push(token);
+        }
+        state.tokens = tokens;
+      }
+      if (opts.parts === true || opts.tokens === true) {
+        let prevIndex;
+        for (let idx = 0; idx < slashes.length; idx++) {
+          const n = prevIndex ? prevIndex + 1 : start;
+          const i = slashes[idx];
+          const value = input.slice(n, i);
+          if (opts.tokens) {
+            if (idx === 0 && start !== 0) {
+              tokens[idx].isPrefix = true;
+              tokens[idx].value = prefix;
+            } else {
+              tokens[idx].value = value;
+            }
+            depth(tokens[idx]);
+            state.maxDepth += tokens[idx].depth;
+          }
+          if (idx !== 0 || value !== "") {
+            parts.push(value);
+          }
+          prevIndex = i;
+        }
+        if (prevIndex && prevIndex + 1 < input.length) {
+          const value = input.slice(prevIndex + 1);
+          parts.push(value);
+          if (opts.tokens) {
+            tokens[tokens.length - 1].value = value;
+            depth(tokens[tokens.length - 1]);
+            state.maxDepth += tokens[tokens.length - 1].depth;
+          }
+        }
+        state.slashes = slashes;
+        state.parts = parts;
+      }
+      return state;
+    };
+    module.exports = scan;
+  }
+});
+
+// node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/lib/parse.js
+var require_parse = __commonJS({
+  "node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/lib/parse.js"(exports, module) {
+    "use strict";
+    var constants = require_constants();
+    var utils = require_utils();
+    var {
+      MAX_LENGTH,
+      POSIX_REGEX_SOURCE,
+      REGEX_NON_SPECIAL_CHARS,
+      REGEX_SPECIAL_CHARS_BACKREF,
+      REPLACEMENTS
+    } = constants;
+    var expandRange = (args, options) => {
+      if (typeof options.expandRange === "function") {
+        return options.expandRange(...args, options);
+      }
+      args.sort();
+      const value = `[${args.join("-")}]`;
+      try {
+        new RegExp(value);
+      } catch (ex) {
+        return args.map((v) => utils.escapeRegex(v)).join("..");
+      }
+      return value;
+    };
+    var syntaxError = (type, char) => {
+      return `Missing ${type}: "${char}" - use "\\\\${char}" to match literal characters`;
+    };
+    var splitTopLevel = (input) => {
+      const parts = [];
+      let bracket = 0;
+      let paren = 0;
+      let quote = 0;
+      let value = "";
+      let escaped = false;
+      for (const ch of input) {
+        if (escaped === true) {
+          value += ch;
+          escaped = false;
+          continue;
+        }
+        if (ch === "\\") {
+          value += ch;
+          escaped = true;
+          continue;
+        }
+        if (ch === '"') {
+          quote = quote === 1 ? 0 : 1;
+          value += ch;
+          continue;
+        }
+        if (quote === 0) {
+          if (ch === "[") {
+            bracket++;
+          } else if (ch === "]" && bracket > 0) {
+            bracket--;
+          } else if (bracket === 0) {
+            if (ch === "(") {
+              paren++;
+            } else if (ch === ")" && paren > 0) {
+              paren--;
+            } else if (ch === "|" && paren === 0) {
+              parts.push(value);
+              value = "";
+              continue;
+            }
+          }
+        }
+        value += ch;
+      }
+      parts.push(value);
+      return parts;
+    };
+    var isPlainBranch = (branch) => {
+      let escaped = false;
+      for (const ch of branch) {
+        if (escaped === true) {
+          escaped = false;
+          continue;
+        }
+        if (ch === "\\") {
+          escaped = true;
+          continue;
+        }
+        if (/[?*+@!()[\]{}]/.test(ch)) {
+          return false;
+        }
+      }
+      return true;
+    };
+    var normalizeSimpleBranch = (branch) => {
+      let value = branch.trim();
+      let changed = true;
+      while (changed === true) {
+        changed = false;
+        if (/^@\([^\\()[\]{}|]+\)$/.test(value)) {
+          value = value.slice(2, -1);
+          changed = true;
+        }
+      }
+      if (!isPlainBranch(value)) {
+        return;
+      }
+      return value.replace(/\\(.)/g, "$1");
+    };
+    var hasRepeatedCharPrefixOverlap = (branches) => {
+      const values = branches.map(normalizeSimpleBranch).filter(Boolean);
+      for (let i = 0; i < values.length; i++) {
+        for (let j = i + 1; j < values.length; j++) {
+          const a = values[i];
+          const b = values[j];
+          const char = a[0];
+          if (!char || a !== char.repeat(a.length) || b !== char.repeat(b.length)) {
+            continue;
+          }
+          if (a === b || a.startsWith(b) || b.startsWith(a)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    };
+    var parseRepeatedExtglob = (pattern, requireEnd = true) => {
+      if (pattern[0] !== "+" && pattern[0] !== "*" || pattern[1] !== "(") {
+        return;
+      }
+      let bracket = 0;
+      let paren = 0;
+      let quote = 0;
+      let escaped = false;
+      for (let i = 1; i < pattern.length; i++) {
+        const ch = pattern[i];
+        if (escaped === true) {
+          escaped = false;
+          continue;
+        }
+        if (ch === "\\") {
+          escaped = true;
+          continue;
+        }
+        if (ch === '"') {
+          quote = quote === 1 ? 0 : 1;
+          continue;
+        }
+        if (quote === 1) {
+          continue;
+        }
+        if (ch === "[") {
+          bracket++;
+          continue;
+        }
+        if (ch === "]" && bracket > 0) {
+          bracket--;
+          continue;
+        }
+        if (bracket > 0) {
+          continue;
+        }
+        if (ch === "(") {
+          paren++;
+          continue;
+        }
+        if (ch === ")") {
+          paren--;
+          if (paren === 0) {
+            if (requireEnd === true && i !== pattern.length - 1) {
+              return;
+            }
+            return {
+              type: pattern[0],
+              body: pattern.slice(2, i),
+              end: i
+            };
+          }
+        }
+      }
+    };
+    var getStarExtglobSequenceOutput = (pattern) => {
+      let index = 0;
+      const chars = [];
+      while (index < pattern.length) {
+        const match = parseRepeatedExtglob(pattern.slice(index), false);
+        if (!match || match.type !== "*") {
+          return;
+        }
+        const branches = splitTopLevel(match.body).map((branch2) => branch2.trim());
+        if (branches.length !== 1) {
+          return;
+        }
+        const branch = normalizeSimpleBranch(branches[0]);
+        if (!branch || branch.length !== 1) {
+          return;
+        }
+        chars.push(branch);
+        index += match.end + 1;
+      }
+      if (chars.length < 1) {
+        return;
+      }
+      const source = chars.length === 1 ? utils.escapeRegex(chars[0]) : `[${chars.map((ch) => utils.escapeRegex(ch)).join("")}]`;
+      return `${source}*`;
+    };
+    var repeatedExtglobRecursion = (pattern) => {
+      let depth = 0;
+      let value = pattern.trim();
+      let match = parseRepeatedExtglob(value);
+      while (match) {
+        depth++;
+        value = match.body.trim();
+        match = parseRepeatedExtglob(value);
+      }
+      return depth;
+    };
+    var analyzeRepeatedExtglob = (body, options) => {
+      if (options.maxExtglobRecursion === false) {
+        return { risky: false };
+      }
+      const max = typeof options.maxExtglobRecursion === "number" ? options.maxExtglobRecursion : constants.DEFAULT_MAX_EXTGLOB_RECURSION;
+      const branches = splitTopLevel(body).map((branch) => branch.trim());
+      if (branches.length > 1) {
+        if (branches.some((branch) => branch === "") || branches.some((branch) => /^[*?]+$/.test(branch)) || hasRepeatedCharPrefixOverlap(branches)) {
+          return { risky: true };
+        }
+      }
+      for (const branch of branches) {
+        const safeOutput = getStarExtglobSequenceOutput(branch);
+        if (safeOutput) {
+          return { risky: true, safeOutput };
+        }
+        if (repeatedExtglobRecursion(branch) > max) {
+          return { risky: true };
+        }
+      }
+      return { risky: false };
+    };
+    var parse = (input, options) => {
+      if (typeof input !== "string") {
+        throw new TypeError("Expected a string");
+      }
+      input = REPLACEMENTS[input] || input;
+      const opts = { ...options };
+      const max = typeof opts.maxLength === "number" ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+      let len = input.length;
+      if (len > max) {
+        throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
+      }
+      const bos = { type: "bos", value: "", output: opts.prepend || "" };
+      const tokens = [bos];
+      const capture = opts.capture ? "" : "?:";
+      const PLATFORM_CHARS = constants.globChars(opts.windows);
+      const EXTGLOB_CHARS = constants.extglobChars(PLATFORM_CHARS);
+      const {
+        DOT_LITERAL,
+        PLUS_LITERAL,
+        SLASH_LITERAL,
+        ONE_CHAR,
+        DOTS_SLASH,
+        NO_DOT,
+        NO_DOT_SLASH,
+        NO_DOTS_SLASH,
+        QMARK,
+        QMARK_NO_DOT,
+        STAR,
+        START_ANCHOR
+      } = PLATFORM_CHARS;
+      const globstar = (opts2) => {
+        return `(${capture}(?:(?!${START_ANCHOR}${opts2.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+      };
+      const nodot = opts.dot ? "" : NO_DOT;
+      const qmarkNoDot = opts.dot ? QMARK : QMARK_NO_DOT;
+      let star = opts.bash === true ? globstar(opts) : STAR;
+      if (opts.capture) {
+        star = `(${star})`;
+      }
+      if (typeof opts.noext === "boolean") {
+        opts.noextglob = opts.noext;
+      }
+      const state = {
+        input,
+        index: -1,
+        start: 0,
+        dot: opts.dot === true,
+        consumed: "",
+        output: "",
+        prefix: "",
+        backtrack: false,
+        negated: false,
+        brackets: 0,
+        braces: 0,
+        parens: 0,
+        quotes: 0,
+        globstar: false,
+        tokens
+      };
+      input = utils.removePrefix(input, state);
+      len = input.length;
+      const extglobs = [];
+      const braces = [];
+      const stack = [];
+      let prev = bos;
+      let value;
+      const eos = () => state.index === len - 1;
+      const peek = state.peek = (n = 1) => input[state.index + n];
+      const advance = state.advance = () => input[++state.index] || "";
+      const remaining = () => input.slice(state.index + 1);
+      const consume = (value2 = "", num = 0) => {
+        state.consumed += value2;
+        state.index += num;
+      };
+      const append = (token) => {
+        state.output += token.output != null ? token.output : token.value;
+        consume(token.value);
+      };
+      const negate = () => {
+        let count = 1;
+        while (peek() === "!" && (peek(2) !== "(" || peek(3) === "?")) {
+          advance();
+          state.start++;
+          count++;
+        }
+        if (count % 2 === 0) {
+          return false;
+        }
+        state.negated = true;
+        state.start++;
+        return true;
+      };
+      const increment = (type) => {
+        state[type]++;
+        stack.push(type);
+      };
+      const decrement = (type) => {
+        state[type]--;
+        stack.pop();
+      };
+      const push = (tok) => {
+        if (prev.type === "globstar") {
+          const isBrace = state.braces > 0 && (tok.type === "comma" || tok.type === "brace");
+          const isExtglob = tok.extglob === true || extglobs.length && (tok.type === "pipe" || tok.type === "paren");
+          if (tok.type !== "slash" && tok.type !== "paren" && !isBrace && !isExtglob) {
+            state.output = state.output.slice(0, -prev.output.length);
+            prev.type = "star";
+            prev.value = "*";
+            prev.output = star;
+            state.output += prev.output;
+          }
+        }
+        if (extglobs.length && tok.type !== "paren") {
+          extglobs[extglobs.length - 1].inner += tok.value;
+        }
+        if (tok.value || tok.output) append(tok);
+        if (prev && prev.type === "text" && tok.type === "text") {
+          prev.output = (prev.output || prev.value) + tok.value;
+          prev.value += tok.value;
+          return;
+        }
+        tok.prev = prev;
+        tokens.push(tok);
+        prev = tok;
+      };
+      const extglobOpen = (type, value2) => {
+        const token = { ...EXTGLOB_CHARS[value2], conditions: 1, inner: "" };
+        token.prev = prev;
+        token.parens = state.parens;
+        token.output = state.output;
+        token.startIndex = state.index;
+        token.tokensIndex = tokens.length;
+        const output = (opts.capture ? "(" : "") + token.open;
+        increment("parens");
+        push({ type, value: value2, output: state.output ? "" : ONE_CHAR });
+        push({ type: "paren", extglob: true, value: advance(), output });
+        extglobs.push(token);
+      };
+      const extglobClose = (token) => {
+        const literal = input.slice(token.startIndex, state.index + 1);
+        const body = input.slice(token.startIndex + 2, state.index);
+        const analysis = analyzeRepeatedExtglob(body, opts);
+        if ((token.type === "plus" || token.type === "star") && analysis.risky) {
+          const safeOutput = analysis.safeOutput ? (token.output ? "" : ONE_CHAR) + (opts.capture ? `(${analysis.safeOutput})` : analysis.safeOutput) : void 0;
+          const open = tokens[token.tokensIndex];
+          open.type = "text";
+          open.value = literal;
+          open.output = safeOutput || utils.escapeRegex(literal);
+          for (let i = token.tokensIndex + 1; i < tokens.length; i++) {
+            tokens[i].value = "";
+            tokens[i].output = "";
+            delete tokens[i].suffix;
+          }
+          state.output = token.output + open.output;
+          state.backtrack = true;
+          push({ type: "paren", extglob: true, value, output: "" });
+          decrement("parens");
+          return;
+        }
+        let output = token.close + (opts.capture ? ")" : "");
+        let rest;
+        if (token.type === "negate") {
+          let extglobStar = star;
+          if (token.inner && token.inner.length > 1 && token.inner.includes("/")) {
+            extglobStar = globstar(opts);
+          }
+          if (extglobStar !== star || eos() || /^\)+$/.test(remaining())) {
+            output = token.close = `)$))${extglobStar}`;
+          }
+          if (token.inner.includes("*") && (rest = remaining()) && /^\.[^\\/.]+$/.test(rest)) {
+            const expression = parse(rest, { ...options, fastpaths: false }).output;
+            output = token.close = `)${expression})${extglobStar})`;
+          }
+          if (token.prev.type === "bos") {
+            state.negatedExtglob = true;
+          }
+        }
+        push({ type: "paren", extglob: true, value, output });
+        decrement("parens");
+      };
+      if (opts.fastpaths !== false && !/(^[*!]|[/()[\]{}"])/.test(input)) {
+        let backslashes = false;
+        let output = input.replace(REGEX_SPECIAL_CHARS_BACKREF, (m, esc, chars, first, rest, index) => {
+          if (first === "\\") {
+            backslashes = true;
+            return m;
+          }
+          if (first === "?") {
+            if (esc) {
+              return esc + first + (rest ? QMARK.repeat(rest.length) : "");
+            }
+            if (index === 0) {
+              return qmarkNoDot + (rest ? QMARK.repeat(rest.length) : "");
+            }
+            return QMARK.repeat(chars.length);
+          }
+          if (first === ".") {
+            return DOT_LITERAL.repeat(chars.length);
+          }
+          if (first === "*") {
+            if (esc) {
+              return esc + first + (rest ? star : "");
+            }
+            return star;
+          }
+          return esc ? m : `\\${m}`;
+        });
+        if (backslashes === true) {
+          if (opts.unescape === true) {
+            output = output.replace(/\\/g, "");
+          } else {
+            output = output.replace(/\\+/g, (m) => {
+              return m.length % 2 === 0 ? "\\\\" : m ? "\\" : "";
+            });
+          }
+        }
+        if (output === input && opts.contains === true) {
+          state.output = input;
+          return state;
+        }
+        state.output = utils.wrapOutput(output, state, options);
+        return state;
+      }
+      while (!eos()) {
+        value = advance();
+        if (value === "\0") {
+          continue;
+        }
+        if (value === "\\") {
+          const next = peek();
+          if (next === "/" && opts.bash !== true) {
+            continue;
+          }
+          if (next === "." || next === ";") {
+            continue;
+          }
+          if (!next) {
+            value += "\\";
+            push({ type: "text", value });
+            continue;
+          }
+          const match = /^\\+/.exec(remaining());
+          let slashes = 0;
+          if (match && match[0].length > 2) {
+            slashes = match[0].length;
+            state.index += slashes;
+            if (slashes % 2 !== 0) {
+              value += "\\";
+            }
+          }
+          if (opts.unescape === true) {
+            value = advance();
+          } else {
+            value += advance();
+          }
+          if (state.brackets === 0) {
+            push({ type: "text", value });
+            continue;
+          }
+        }
+        if (state.brackets > 0 && (value !== "]" || prev.value === "[" || prev.value === "[^")) {
+          if (opts.posix !== false && value === ":") {
+            const inner = prev.value.slice(1);
+            if (inner.includes("[")) {
+              prev.posix = true;
+              if (inner.includes(":")) {
+                const idx = prev.value.lastIndexOf("[");
+                const pre = prev.value.slice(0, idx);
+                const rest2 = prev.value.slice(idx + 2);
+                const posix = POSIX_REGEX_SOURCE[rest2];
+                if (posix) {
+                  prev.value = pre + posix;
+                  state.backtrack = true;
+                  advance();
+                  if (!bos.output && tokens.indexOf(prev) === 1) {
+                    bos.output = ONE_CHAR;
+                  }
+                  continue;
+                }
+              }
+            }
+          }
+          if (value === "[" && peek() !== ":" || value === "-" && peek() === "]") {
+            value = `\\${value}`;
+          }
+          if (value === "]" && (prev.value === "[" || prev.value === "[^")) {
+            value = `\\${value}`;
+          }
+          if (opts.posix === true && value === "!" && prev.value === "[") {
+            value = "^";
+          }
+          prev.value += value;
+          append({ value });
+          continue;
+        }
+        if (state.quotes === 1 && value !== '"') {
+          value = utils.escapeRegex(value);
+          prev.value += value;
+          append({ value });
+          continue;
+        }
+        if (value === '"') {
+          state.quotes = state.quotes === 1 ? 0 : 1;
+          if (opts.keepQuotes === true) {
+            push({ type: "text", value });
+          }
+          continue;
+        }
+        if (value === "(") {
+          increment("parens");
+          push({ type: "paren", value });
+          continue;
+        }
+        if (value === ")") {
+          if (state.parens === 0 && opts.strictBrackets === true) {
+            throw new SyntaxError(syntaxError("opening", "("));
+          }
+          const extglob = extglobs[extglobs.length - 1];
+          if (extglob && state.parens === extglob.parens + 1) {
+            extglobClose(extglobs.pop());
+            continue;
+          }
+          push({ type: "paren", value, output: state.parens ? ")" : "\\)" });
+          decrement("parens");
+          continue;
+        }
+        if (value === "[") {
+          if (opts.nobracket === true || !remaining().includes("]")) {
+            if (opts.nobracket !== true && opts.strictBrackets === true) {
+              throw new SyntaxError(syntaxError("closing", "]"));
+            }
+            value = `\\${value}`;
+          } else {
+            increment("brackets");
+          }
+          push({ type: "bracket", value });
+          continue;
+        }
+        if (value === "]") {
+          if (opts.nobracket === true || prev && prev.type === "bracket" && prev.value.length === 1) {
+            push({ type: "text", value, output: `\\${value}` });
+            continue;
+          }
+          if (state.brackets === 0) {
+            if (opts.strictBrackets === true) {
+              throw new SyntaxError(syntaxError("opening", "["));
+            }
+            push({ type: "text", value, output: `\\${value}` });
+            continue;
+          }
+          decrement("brackets");
+          const prevValue = prev.value.slice(1);
+          if (prev.posix !== true && prevValue[0] === "^" && !prevValue.includes("/")) {
+            value = `/${value}`;
+          }
+          prev.value += value;
+          append({ value });
+          if (opts.literalBrackets === false || utils.hasRegexChars(prevValue)) {
+            continue;
+          }
+          const escaped = utils.escapeRegex(prev.value);
+          state.output = state.output.slice(0, -prev.value.length);
+          if (opts.literalBrackets === true) {
+            state.output += escaped;
+            prev.value = escaped;
+            continue;
+          }
+          prev.value = `(${capture}${escaped}|${prev.value})`;
+          state.output += prev.value;
+          continue;
+        }
+        if (value === "{" && opts.nobrace !== true) {
+          increment("braces");
+          const open = {
+            type: "brace",
+            value,
+            output: "(",
+            outputIndex: state.output.length,
+            tokensIndex: state.tokens.length
+          };
+          braces.push(open);
+          push(open);
+          continue;
+        }
+        if (value === "}") {
+          const brace = braces[braces.length - 1];
+          if (opts.nobrace === true || !brace) {
+            push({ type: "text", value, output: value });
+            continue;
+          }
+          let output = ")";
+          if (brace.dots === true) {
+            const arr = tokens.slice();
+            const range = [];
+            for (let i = arr.length - 1; i >= 0; i--) {
+              tokens.pop();
+              if (arr[i].type === "brace") {
+                break;
+              }
+              if (arr[i].type !== "dots") {
+                range.unshift(arr[i].value);
+              }
+            }
+            output = expandRange(range, opts);
+            state.backtrack = true;
+          }
+          if (brace.comma !== true && brace.dots !== true) {
+            const out = state.output.slice(0, brace.outputIndex);
+            const toks = state.tokens.slice(brace.tokensIndex);
+            brace.value = brace.output = "\\{";
+            value = output = "\\}";
+            state.output = out;
+            for (const t of toks) {
+              state.output += t.output || t.value;
+            }
+          }
+          push({ type: "brace", value, output });
+          decrement("braces");
+          braces.pop();
+          continue;
+        }
+        if (value === "|") {
+          if (extglobs.length > 0) {
+            extglobs[extglobs.length - 1].conditions++;
+          }
+          push({ type: "text", value });
+          continue;
+        }
+        if (value === ",") {
+          let output = value;
+          const brace = braces[braces.length - 1];
+          if (brace && stack[stack.length - 1] === "braces") {
+            brace.comma = true;
+            output = "|";
+          }
+          push({ type: "comma", value, output });
+          continue;
+        }
+        if (value === "/") {
+          if (prev.type === "dot" && state.index === state.start + 1) {
+            state.start = state.index + 1;
+            state.consumed = "";
+            state.output = "";
+            tokens.pop();
+            prev = bos;
+            continue;
+          }
+          push({ type: "slash", value, output: SLASH_LITERAL });
+          continue;
+        }
+        if (value === ".") {
+          if (state.braces > 0 && prev.type === "dot") {
+            if (prev.value === ".") prev.output = DOT_LITERAL;
+            const brace = braces[braces.length - 1];
+            prev.type = "dots";
+            prev.output += value;
+            prev.value += value;
+            brace.dots = true;
+            continue;
+          }
+          if (state.braces + state.parens === 0 && prev.type !== "bos" && prev.type !== "slash") {
+            push({ type: "text", value, output: DOT_LITERAL });
+            continue;
+          }
+          push({ type: "dot", value, output: DOT_LITERAL });
+          continue;
+        }
+        if (value === "?") {
+          const isGroup = prev && prev.value === "(";
+          if (!isGroup && opts.noextglob !== true && peek() === "(" && peek(2) !== "?") {
+            extglobOpen("qmark", value);
+            continue;
+          }
+          if (prev && prev.type === "paren") {
+            const next = peek();
+            let output = value;
+            if (prev.value === "(" && !/[!=<:]/.test(next) || next === "<" && !/<([!=]|\w+>)/.test(remaining())) {
+              output = `\\${value}`;
+            }
+            push({ type: "text", value, output });
+            continue;
+          }
+          if (opts.dot !== true && (prev.type === "slash" || prev.type === "bos")) {
+            push({ type: "qmark", value, output: QMARK_NO_DOT });
+            continue;
+          }
+          push({ type: "qmark", value, output: QMARK });
+          continue;
+        }
+        if (value === "!") {
+          if (opts.noextglob !== true && peek() === "(") {
+            if (peek(2) !== "?" || !/[!=<:]/.test(peek(3))) {
+              extglobOpen("negate", value);
+              continue;
+            }
+          }
+          if (opts.nonegate !== true && state.index === 0) {
+            negate();
+            continue;
+          }
+        }
+        if (value === "+") {
+          if (opts.noextglob !== true && peek() === "(" && peek(2) !== "?") {
+            extglobOpen("plus", value);
+            continue;
+          }
+          if (prev && prev.value === "(" || opts.regex === false) {
+            push({ type: "plus", value, output: PLUS_LITERAL });
+            continue;
+          }
+          if (prev && (prev.type === "bracket" || prev.type === "paren" || prev.type === "brace") || state.parens > 0) {
+            push({ type: "plus", value });
+            continue;
+          }
+          push({ type: "plus", value: PLUS_LITERAL });
+          continue;
+        }
+        if (value === "@") {
+          if (opts.noextglob !== true && peek() === "(" && peek(2) !== "?") {
+            push({ type: "at", extglob: true, value, output: "" });
+            continue;
+          }
+          push({ type: "text", value });
+          continue;
+        }
+        if (value !== "*") {
+          if (value === "$" || value === "^") {
+            value = `\\${value}`;
+          }
+          const match = REGEX_NON_SPECIAL_CHARS.exec(remaining());
+          if (match) {
+            value += match[0];
+            state.index += match[0].length;
+          }
+          push({ type: "text", value });
+          continue;
+        }
+        if (prev && (prev.type === "globstar" || prev.star === true)) {
+          prev.type = "star";
+          prev.star = true;
+          prev.value += value;
+          prev.output = star;
+          state.backtrack = true;
+          state.globstar = true;
+          consume(value);
+          continue;
+        }
+        let rest = remaining();
+        if (opts.noextglob !== true && /^\([^?]/.test(rest)) {
+          extglobOpen("star", value);
+          continue;
+        }
+        if (prev.type === "star") {
+          if (opts.noglobstar === true) {
+            consume(value);
+            continue;
+          }
+          const prior = prev.prev;
+          const before = prior.prev;
+          const isStart = prior.type === "slash" || prior.type === "bos";
+          const afterStar = before && (before.type === "star" || before.type === "globstar");
+          if (opts.bash === true && (!isStart || rest[0] && rest[0] !== "/")) {
+            push({ type: "star", value, output: "" });
+            continue;
+          }
+          const isBrace = state.braces > 0 && (prior.type === "comma" || prior.type === "brace");
+          const isExtglob = extglobs.length && (prior.type === "pipe" || prior.type === "paren");
+          if (!isStart && prior.type !== "paren" && !isBrace && !isExtglob) {
+            push({ type: "star", value, output: "" });
+            continue;
+          }
+          while (rest.slice(0, 3) === "/**") {
+            const after = input[state.index + 4];
+            if (after && after !== "/") {
+              break;
+            }
+            rest = rest.slice(3);
+            consume("/**", 3);
+          }
+          if (prior.type === "bos" && eos()) {
+            prev.type = "globstar";
+            prev.value += value;
+            prev.output = globstar(opts);
+            state.output = prev.output;
+            state.globstar = true;
+            consume(value);
+            continue;
+          }
+          if (prior.type === "slash" && prior.prev.type !== "bos" && !afterStar && eos()) {
+            state.output = state.output.slice(0, -(prior.output + prev.output).length);
+            prior.output = `(?:${prior.output}`;
+            prev.type = "globstar";
+            prev.output = globstar(opts) + (opts.strictSlashes ? ")" : "|$)");
+            prev.value += value;
+            state.globstar = true;
+            state.output += prior.output + prev.output;
+            consume(value);
+            continue;
+          }
+          if (prior.type === "slash" && prior.prev.type !== "bos" && rest[0] === "/") {
+            const end = rest[1] !== void 0 ? "|$" : "";
+            state.output = state.output.slice(0, -(prior.output + prev.output).length);
+            prior.output = `(?:${prior.output}`;
+            prev.type = "globstar";
+            prev.output = `${globstar(opts)}${SLASH_LITERAL}|${SLASH_LITERAL}${end})`;
+            prev.value += value;
+            state.output += prior.output + prev.output;
+            state.globstar = true;
+            consume(value + advance());
+            push({ type: "slash", value: "/", output: "" });
+            continue;
+          }
+          if (prior.type === "bos" && rest[0] === "/") {
+            prev.type = "globstar";
+            prev.value += value;
+            prev.output = `(?:^|${SLASH_LITERAL}|${globstar(opts)}${SLASH_LITERAL})`;
+            state.output = prev.output;
+            state.globstar = true;
+            consume(value + advance());
+            push({ type: "slash", value: "/", output: "" });
+            continue;
+          }
+          state.output = state.output.slice(0, -prev.output.length);
+          prev.type = "globstar";
+          prev.output = globstar(opts);
+          prev.value += value;
+          state.output += prev.output;
+          state.globstar = true;
+          consume(value);
+          continue;
+        }
+        const token = { type: "star", value, output: star };
+        if (opts.bash === true) {
+          token.output = ".*?";
+          if (prev.type === "bos" || prev.type === "slash") {
+            token.output = nodot + token.output;
+          }
+          push(token);
+          continue;
+        }
+        if (prev && (prev.type === "bracket" || prev.type === "paren") && opts.regex === true) {
+          token.output = value;
+          push(token);
+          continue;
+        }
+        if (state.index === state.start || prev.type === "slash" || prev.type === "dot") {
+          if (prev.type === "dot") {
+            state.output += NO_DOT_SLASH;
+            prev.output += NO_DOT_SLASH;
+          } else if (opts.dot === true) {
+            state.output += NO_DOTS_SLASH;
+            prev.output += NO_DOTS_SLASH;
+          } else {
+            state.output += nodot;
+            prev.output += nodot;
+          }
+          if (peek() !== "*") {
+            state.output += ONE_CHAR;
+            prev.output += ONE_CHAR;
+          }
+        }
+        push(token);
+      }
+      while (state.brackets > 0) {
+        if (opts.strictBrackets === true) throw new SyntaxError(syntaxError("closing", "]"));
+        state.output = utils.escapeLast(state.output, "[");
+        decrement("brackets");
+      }
+      while (state.parens > 0) {
+        if (opts.strictBrackets === true) throw new SyntaxError(syntaxError("closing", ")"));
+        state.output = utils.escapeLast(state.output, "(");
+        decrement("parens");
+      }
+      while (state.braces > 0) {
+        if (opts.strictBrackets === true) throw new SyntaxError(syntaxError("closing", "}"));
+        state.output = utils.escapeLast(state.output, "{");
+        decrement("braces");
+      }
+      if (opts.strictSlashes !== true && (prev.type === "star" || prev.type === "bracket")) {
+        push({ type: "maybe_slash", value: "", output: `${SLASH_LITERAL}?` });
+      }
+      if (state.backtrack === true) {
+        state.output = "";
+        for (const token of state.tokens) {
+          state.output += token.output != null ? token.output : token.value;
+          if (token.suffix) {
+            state.output += token.suffix;
+          }
+        }
+      }
+      return state;
+    };
+    parse.fastpaths = (input, options) => {
+      const opts = { ...options };
+      const max = typeof opts.maxLength === "number" ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+      const len = input.length;
+      if (len > max) {
+        throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
+      }
+      input = REPLACEMENTS[input] || input;
+      const {
+        DOT_LITERAL,
+        SLASH_LITERAL,
+        ONE_CHAR,
+        DOTS_SLASH,
+        NO_DOT,
+        NO_DOTS,
+        NO_DOTS_SLASH,
+        STAR,
+        START_ANCHOR
+      } = constants.globChars(opts.windows);
+      const nodot = opts.dot ? NO_DOTS : NO_DOT;
+      const slashDot = opts.dot ? NO_DOTS_SLASH : NO_DOT;
+      const capture = opts.capture ? "" : "?:";
+      const state = { negated: false, prefix: "" };
+      let star = opts.bash === true ? ".*?" : STAR;
+      if (opts.capture) {
+        star = `(${star})`;
+      }
+      const globstar = (opts2) => {
+        if (opts2.noglobstar === true) return star;
+        return `(${capture}(?:(?!${START_ANCHOR}${opts2.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+      };
+      const create = (str) => {
+        switch (str) {
+          case "*":
+            return `${nodot}${ONE_CHAR}${star}`;
+          case ".*":
+            return `${DOT_LITERAL}${ONE_CHAR}${star}`;
+          case "*.*":
+            return `${nodot}${star}${DOT_LITERAL}${ONE_CHAR}${star}`;
+          case "*/*":
+            return `${nodot}${star}${SLASH_LITERAL}${ONE_CHAR}${slashDot}${star}`;
+          case "**":
+            return nodot + globstar(opts);
+          case "**/*":
+            return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${slashDot}${ONE_CHAR}${star}`;
+          case "**/*.*":
+            return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${slashDot}${star}${DOT_LITERAL}${ONE_CHAR}${star}`;
+          case "**/.*":
+            return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${DOT_LITERAL}${ONE_CHAR}${star}`;
+          default: {
+            const match = /^(.*?)\.(\w+)$/.exec(str);
+            if (!match) return;
+            const source2 = create(match[1]);
+            if (!source2) return;
+            return source2 + DOT_LITERAL + match[2];
+          }
+        }
+      };
+      const output = utils.removePrefix(input, state);
+      let source = create(output);
+      if (source && opts.strictSlashes !== true) {
+        source += `${SLASH_LITERAL}?`;
+      }
+      return source;
+    };
+    module.exports = parse;
+  }
+});
+
+// node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/lib/picomatch.js
+var require_picomatch = __commonJS({
+  "node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/lib/picomatch.js"(exports, module) {
+    "use strict";
+    var scan = require_scan();
+    var parse = require_parse();
+    var utils = require_utils();
+    var constants = require_constants();
+    var isObject = (val) => val && typeof val === "object" && !Array.isArray(val);
+    var picomatch2 = (glob, options, returnState = false) => {
+      if (Array.isArray(glob)) {
+        const fns = glob.map((input) => picomatch2(input, options, returnState));
+        const arrayMatcher = (str) => {
+          for (const isMatch of fns) {
+            const state2 = isMatch(str);
+            if (state2) return state2;
+          }
+          return false;
+        };
+        return arrayMatcher;
+      }
+      const isState = isObject(glob) && glob.tokens && glob.input;
+      if (glob === "" || typeof glob !== "string" && !isState) {
+        throw new TypeError("Expected pattern to be a non-empty string");
+      }
+      const opts = options || {};
+      const posix = opts.windows;
+      const regex = isState ? picomatch2.compileRe(glob, options) : picomatch2.makeRe(glob, options, false, true);
+      const state = regex.state;
+      delete regex.state;
+      let isIgnored = () => false;
+      if (opts.ignore) {
+        const ignoreOpts = { ...options, ignore: null, onMatch: null, onResult: null };
+        isIgnored = picomatch2(opts.ignore, ignoreOpts, returnState);
+      }
+      const matcher = (input, returnObject = false) => {
+        const { isMatch, match, output } = picomatch2.test(input, regex, options, { glob, posix });
+        const result = { glob, state, regex, posix, input, output, match, isMatch };
+        if (typeof opts.onResult === "function") {
+          opts.onResult(result);
+        }
+        if (isMatch === false) {
+          result.isMatch = false;
+          return returnObject ? result : false;
+        }
+        if (isIgnored(input)) {
+          if (typeof opts.onIgnore === "function") {
+            opts.onIgnore(result);
+          }
+          result.isMatch = false;
+          return returnObject ? result : false;
+        }
+        if (typeof opts.onMatch === "function") {
+          opts.onMatch(result);
+        }
+        return returnObject ? result : true;
+      };
+      if (returnState) {
+        matcher.state = state;
+      }
+      return matcher;
+    };
+    picomatch2.test = (input, regex, options, { glob, posix } = {}) => {
+      if (typeof input !== "string") {
+        throw new TypeError("Expected input to be a string");
+      }
+      if (input === "") {
+        return { isMatch: false, output: "" };
+      }
+      const opts = options || {};
+      const format = opts.format || (posix ? utils.toPosixSlashes : null);
+      let match = input === glob;
+      let output = match && format ? format(input) : input;
+      if (match === false) {
+        output = format ? format(input) : input;
+        match = output === glob;
+      }
+      if (match === false || opts.capture === true) {
+        if (opts.matchBase === true || opts.basename === true) {
+          match = picomatch2.matchBase(input, regex, options, posix);
+        } else {
+          match = regex.exec(output);
+        }
+      }
+      return { isMatch: Boolean(match), match, output };
+    };
+    picomatch2.matchBase = (input, glob, options) => {
+      const regex = glob instanceof RegExp ? glob : picomatch2.makeRe(glob, options);
+      return regex.test(utils.basename(input));
+    };
+    picomatch2.isMatch = (str, patterns, options) => picomatch2(patterns, options)(str);
+    picomatch2.parse = (pattern, options) => {
+      if (Array.isArray(pattern)) return pattern.map((p) => picomatch2.parse(p, options));
+      return parse(pattern, { ...options, fastpaths: false });
+    };
+    picomatch2.scan = (input, options) => scan(input, options);
+    picomatch2.compileRe = (state, options, returnOutput = false, returnState = false) => {
+      if (returnOutput === true) {
+        return state.output;
+      }
+      const opts = options || {};
+      const prepend = opts.contains ? "" : "^";
+      const append = opts.contains ? "" : "$";
+      let source = `${prepend}(?:${state.output})${append}`;
+      if (state && state.negated === true) {
+        source = `^(?!${source}).*$`;
+      }
+      const regex = picomatch2.toRegex(source, options);
+      if (returnState === true) {
+        regex.state = state;
+      }
+      return regex;
+    };
+    picomatch2.makeRe = (input, options = {}, returnOutput = false, returnState = false) => {
+      if (!input || typeof input !== "string") {
+        throw new TypeError("Expected a non-empty string");
+      }
+      let parsed = { negated: false, fastpaths: true };
+      if (options.fastpaths !== false && (input[0] === "." || input[0] === "*")) {
+        parsed.output = parse.fastpaths(input, options);
+      }
+      if (!parsed.output) {
+        parsed = parse(input, options);
+      }
+      return picomatch2.compileRe(parsed, options, returnOutput, returnState);
+    };
+    picomatch2.toRegex = (source, options) => {
+      try {
+        const opts = options || {};
+        return new RegExp(source, opts.flags || (opts.nocase ? "i" : ""));
+      } catch (err) {
+        if (options && options.debug === true) throw err;
+        return /$^/;
+      }
+    };
+    picomatch2.constants = constants;
+    module.exports = picomatch2;
+  }
+});
+
+// node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/index.js
+var require_picomatch2 = __commonJS({
+  "node_modules/.pnpm/picomatch@4.0.4/node_modules/picomatch/index.js"(exports, module) {
+    "use strict";
+    var pico = require_picomatch();
+    var utils = require_utils();
+    function picomatch2(glob, options, returnState = false) {
+      if (options && (options.windows === null || options.windows === void 0)) {
+        options = { ...options, windows: utils.isWindows() };
+      }
+      return pico(glob, options, returnState);
+    }
+    Object.assign(picomatch2, pico);
+    module.exports = picomatch2;
+  }
+});
 
 // node_modules/.pnpm/readyup@0.19.0_esbuild@0.28.0/node_modules/readyup/dist/esm/authoring.js
 function defineRdyKit(kit) {
@@ -95,8 +1866,295 @@ function hasMinDevDependencyVersion(name, minVersion, options) {
   return compareVersions(versionMatch, minVersion) >= 0;
 }
 
+// node_modules/.pnpm/readyup@0.19.0_esbuild@0.28.0/node_modules/readyup/dist/esm/check-utils/workspaces.js
+var import_picomatch = __toESM(require_picomatch2(), 1);
+import { existsSync as existsSync2, readdirSync } from "node:fs";
+import { join as join2, resolve } from "node:path";
+
+// node_modules/.pnpm/readyup@0.19.0_esbuild@0.28.0/node_modules/readyup/dist/esm/check-utils/pnpmWorkspaceYaml.js
+import { readFileSync as readFileSync2 } from "node:fs";
+function readPnpmWorkspacePackages(absolutePath) {
+  const content = readFileSync2(absolutePath, "utf8");
+  const lines = content.split(/\r?\n/);
+  rejectGlobalUnsupportedFeatures(absolutePath, lines);
+  const packagesLineIndex = findPackagesKeyLine(lines);
+  if (packagesLineIndex === -1) return null;
+  const packagesLine = lines[packagesLineIndex] ?? "";
+  const inlineValue = extractInlineValue(packagesLine);
+  if (inlineValue !== null && inlineValue.length > 0) {
+    throwUnsupported(absolutePath, packagesLineIndex, packagesLine, "non-list value for `packages:`");
+  }
+  return collectSequenceItems(absolutePath, lines, packagesLineIndex);
+}
+function rejectGlobalUnsupportedFeatures(absolutePath, lines) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const trimmed = line.trim();
+    if (trimmed === "---" || trimmed === "...") {
+      throwUnsupported(absolutePath, index, line, "multi-document stream marker");
+    }
+  }
+}
+function findPackagesKeyLine(lines) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (isBlankOrComment(line)) continue;
+    if (/^\s/.test(line)) continue;
+    const match = /^([A-Za-z_][\w-]*)\s*:(.*)$/.exec(line);
+    if (match === null) continue;
+    if (match[1] === "packages") return index;
+  }
+  return -1;
+}
+function extractInlineValue(line) {
+  const colonIndex = line.indexOf(":");
+  if (colonIndex === -1) return null;
+  const rest = line.slice(colonIndex + 1);
+  const commentStripped = stripInlineComment(rest);
+  const trimmed = commentStripped.trim();
+  return trimmed;
+}
+function collectSequenceItems(absolutePath, lines, packagesLineIndex) {
+  const items = [];
+  let sequenceIndent = null;
+  for (let index = packagesLineIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (isBlankOrComment(line)) continue;
+    const leadingSpaces = countLeadingSpaces(line);
+    if (leadingSpaces === 0) break;
+    const trimmed = line.slice(leadingSpaces);
+    if (!trimmed.startsWith("-")) {
+      throwUnsupported(absolutePath, index, line, "non-list value for `packages:`");
+    }
+    if (sequenceIndent === null) {
+      sequenceIndent = leadingSpaces;
+    } else if (leadingSpaces !== sequenceIndent) {
+      throwUnsupported(absolutePath, index, line, "inconsistent indentation in `packages:` sequence");
+    }
+    const afterDash = trimmed.slice(1);
+    rejectItemLevelUnsupportedFeatures(absolutePath, index, line, afterDash);
+    const rawValue = afterDash.replace(/^\s*/, "");
+    const withoutComment = stripInlineComment(rawValue).trimEnd();
+    if (withoutComment === "") {
+      throwUnsupported(absolutePath, index, line, "empty sequence item or nested structure");
+    }
+    const value = unquote(withoutComment, absolutePath, index, line);
+    if (value.startsWith("!")) {
+      throwNegationUnsupported(absolutePath, index, line, value);
+    }
+    items.push(value);
+  }
+  return items;
+}
+function rejectItemLevelUnsupportedFeatures(absolutePath, lineIndex, line, after) {
+  const trimmed = after.replace(/^\s*/, "");
+  if (trimmed === "") return;
+  const firstChar = trimmed[0];
+  if (firstChar === "&") {
+    throwUnsupported(absolutePath, lineIndex, line, "anchor (&name)");
+  }
+  if (firstChar === "*") {
+    throwUnsupported(absolutePath, lineIndex, line, "alias (*name)");
+  }
+  if (firstChar === "[" || firstChar === "{") {
+    throwUnsupported(absolutePath, lineIndex, line, "flow sequence or mapping");
+  }
+  if (firstChar === "|" || firstChar === ">") {
+    throwUnsupported(absolutePath, lineIndex, line, "block scalar (| or >)");
+  }
+  if (trimmed.startsWith("!!")) {
+    throwUnsupported(absolutePath, lineIndex, line, "YAML tag");
+  }
+}
+function unquote(value, absolutePath, lineIndex, line) {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value.at(-1);
+    if (first === "'" && last === "'") {
+      return value.slice(1, -1);
+    }
+    if (first === '"' && last === '"') {
+      return value.slice(1, -1);
+    }
+  }
+  if (value.startsWith("'") || value.startsWith('"')) {
+    throwUnsupported(absolutePath, lineIndex, line, "unterminated quoted scalar");
+  }
+  return value;
+}
+function stripInlineComment(text) {
+  let inSingle = false;
+  let inDouble = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (!inDouble && char === "'") {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (!inSingle && char === '"') {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (!inSingle && !inDouble && char === "#" && (index === 0 || /\s/.test(text[index - 1] ?? ""))) {
+      return text.slice(0, index);
+    }
+  }
+  return text;
+}
+function isBlankOrComment(line) {
+  const trimmed = line.trim();
+  return trimmed === "" || trimmed.startsWith("#");
+}
+function countLeadingSpaces(line) {
+  let count = 0;
+  while (count < line.length && line[count] === " ") count += 1;
+  return count;
+}
+function throwUnsupported(absolutePath, lineIndex, line, feature) {
+  const lineNumber = lineIndex + 1;
+  const message = `pnpm-workspace.yaml: unsupported YAML feature (${feature}) at ${absolutePath}:${lineNumber}
+  ${line}
+readyup's workspace discovery handles the common block-sequence form for \`packages:\`.
+If you need broader YAML support, please open an issue.`;
+  throw new Error(message);
+}
+function throwNegationUnsupported(absolutePath, lineIndex, line, pattern) {
+  const lineNumber = lineIndex + 1;
+  const message = `pnpm-workspace.yaml: negation pattern "${pattern}" is not supported at ${absolutePath}:${lineNumber}
+  ${line}
+Negation patterns are not supported in this release of readyup's workspace discovery.
+If you need negation support, please open an issue.`;
+  throw new Error(message);
+}
+
+// node_modules/.pnpm/readyup@0.19.0_esbuild@0.28.0/node_modules/readyup/dist/esm/check-utils/workspaces.js
+var MAX_WALK_DEPTH = 10;
+var PRUNED_NAMES = /* @__PURE__ */ new Set(["node_modules"]);
+function discoverWorkspaces(options) {
+  const cwd = process.cwd();
+  const rootPackageJsonPath = join2(cwd, "package.json");
+  const patternResult = resolveWorkspacePatterns(cwd);
+  if (patternResult === null) {
+    const rootPackageJson = readJsonFile("package.json");
+    if (rootPackageJson === void 0) {
+      throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
+    }
+    const workspace = buildWorkspaceFromPackageJson(".", cwd, rootPackageJson);
+    return applyFilter([workspace], options?.filter);
+  }
+  if (!existsSync2(rootPackageJsonPath)) {
+    throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
+  }
+  const matchedDirs = expandPatterns(cwd, patternResult.patterns, patternResult.source);
+  const workspaces = [];
+  for (const relDir of matchedDirs) {
+    const workspace = buildWorkspace(cwd, relDir);
+    if (workspace !== void 0) {
+      workspaces.push(workspace);
+    }
+  }
+  return applyFilter(workspaces, options?.filter);
+}
+function applyFilter(workspaces, filter) {
+  if (filter === void 0) return workspaces;
+  return workspaces.filter(filter);
+}
+function resolveWorkspacePatterns(cwd) {
+  const pnpmWorkspacePath = join2(cwd, "pnpm-workspace.yaml");
+  if (existsSync2(pnpmWorkspacePath)) {
+    const patterns = readPnpmWorkspacePackages(pnpmWorkspacePath);
+    if (patterns !== null) {
+      return { patterns, source: "pnpm-workspace.yaml" };
+    }
+  }
+  const rootPackageJson = readJsonFile("package.json");
+  if (rootPackageJson !== void 0) {
+    const workspaces = rootPackageJson.workspaces;
+    const npmPatterns = extractNpmWorkspacePatterns(workspaces);
+    if (npmPatterns !== null) {
+      return { patterns: npmPatterns, source: "package.json" };
+    }
+  }
+  return null;
+}
+function extractNpmWorkspacePatterns(workspaces) {
+  if (Array.isArray(workspaces)) {
+    const strings = workspaces.filter((entry) => typeof entry === "string");
+    if (strings.length !== workspaces.length) return null;
+    return strings;
+  }
+  if (isRecord(workspaces)) {
+    const nested = workspaces.packages;
+    if (Array.isArray(nested)) {
+      const strings = nested.filter((entry) => typeof entry === "string");
+      if (strings.length !== nested.length) return null;
+      return strings;
+    }
+  }
+  return null;
+}
+function expandPatterns(cwd, patterns, source) {
+  if (patterns.length === 0) return [];
+  for (const pattern of patterns) {
+    if (pattern.startsWith("!")) {
+      throw new Error(
+        `Workspace discovery: negation pattern "${pattern}" in ${source} is not supported.
+Negation patterns are not supported in this release of readyup.
+If you need negation support, please open an issue.`
+      );
+    }
+  }
+  const matchers = patterns.map((pattern) => (0, import_picomatch.default)(normalizePattern(pattern)));
+  const matched = /* @__PURE__ */ new Set();
+  walk(cwd, ".", 0, (relDir) => {
+    if (relDir === ".") return;
+    if (matchers.some((isMatch) => isMatch(relDir))) {
+      matched.add(relDir);
+    }
+  });
+  return [...matched].sort();
+}
+function normalizePattern(pattern) {
+  if (pattern.endsWith("/")) return pattern.slice(0, -1);
+  return pattern;
+}
+function walk(cwd, relDir, depth, visit) {
+  visit(relDir);
+  if (depth >= MAX_WALK_DEPTH) return;
+  const absDir = relDir === "." ? cwd : join2(cwd, relDir);
+  let entries;
+  try {
+    entries = readdirSync(absDir, { withFileTypes: true, encoding: "utf8" });
+  } catch (error) {
+    const code = isRecord(error) && typeof error.code === "string" ? error.code : void 0;
+    if (code === "ENOENT" || code === "EACCES" || code === "EPERM") return;
+    throw error;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const name = entry.name;
+    if (PRUNED_NAMES.has(name)) continue;
+    if (name.startsWith(".")) continue;
+    const childRel = relDir === "." ? name : `${relDir}/${name}`;
+    walk(cwd, childRel, depth + 1, visit);
+  }
+}
+function buildWorkspace(cwd, relDir) {
+  const absoluteDir = resolve(cwd, relDir);
+  const packageJsonRelativePath = relDir === "." ? "package.json" : `${relDir}/package.json`;
+  const packageJson = readJsonFile(packageJsonRelativePath);
+  if (packageJson === void 0) return void 0;
+  return buildWorkspaceFromPackageJson(relDir, absoluteDir, packageJson);
+}
+function buildWorkspaceFromPackageJson(relDir, absolutePath, packageJson) {
+  const nameValue = packageJson.name;
+  const name = typeof nameValue === "string" ? nameValue : void 0;
+  const isPackage = packageJson.private !== true;
+  return { dir: relDir, absolutePath, name, isPackage, packageJson };
+}
+
 // packages/release-kit/src/init/detectRepoType.ts
-import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
+import { existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
 
 // packages/release-kit/src/typeGuards.ts
 function isRecord2(value) {
@@ -116,11 +2174,11 @@ function parseJsonRecord(raw) {
 
 // packages/release-kit/src/init/detectRepoType.ts
 function detectRepoType() {
-  if (existsSync2("pnpm-workspace.yaml")) {
+  if (existsSync3("pnpm-workspace.yaml")) {
     return "monorepo";
   }
-  if (existsSync2("package.json")) {
-    const raw = readFileSync2("package.json", "utf8");
+  if (existsSync3("package.json")) {
+    const raw = readFileSync3("package.json", "utf8");
     const pkg = parseJsonRecord(raw);
     if (pkg !== void 0 && Array.isArray(pkg.workspaces)) {
       return "monorepo";
@@ -136,6 +2194,9 @@ function getMinVersion() {
     throw new TypeError("release-kit/package.json: 'version' must be a string");
   }
   return picked.version;
+}
+function hasPublishablePackages() {
+  return discoverWorkspaces({ filter: (w) => w.isPackage }).length > 0;
 }
 var CLIFF_TEMPLATE_HASH = "520ffdde4cbbef671f229d1e1f63c09a3c4ef0b2d76208386e372419d18065c7";
 var COMMON_PRESET_HASH = "d12ffccbd5e4d9af8ecf47744b143f6c9f80bcf5e496cf1983b66834f0ae7825";
@@ -183,18 +2244,19 @@ var release_kit_default = defineRdyKit({
                 return fileMatchesHash(".github/workflows/release.yaml", hash);
               },
               fix: "Run `release-kit init --force` to regenerate release.yaml from the current template"
+            },
+            {
+              name: "release.yaml does not reference deprecated tag ref",
+              severity: "error",
+              check: () => fileDoesNotContain(".github/workflows/release.yaml", /@(release|publish)-workflow-v[0-9]/),
+              fix: "Update release.yaml to use @workflow/release-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)"
             }
           ]
         },
         {
-          name: "release.yaml does not reference deprecated tag ref",
-          severity: "error",
-          check: () => fileDoesNotContain(".github/workflows/release.yaml", /@(release|publish)-workflow-v[0-9]/),
-          fix: "Update release.yaml to use @workflow/release-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)"
-        },
-        {
           name: "publish.yaml workflow exists",
           severity: "warn",
+          skip: () => !hasPublishablePackages() ? "no publishable packages" : false,
           check: () => fileExists(".github/workflows/publish.yaml"),
           fix: "Add .github/workflows/publish.yaml using the publish workflow template",
           checks: [
@@ -206,14 +2268,14 @@ var release_kit_default = defineRdyKit({
                 return fileMatchesHash(".github/workflows/publish.yaml", hash);
               },
               fix: "Run `release-kit init --force` to regenerate publish.yaml from the current template"
+            },
+            {
+              name: "publish.yaml does not reference deprecated tag ref",
+              severity: "error",
+              check: () => fileDoesNotContain(".github/workflows/publish.yaml", /@(release|publish)-workflow-v[0-9]/),
+              fix: "Update publish.yaml to use @workflow/publish-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)"
             }
           ]
-        },
-        {
-          name: "publish.yaml does not reference deprecated tag ref",
-          severity: "error",
-          check: () => fileDoesNotContain(".github/workflows/publish.yaml", /@(release|publish)-workflow-v[0-9]/),
-          fix: "Update publish.yaml to use @workflow/publish-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)"
         },
         {
           name: "config does not use removed tagPrefix",
@@ -326,15 +2388,12 @@ function readmeHasReleaseNotesMarkers(content) {
   return content.includes("<!-- section:release-notes -->") && content.includes("<!-- /section:release-notes -->");
 }
 function readmesHaveReleaseNotesMarkers() {
-  if (detectRepoType() === "single-package") {
-    const content = readFile("README.md");
-    return content !== void 0 && readmeHasReleaseNotesMarkers(content);
-  }
   const failing = [];
-  for (const { dir } of getPublishablePackages()) {
-    const content = readFile(`${dir}/README.md`);
+  for (const { dir } of discoverWorkspaces({ filter: (w) => w.isPackage })) {
+    const readmePath = dir === "." ? "README.md" : `${dir}/README.md`;
+    const content = readFile(readmePath);
     if (content === void 0 || !readmeHasReleaseNotesMarkers(content)) {
-      failing.push(`${dir}/README.md`);
+      failing.push(readmePath);
     }
   }
   if (failing.length === 0) return true;
@@ -350,22 +2409,6 @@ function labelsHaveCurrentPresetHash(presetName, expectedHash) {
   const match = pattern.exec(content);
   return match !== null && match[1] === expectedHash;
 }
-function getPublishablePackages() {
-  const packagesDir = join2(process.cwd(), "packages");
-  if (!existsSync3(packagesDir)) return [];
-  const entries = readdirSync(packagesDir, { withFileTypes: true });
-  const publishable = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const dir = `packages/${entry.name}`;
-    const content = readFile(`${dir}/package.json`);
-    if (content === void 0) continue;
-    const pkg = parseJsonRecord(content);
-    if (pkg?.private === true) continue;
-    publishable.push({ dir });
-  }
-  return publishable;
-}
 export {
   CLIFF_TEMPLATE_HASH,
   COMMON_PRESET_HASH,
@@ -375,7 +2418,6 @@ export {
   RELEASE_WORKFLOW_HASH_SINGLE,
   SYNC_LABELS_WORKFLOW_HASH,
   release_kit_default as default,
-  getPublishablePackages,
   readmeHasReleaseNotesMarkers,
   readmesHaveReleaseNotesMarkers
 };

--- a/.readyup/kits/release-kit.ts
+++ b/.readyup/kits/release-kit.ts
@@ -9,12 +9,10 @@
  * Run from a target repo's working directory:
  *   rdy run --file <path-to>/release-kit.js
  */
-import { existsSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
-
 import type { CheckOutcome } from 'readyup';
 import {
   defineRdyKit,
+  discoverWorkspaces,
   fileDoesNotContain,
   fileExists,
   fileMatchesHash,
@@ -25,7 +23,6 @@ import {
 } from 'readyup';
 
 import { detectRepoType } from '../../packages/release-kit/src/init/detectRepoType.ts';
-import { parseJsonRecord } from '../../packages/release-kit/src/init/parseJsonRecord.ts';
 
 // `pickJson` is a compile-time helper: `rdy compile` rewrites the call to inline
 // only the listed fields. Defer the call into a function so module load does
@@ -37,6 +34,10 @@ function getMinVersion(): string {
     throw new TypeError("release-kit/package.json: 'version' must be a string");
   }
   return picked.version;
+}
+
+function hasPublishablePackages(): boolean {
+  return discoverWorkspaces({ filter: (w) => w.isPackage }).length > 0;
 }
 
 // SHA-256 hashes of release-kit artifacts. Keep in sync —
@@ -91,17 +92,18 @@ export default defineRdyKit({
               },
               fix: 'Run `release-kit init --force` to regenerate release.yaml from the current template',
             },
+            {
+              name: 'release.yaml does not reference deprecated tag ref',
+              severity: 'error',
+              check: () => fileDoesNotContain('.github/workflows/release.yaml', /@(release|publish)-workflow-v[0-9]/),
+              fix: 'Update release.yaml to use @workflow/release-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)',
+            },
           ],
-        },
-        {
-          name: 'release.yaml does not reference deprecated tag ref',
-          severity: 'error',
-          check: () => fileDoesNotContain('.github/workflows/release.yaml', /@(release|publish)-workflow-v[0-9]/),
-          fix: 'Update release.yaml to use @workflow/release-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)',
         },
         {
           name: 'publish.yaml workflow exists',
           severity: 'warn',
+          skip: () => (!hasPublishablePackages() ? 'no publishable packages' : false),
           check: () => fileExists('.github/workflows/publish.yaml'),
           fix: 'Add .github/workflows/publish.yaml using the publish workflow template',
           checks: [
@@ -115,13 +117,13 @@ export default defineRdyKit({
               },
               fix: 'Run `release-kit init --force` to regenerate publish.yaml from the current template',
             },
+            {
+              name: 'publish.yaml does not reference deprecated tag ref',
+              severity: 'error',
+              check: () => fileDoesNotContain('.github/workflows/publish.yaml', /@(release|publish)-workflow-v[0-9]/),
+              fix: 'Update publish.yaml to use @workflow/publish-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)',
+            },
           ],
-        },
-        {
-          name: 'publish.yaml does not reference deprecated tag ref',
-          severity: 'error',
-          check: () => fileDoesNotContain('.github/workflows/publish.yaml', /@(release|publish)-workflow-v[0-9]/),
-          fix: 'Update publish.yaml to use @workflow/publish-v1 (run `release-kit init --force` to regenerate, or replace the ref manually)',
         },
         {
           name: 'config does not use removed tagPrefix',
@@ -255,24 +257,20 @@ export function readmeHasReleaseNotesMarkers(content: string): boolean {
 }
 
 /**
- * Check README markers across the consumer repo, adapting to repo type.
+ * Check README markers across the consumer repo, iterating publishable workspaces.
  *
- * Single-package: validates the root `README.md`. A missing README fails the check.
- * Monorepo: validates `${dir}/README.md` for each publishable package and aggregates
- * failures into the `CheckOutcome.detail` field. A missing README within a package
- * counts as a failure for that package (no README → no markers).
+ * Validates `${dir}/README.md` for each publishable package and aggregates failures
+ * into the `CheckOutcome.detail` field. A missing README counts as a failure for
+ * that package (no README → no markers). In single-package mode, `discoverWorkspaces`
+ * yields a single root entry (`dir: '.'`), so the same loop handles both repo types.
  */
 export function readmesHaveReleaseNotesMarkers(): boolean | CheckOutcome {
-  if (detectRepoType() === 'single-package') {
-    const content = readFile('README.md');
-    return content !== undefined && readmeHasReleaseNotesMarkers(content);
-  }
-
   const failing: string[] = [];
-  for (const { dir } of getPublishablePackages()) {
-    const content = readFile(`${dir}/README.md`);
+  for (const { dir } of discoverWorkspaces({ filter: (w) => w.isPackage })) {
+    const readmePath = dir === '.' ? 'README.md' : `${dir}/README.md`;
+    const content = readFile(readmePath);
     if (content === undefined || !readmeHasReleaseNotesMarkers(content)) {
-      failing.push(`${dir}/README.md`);
+      failing.push(readmePath);
     }
   }
 
@@ -290,31 +288,4 @@ function labelsHaveCurrentPresetHash(presetName: string, expectedHash: string): 
   const pattern = new RegExp(`^# ${presetName} preset hash: (.+)$`, 'm');
   const match = pattern.exec(content);
   return match !== null && match[1] === expectedHash;
-}
-
-/**
- * Enumerate publishable workspace packages by walking `packages/{dir}` and
- * filtering out any whose `package.json` has `"private": true`.
- *
- * Returns `[]` when `packages/` does not exist. Assumes the conventional
- * `packages/{dir}` layout (matches the existing pattern used in
- * `.readyup/kits/nmr.ts`); does not parse `pnpm-workspace.yaml` or root
- * `package.json` `workspaces`.
- */
-export function getPublishablePackages(): Array<{ dir: string }> {
-  const packagesDir = join(process.cwd(), 'packages');
-  if (!existsSync(packagesDir)) return [];
-
-  const entries = readdirSync(packagesDir, { withFileTypes: true });
-  const publishable: Array<{ dir: string }> = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const dir = `packages/${entry.name}`;
-    const content = readFile(`${dir}/package.json`);
-    if (content === undefined) continue;
-    const pkg = parseJsonRecord(content);
-    if (pkg?.private === true) continue;
-    publishable.push({ dir });
-  }
-  return publishable;
 }

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -29,7 +29,7 @@
       "name": "release-kit",
       "path": "kits/release-kit.js",
       "source": "kits/release-kit.ts",
-      "targetHash": "e98418c4"
+      "targetHash": "76bf81fe"
     }
   ]
 }


### PR DESCRIPTION
## What

Fixes an issue where the `release-kit` readyup kit emitted a non-actionable warning about a missing `publish.yaml` workflow in repos that don't publish anything — single-package repos with `"private": true` and monorepos with zero non-private workspaces. The check now skips with reason "no publishable packages" when applicable.

Also tightens the kit's check tree so that each `…does not reference deprecated tag ref` check is now a nested child of its corresponding `…workflow exists` parent, alongside the existing `…matches template` child. As a result, when the workflow file is missing, blocked content checks render clearly under the parent in `rdy run` output instead of silently passing as no-ops.

## Why

Consumers running the kit against repos that don't publish packages were getting a warning they couldn't act on. The structural inconsistency in the check tree — file-content checks living as top-level siblings of their existence checks — was relying on an implicit contract (`fileDoesNotContain` no-ops on missing files) rather than expressing the precondition explicitly, which made the kit's report less informative when a workflow file was absent.

## Details

### Fixes

- The `publish.yaml workflow exists` subtree now skips with reason `"no publishable packages"` when no workspace package has `"private" !== true`. The skip cascades to both nested children automatically.
- Publishability is determined from `discoverWorkspaces({ filter: (w) => w.isPackage })` shipped in `readyup@0.19.0`, which returns a root-as-entry in single-package mode, so the same predicate works uniformly across monorepo and single-package layouts without caller-side branching.

### Refactoring

- Restructures both workflow check trees so that each `…does not reference deprecated tag ref` check is a nested child of the corresponding `…workflow exists` parent, alongside the existing `…matches template` child. Applies to both `publish.yaml` and `release.yaml`.
- Removes the kit-local `getPublishablePackages` helper in favor of `discoverWorkspaces` from `readyup`. `readmesHaveReleaseNotesMarkers` now iterates the upstream helper directly and collapses its single-package and monorepo branches into a single loop.
- Drops the `node:fs`, `node:path`, and `parseJsonRecord` imports that were only used by the removed helper.

### Tests

- Replaces `getPublishablePackages` mock setup (mocking `node:fs.readdirSync` and per-`package.json` reads) with mocks of `readyup.discoverWorkspaces` and `readyup.readFile`, simplifying fixture construction.
- Removes the dedicated `getPublishablePackages` test block (behavior now owned by `readyup`); preserves and adapts the `readmesHaveReleaseNotesMarkers` tests, including a new assertion that single-package failures now surface a `CheckOutcome` with a useful `detail` message instead of a bare `false`.

### Dependencies

- Consumes `discoverWorkspaces` and the `Workspace` type newly exported from `readyup@0.19.0`. The dependency bump landed previously on this branch.

Closes #307 