### PR TITLE
Add `project` block for project-level release stage

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -116,6 +116,7 @@ The config file supports both `export default config` and `export const config =
 | `scopeAliases`    | `Record<string, string>`         | Maps shorthand scope names to canonical names in commits                                                                      |
 | `workTypes`       | `Record<string, WorkTypeConfig>` | Work type definitions, merged with defaults by key                                                                            |
 | `retiredPackages` | `RetiredPackage[]`               | Packages that once lived in this repo but have been extracted or removed; suppresses undeclared-tag-prefix warnings           |
+| `project`         | `ProjectConfig`                  | Opt-in project-level release block. Declaring `project: {}` (even empty) enables a project-release stage in `prepare`         |
 
 All fields are optional.
 
@@ -169,6 +170,61 @@ Validation rules:
 - A `tagPrefix` that collides with an active workspace's derived prefix or any declared `workspaces[].legacyIdentities[].tagPrefix` is rejected. A retired prefix cannot also be current or legacy.
 
 `show-tag-prefixes` currently does not render a dedicated "Retired packages" section (deferred). Declaring a retired entry is verifiable by confirming that its `tagPrefix` stops appearing under "Undeclared tag prefixes" in the `show-tag-prefixes` output.
+
+### Project releases
+
+Some monorepos ship a single combined deliverable — a Chrome extension, a CLI binary, a packaged desktop app — for which the per-workspace tags and changelogs alone do not describe what the user actually receives. Declare the optional `project` block to add a project-level release stage that runs alongside the per-workspace pipeline.
+
+```typescript
+import type { ReleaseKitConfig } from '@williamthorsen/release-kit';
+
+const config: ReleaseKitConfig = {
+  // Empty object is enough to opt in. Every non-excluded workspace contributes.
+  project: {},
+};
+
+export default config;
+```
+
+When configured, each `release-kit prepare` run additionally:
+
+- Computes commits since the last project tag (`<tagPrefix><version>`), filtered to the union of every contributing workspace's paths.
+- Bumps the root `package.json`'s `version` field using the same bump-derivation rules as workspaces (or the `--bump=...` override).
+- Regenerates the root `./CHANGELOG.md` via `git-cliff`, scoped to the project's `tagPrefix` and contributing paths.
+- Emits `./.meta/changelog.json` (when `changelogJson.enabled`).
+- With `--with-release-notes`, additionally emits `./docs/RELEASE_NOTES.v<version>.md`.
+- Appends the project tag to `tmp/.release-tags` so `release-kit commit` and `release-kit tag` pick it up alongside per-workspace tags.
+
+If no contributing workspace has commits since the last project tag, the project release is silently skipped — same behavior as a per-workspace skip.
+
+#### `ProjectConfig`
+
+```typescript
+interface ProjectConfig {
+  tagPrefix?: string; // Defaults to 'v'
+}
+```
+
+| Field       | Default | Description                                                          |
+| ----------- | ------- | -------------------------------------------------------------------- |
+| `tagPrefix` | `'v'`   | Prefix for project tags. The full tag is `${tagPrefix}${newVersion}` |
+
+Contributing workspaces are implicit: every non-excluded discovered workspace contributes. There is no field to override the contributing set in this initial release; if a future consumer needs to release a workspace as a component but exclude it from the project release, that override can be added then.
+
+Validation rules:
+
+- The root `package.json` must exist and declare a `version` field. release-kit reports a clear error at config-load time if either is missing.
+- `project.tagPrefix` must not collide with any active workspace's derived `tagPrefix`, any `workspaces[].legacyIdentities[].tagPrefix`, or any `retiredPackages[].tagPrefix`. The collision check is strict-prefix: a project prefix `'v'` collides with a workspace prefix `'vue-helpers-v'` because `git describe --match=v*` would return tags from both.
+- The `project` block is rejected in single-package mode (the implicit "all non-excluded workspaces contribute" rule is meaningless in a single-package repo).
+- Unknown fields inside `project` are rejected.
+
+CLI flag interactions:
+
+- `--dry-run` previews project artifacts alongside workspace artifacts; no files are written.
+- `--bump=major|minor|patch` propagates to the project release.
+- `--force` combined with `--bump` runs the project release even with no commits since the last project tag.
+- `--only` is **rejected with a clear error** when `project` is configured. `--only` is a surgical, single-workspace operation; combining it with a project release that rolls up every contributing workspace would create ambiguous semantics. To release a single workspace, use a config without a `project` block, or run a full `prepare` (no `--only`) to include the project release.
+- `--set-version` cannot co-exist with a configured project block, since `--set-version` requires `--only` in monorepo mode (and `--only` is rejected when `project` is configured).
 
 ### `VersionPatterns`
 
@@ -227,7 +283,7 @@ Run release preparation with automatic workspace discovery.
 | `--bump=major\|minor\|patch` | Override the bump type for all workspaces                                                                    |
 | `--set-version=X.Y.Z`        | Set an explicit canonical semver version; bypasses commit-derived bumps. Requires `--only` in monorepo mode. |
 | `--force`                    | Bypass the "no commits since last tag" check (requires `--bump`)                                             |
-| `--only=name1,name2`         | Only process the named workspaces (monorepo only)                                                            |
+| `--only=name1,name2`         | Only process the named workspaces (monorepo only; rejected when a `project` block is configured)             |
 | `--with-release-notes`       | Write per-workspace release-notes previews under `{workspacePath}/docs/`                                     |
 | `--help`, `-h`               | Show help                                                                                                    |
 

--- a/packages/release-kit/src/__tests__/buildReleaseSummary.unit.test.ts
+++ b/packages/release-kit/src/__tests__/buildReleaseSummary.unit.test.ts
@@ -102,4 +102,71 @@ describe(buildReleaseSummary, () => {
   it('returns empty string when there are no workspaces', () => {
     expect(buildReleaseSummary(makeResult())).toBe('');
   });
+
+  describe('project release section', () => {
+    it('appends the project section after workspace sections when project commits exist', () => {
+      const result = makeResult({
+        workspaces: [
+          {
+            name: 'arrays',
+            status: 'released',
+            tag: 'arrays-v1.1.0',
+            commitCount: 1,
+            bumpedFiles: [],
+            changelogFiles: [],
+            commits: [{ message: 'arrays|feat: Add compact', hash: 'a1' }],
+          },
+        ],
+        project: {
+          status: 'released',
+          commitCount: 1,
+          releaseType: 'minor',
+          currentVersion: '0.9.0',
+          newVersion: '0.10.0',
+          tag: 'v0.10.0',
+          bumpedFiles: ['./package.json'],
+          changelogFiles: ['./CHANGELOG.md'],
+          commits: [{ message: 'arrays|feat: Add compact', hash: 'a1' }],
+        },
+      });
+
+      expect(buildReleaseSummary(result)).toBe('arrays-v1.1.0\n- feat: Add compact\n\nv0.10.0\n- feat: Add compact');
+    });
+
+    it('emits only the project section when no workspace contributed commits', () => {
+      const result = makeResult({
+        project: {
+          status: 'released',
+          commitCount: 1,
+          releaseType: 'patch',
+          currentVersion: '0.9.0',
+          newVersion: '0.9.1',
+          tag: 'v0.9.1',
+          bumpedFiles: ['./package.json'],
+          changelogFiles: ['./CHANGELOG.md'],
+          commits: [{ message: 'arrays|fix: Patch bug', hash: 'b1' }],
+        },
+      });
+
+      expect(buildReleaseSummary(result)).toBe('v0.9.1\n- fix: Patch bug');
+    });
+
+    it('omits the project section when no project commits exist', () => {
+      const result = makeResult({
+        project: {
+          status: 'released',
+          commitCount: 0,
+          releaseType: 'patch',
+          currentVersion: '0.9.0',
+          newVersion: '0.9.1',
+          tag: 'v0.9.1',
+          bumpedFiles: ['./package.json'],
+          changelogFiles: ['./CHANGELOG.md'],
+          commits: [],
+        },
+      });
+
+      expect(buildReleaseSummary(result)).toBe('');
+    });
+  });
 });

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -16,7 +16,13 @@ vi.mock('jiti', () => ({
 }));
 
 import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from '../defaults.ts';
-import { CONFIG_FILE_PATH, loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig } from '../loadConfig.ts';
+import {
+  CONFIG_FILE_PATH,
+  loadConfig,
+  mergeMonorepoConfig,
+  mergeSinglePackageConfig,
+  readRootPackageVersion,
+} from '../loadConfig.ts';
 
 /**
  * Configure `mockReadFileSync` to return a `package.json` with the given `name` per workspace
@@ -376,6 +382,152 @@ describe(mergeMonorepoConfig, () => {
   });
 });
 
+describe(readRootPackageVersion, () => {
+  afterEach(() => {
+    mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
+  });
+
+  it('returns exists=false when the root package.json is missing', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(readRootPackageVersion()).toStrictEqual({ exists: false, version: undefined });
+  });
+
+  it('returns the version when the root package.json declares one', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'root', version: '1.2.3' }));
+    expect(readRootPackageVersion()).toStrictEqual({ exists: true, version: '1.2.3' });
+  });
+
+  it('returns version=undefined when the root package.json has no version field', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'root' }));
+    expect(readRootPackageVersion()).toStrictEqual({ exists: true, version: undefined });
+  });
+
+  it('throws a clear error when the root package.json contains invalid JSON', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('{ not valid json');
+    expect(() => readRootPackageVersion()).toThrow(/Failed to parse root package\.json/);
+  });
+});
+
+describe('mergeMonorepoConfig project block', () => {
+  const discoveredPaths = ['packages/arrays', 'packages/strings'];
+
+  beforeEach(() => {
+    mockPackageNames({
+      'packages/arrays': '@scope/arrays',
+      'packages/strings': '@scope/strings',
+    });
+  });
+
+  afterEach(() => {
+    mockReadFileSync.mockReset();
+  });
+
+  it('omits project from the merged config when the consumer did not declare one', () => {
+    const result = mergeMonorepoConfig(discoveredPaths, undefined);
+    expect(result.project).toBeUndefined();
+  });
+
+  it('resolves an empty project block to the default tagPrefix', () => {
+    const result = mergeMonorepoConfig(discoveredPaths, { project: {} }, { exists: true, version: '0.9.0' });
+    expect(result.project).toStrictEqual({ tagPrefix: 'v' });
+  });
+
+  it('preserves a custom project tagPrefix', () => {
+    const result = mergeMonorepoConfig(
+      discoveredPaths,
+      { project: { tagPrefix: 'release-v' } },
+      { exists: true, version: '0.9.0' },
+    );
+    expect(result.project).toStrictEqual({ tagPrefix: 'release-v' });
+  });
+
+  it('throws when project is configured but the root package.json is missing', () => {
+    expect(() => mergeMonorepoConfig(discoveredPaths, { project: {} }, { exists: false, version: undefined })).toThrow(
+      /project block requires a root package\.json/,
+    );
+  });
+
+  it('throws when project is configured but the root package.json has no version field', () => {
+    expect(() => mergeMonorepoConfig(discoveredPaths, { project: {} }, { exists: true, version: undefined })).toThrow(
+      /add a 'version' field to your root package\.json/,
+    );
+  });
+
+  it('throws when no rootPackage info is supplied alongside a project block', () => {
+    expect(() => mergeMonorepoConfig(discoveredPaths, { project: {} })).toThrow(
+      /project block requires a root package\.json/,
+    );
+  });
+
+  it('rejects a project tagPrefix colliding with a workspace derived prefix', () => {
+    mockPackageNames({
+      'packages/v-helpers': '@scope/v-helpers',
+    });
+    expect(() =>
+      mergeMonorepoConfig(['packages/v-helpers'], { project: { tagPrefix: 'v' } }, { exists: true, version: '0.9.0' }),
+    ).toThrow(/Tag prefix collision/);
+  });
+
+  it('rejects a project tagPrefix that strict-prefix-collides with a workspace prefix', () => {
+    // `git describe --match=v*` would also match `vue-helpers-v1.0.0` tags.
+    mockPackageNames({
+      'packages/vue-helpers': '@scope/vue-helpers',
+    });
+    expect(() =>
+      mergeMonorepoConfig(
+        ['packages/vue-helpers'],
+        { project: { tagPrefix: 'v' } },
+        { exists: true, version: '0.9.0' },
+      ),
+    ).toThrow(/Tag prefix collision: 'vue-helpers-v' .* and 'v' \(project\)/);
+  });
+
+  it('rejects a project tagPrefix colliding with a declared legacy identity', () => {
+    expect(() =>
+      mergeMonorepoConfig(
+        discoveredPaths,
+        {
+          workspaces: [{ dir: 'arrays', legacyIdentities: [{ name: '@old-scope/arrays', tagPrefix: 'release-v' }] }],
+          project: { tagPrefix: 'release-v' },
+        },
+        { exists: true, version: '0.9.0' },
+      ),
+    ).toThrow(/Tag prefix collision: 'release-v'/);
+  });
+
+  it('rejects a project tagPrefix colliding with a retired-package prefix', () => {
+    expect(() =>
+      mergeMonorepoConfig(
+        discoveredPaths,
+        {
+          retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v' }],
+          project: { tagPrefix: 'preflight-v' },
+        },
+        { exists: true, version: '0.9.0' },
+      ),
+    ).toThrow(/Tag prefix collision: 'preflight-v'/);
+  });
+
+  it('accepts a workspace whose legacyIdentities reuses its own current tagPrefix (different name)', () => {
+    // Existing intra-workspace rename pattern must keep working — a workspace's own current
+    // prefix and its declared legacy identity prefix can match without colliding.
+    expect(() =>
+      mergeMonorepoConfig(discoveredPaths, {
+        workspaces: [
+          {
+            dir: 'arrays',
+            legacyIdentities: [{ name: '@old-scope/arrays', tagPrefix: 'arrays-v' }],
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+});
+
 describe(mergeSinglePackageConfig, () => {
   it('returns defaults when no config is provided', () => {
     const result = mergeSinglePackageConfig(undefined);
@@ -385,6 +537,12 @@ describe(mergeSinglePackageConfig, () => {
     expect(result.changelogPaths).toStrictEqual(['.']);
     expect(result.workTypes).toStrictEqual(DEFAULT_WORK_TYPES);
     expect(result.versionPatterns).toStrictEqual(DEFAULT_VERSION_PATTERNS);
+  });
+
+  it('rejects a configured project block in single-package mode', () => {
+    expect(() => mergeSinglePackageConfig({ project: {} })).toThrow(
+      'project block is not supported in single-package mode',
+    );
   });
 
   it('merges custom workTypes with defaults', () => {

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -4,12 +4,14 @@ const mockAssertCleanWorkingTree = vi.hoisted(() => vi.fn());
 const mockBuildReleaseSummary = vi.hoisted(() => vi.fn());
 const mockDiscoverWorkspaces = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockReleasePrepareMono = vi.hoisted(() => vi.fn());
 const mockReleasePrepare = vi.hoisted(() => vi.fn());
 const mockWriteFileWithCheck = vi.hoisted(() => vi.fn());
 
 vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
   readFileSync: mockReadFileSync,
 }));
 
@@ -74,6 +76,9 @@ describe(prepareCommand, () => {
     mockBuildReleaseSummary.mockReturnValue('');
     mockDiscoverWorkspaces.mockResolvedValue(['packages/arrays', 'packages/strings']);
     mockLoadConfig.mockResolvedValue(undefined);
+    // Default: pretend the root package.json does not exist. Tests that exercise the project
+    // block override this in-test to return a valid version.
+    mockExistsSync.mockReturnValue(false);
     mockReadFileSync.mockImplementation((filePath: string) => {
       if (filePath === 'packages/arrays/package.json') {
         return JSON.stringify({ name: '@scope/arrays' });
@@ -99,6 +104,7 @@ describe(prepareCommand, () => {
     mockBuildReleaseSummary.mockReset();
     mockDiscoverWorkspaces.mockReset();
     mockLoadConfig.mockReset();
+    mockExistsSync.mockReset();
     mockReadFileSync.mockReset();
     mockReleasePrepareMono.mockReset();
     mockReleasePrepare.mockReset();
@@ -447,6 +453,37 @@ describe(prepareCommand, () => {
 
     const callArgs = mockReleasePrepareMono.mock.calls[0]?.[1];
     expect(callArgs).not.toHaveProperty('withReleaseNotes');
+  });
+
+  describe('--only with project block', () => {
+    beforeEach(() => {
+      // Configure the mocks so the project block is loaded and the root package.json is valid.
+      mockLoadConfig.mockResolvedValue({ project: {} });
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockImplementation((filePath: string) => {
+        if (filePath === 'packages/arrays/package.json') {
+          return JSON.stringify({ name: '@scope/arrays' });
+        }
+        if (filePath === 'packages/strings/package.json') {
+          return JSON.stringify({ name: '@scope/strings' });
+        }
+        // Root package.json for the project block prerequisite check.
+        return JSON.stringify({ name: 'root', version: '0.9.0' });
+      });
+    });
+
+    it('rejects --only with a clear error before any release work runs', async () => {
+      await expect(prepareCommand(['--only=arrays'])).rejects.toThrow(ExitError);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('--only cannot be combined with a project release'),
+      );
+      expect(mockReleasePrepareMono).not.toHaveBeenCalled();
+    });
+
+    it('runs normally without --only when project is configured', async () => {
+      await prepareCommand([]);
+      expect(mockReleasePrepareMono).toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -1359,6 +1359,121 @@ describe(releasePrepareMono, () => {
     });
   });
 
+  describe('project block wiring', () => {
+    it('does not run any project-related code when config.project is undefined', () => {
+      const config = makeConfig({
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+        ],
+      });
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          return 'arrays-v1.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          return 'feat: addabc';
+        }
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      expect(result.project).toBeUndefined();
+      // The arrays workspace was bumped; no project tag was added.
+      expect(result.tags).toStrictEqual(['arrays-v1.1.0']);
+    });
+
+    it('runs the project release when config.project is defined and surfaces it on result.project', () => {
+      const config = makeConfig({
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+        ],
+        project: { tagPrefix: 'v' },
+      });
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          const matchArg = args.find((a: string) => a.startsWith('--match='));
+          if (matchArg === '--match=arrays-v*') return 'arrays-v1.0.0\n';
+          if (matchArg === '--match=v*') return 'v0.9.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          return 'feat: shipabc123';
+        }
+        return '';
+      });
+      mockReadFileSync.mockImplementation((filePath: string) => {
+        if (filePath === './package.json') return JSON.stringify({ name: 'root', version: '0.9.0' });
+        return JSON.stringify({ version: '1.0.0' });
+      });
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      expect(result.project).toBeDefined();
+      expect(result.project?.tag).toBe('v0.10.0');
+      expect(result.project?.releaseType).toBe('minor');
+      expect(result.tags).toContain('arrays-v1.1.0');
+      expect(result.tags).toContain('v0.10.0');
+    });
+
+    it('passes project files to the format command alongside per-workspace files', () => {
+      const config = makeConfig({
+        formatCommand: 'npx prettier --write',
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+        ],
+        project: { tagPrefix: 'v' },
+      });
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          const matchArg = args.find((a: string) => a.startsWith('--match='));
+          if (matchArg === '--match=arrays-v*') return 'arrays-v1.0.0\n';
+          if (matchArg === '--match=v*') return 'v0.9.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          return 'feat: shipabc123';
+        }
+        return '';
+      });
+      mockReadFileSync.mockImplementation((filePath: string) => {
+        if (filePath === './package.json') return JSON.stringify({ name: 'root', version: '0.9.0' });
+        return JSON.stringify({ version: '1.0.0' });
+      });
+
+      releasePrepareMono(config, { dryRun: false });
+
+      expect(mockExecSync).toHaveBeenCalledTimes(1);
+      const formatCall = mockExecSync.mock.calls[0]?.[0];
+      expect(formatCall).toContain('packages/arrays/package.json');
+      expect(formatCall).toContain('./package.json');
+      expect(formatCall).toContain('./CHANGELOG.md');
+    });
+  });
+
   describe('--with-release-notes flag', () => {
     function setupArraysWithFeat(): MonorepoReleaseConfig {
       const config = makeConfig({

--- a/packages/release-kit/src/__tests__/releasePrepareProject.int.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareProject.int.test.ts
@@ -1,0 +1,288 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mergeMonorepoConfig } from '../loadConfig.ts';
+import { releasePrepareMono } from '../releasePrepareMono.ts';
+
+/**
+ * End-to-end project-release tests that:
+ * - Create a real git repo in a temp directory.
+ * - Seed it with three workspaces, an initial commit, a `v0.9.0` legacy tag, and a mix of
+ *   `feat`/`fix` commits per workspace since.
+ * - Run `releasePrepareMono` with a `project: {}` block declared in the config.
+ * - Assert at the file-content level: project tag in result, root `package.json` bumped, root
+ *   `CHANGELOG.md` regenerated with expected entries, project tag included alongside the
+ *   per-workspace tags.
+ *
+ * `git-cliff` is invoked through `npx --yes`, so the test environment must have network
+ * access to download git-cliff on first run (cached after).
+ */
+
+interface Fixture {
+  repoDir: string;
+  cleanup: () => void;
+}
+
+/**
+ * Build a temp git repo with three workspaces (`pkg-a`, `pkg-b`, `pkg-c`), a legacy `v0.9.0`
+ * tag at the initial commit, and three feat/fix commits since (one per workspace).
+ */
+function setupFixture(): Fixture {
+  const repoDir = mkdtempSync(join(tmpdir(), 'release-kit-project-'));
+  const run = (command: string, args: string[]): void => {
+    execFileSync(command, args, { cwd: repoDir, stdio: ['ignore', 'pipe', 'pipe'] });
+  };
+
+  // Initialize a clean repo with deterministic config so `git commit` does not require a
+  // global identity to be set on the host.
+  run('git', ['init', '--quiet', '--initial-branch=main']);
+  run('git', ['config', 'user.email', 'test@example.com']);
+  run('git', ['config', 'user.name', 'Test User']);
+  run('git', ['config', 'commit.gpgsign', 'false']);
+  run('git', ['config', 'tag.gpgSign', 'false']);
+
+  // Root package.json (project block prerequisite).
+  writeFileSync(
+    join(repoDir, 'package.json'),
+    JSON.stringify({ name: 'fixture-monorepo', version: '0.9.0', private: true }, null, 2) + '\n',
+    'utf8',
+  );
+
+  // pnpm workspace declaration so `discoverWorkspaces` finds the three packages and the
+  // CLI takes the monorepo branch rather than single-package mode.
+  writeFileSync(join(repoDir, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n", 'utf8');
+
+  // Three workspaces.
+  for (const name of ['pkg-a', 'pkg-b', 'pkg-c']) {
+    const wsDir = join(repoDir, 'packages', name);
+    mkdirSync(wsDir, { recursive: true });
+    writeFileSync(
+      join(wsDir, 'package.json'),
+      JSON.stringify({ name: `@fixture/${name}`, version: '1.0.0' }, null, 2) + '\n',
+      'utf8',
+    );
+    writeFileSync(
+      join(wsDir, 'index.ts'),
+      `export const ${name.replace('-', '_')} = ${JSON.stringify(name)};\n`,
+      'utf8',
+    );
+  }
+
+  // Initial commit, then anchor the legacy v0.9.0 tag at it.
+  run('git', ['add', '-A']);
+  run('git', ['commit', '--quiet', '-m', 'chore: initial commit']);
+  run('git', ['tag', 'v0.9.0']);
+  // Per-workspace baselines so per-workspace `getCommitsSinceTarget` finds a tag.
+  run('git', ['tag', 'pkg-a-v1.0.0']);
+  run('git', ['tag', 'pkg-b-v1.0.0']);
+  run('git', ['tag', 'pkg-c-v1.0.0']);
+
+  // One feat per workspace plus one fix. The `##` synthetic ticket prefix is required by
+  // the bundled cliff.toml.template's commit_parsers (any unticketed commit is skipped).
+  for (const name of ['pkg-a', 'pkg-b']) {
+    writeFileSync(join(repoDir, 'packages', name, 'feature.ts'), `export const flag = true;\n`, 'utf8');
+    run('git', ['add', '-A']);
+    run('git', ['commit', '--quiet', '-m', `## ${name}|feat: Add feature flag`]);
+  }
+  writeFileSync(join(repoDir, 'packages', 'pkg-c', 'patch.ts'), `export const patched = true;\n`, 'utf8');
+  run('git', ['add', '-A']);
+  run('git', ['commit', '--quiet', '-m', '## pkg-c|fix: Patch latent bug']);
+
+  return {
+    repoDir,
+    cleanup: () => rmSync(repoDir, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Switch CWD to the fixture repo for the duration of the closure. Restores the prior CWD
+ * even if the closure throws — release-kit reads `process.cwd()` to resolve paths.
+ */
+function withinFixture<T>(repoDir: string, fn: () => T): T {
+  const previous = process.cwd();
+  process.chdir(repoDir);
+  try {
+    return fn();
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+describe('releasePrepareProject (integration)', () => {
+  let fixture: Fixture;
+
+  beforeEach(() => {
+    fixture = setupFixture();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  it('runs the project release alongside per-workspace releases and writes all artifacts', () => {
+    withinFixture(fixture.repoDir, () => {
+      const config = mergeMonorepoConfig(
+        ['packages/pkg-a', 'packages/pkg-b', 'packages/pkg-c'],
+        { project: {}, changelogJson: { enabled: false } },
+        { exists: true, version: '0.9.0' },
+      );
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      // Project release happened.
+      expect(result.project).toBeDefined();
+      expect(result.project?.previousTag).toBe('v0.9.0');
+      // 2 feat + 1 fix → minor bump → 0.10.0 (pre-1.0 collapse not relevant since feat is minor).
+      expect(result.project?.releaseType).toBe('minor');
+      expect(result.project?.newVersion).toBe('0.10.0');
+      expect(result.project?.tag).toBe('v0.10.0');
+
+      // Tags includes both the project tag and per-workspace tags.
+      expect(result.tags).toContain('v0.10.0');
+      expect(result.tags).toContain('pkg-a-v1.1.0');
+      expect(result.tags).toContain('pkg-b-v1.1.0');
+      expect(result.tags).toContain('pkg-c-v1.0.1');
+
+      // Root package.json bumped to 0.10.0.
+      const rootPackageJson: { version: string } = JSON.parse(
+        readFileSync(join(fixture.repoDir, 'package.json'), 'utf8'),
+      );
+      expect(rootPackageJson.version).toBe('0.10.0');
+
+      // Root CHANGELOG.md regenerated and contains the new version header. The bundled
+      // cliff template strips the leading `v` from the version (`trim_start_matches`), so
+      // the rendered heading is `## [0.10.0] - <date>` rather than `## [v0.10.0]`.
+      const rootChangelogPath = join(fixture.repoDir, 'CHANGELOG.md');
+      expect(existsSync(rootChangelogPath)).toBe(true);
+      const rootChangelog = readFileSync(rootChangelogPath, 'utf8');
+      expect(rootChangelog).toContain('## [0.10.0]');
+      // Project-level changelog includes commits from every contributing workspace.
+      expect(rootChangelog).toContain('Add feature flag');
+      expect(rootChangelog).toContain('Patch latent bug');
+      // The previous release is preserved in the regenerated file.
+      expect(rootChangelog).toContain('## [0.9.0]');
+    });
+  }, 60_000);
+
+  it('overrides the project bump when --bump=major is supplied (1.x baseline)', () => {
+    // Reset the fixture's root version to 1.x so the major bump is not collapsed by the
+    // pre-1.0 rule in `bumpVersion`.
+    writeFileSync(
+      join(fixture.repoDir, 'package.json'),
+      JSON.stringify({ name: 'fixture-monorepo', version: '1.0.0', private: true }, null, 2) + '\n',
+      'utf8',
+    );
+    execFileSync('git', ['add', '-A'], { cwd: fixture.repoDir, stdio: ['ignore', 'pipe', 'pipe'] });
+    execFileSync('git', ['commit', '--quiet', '-m', 'chore: bump baseline'], {
+      cwd: fixture.repoDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    execFileSync('git', ['tag', 'v1.0.0'], { cwd: fixture.repoDir, stdio: ['ignore', 'pipe', 'pipe'] });
+
+    withinFixture(fixture.repoDir, () => {
+      const config = mergeMonorepoConfig(
+        ['packages/pkg-a', 'packages/pkg-b', 'packages/pkg-c'],
+        { project: {}, changelogJson: { enabled: false } },
+        { exists: true, version: '1.0.0' },
+      );
+
+      const result = releasePrepareMono(config, { dryRun: false, bumpOverride: 'major' });
+
+      expect(result.project?.releaseType).toBe('major');
+      expect(result.project?.newVersion).toBe('2.0.0');
+      expect(result.tags).toContain('v2.0.0');
+    });
+  }, 60_000);
+
+  it('writes no files in --dry-run mode but still computes the project tag', () => {
+    withinFixture(fixture.repoDir, () => {
+      const config = mergeMonorepoConfig(
+        ['packages/pkg-a', 'packages/pkg-b', 'packages/pkg-c'],
+        { project: {}, changelogJson: { enabled: false } },
+        { exists: true, version: '0.9.0' },
+      );
+
+      const result = releasePrepareMono(config, { dryRun: true });
+
+      expect(result.project?.tag).toBe('v0.10.0');
+      expect(result.tags).toContain('v0.10.0');
+
+      // Nothing was written to disk.
+      const rootPackageJson: { version: string } = JSON.parse(
+        readFileSync(join(fixture.repoDir, 'package.json'), 'utf8'),
+      );
+      expect(rootPackageJson.version).toBe('0.9.0');
+      expect(existsSync(join(fixture.repoDir, 'CHANGELOG.md'))).toBe(false);
+    });
+  }, 60_000);
+
+  it('emits the project release-notes preview when --with-release-notes is set and changelogJson is enabled', () => {
+    withinFixture(fixture.repoDir, () => {
+      const config = mergeMonorepoConfig(
+        ['packages/pkg-a', 'packages/pkg-b', 'packages/pkg-c'],
+        { project: {} },
+        { exists: true, version: '0.9.0' },
+      );
+
+      releasePrepareMono(config, { dryRun: false, withReleaseNotes: true });
+
+      // The project preview file lives at root docs/.
+      const previewPath = join(fixture.repoDir, 'docs', 'RELEASE_NOTES.v0.10.0.md');
+      expect(existsSync(previewPath)).toBe(true);
+      const preview = readFileSync(previewPath, 'utf8');
+      expect(preview).toContain('Release notes — v0.10.0');
+    });
+  }, 60_000);
+
+  it('rejects --only via prepareCommand before any project work runs', async () => {
+    // The CLI guard lives in prepareCommand. We exercise it directly so the integration test
+    // reflects the user-observable behavior end-to-end. Failure must occur before any file is
+    // written: assert no CHANGELOG.md, no bumped version, no project-tag artifact.
+    const { prepareCommand } = await import('../prepareCommand.ts');
+    let exitCode: number | undefined;
+    const errors: string[] = [];
+
+    // Write a minimal release-kit config that declares the project block.
+    mkdirSync(join(fixture.repoDir, '.config'), { recursive: true });
+    writeFileSync(
+      join(fixture.repoDir, '.config', 'release-kit.config.ts'),
+      'export default { project: {} };\n',
+      'utf8',
+    );
+
+    const previousCwd = process.cwd();
+    process.chdir(fixture.repoDir);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((msg: unknown) => {
+      if (typeof msg === 'string') {
+        errors.push(msg);
+      }
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      exitCode = typeof code === 'number' ? code : undefined;
+      throw new Error('process.exit');
+    });
+
+    try {
+      await prepareCommand(['--only=pkg-a', '--no-git-checks']);
+    } catch {
+      // Expected: process.exit threw.
+    } finally {
+      consoleErrorSpy.mockRestore();
+      exitSpy.mockRestore();
+      process.chdir(previousCwd);
+    }
+
+    expect(exitCode).toBe(1);
+    expect(errors.some((m) => m.includes('--only cannot be combined with a project release'))).toBe(true);
+    // No file was written.
+    expect(existsSync(join(fixture.repoDir, 'CHANGELOG.md'))).toBe(false);
+    const rootPackageJson: { version: string } = JSON.parse(
+      readFileSync(join(fixture.repoDir, 'package.json'), 'utf8'),
+    );
+    expect(rootPackageJson.version).toBe('0.9.0');
+  }, 60_000);
+});

--- a/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockMkdirSync = vi.hoisted(() => vi.fn());
+const mockMkdtempSync = vi.hoisted(() => vi.fn());
+const mockRmSync = vi.hoisted(() => vi.fn());
+const mockCopyFileSync = vi.hoisted(() => vi.fn());
+const mockGenerateChangelogJson = vi.hoisted(() => vi.fn());
+const mockWriteReleaseNotesPreviews = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+vi.mock('node:fs', () => ({
+  copyFileSync: mockCopyFileSync,
+  existsSync: mockExistsSync,
+  mkdirSync: mockMkdirSync,
+  mkdtempSync: mockMkdtempSync,
+  readFileSync: mockReadFileSync,
+  rmSync: mockRmSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+vi.mock('../resolveCliffConfigPath.ts', () => ({
+  resolveCliffConfigPath: () => 'cliff.toml',
+}));
+
+vi.mock('../generateChangelogJson.ts', () => ({
+  generateChangelogJson: mockGenerateChangelogJson,
+  generateSyntheticChangelogJson: vi.fn(),
+}));
+
+vi.mock('../writeReleaseNotesPreviews.ts', () => ({
+  writeReleaseNotesPreviews: mockWriteReleaseNotesPreviews,
+}));
+
+import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG } from '../defaults.ts';
+import { releasePrepareProject } from '../releasePrepareProject.ts';
+import type { MonorepoReleaseConfig, WorkspaceConfig } from '../types.ts';
+
+function makeWorkspace(overrides: Partial<WorkspaceConfig> & Pick<WorkspaceConfig, 'dir'>): WorkspaceConfig {
+  const { dir } = overrides;
+  return {
+    name: `@test/${dir}`,
+    tagPrefix: `${dir}-v`,
+    workspacePath: `packages/${dir}`,
+    packageFiles: [`packages/${dir}/package.json`],
+    changelogPaths: [`packages/${dir}`],
+    paths: [`packages/${dir}/**`],
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides?: Partial<MonorepoReleaseConfig>): MonorepoReleaseConfig {
+  return {
+    workspaces: [makeWorkspace({ dir: 'arrays' }), makeWorkspace({ dir: 'strings' })],
+    workTypes: { feat: { header: 'Features' }, fix: { header: 'Bug fixes' } },
+    changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: false },
+    releaseNotes: { ...DEFAULT_RELEASE_NOTES_CONFIG },
+    project: { tagPrefix: 'v' },
+    ...overrides,
+  };
+}
+
+/** Default git mock: legacy v0.9.0 baseline tag, one feat commit since. */
+function setupDefaultGit(): void {
+  mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === 'git' && args[0] === 'describe') {
+      return 'v0.9.0\n';
+    }
+    if (cmd === 'git' && args[0] === 'log') {
+      return 'feat: ship projectabc123';
+    }
+    // git-cliff invocation: returns nothing meaningful in this orchestrator's path (we
+    // only use the args).
+    return '';
+  });
+}
+
+describe(releasePrepareProject, () => {
+  beforeEach(() => {
+    mockGenerateChangelogJson.mockImplementation((_config, changelogPath: string) => [
+      `${changelogPath}/.meta/changelog.json`,
+    ]);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'root', version: '0.9.0' }));
+    mockExistsSync.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    mockExecFileSync.mockReset();
+    mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
+    mockMkdirSync.mockReset();
+    mockMkdtempSync.mockReset();
+    mockRmSync.mockReset();
+    mockCopyFileSync.mockReset();
+    mockGenerateChangelogJson.mockReset();
+    mockWriteReleaseNotesPreviews.mockReset();
+  });
+
+  it('returns undefined when no commits since the last project tag and no force', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') return 'v0.9.0\n';
+      if (cmd === 'git' && args[0] === 'log') return '';
+      return '';
+    });
+    const tags: string[] = [];
+    const modifiedFiles: string[] = [];
+
+    const result = releasePrepareProject({
+      config: makeConfig(),
+      options: { dryRun: false },
+      modifiedFiles,
+      tags,
+    });
+
+    expect(result).toBeUndefined();
+    expect(tags).toStrictEqual([]);
+    expect(modifiedFiles).toStrictEqual([]);
+  });
+
+  it('bumps root package.json, writes ./CHANGELOG.md, appends tag, and appends modified files', () => {
+    setupDefaultGit();
+    const tags: string[] = [];
+    const modifiedFiles: string[] = [];
+
+    const result = releasePrepareProject({
+      config: makeConfig(),
+      options: { dryRun: false },
+      modifiedFiles,
+      tags,
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.tag).toBe('v0.10.0');
+    expect(result?.releaseType).toBe('minor');
+    expect(result?.currentVersion).toBe('0.9.0');
+    expect(result?.newVersion).toBe('0.10.0');
+    expect(result?.changelogFiles).toContain('./CHANGELOG.md');
+
+    expect(tags).toStrictEqual(['v0.10.0']);
+    expect(modifiedFiles).toContain('./package.json');
+    expect(modifiedFiles).toContain('./CHANGELOG.md');
+
+    // Root package.json was written with the new version.
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      './package.json',
+      expect.stringContaining('"version": "0.10.0"'),
+      'utf8',
+    );
+
+    // git-cliff invoked with tag-pattern derived from project tagPrefix and contributing paths.
+    const cliffCall = mockExecFileSync.mock.calls.find(
+      (call) => call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff'),
+    );
+    expect(cliffCall).toBeDefined();
+    const cliffArgs = cliffCall?.[1];
+    expect(cliffArgs).toContain('--tag-pattern');
+    expect(cliffArgs).toContain('v[0-9].*');
+    expect(cliffArgs).toContain('--include-path');
+    expect(cliffArgs).toContain('packages/arrays/**');
+    expect(cliffArgs).toContain('packages/strings/**');
+    expect(cliffArgs).toContain('--output');
+    expect(cliffArgs).toContain('./CHANGELOG.md');
+    expect(cliffArgs).toContain('--tag');
+    expect(cliffArgs).toContain('v0.10.0');
+  });
+
+  it('uses bumpOverride instead of commit-derived bump type', () => {
+    setupDefaultGit();
+    // Use a 1.x baseline so the major bump is not collapsed by the pre-1.0 rule in `bumpVersion`.
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'root', version: '1.5.2' }));
+    const tags: string[] = [];
+    const modifiedFiles: string[] = [];
+
+    const result = releasePrepareProject({
+      config: makeConfig(),
+      options: { dryRun: false, bumpOverride: 'major' },
+      modifiedFiles,
+      tags,
+    });
+
+    expect(result?.releaseType).toBe('major');
+    expect(result?.newVersion).toBe('2.0.0');
+    expect(tags).toStrictEqual(['v2.0.0']);
+  });
+
+  it('runs with no commits when --force is set with --bump', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') return 'v0.9.0\n';
+      if (cmd === 'git' && args[0] === 'log') return '';
+      return '';
+    });
+    const tags: string[] = [];
+    const modifiedFiles: string[] = [];
+
+    const result = releasePrepareProject({
+      config: makeConfig(),
+      options: { dryRun: false, force: true, bumpOverride: 'patch' },
+      modifiedFiles,
+      tags,
+    });
+
+    expect(result?.releaseType).toBe('patch');
+    expect(result?.newVersion).toBe('0.9.1');
+    expect(tags).toStrictEqual(['v0.9.1']);
+  });
+
+  it('does not write any files in dry-run mode', () => {
+    setupDefaultGit();
+    const tags: string[] = [];
+    const modifiedFiles: string[] = [];
+
+    const result = releasePrepareProject({
+      config: makeConfig(),
+      options: { dryRun: true },
+      modifiedFiles,
+      tags,
+    });
+
+    expect(result?.tag).toBe('v0.10.0');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    // git-cliff is not invoked under dry-run.
+    expect(
+      mockExecFileSync.mock.calls.find(
+        (call) => call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff'),
+      ),
+    ).toBeUndefined();
+  });
+
+  it('emits release-notes previews when --with-release-notes is set and changelogJson.enabled', () => {
+    setupDefaultGit();
+    const config = makeConfig({
+      changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true },
+    });
+    const tags: string[] = [];
+    const modifiedFiles: string[] = [];
+
+    releasePrepareProject({
+      config,
+      options: { dryRun: false, withReleaseNotes: true },
+      modifiedFiles,
+      tags,
+    });
+
+    expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledTimes(1);
+    expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspacePath: '.',
+        tag: 'v0.10.0',
+        dryRun: false,
+        changelogJsonPath: './.meta/changelog.json',
+      }),
+    );
+  });
+
+  it('does not emit release-notes previews when the flag is omitted', () => {
+    setupDefaultGit();
+    const config = makeConfig({
+      changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true },
+    });
+
+    releasePrepareProject({
+      config,
+      options: { dryRun: false },
+      modifiedFiles: [],
+      tags: [],
+    });
+
+    expect(mockWriteReleaseNotesPreviews).not.toHaveBeenCalled();
+  });
+
+  it('first-run: legacy v0.9.0 baseline produces a bump derived from the contributing-paths commits', () => {
+    // findLatestTag returns the legacy `v0.9.0` tag; commits since are the source of truth for
+    // the project bump. The legacy tag shape is the same as the project tagPrefix `v`.
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'describe') return 'v0.9.0\n';
+      if (cmd === 'git' && args[0] === 'log') {
+        return 'fix: patch arrays bugabc\nfeat: ship strings helperdef';
+      }
+      return '';
+    });
+    const tags: string[] = [];
+
+    const result = releasePrepareProject({
+      config: makeConfig(),
+      options: { dryRun: false },
+      modifiedFiles: [],
+      tags,
+    });
+
+    expect(result?.previousTag).toBe('v0.9.0');
+    expect(result?.commitCount).toBe(2);
+    expect(result?.releaseType).toBe('minor'); // feat triggers minor over fix's patch
+    expect(result?.newVersion).toBe('0.10.0');
+    expect(tags).toStrictEqual(['v0.10.0']);
+  });
+
+  it('throws when called without a project block', () => {
+    const config = makeConfig();
+    delete config.project;
+    expect(() =>
+      releasePrepareProject({
+        config,
+        options: { dryRun: false },
+        modifiedFiles: [],
+        tags: [],
+      }),
+    ).toThrow(/without a configured project block/);
+  });
+});

