### PR TITLE
#306 Make publish's clean-tree safety gate reachable

### DIFF
--- a/.github/workflows/publish.reusable.yaml
+++ b/.github/workflows/publish.reusable.yaml
@@ -73,4 +73,7 @@ jobs:
         run: pnpm --filter @williamthorsen/release-kit... run prepare
 
       - name: Publish
-        run: npx --yes @williamthorsen/release-kit publish ${{ inputs.provenance && '--provenance' || '' }} ${{ inputs.tags != '' && format('--tags="{0}"', inputs.tags) || '' }} --no-git-checks
+        run: |
+          npx --yes @williamthorsen/release-kit publish \
+            ${{ inputs.provenance && '--provenance' || '' }} \
+            ${{ inputs.tags != '' && format('--tags="{0}"', inputs.tags) || '' }}

--- a/packages/release-kit/src/__tests__/publish.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publish.unit.test.ts
@@ -22,7 +22,7 @@ describe(publishPackage, () => {
   const singleTag: ResolvedTag = { tag: 'v1.0.0', dir: '.', workspacePath: '.' };
 
   it('runs npm publish from the correct directory', () => {
-    publishPackage(singleTag, 'npm', { dryRun: false, noGitChecks: false, provenance: false });
+    publishPackage(singleTag, 'npm', { dryRun: false, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish'], {
       cwd: '.',
@@ -30,19 +30,19 @@ describe(publishPackage, () => {
     });
   });
 
-  it('runs pnpm publish from the correct directory', () => {
+  it('runs pnpm publish from the correct directory with --no-git-checks always emitted', () => {
     const tag: ResolvedTag = { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' };
 
-    publishPackage(tag, 'pnpm', { dryRun: false, noGitChecks: false, provenance: false });
+    publishPackage(tag, 'pnpm', { dryRun: false, provenance: false });
 
-    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish'], {
+    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--no-git-checks'], {
       cwd: 'packages/core',
       stdio: 'inherit',
     });
   });
 
-  it('forwards --dry-run flag', () => {
-    publishPackage(singleTag, 'npm', { dryRun: true, noGitChecks: false, provenance: false });
+  it('forwards --dry-run flag for npm', () => {
+    publishPackage(singleTag, 'npm', { dryRun: true, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish', '--dry-run'], {
       cwd: '.',
@@ -50,17 +50,8 @@ describe(publishPackage, () => {
     });
   });
 
-  it('forwards --no-git-checks only for pnpm', () => {
-    publishPackage(singleTag, 'pnpm', { dryRun: false, noGitChecks: true, provenance: false });
-
-    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--no-git-checks'], {
-      cwd: '.',
-      stdio: 'inherit',
-    });
-  });
-
-  it('does not forward --no-git-checks for npm', () => {
-    publishPackage(singleTag, 'npm', { dryRun: false, noGitChecks: true, provenance: false });
+  it('does not emit --no-git-checks for npm', () => {
+    publishPackage(singleTag, 'npm', { dryRun: false, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish'], {
       cwd: '.',
@@ -68,8 +59,8 @@ describe(publishPackage, () => {
     });
   });
 
-  it('does not forward --no-git-checks for yarn', () => {
-    publishPackage(singleTag, 'yarn', { dryRun: false, noGitChecks: true, provenance: false });
+  it('does not emit --no-git-checks for yarn', () => {
+    publishPackage(singleTag, 'yarn', { dryRun: false, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['publish'], {
       cwd: '.',
@@ -78,7 +69,7 @@ describe(publishPackage, () => {
   });
 
   it('runs yarn npm publish for yarn-berry', () => {
-    publishPackage(singleTag, 'yarn-berry', { dryRun: false, noGitChecks: false, provenance: false });
+    publishPackage(singleTag, 'yarn-berry', { dryRun: false, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish'], {
       cwd: '.',
@@ -87,7 +78,7 @@ describe(publishPackage, () => {
   });
 
   it('forwards --dry-run for yarn-berry', () => {
-    publishPackage(singleTag, 'yarn-berry', { dryRun: true, noGitChecks: false, provenance: false });
+    publishPackage(singleTag, 'yarn-berry', { dryRun: true, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish', '--dry-run'], {
       cwd: '.',
@@ -95,8 +86,8 @@ describe(publishPackage, () => {
     });
   });
 
-  it('does not forward --no-git-checks for yarn-berry', () => {
-    publishPackage(singleTag, 'yarn-berry', { dryRun: false, noGitChecks: true, provenance: false });
+  it('does not emit --no-git-checks for yarn-berry', () => {
+    publishPackage(singleTag, 'yarn-berry', { dryRun: false, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish'], {
       cwd: '.',
@@ -104,8 +95,8 @@ describe(publishPackage, () => {
     });
   });
 
-  it('forwards both --dry-run and --no-git-checks for pnpm', () => {
-    publishPackage(singleTag, 'pnpm', { dryRun: true, noGitChecks: true, provenance: false });
+  it('forwards --dry-run alongside --no-git-checks for pnpm', () => {
+    publishPackage(singleTag, 'pnpm', { dryRun: true, provenance: false });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--dry-run', '--no-git-checks'], {
       cwd: '.',
@@ -114,7 +105,7 @@ describe(publishPackage, () => {
   });
 
   it('forwards --provenance for npm', () => {
-    publishPackage(singleTag, 'npm', { dryRun: false, noGitChecks: false, provenance: true });
+    publishPackage(singleTag, 'npm', { dryRun: false, provenance: true });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('npm', ['publish', '--provenance'], {
       cwd: '.',
@@ -122,17 +113,17 @@ describe(publishPackage, () => {
     });
   });
 
-  it('forwards --provenance for pnpm', () => {
-    publishPackage(singleTag, 'pnpm', { dryRun: false, noGitChecks: false, provenance: true });
+  it('forwards --provenance for pnpm alongside --no-git-checks', () => {
+    publishPackage(singleTag, 'pnpm', { dryRun: false, provenance: true });
 
-    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--provenance'], {
+    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--no-git-checks', '--provenance'], {
       cwd: '.',
       stdio: 'inherit',
     });
   });
 
   it('forwards --provenance for yarn-berry', () => {
-    publishPackage(singleTag, 'yarn-berry', { dryRun: false, noGitChecks: false, provenance: true });
+    publishPackage(singleTag, 'yarn-berry', { dryRun: false, provenance: true });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['npm', 'publish', '--provenance'], {
       cwd: '.',
@@ -141,7 +132,7 @@ describe(publishPackage, () => {
   });
 
   it('does not forward --provenance for classic yarn', () => {
-    publishPackage(singleTag, 'yarn', { dryRun: false, noGitChecks: false, provenance: true });
+    publishPackage(singleTag, 'yarn', { dryRun: false, provenance: true });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['publish'], {
       cwd: '.',
@@ -149,17 +140,8 @@ describe(publishPackage, () => {
     });
   });
 
-  it('forwards --dry-run and --provenance together for pnpm', () => {
-    publishPackage(singleTag, 'pnpm', { dryRun: true, noGitChecks: false, provenance: true });
-
-    expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--dry-run', '--provenance'], {
-      cwd: '.',
-      stdio: 'inherit',
-    });
-  });
-
-  it('forwards all three flags in deterministic order for pnpm', () => {
-    publishPackage(singleTag, 'pnpm', { dryRun: true, noGitChecks: true, provenance: true });
+  it('forwards --dry-run, --no-git-checks, and --provenance in deterministic order for pnpm', () => {
+    publishPackage(singleTag, 'pnpm', { dryRun: true, provenance: true });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['publish', '--dry-run', '--no-git-checks', '--provenance'], {
       cwd: '.',
@@ -168,7 +150,7 @@ describe(publishPackage, () => {
   });
 
   it('forwards --dry-run but suppresses --provenance for classic yarn', () => {
-    publishPackage(singleTag, 'yarn', { dryRun: true, noGitChecks: false, provenance: true });
+    publishPackage(singleTag, 'yarn', { dryRun: true, provenance: true });
 
     expect(mockExecFileSync).toHaveBeenCalledWith('yarn', ['publish', '--dry-run'], {
       cwd: '.',

--- a/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
@@ -11,6 +11,7 @@ const mockInjectReleaseNotesIntoReadme = vi.hoisted(() => vi.fn());
 const mockResolveReadmePath = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
 const mockDeriveWorkspaceConfig = vi.hoisted(() => vi.fn());
+const mockAssertCleanWorkingTree = vi.hoisted(() => vi.fn());
 
 vi.mock('node:fs', () => ({
   writeFileSync: mockWriteFileSync,
@@ -55,6 +56,10 @@ vi.mock('../createGithubRelease.ts', () => ({
 vi.mock('../injectReleaseNotesIntoReadme.ts', () => ({
   injectReleaseNotesIntoReadme: mockInjectReleaseNotesIntoReadme,
   resolveReadmePath: mockResolveReadmePath,
+}));
+
+vi.mock('../assertCleanWorkingTree.ts', () => ({
+  assertCleanWorkingTree: mockAssertCleanWorkingTree,
 }));
 
 import { publishCommand } from '../publishCommand.ts';
@@ -106,6 +111,7 @@ describe(publishCommand, () => {
     mockResolveReadmePath.mockReset();
     mockWriteFileSync.mockReset();
     mockDeriveWorkspaceConfig.mockReset();
+    mockAssertCleanWorkingTree.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -115,7 +121,7 @@ describe(publishCommand, () => {
     expect(mockPublishPackage).toHaveBeenCalledWith(
       { tag: 'v1.0.0', dir: '.', workspacePath: '.' },
       'npm',
-      expect.objectContaining({ dryRun: false, noGitChecks: false, provenance: false }),
+      expect.objectContaining({ dryRun: false, provenance: false }),
     );
   });
 
@@ -125,18 +131,19 @@ describe(publishCommand, () => {
     expect(mockPublishPackage).toHaveBeenCalledWith(
       expect.anything(),
       'npm',
-      expect.objectContaining({ dryRun: true, noGitChecks: false, provenance: false }),
+      expect.objectContaining({ dryRun: true, provenance: false }),
     );
   });
 
-  it('passes noGitChecks when --no-git-checks is provided', async () => {
+  it('does not thread --no-git-checks into publishPackage options', async () => {
     await publishCommand(['--no-git-checks']);
 
     expect(mockPublishPackage).toHaveBeenCalledWith(
       expect.anything(),
       'npm',
-      expect.objectContaining({ dryRun: false, noGitChecks: true, provenance: false }),
+      expect.objectContaining({ dryRun: false, provenance: false }),
     );
+    expect(mockPublishPackage.mock.calls[0]?.[2]).not.toHaveProperty('noGitChecks');
   });
 
   it('passes provenance when --provenance is provided', async () => {
@@ -145,7 +152,7 @@ describe(publishCommand, () => {
     expect(mockPublishPackage).toHaveBeenCalledWith(
       expect.anything(),
       'npm',
-      expect.objectContaining({ dryRun: false, noGitChecks: false, provenance: true }),
+      expect.objectContaining({ dryRun: false, provenance: true }),
     );
   });
 
@@ -197,7 +204,7 @@ describe(publishCommand, () => {
     expect(mockPublishPackage).toHaveBeenCalledWith(
       { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
       'npm',
-      expect.objectContaining({ dryRun: false, noGitChecks: false, provenance: false }),
+      expect.objectContaining({ dryRun: false, provenance: false }),
     );
   });
 
@@ -211,7 +218,7 @@ describe(publishCommand, () => {
     expect(mockPublishPackage).toHaveBeenCalledWith(
       { tag: 'v1.0.0', dir: '.', workspacePath: '.' },
       'npm',
-      expect.objectContaining({ dryRun: false, noGitChecks: false, provenance: false }),
+      expect.objectContaining({ dryRun: false, provenance: false }),
     );
   });
 
@@ -457,6 +464,50 @@ describe(publishCommand, () => {
 
       expect(mockResolveReadmePath).not.toHaveBeenCalled();
       expect(mockInjectReleaseNotesIntoReadme).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clean-tree gate', () => {
+    it('exits with error when the working tree is dirty', async () => {
+      mockAssertCleanWorkingTree.mockImplementation(() => {
+        throw new Error('Working tree has uncommitted changes.');
+      });
+
+      let thrown: ExitError | undefined;
+      try {
+        await publishCommand([]);
+      } catch (error: unknown) {
+        if (error instanceof ExitError) {
+          thrown = error;
+        }
+      }
+
+      expect(thrown).toBeInstanceOf(ExitError);
+      expect(thrown?.code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('uncommitted changes'));
+      expect(mockResolveReleaseTags).not.toHaveBeenCalled();
+      expect(mockPublishPackage).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when the working tree is clean', async () => {
+      await publishCommand([]);
+
+      expect(mockAssertCleanWorkingTree).toHaveBeenCalledTimes(1);
+      expect(mockPublishPackage).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the check when --no-git-checks is provided', async () => {
+      await publishCommand(['--no-git-checks']);
+
+      expect(mockAssertCleanWorkingTree).not.toHaveBeenCalled();
+      expect(mockPublishPackage).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the check when --dry-run is provided', async () => {
+      await publishCommand(['--dry-run']);
+
+      expect(mockAssertCleanWorkingTree).not.toHaveBeenCalled();
+      expect(mockPublishPackage).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/release-kit/src/assertCleanWorkingTree.ts
+++ b/packages/release-kit/src/assertCleanWorkingTree.ts
@@ -13,7 +13,7 @@ export function assertCleanWorkingTree(): void {
 
   if (status.length > 0) {
     throw new Error(
-      'Working tree has uncommitted changes. Commit or stash them before running prepare, or use --no-git-checks to bypass this check.',
+      'Working tree has uncommitted changes. Commit or stash them, or use --no-git-checks to bypass this check.',
     );
   }
 }

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -200,7 +200,7 @@ Publish packages that have release tags on HEAD.
 
 Options:
   --dry-run              Preview without publishing
-  --no-git-checks        Skip git checks (pnpm only)
+  --no-git-checks        Skip the clean-working-tree check
   --tags=tag1,tag2       Only publish the named tags (comma-separated, full tag names)
   --provenance           Generate provenance statement (requires OIDC, not supported by classic yarn)
   --help, -h             Show this help message

--- a/packages/release-kit/src/publish.ts
+++ b/packages/release-kit/src/publish.ts
@@ -5,7 +5,6 @@ import type { ResolvedTag } from './resolveReleaseTags.ts';
 
 export interface PublishOptions {
   dryRun: boolean;
-  noGitChecks: boolean;
   provenance: boolean;
 }
 
@@ -15,9 +14,9 @@ export function publishPackage(
   packageManager: PackageManager,
   options: PublishOptions,
 ): void {
-  const { dryRun, noGitChecks, provenance } = options;
+  const { dryRun, provenance } = options;
   const executable = resolveExecutable(packageManager);
-  const args = buildPublishArgs(packageManager, { dryRun, noGitChecks, provenance });
+  const args = buildPublishArgs(packageManager, { dryRun, provenance });
 
   console.info(
     `\n${dryRun ? '[dry-run] ' : ''}Running: ${executable} ${args.join(' ')} (cwd: ${resolvedTag.workspacePath})`,
@@ -33,7 +32,12 @@ function resolveExecutable(packageManager: PackageManager): string {
   return packageManager;
 }
 
-/** Build the argument list for the publish command. */
+/**
+ * Build the argument list for the publish command.
+ *
+ * `--no-git-checks` is always emitted for pnpm: release-kit performs its own clean-tree check
+ * upstream, and the README injection that follows would otherwise trigger pnpm's check.
+ */
 function buildPublishArgs(packageManager: PackageManager, options: PublishOptions): string[] {
   const args = packageManager === 'yarn-berry' ? ['npm', 'publish'] : ['publish'];
 
@@ -41,7 +45,7 @@ function buildPublishArgs(packageManager: PackageManager, options: PublishOption
     args.push('--dry-run');
   }
 
-  if (options.noGitChecks && packageManager === 'pnpm') {
+  if (packageManager === 'pnpm') {
     args.push('--no-git-checks');
   }
 

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
 
+import { assertCleanWorkingTree } from './assertCleanWorkingTree.ts';
 import { detectPackageManager } from './detectPackageManager.ts';
 import { injectReleaseNotesIntoReadme, resolveReadmePath } from './injectReleaseNotesIntoReadme.ts';
 import { parseRequestedTags } from './parseRequestedTags.ts';
@@ -34,6 +35,19 @@ export async function publishCommand(argv: string[]): Promise<void> {
   }
 
   const { dryRun, noGitChecks, provenance } = parsed.flags;
+
+  // Guard against running on a dirty working tree (skip for dry runs and --no-git-checks).
+  // Mirrors prepareCommand and tagCommand: release-kit owns the check; pnpm's own check is
+  // bypassed downstream because release-kit deliberately mutates the README during publish.
+  if (!dryRun && !noGitChecks) {
+    try {
+      assertCleanWorkingTree();
+    } catch (error: unknown) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  }
+
   const requestedTags = parseRequestedTags(parsed.flags.tags);
 
   const resolvedTags = await resolveCommandTags(requestedTags);
@@ -73,7 +87,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
       }
 
       try {
-        publishPackage(resolvedTag, packageManager, { dryRun, noGitChecks, provenance });
+        publishPackage(resolvedTag, packageManager, { dryRun, provenance });
         published.push(resolvedTag.tag);
       } finally {
         if (readmePath !== undefined && originalReadme !== undefined) {


### PR DESCRIPTION
## What

Fixes an issue where `release-kit publish` failed with pnpm's "working tree is dirty" error on a clean tree whenever `releaseNotes.shouldInjectIntoReadme: true` was configured. release-kit injects the release notes into the package README before invoking `pnpm publish`, so pnpm's own working-tree check fired on a tree release-kit had just dirtied — even though the user's tree was clean at command start.

The check is now performed by release-kit itself, before any README mutation, mirroring the pattern already used by `prepare` and `tag`. The reusable publish workflow no longer hardcodes `--no-git-checks`, which means the safety gate is reachable in CI as well as locally — a genuinely dirty tree is now refused everywhere.

The `--no-git-checks` flag on `release-kit publish` now skips release-kit's own clean-tree check (consistent with `prepare` and `tag`) rather than being forwarded to pnpm.

## Why

The safety gate was unreachable in practice. Local users with README injection enabled hit the spurious failure described above and had to pass `--no-git-checks` as a workaround. CI users never saw the gate fire because `publish.reusable.yaml` already hardcoded `--no-git-checks` for the same reason. There was no working configuration in which a publish on a *genuinely* dirty tree was refused.

## Details

### Fixes

- `publishCommand` now calls `assertCleanWorkingTree()` at the top, gated by `--dry-run` and `--no-git-checks`, before resolving tags or mutating the README. A dirty tree fails fast with the same error wording used by `prepare` and `tag`.
- `buildPublishArgs` always emits `--no-git-checks` for pnpm. release-kit performs the equivalent check upstream; pnpm's check is redundant and incompatible with the README injection that follows.
- `PublishOptions.noGitChecks` was removed: the option was always going to be overridden anyway, and keeping it would have been misleading. The CLI flag still parses; it just no longer threads through to `publishPackage`.
- `publish.reusable.yaml` no longer hardcodes `--no-git-checks` on the publish command.
- Help text for `release-kit publish` now describes `--no-git-checks` as "Skip the clean-working-tree check" (consistent with `prepare` / `tag`), and the shared error message in `assertCleanWorkingTree` is no longer command-specific.

### Tests

- Added a `clean-tree gate` describe block to `publishCommand.unit.test.ts` covering the four cases: dirty + no flag (fails), clean (proceeds), `--no-git-checks` (skips), `--dry-run` (skips).
- Updated `publish.unit.test.ts` to reflect the simplified `PublishOptions` (no more `noGitChecks` field) and the unconditional `--no-git-checks` emission for pnpm.
- Updated existing `publishCommand.unit.test.ts` expectations to drop the removed `noGitChecks` field from `publishPackage` call assertions.

Closes #306