--- a/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
@@ -631,4 +631,100 @@ describe(reportPrepare, () => {
       expect(output).toContain('(patch, dependency: @scope/core)');
     });
   });
+
+  describe('project release section', () => {
+    it('renders the project section after workspace sections and before the tag summary', () => {
+      const result: PrepareResult = {
+        workspaces: [
+          {
+            name: 'arrays',
+            status: 'released',
+            previousTag: 'arrays-v1.0.0',
+            commitCount: 1,
+            parsedCommitCount: 1,
+            releaseType: 'minor',
+            currentVersion: '1.0.0',
+            newVersion: '1.1.0',
+            tag: 'arrays-v1.1.0',
+            bumpedFiles: ['packages/arrays/package.json'],
+            changelogFiles: ['packages/arrays/CHANGELOG.md'],
+          },
+        ],
+        tags: ['arrays-v1.1.0', 'v0.10.0'],
+        dryRun: false,
+        project: {
+          status: 'released',
+          previousTag: 'v0.9.0',
+          commitCount: 1,
+          parsedCommitCount: 1,
+          releaseType: 'minor',
+          currentVersion: '0.9.0',
+          newVersion: '0.10.0',
+          tag: 'v0.10.0',
+          bumpedFiles: ['./package.json'],
+          changelogFiles: ['./CHANGELOG.md'],
+        },
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain(sectionHeader('project'));
+      expect(output).toContain(`📦 0.9.0 → ${bold('0.10.0')} (minor)`);
+      expect(output).toContain(`🏷️  ${bold('v0.10.0')}`);
+      // Tag summary still includes both per-workspace and project tags.
+      expect(output).toContain(`✅ Release preparation complete.`);
+      expect(output).toContain(`🏷️  ${bold('arrays-v1.1.0')}`);
+    });
+
+    it('renders dry-run prefixes for project bumped and changelog files', () => {
+      const result: PrepareResult = {
+        workspaces: [],
+        tags: ['v0.10.0'],
+        dryRun: true,
+        project: {
+          status: 'released',
+          previousTag: 'v0.9.0',
+          commitCount: 1,
+          parsedCommitCount: 1,
+          releaseType: 'minor',
+          currentVersion: '0.9.0',
+          newVersion: '0.10.0',
+          tag: 'v0.10.0',
+          bumpedFiles: ['./package.json'],
+          changelogFiles: ['./CHANGELOG.md'],
+        },
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain(dim('    [dry-run] Would bump ./package.json'));
+      expect(output).toContain(dim('    [dry-run] Would run: npx --yes git-cliff ... --output ./CHANGELOG.md'));
+    });
+
+    it('omits the project section entirely when result.project is undefined', () => {
+      const result: PrepareResult = {
+        workspaces: [
+          {
+            name: 'arrays',
+            status: 'released',
+            previousTag: 'arrays-v1.0.0',
+            commitCount: 1,
+            parsedCommitCount: 1,
+            releaseType: 'minor',
+            currentVersion: '1.0.0',
+            newVersion: '1.1.0',
+            tag: 'arrays-v1.1.0',
+            bumpedFiles: ['packages/arrays/package.json'],
+            changelogFiles: ['packages/arrays/CHANGELOG.md'],
+          },
+        ],
+        tags: ['arrays-v1.1.0'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).not.toContain(sectionHeader('project'));
+    });
+  });
 });

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -604,6 +604,46 @@ describe(validateConfig, () => {
     });
   });
 
+  describe('project', () => {
+    it('accepts an empty project block', () => {
+      const { config, errors } = validateConfig({ project: {} });
+      expect(errors).toStrictEqual([]);
+      expect(config.project).toStrictEqual({});
+    });
+
+    it('accepts a project block with a tagPrefix', () => {
+      const { config, errors } = validateConfig({ project: { tagPrefix: 'release-v' } });
+      expect(errors).toStrictEqual([]);
+      expect(config.project).toStrictEqual({ tagPrefix: 'release-v' });
+    });
+
+    it('returns an error when project is not an object', () => {
+      const { errors } = validateConfig({ project: 'v' });
+      expect(errors).toContain("'project' must be an object");
+    });
+
+    it('returns an error when tagPrefix is not a string', () => {
+      const { errors } = validateConfig({ project: { tagPrefix: 42 } });
+      expect(errors).toContain('project.tagPrefix: must be a string');
+    });
+
+    it('returns an error when tagPrefix is an empty string', () => {
+      const { errors } = validateConfig({ project: { tagPrefix: '' } });
+      expect(errors).toContain('project.tagPrefix: must be a non-empty string');
+    });
+
+    it('returns an error for unknown subfields', () => {
+      const { errors } = validateConfig({ project: { tagPrefix: 'v', bogus: true } });
+      expect(errors).toContain("project: unknown field 'bogus'");
+    });
+
+    it('omits project from the result when the field is not provided', () => {
+      const { config, errors } = validateConfig({});
+      expect(errors).toStrictEqual([]);
+      expect(config.project).toBeUndefined();
+    });
+  });
+
   describe('cross-field warnings', () => {
     it('warns when shouldInjectIntoReadme is true but changelogJson is disabled', () => {
       const { warnings } = validateConfig({

--- a/packages/release-kit/src/buildReleaseSummary.ts
+++ b/packages/release-kit/src/buildReleaseSummary.ts
@@ -6,8 +6,10 @@ import type { PrepareResult } from './types.ts';
  *
  * Each released workspace with commits gets a section headed by its tag,
  * followed by scope-stripped commit messages as bullet points. Sections
- * are separated by blank lines. Returns an empty string when no released
- * workspaces have commits.
+ * are separated by blank lines. The project release (when present) is
+ * appended as a final section using the same format. Returns an empty
+ * string when no released workspaces have commits and there is no project
+ * release.
  */
 export function buildReleaseSummary(result: PrepareResult): string {
   const sections: string[] = [];
@@ -27,6 +29,15 @@ export function buildReleaseSummary(result: PrepareResult): string {
       lines.push(`- ${stripScope(commit.message)}`);
     }
 
+    sections.push(lines.join('\n'));
+  }
+
+  const project = result.project;
+  if (project !== undefined && project.commits !== undefined && project.commits.length > 0) {
+    const lines = [project.tag];
+    for (const commit of project.commits) {
+      lines.push(`- ${stripScope(commit.message)}`);
+    }
     sections.push(lines.join('\n'));
   }
 

--- a/packages/release-kit/src/defaults.ts
+++ b/packages/release-kit/src/defaults.ts
@@ -37,3 +37,6 @@ export const DEFAULT_CHANGELOG_JSON_CONFIG: ChangelogJsonConfig = {
 export const DEFAULT_RELEASE_NOTES_CONFIG: ReleaseNotesConfig = {
   shouldInjectIntoReadme: false,
 };
+
+/** Default tag prefix for project-level releases. */
+export const DEFAULT_PROJECT_TAG_PREFIX = 'v';

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -19,10 +19,13 @@ export type {
   MonorepoReleaseConfig,
   ParsedCommit,
   PrepareResult,
+  ProjectConfig,
+  ProjectPrepareResult,
   ReleaseConfig,
   ReleaseKitConfig,
   ReleaseNotesConfig,
   ReleaseType,
+  ResolvedProjectConfig,
   RetiredPackage,
   VersionPatterns,
   WorkspaceConfig,
@@ -34,6 +37,7 @@ export type {
 // Defaults
 export {
   DEFAULT_CHANGELOG_JSON_CONFIG,
+  DEFAULT_PROJECT_TAG_PREFIX,
   DEFAULT_RELEASE_NOTES_CONFIG,
   DEFAULT_VERSION_PATTERNS,
   DEFAULT_WORK_TYPES,
@@ -69,6 +73,8 @@ export type { PushReleaseOptions } from './pushRelease.ts';
 export { pushRelease } from './pushRelease.ts';
 export { releasePrepare } from './releasePrepare.ts';
 export { releasePrepareMono } from './releasePrepareMono.ts';
+export type { ReleasePrepareProjectArgs } from './releasePrepareProject.ts';
+export { releasePrepareProject } from './releasePrepareProject.ts';
 export type { RenderOptions } from './renderReleaseNotes.ts';
 export { matchesAudience, renderReleaseNotesMulti, renderReleaseNotesSingle } from './renderReleaseNotes.ts';
 export { reportPrepare } from './reportPrepare.ts';

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -1,8 +1,9 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import {
   DEFAULT_CHANGELOG_JSON_CONFIG,
+  DEFAULT_PROJECT_TAG_PREFIX,
   DEFAULT_RELEASE_NOTES_CONFIG,
   DEFAULT_VERSION_PATTERNS,
   DEFAULT_WORK_TYPES,
@@ -16,10 +17,51 @@ import type {
   ReleaseConfig,
   ReleaseKitConfig,
   ReleaseNotesConfig,
+  ResolvedProjectConfig,
   RetiredPackage,
   WorkspaceConfig,
   WorkTypeConfig,
 } from './types.ts';
+
+/** Path of the root `package.json` consulted when validating a `project` block. */
+export const ROOT_PACKAGE_JSON_PATH = 'package.json';
+
+/**
+ * Read the root `package.json` and return its `version` field.
+ *
+ * Returns `{ exists: false }` when the file is missing, `{ exists: true, version: undefined }`
+ * when the file exists but has no `version` field, and `{ exists: true, version }` when both
+ * are present. The caller (`mergeMonorepoConfig`) decides whether the situation is an error.
+ */
+export function readRootPackageVersion(): { exists: boolean; version: string | undefined } {
+  const absolutePath = path.resolve(process.cwd(), ROOT_PACKAGE_JSON_PATH);
+  if (!existsSync(absolutePath)) {
+    return { exists: false, version: undefined };
+  }
+
+  let contents: string;
+  try {
+    contents = readFileSync(absolutePath, 'utf8');
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to read root ${ROOT_PACKAGE_JSON_PATH}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to parse root ${ROOT_PACKAGE_JSON_PATH}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!isRecord(parsed)) {
+    return { exists: true, version: undefined };
+  }
+  return { exists: true, version: typeof parsed.version === 'string' ? parsed.version : undefined };
+}
 
 /** The path where the consumer-facing config file is expected. */
 export const CONFIG_FILE_PATH = '.config/release-kit.config.ts';
@@ -57,6 +99,16 @@ export async function loadConfig(): Promise<unknown> {
 }
 
 /**
+ * Information about the root `package.json` passed into `mergeMonorepoConfig` when a
+ * `project` block is configured. The async I/O lives in `readRootPackageVersion`; this
+ * function stays a pure transformation.
+ */
+export interface RootPackageInfo {
+  exists: boolean;
+  version: string | undefined;
+}
+
+/**
  * Resolves a final monorepo config from discovered workspaces and an optional user config overlay.
  *
  * Merging rules:
@@ -65,10 +117,15 @@ export async function loadConfig(): Promise<unknown> {
  * - `workTypes`: shallow merge — consumer entries override or add to defaults by key.
  * - `versionPatterns`: consumer value replaces defaults entirely.
  * - `formatCommand`, `cliffConfigPath`, `scopeAliases`: consumer value wins.
+ * - `project`: present iff `userConfig.project` is declared. Resolves `tagPrefix` to
+ *   `DEFAULT_PROJECT_TAG_PREFIX` when omitted. Requires `rootPackage` to be passed and to
+ *   contain a valid `version` field; throws otherwise. The resolved prefix is included in
+ *   the strict-prefix collision check across all workspace and retired-package prefixes.
  */
 export function mergeMonorepoConfig(
   discoveredPaths: string[],
   userConfig: ReleaseKitConfig | undefined,
+  rootPackage?: RootPackageInfo,
 ): MonorepoReleaseConfig {
   // Build default workspaces from discovered paths
   let workspaces: WorkspaceConfig[] = discoveredPaths.map((workspacePath) => deriveWorkspaceConfig(workspacePath));
@@ -99,6 +156,9 @@ export function mergeMonorepoConfig(
     assertRetiredPackagesDoNotCollideWithActive(workspaces, userConfig.retiredPackages);
   }
 
+  // Resolve the project block (when present) and validate the root package.json prerequisites.
+  const project = resolveProjectConfig(userConfig?.project, rootPackage);
+
   // Merge workTypes
   const workTypes = resolveWorkTypes(userConfig?.workTypes);
 
@@ -109,6 +169,12 @@ export function mergeMonorepoConfig(
   const changelogJson = mergeChangelogJsonConfig(userConfig?.changelogJson);
   const releaseNotes = mergeReleaseNotesConfig(userConfig?.releaseNotes);
 
+  // Run the strict-prefix collision check across the union of every active, legacy, retired,
+  // and (when configured) project tag prefix. Catches both the existing equality case and the
+  // new strict-prefix-of-other case (`v` vs `vue-helpers-v`). Rejecting at load time prevents
+  // `git describe --match=<prefix>*` from returning cross-matches at release time.
+  assertNoTagPrefixCollisions(workspaces, userConfig?.retiredPackages, project);
+
   const result: MonorepoReleaseConfig = {
     workspaces,
     workTypes,
@@ -116,6 +182,10 @@ export function mergeMonorepoConfig(
     changelogJson,
     releaseNotes,
   };
+
+  if (project !== undefined) {
+    result.project = project;
+  }
 
   const formatCommand = userConfig?.formatCommand;
   if (formatCommand !== undefined) {
@@ -137,8 +207,16 @@ export function mergeMonorepoConfig(
 
 /**
  * Resolves a final single-package config from an optional user config overlay.
+ *
+ * Rejects a configured `project` block: project-level releases are a monorepo-only feature,
+ * since the implicit "all non-excluded workspaces contribute" rule is meaningless in a
+ * single-package repo.
  */
 export function mergeSinglePackageConfig(userConfig: ReleaseKitConfig | undefined): ReleaseConfig {
+  if (userConfig?.project !== undefined) {
+    throw new Error('project block is not supported in single-package mode');
+  }
+
   const workTypes = resolveWorkTypes(userConfig?.workTypes);
 
   const versionPatterns =
@@ -250,11 +328,122 @@ function assertRetiredPackagesDoNotCollideWithActive(
 }
 
 /**
+ * Resolve the consumer-facing `project` block to a `ResolvedProjectConfig`.
+ *
+ * Returns `undefined` when the consumer did not declare a `project` block. Otherwise applies
+ * defaults (`tagPrefix` → `DEFAULT_PROJECT_TAG_PREFIX`) and validates that the root
+ * `package.json` exists with a `version` field — both prerequisites for emitting a project
+ * tag and bumping a project version. Throws a clear, action-naming error otherwise.
+ *
+ * The root-package read itself happens upstream in `loadConfig` (which is async). This
+ * function is a pure transformation and never touches the filesystem.
+ */
+function resolveProjectConfig(
+  userProject: { tagPrefix?: string } | undefined,
+  rootPackage: RootPackageInfo | undefined,
+): ResolvedProjectConfig | undefined {
+  if (userProject === undefined) {
+    return undefined;
+  }
+
+  if (rootPackage === undefined || !rootPackage.exists) {
+    throw new Error(
+      `project block requires a root ${ROOT_PACKAGE_JSON_PATH}; create one with a 'version' field at the repo root`,
+    );
+  }
+  if (rootPackage.version === undefined) {
+    throw new Error(
+      `project block requires root ${ROOT_PACKAGE_JSON_PATH} to have a 'version' field; add a 'version' field to your root package.json`,
+    );
+  }
+
+  return { tagPrefix: userProject.tagPrefix ?? DEFAULT_PROJECT_TAG_PREFIX };
+}
+
+/**
+ * Throw when any pair of declared tag prefixes from distinct owners is identical or one is a
+ * strict prefix of the other.
+ *
+ * The strict-prefix rule extends the equality check to catch glob-overlap cases:
+ * `git describe --match=<prefix>*` matches both `prefix` and `prefix-suffix`-style tags, so
+ * a project prefix `'v'` would silently match a workspace prefix like `'vue-helpers-v'`.
+ * Operates over the union of: every workspace's derived prefix, every workspace's declared
+ * `legacyIdentities[].tagPrefix`, every `retiredPackages[].tagPrefix`, and (when configured)
+ * the project's resolved `tagPrefix`. Within a single workspace, prefix overlap between the
+ * derived prefix and a declared legacy identity is an intentional rename pattern (a prior
+ * identity reusing the same tag shape under a different npm name), so collisions are only
+ * checked across distinct owners. Each prefix is paired with a human-readable source label
+ * so the error message points the consumer at the colliding declarations.
+ */
+function assertNoTagPrefixCollisions(
+  workspaces: readonly WorkspaceConfig[],
+  retiredPackages: readonly RetiredPackage[] | undefined,
+  project: ResolvedProjectConfig | undefined,
+): void {
+  // region | Helpers
+  interface PrefixSource {
+    prefix: string;
+    label: string;
+    /** Stable identifier for the owning declaration (one workspace, one retired entry, project). */
+    owner: string;
+  }
+  // endregion | Helpers
+
+  const sources: PrefixSource[] = [];
+  for (const workspace of workspaces) {
+    const owner = `ws:${workspace.dir}`;
+    sources.push({ prefix: workspace.tagPrefix, label: `workspace '${workspace.dir}'`, owner });
+    for (const identity of workspace.legacyIdentities ?? []) {
+      sources.push({
+        prefix: identity.tagPrefix,
+        label: `workspace '${workspace.dir}' legacyIdentities entry (name='${identity.name}')`,
+        owner,
+      });
+    }
+  }
+  for (const [index, retired] of (retiredPackages ?? []).entries()) {
+    sources.push({
+      prefix: retired.tagPrefix,
+      label: `retiredPackages entry (name='${retired.name}')`,
+      owner: `retired:${index}`,
+    });
+  }
+  if (project !== undefined) {
+    sources.push({ prefix: project.tagPrefix, label: 'project', owner: 'project' });
+  }
+
+  for (let i = 0; i < sources.length; i++) {
+    for (let j = i + 1; j < sources.length; j++) {
+      const a = sources[i];
+      const b = sources[j];
+      if (a === undefined || b === undefined) continue;
+      if (a.owner === b.owner) continue;
+      if (isPrefixCollision(a.prefix, b.prefix)) {
+        throw new Error(
+          `Tag prefix collision: '${a.prefix}' (${a.label}) and '${b.prefix}' (${b.label}). ` +
+            'One prefix is identical to or a strict prefix of the other; ' +
+            'this would cause `git describe --match=<prefix>*` to return cross-matches.',
+        );
+      }
+    }
+  }
+}
+
+/** True when prefixes are equal or one starts with the other. */
+function isPrefixCollision(a: string, b: string): boolean {
+  return a === b || a.startsWith(b) || b.startsWith(a);
+}
+
+/**
  * Throw when two or more workspaces share the same `tagPrefix`.
  *
  * A collision means two workspaces would produce indistinguishable tags, breaking both tag
  * creation and tag resolution. The error lists every colliding workspace path so the author
  * can rename one of the conflicting `package.json` `name` fields.
+ *
+ * This guards the pre-merge state when only workspaces have been derived. The broader
+ * strict-prefix check across legacy, retired, and project prefixes runs later in
+ * `assertNoTagPrefixCollisions`.
  */
 function assertUniqueTagPrefixes(workspaces: readonly WorkspaceConfig[]): void {
   const pathsByPrefix = new Map<string, string[]>();

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -8,7 +8,7 @@ import { assertCleanWorkingTree } from './assertCleanWorkingTree.ts';
 import { buildReleaseSummary } from './buildReleaseSummary.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
 import { dim } from './format.ts';
-import { loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig } from './loadConfig.ts';
+import { loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig, readRootPackageVersion } from './loadConfig.ts';
 import { releasePrepare } from './releasePrepare.ts';
 import { releasePrepareMono } from './releasePrepareMono.ts';
 import { reportPrepare } from './reportPrepare.ts';
@@ -47,7 +47,8 @@ Options:
   --set-version=X.Y.Z   Set an explicit version; bypasses commit-derived bumps. Requires --only in monorepo mode.
   --force               Force a release even when there are no commits since the last tag (requires --bump)
   --no-git-checks, -n   Skip the clean-working-tree check
-  --only=name1,name2    Only process the named workspaces (comma-separated, monorepo only)
+  --only=name1,name2    Only process the named workspaces (comma-separated, monorepo only;
+                         rejected when a 'project' block is configured)
   --with-release-notes  Also write per-workspace release-notes previews under {workspacePath}/docs/
                          (docs/README.v{version}.md and docs/RELEASE_NOTES.v{version}.md).
                          Recommended .gitignore entry: packages/*/docs/*.v*.md (or docs/*.v*.md).
@@ -245,9 +246,25 @@ function runMonorepoMode(
 ): void {
   let config: MonorepoReleaseConfig;
   try {
-    config = mergeMonorepoConfig(discoveredPaths, userConfig);
+    // Read the root package.json once so `mergeMonorepoConfig` (a pure transform) can
+    // validate the project block's prerequisites without doing I/O of its own.
+    const rootPackage = readRootPackageVersion();
+    config = mergeMonorepoConfig(discoveredPaths, userConfig, rootPackage);
   } catch (error: unknown) {
     console.error(`Error resolving workspaces: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  // Reject `--only` when a project block is configured. Project releases roll up every
+  // contributing workspace; narrowing to a single workspace would produce ambiguous semantics
+  // around which workspaces participate in the project bump. A consumer that needs to release
+  // a single workspace must do so on a config without a `project` block.
+  if (only !== undefined && config.project !== undefined) {
+    console.error(
+      'Error: --only cannot be combined with a project release. ' +
+        'To release a single workspace, use a config without a `project` block, ' +
+        'or run a full `prepare` (no --only) to include the project release.',
+    );
     process.exit(1);
   }
 

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -16,11 +16,13 @@ import type { CurrentVersions, ReleaseEntry } from './propagateBumps.ts';
 import { propagateBumps } from './propagateBumps.ts';
 import { readCurrentVersion } from './readCurrentVersion.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
+import { releasePrepareProject } from './releasePrepareProject.ts';
 import { deriveSectionOrder } from './resolveReleaseNotesConfig.ts';
 import type {
   Commit,
   MonorepoReleaseConfig,
   PrepareResult,
+  ProjectPrepareResult,
   ReleaseType,
   WorkspaceConfig,
   WorkspacePrepareResult,
@@ -128,6 +130,16 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     return orderA - orderB;
   });
 
+  // === Phase 3b: Project release ===
+  // Runs after the per-workspace loop (so contributing workspaces are settled) but before
+  // `runFormatCommand` (so root files participate in formatting). `prepareCommand` rejects
+  // `--only` upstream when a project block is configured, so the orchestrator does not need
+  // a per-workspace narrowing guard here.
+  let project: ProjectPrepareResult | undefined;
+  if (config.project !== undefined) {
+    project = releasePrepareProject({ config, options, modifiedFiles, tags });
+  }
+
   // === Phase 4: Format ===
   const formatCommand = runFormatCommand(config, tags, modifiedFiles, dryRun);
 
@@ -137,6 +149,7 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     formatCommand,
     dryRun,
     ...(warnings.length > 0 ? { warnings } : {}),
+    ...(project === undefined ? {} : { project }),
   };
 }
 

--- a/packages/release-kit/src/releasePrepareProject.ts
+++ b/packages/release-kit/src/releasePrepareProject.ts
@@ -1,0 +1,146 @@
+import { bumpAllVersions } from './bumpAllVersions.ts';
+import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
+import { determineBumpFromCommits } from './determineBumpFromCommits.ts';
+import { generateChangelogJson } from './generateChangelogJson.ts';
+import { buildTagPattern, generateChangelog } from './generateChangelogs.ts';
+import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
+import type { ReleasePrepareOptions } from './releasePrepare.ts';
+import { deriveSectionOrder } from './resolveReleaseNotesConfig.ts';
+import type { Commit, MonorepoReleaseConfig, ProjectPrepareResult, ReleaseType } from './types.ts';
+import { writeReleaseNotesPreviews } from './writeReleaseNotesPreviews.ts';
+
+/** File path for the root `package.json` bumped during the project release stage. */
+const ROOT_PACKAGE_FILE = './package.json';
+
+/** Path argument passed to `generateChangelog`/`generateChangelogJson`; resolves to root paths at runtime. */
+const ROOT_CHANGELOG_PATH = '.';
+
+/** Inputs to the project-release stage. */
+export interface ReleasePrepareProjectArgs {
+  /** Resolved monorepo config; `config.project` must be defined when this function is called. */
+  config: MonorepoReleaseConfig;
+  options: ReleasePrepareOptions;
+  /** Mutated in-place to append project-level files (root package.json, root CHANGELOG.md, root changelog.json). */
+  modifiedFiles: string[];
+  /** Mutated in-place to append the project tag. */
+  tags: string[];
+}
+
+/**
+ * Run the project-level release stage.
+ *
+ * Mirrors the per-workspace pipeline shape — find baseline tag → derive bump → bump version →
+ * regenerate CHANGELOG → optionally emit changelog.json and release-notes previews — but
+ * targets the root `package.json` and the root `CHANGELOG.md`. Contributing paths are the
+ * union of every (already-filtered) workspace's `paths`.
+ *
+ * Returns `undefined` when there are no commits in the contributing window since the last
+ * project tag and `options.force` is not set, mirroring per-workspace skip behavior. The
+ * caller should attach the returned result (when defined) to `PrepareResult.project`.
+ *
+ * Caller contract: `prepareCommand` rejects `--only` upstream when a project block is
+ * configured, so this orchestrator never has to reason about workspace-narrowing flags.
+ */
+export function releasePrepareProject(args: ReleasePrepareProjectArgs): ProjectPrepareResult | undefined {
+  const { config, options, modifiedFiles, tags } = args;
+  const { dryRun, bumpOverride, withReleaseNotes, force } = options;
+  const project = config.project;
+  if (project === undefined) {
+    throw new Error('releasePrepareProject called without a configured project block');
+  }
+
+  const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
+  const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
+
+  // 1. Compute contributing paths (union of every non-excluded workspace's paths).
+  const contributingPaths = config.workspaces.flatMap((workspace) => workspace.paths);
+
+  // 2. Find the most recent project tag and the commits since it under contributing paths.
+  const { tag, commits } = getCommitsSinceTarget([project.tagPrefix], contributingPaths);
+
+  // 3. Determine bump type. Override > commit-derived > skip.
+  let releaseType: ReleaseType | undefined;
+  let parsedCommitCount: number | undefined;
+  let unparseableCommits: Commit[] | undefined;
+
+  if (bumpOverride !== undefined) {
+    releaseType = bumpOverride;
+  } else {
+    const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.scopeAliases);
+    releaseType = determination.releaseType;
+    parsedCommitCount = determination.parsedCommitCount;
+    unparseableCommits = determination.unparseableCommits;
+  }
+
+  // 4. Skip silently when no commits and no force; mirrors per-workspace skip semantics.
+  if (releaseType === undefined && force !== true && commits.length === 0) {
+    return undefined;
+  }
+  if (releaseType === undefined) {
+    // Commits exist but produced no parsed type AND force not set → skip too.
+    return undefined;
+  }
+
+  // 5/6. Bump root package.json (handles dry-run internally).
+  const bump = bumpAllVersions([ROOT_PACKAGE_FILE], releaseType, dryRun);
+
+  // 7. Compose the project tag.
+  const newTag = `${project.tagPrefix}${bump.newVersion}`;
+
+  // 8. Generate the root CHANGELOG via git-cliff, filtered to project tags only.
+  const tagPattern = buildTagPattern([project.tagPrefix]);
+  const changelogFiles = generateChangelog(config, ROOT_CHANGELOG_PATH, newTag, dryRun, {
+    tagPattern,
+    includePaths: contributingPaths,
+  });
+
+  // 9. Emit the root changelog.json when enabled.
+  let changelogJsonFiles: string[] = [];
+  if (config.changelogJson.enabled) {
+    changelogJsonFiles = generateChangelogJson(config, ROOT_CHANGELOG_PATH, newTag, dryRun, {
+      tagPattern,
+      includePaths: contributingPaths,
+    });
+  }
+
+  // 10. Optional release-notes previews under root docs/.
+  const firstChangelogJsonPath = changelogJsonFiles[0];
+  if (withReleaseNotes === true && config.changelogJson.enabled && firstChangelogJsonPath !== undefined) {
+    const sectionOrder = deriveSectionOrder(workTypes);
+    writeReleaseNotesPreviews({
+      workspacePath: ROOT_CHANGELOG_PATH,
+      tag: newTag,
+      changelogJsonPath: firstChangelogJsonPath,
+      sectionOrder,
+      dryRun,
+    });
+  }
+
+  // 11. Append the project tag and modified files to the shared aggregators so downstream
+  // commands (`commit`, `tag`, format command) see them alongside per-workspace artifacts.
+  tags.push(newTag);
+  modifiedFiles.push(ROOT_PACKAGE_FILE, ...changelogFiles, ...changelogJsonFiles);
+
+  // 12. Build and return the result.
+  const result: ProjectPrepareResult = {
+    status: 'released',
+    commitCount: commits.length,
+    releaseType,
+    currentVersion: bump.currentVersion,
+    newVersion: bump.newVersion,
+    tag: newTag,
+    bumpedFiles: bump.files,
+    changelogFiles,
+    commits,
+  };
+  if (tag !== undefined) {
+    result.previousTag = tag;
+  }
+  if (parsedCommitCount !== undefined) {
+    result.parsedCommitCount = parsedCommitCount;
+  }
+  if (unparseableCommits !== undefined) {
+    result.unparseableCommits = unparseableCommits;
+  }
+  return result;
+}

--- a/packages/release-kit/src/reportPrepare.ts
+++ b/packages/release-kit/src/reportPrepare.ts
@@ -1,15 +1,16 @@
 import { bold, dim, sectionHeader } from './format.ts';
-import type { PrepareResult, PropagationSource, WorkspacePrepareResult } from './types.ts';
+import type { PrepareResult, ProjectPrepareResult, PropagationSource, WorkspacePrepareResult } from './types.ts';
 
 /**
  * Format a `PrepareResult` into styled terminal output.
  *
  * Pure function: accepts structured data, returns a string. Never writes to stdout.
  * Single-workspace mode (no `name` field) renders flat output; multi-workspace mode
- * renders section headers per workspace and a tag summary at the end.
+ * renders section headers per workspace, an optional project section, and a tag summary
+ * at the end.
  */
 export function reportPrepare(result: PrepareResult): string {
-  const isMultiWorkspace = result.workspaces.some((w) => w.name !== undefined);
+  const isMultiWorkspace = result.workspaces.some((w) => w.name !== undefined) || result.project !== undefined;
 
   if (isMultiWorkspace) {
     return formatMultiWorkspace(result);
@@ -92,6 +93,10 @@ function formatMultiWorkspace(result: PrepareResult): string {
     formatWorkspaceSection(lines, workspace, result.dryRun);
   }
 
+  if (result.project !== undefined) {
+    formatProjectSection(lines, result.project, result.dryRun);
+  }
+
   // Format command
   formatFormatCommand(lines, result);
 
@@ -109,6 +114,67 @@ function formatMultiWorkspace(result: PrepareResult): string {
   }
 
   return lines.join('\n');
+}
+
+/**
+ * Render the project release section using the same shape as a workspace section. The
+ * project release always corresponds to a single bump (no propagation, no `--set-version`),
+ * so the rendering branches are simpler than `formatWorkspaceSection`.
+ */
+function formatProjectSection(lines: string[], project: ProjectPrepareResult, dryRun: boolean): void {
+  lines.push(`\n${sectionHeader('project')}`);
+
+  const since = project.previousTag === undefined ? '(no previous release found)' : `since ${project.previousTag}`;
+  lines.push(dim(`  Found ${project.commitCount} commits ${since}`));
+
+  if (project.parsedCommitCount !== undefined) {
+    lines.push(dim(`  Parsed ${project.parsedCommitCount} typed commits`));
+  } else {
+    lines.push(`  Using bump override: ${project.releaseType}`);
+  }
+
+  formatProjectUnparseable(lines, project);
+
+  lines.push(
+    dim(`  Bumping versions (${project.releaseType})...`),
+    `  📦 ${project.currentVersion} → ${bold(project.newVersion)} (${project.releaseType})`,
+  );
+
+  for (const file of project.bumpedFiles) {
+    if (dryRun) {
+      lines.push(dim(`    [dry-run] Would bump ${file}`));
+    } else {
+      lines.push(dim(`    Bumped ${file}`));
+    }
+  }
+
+  lines.push(dim('  Generating changelogs...'));
+  for (const file of project.changelogFiles) {
+    if (dryRun) {
+      lines.push(dim(`    [dry-run] Would run: npx --yes git-cliff ... --output ${file}`));
+    } else {
+      lines.push(dim(`    Generating changelog: ${file}`));
+    }
+  }
+
+  lines.push(`  🏷️  ${bold(project.tag)}`);
+}
+
+/** Append the unparseable-commit warning lines for a project release, if any. */
+function formatProjectUnparseable(lines: string[], project: ProjectPrepareResult): void {
+  const unparseable = project.unparseableCommits;
+  if (unparseable === undefined || unparseable.length === 0) {
+    return;
+  }
+  const count = unparseable.length;
+  const isPatchFloor = project.parsedCommitCount === 0;
+  const suffix = isPatchFloor ? ' (defaulting to patch bump)' : '';
+  lines.push(`    ⚠️  ${count} commit${count === 1 ? '' : 's'} could not be parsed${suffix}`);
+  for (const commit of unparseable) {
+    const shortHash = commit.hash.slice(0, 7);
+    const truncatedMessage = commit.message.length > 72 ? `${commit.message.slice(0, 69)}...` : commit.message;
+    lines.push(`      · ${shortHash} ${truncatedMessage}`);
+  }
 }
 
 /** Render a single workspace's section within multi-workspace output. */

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -37,6 +37,28 @@ export interface ReleaseNotesConfig {
   shouldInjectIntoReadme: boolean;
 }
 
+/**
+ * Consumer-facing project-release config (`project` block in `release-kit.config.ts`).
+ *
+ * Declaring an empty `project: {}` opts the repo into project-level releases. All fields
+ * are optional; defaults are applied during config merging. The set of contributing
+ * workspaces is implicit — every non-excluded discovered workspace contributes.
+ */
+export interface ProjectConfig {
+  /** Tag prefix for project-level tags (e.g., `'v'` produces `'v1.2.0'`). Defaults to `'v'`. */
+  tagPrefix?: string;
+}
+
+/**
+ * Project-release config after merging defaults. Mirrors the `ReleaseNotesConfig`/
+ * `ResolvedReleaseNotesConfig`-style split: optional fields in `ProjectConfig` become
+ * required in `ResolvedProjectConfig`.
+ */
+export interface ResolvedProjectConfig {
+  /** Resolved tag prefix for project-level tags. */
+  tagPrefix: string;
+}
+
 /** Identifies a dependency whose version bump triggered a propagated release. */
 export interface PropagationSource {
   packageName: string;
@@ -75,6 +97,32 @@ export interface WorkspacePrepareResult {
   setVersion?: string | undefined;
 }
 
+/**
+ * Result of preparing a project-level release.
+ *
+ * Mirrors `WorkspacePrepareResult`'s shape minus the workspace-only fields (`name`,
+ * `propagatedFrom`, `setVersion`). A separate type is used rather than reusing
+ * `WorkspacePrepareResult` so the project entry can be disambiguated structurally —
+ * consumers and tests can branch on `result.project !== undefined` without inspecting
+ * an array entry's shape.
+ */
+export interface ProjectPrepareResult {
+  status: 'released';
+  previousTag?: string | undefined;
+  commitCount: number;
+  parsedCommitCount?: number | undefined;
+  releaseType: ReleaseType;
+  currentVersion: string;
+  newVersion: string;
+  tag: string;
+  bumpedFiles: string[];
+  changelogFiles: string[];
+  /** Raw commits in the project's contributing-paths window since the last project tag. */
+  commits?: Commit[] | undefined;
+  /** Commits that could not be parsed into a recognized work type. */
+  unparseableCommits?: Commit[] | undefined;
+}
+
 /** Aggregate result of the prepare workflow for both single-package and monorepo modes. */
 export interface PrepareResult {
   workspaces: WorkspacePrepareResult[];
@@ -89,6 +137,8 @@ export interface PrepareResult {
   dryRun: boolean;
   /** Warnings surfaced during preparation (e.g., circular dependency detection). */
   warnings?: string[] | undefined;
+  /** Result of the project-level release stage (present only when `config.project` is configured and the stage ran). */
+  project?: ProjectPrepareResult | undefined;
 }
 
 /** Configuration for a single work type used in commit categorization. */
@@ -154,6 +204,14 @@ export interface ReleaseKitConfig {
    * not flag them as undeclared candidates.
    */
   retiredPackages?: RetiredPackage[];
+  /**
+   * Project-level release block. Declaring `project: {}` (even empty) opts the repo into
+   * project-level releases: each `prepare` run additionally bumps the root `package.json`,
+   * regenerates the root `CHANGELOG.md`, and emits a project tag. Contributing workspaces
+   * are implicitly all non-excluded discovered workspaces. Single-package mode does not
+   * support this block.
+   */
+  project?: ProjectConfig;
 }
 
 /**
@@ -279,6 +337,12 @@ export interface MonorepoReleaseConfig {
   changelogJson: ChangelogJsonConfig;
   /** Controls release notes consumption (README injection). */
   releaseNotes: ReleaseNotesConfig;
+  /**
+   * Project-level release config. Present iff the consumer declared `project: {}`. When
+   * present, `releasePrepareMono` runs an additional project-release stage after the
+   * per-workspace loop.
+   */
+  project?: ResolvedProjectConfig;
 }
 
 /** Configuration for the release workflow. */

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -1,5 +1,5 @@
 import { isRecord } from './typeGuards.ts';
-import type { LegacyIdentity, ReleaseKitConfig, RetiredPackage } from './types.ts';
+import type { LegacyIdentity, ProjectConfig, ReleaseKitConfig, RetiredPackage } from './types.ts';
 
 /**
  * Validates a raw config object loaded from `.config/release-kit.config.ts`.
@@ -21,6 +21,7 @@ export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors
     'changelogJson',
     'cliffConfigPath',
     'formatCommand',
+    'project',
     'releaseNotes',
     'retiredPackages',
     'scopeAliases',
@@ -44,6 +45,7 @@ export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors
   validateStringField('cliffConfigPath', raw.cliffConfigPath, config, errors);
   validateScopeAliases(raw.scopeAliases, config, errors);
   validateRetiredPackages(raw.retiredPackages, config, errors);
+  validateProjectConfig(raw.project, config, errors);
 
   // Cross-field warnings: releaseNotes features require changelogJson to be enabled.
   const warnings: string[] = [];
@@ -99,6 +101,43 @@ function validateChangelogJson(value: unknown, config: ReleaseKitConfig, errors:
   }
 
   config.changelogJson = result;
+}
+
+/**
+ * Validate the optional `project` config block.
+ *
+ * Accepts an empty object (`{}`) as a valid opt-in marker. Rejects unknown subfields and
+ * non-string `tagPrefix`. Tag-prefix collision validation lives in `loadConfig` since it
+ * requires the discovered workspace list.
+ */
+function validateProjectConfig(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
+  if (value === undefined) return;
+
+  if (!isRecord(value)) {
+    errors.push("'project' must be an object");
+    return;
+  }
+
+  const knownProjectFields = new Set(['tagPrefix']);
+  for (const key of Object.keys(value)) {
+    if (!knownProjectFields.has(key)) {
+      errors.push(`project: unknown field '${key}'`);
+    }
+  }
+
+  const result: ProjectConfig = {};
+
+  if (value.tagPrefix !== undefined) {
+    if (typeof value.tagPrefix !== 'string') {
+      errors.push('project.tagPrefix: must be a string');
+    } else if (value.tagPrefix === '') {
+      errors.push('project.tagPrefix: must be a non-empty string');
+    } else {
+      result.tagPrefix = value.tagPrefix;
+    }
+  }
+
+  config.project = result;
 }
 
 function validateReleaseNotes(value: unknown, config: ReleaseKitConfig, errors: string[]): void {


### PR DESCRIPTION
## What

Adds support for monorepos that ship a single combined deliverable to version, changelog, and release-note the project itself rather than only its constituent workspaces. Declaring an opt-in `project: {}` block in `release-kit.config.ts` (with optional `tagPrefix?: string`, defaulting to `'v'`) enables a project-level release stage in `release-kit prepare` that bumps the root `package.json`, regenerates the root `CHANGELOG.md` from commits across all contributing workspaces, optionally emits a release-notes preview, and appends a project tag — all in addition to the existing per-workspace pipeline. Repos without the block continue to work unchanged.

## Why

Monorepos whose deliverable is a single combined artifact (a Chrome extension, a CLI binary, a packaged desktop app) had no way to version, changelog, or release-note the project itself — release-kit only modeled per-workspace releases. End users seeing a single shipped artifact had release notes that could only reflect one workspace's slice. The Atlassian Feature Gate Chrome Extension, for example, has a root `CHANGELOG.md` frozen at `0.9.0` since per-workspace tagging was introduced. This change closes that gap by adding a parallel project-level pipeline that reuses the existing primitives.

## Details

### Features

- `release-kit prepare` runs a project-level release stage when the new `project` block is configured. The stage derives the bump from commits since the last project tag, filtered to the union of all non-excluded workspaces' paths; bumps the root `package.json` version; regenerates the root `CHANGELOG.md` via `git-cliff` using the project's `tagPrefix` for `--tag-pattern` and contributing paths for `--include-path`; emits the root `.meta/changelog.json` when `changelogJson.enabled`; and optionally emits `./docs/RELEASE_NOTES.v<version>.md` when `--with-release-notes` is set. The project tag is appended to `tmp/.release-tags` and a project section is appended to `tmp/.release-summary` and `reportPrepare`'s output, so the existing `release-kit commit` and `release-kit tag` flows pick it up unchanged.
- CLI flags interact as documented: `--dry-run` previews project artifacts alongside workspace ones; `--bump=X` propagates to the project; `--force` enables release with no commits; `--only` is rejected at command-invocation time when `project` is configured, with a clear error and an updated `--only` help-text note.

### Fixes

- The strict-prefix tag-prefix collision check (new `assertNoTagPrefixCollisions`) replaces the previous equality-only check, catching cases where one prefix is a strict prefix of another (e.g., `v` matching `vue-helpers-v` via `git describe --match=v*`). The check spans active workspaces, legacy identities, retired packages, and the project block. This rule now applies to every monorepo consumer, not only those declaring `project` — the underlying glob risk exists either way; existing consumers with strict-prefix-overlapping derived prefixes will see new validation errors at config-load time.
- Config validation rejects: missing root `package.json` or missing `version` field when `project` is configured (with a clear error pointing the consumer to add one); the `project` block in single-package mode; unknown subfields inside `project`; and `--only` combined with `project` at command-invocation time.

### Refactoring

- `mergeMonorepoConfig` retains its pure-transformation profile by accepting a `RootPackageInfo` parameter; the root `package.json` read happens in the async `loadConfig` layer (new `readRootPackageVersion` helper) and the loaded value is passed in as input.
- The new `releasePrepareProject` orchestrator reuses existing primitives — `getCommitsSinceTarget`, `determineBumpFromCommits`, `bumpAllVersions`, `generateChangelog`, `generateChangelogJson`, `writeReleaseNotesPreviews`. The orchestrator is wired into `releasePrepareMono` after the per-workspace `executeReleaseSet` loop and before `runFormatCommand`, so root files (the bumped `package.json` and regenerated `CHANGELOG.md`) reach the format command's argument list. The orchestrator mutates the caller's `tags` and `modifiedFiles` arrays and returns a `ProjectPrepareResult` (or `undefined` when no commits and no force).

### Tests

- New unit tests are co-located with each layer covering: the project block validation (`validateConfig`); the resolved-config merge, root `package.json` read paths, strict-prefix collision rejection across all four sources, and single-package rejection (`loadConfig`); the orchestrator's skip-on-no-commits, default flow, `--bump` override, `--force --bump`, `--dry-run`, `--with-release-notes`, and first-run-with-legacy-tag scenarios (`releasePrepareProject`); the `--only` rejection and no-regression paths (`prepareCommand`); the orchestrator wiring (`releasePrepareMono`); and the project section rendering positions and dry-run prefixes (`reportPrepare`, `buildReleaseSummary`).
- A new real-git integration test (`releasePrepareProject.int.test.ts`) spins up a temp git repo with three workspaces, a `v0.9.0` legacy tag, per-workspace baseline tags, and a mix of `feat`/`fix` commits. Five scenarios are asserted at the file-content level: default flow (project tag, root `package.json` bumped, root `CHANGELOG.md` regenerated with both old and new entries, all expected tags emitted), `--bump=major` override, `--dry-run` no writes, `--with-release-notes` preview emission, and `--only` rejection through `prepareCommand` with no files written.

Closes #308