### PR TITLE
#312 Make `--set-version` + `project` rejection explicit

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -213,7 +213,7 @@ Contributing workspaces are implicit: every non-excluded discovered workspace co
 
 Validation rules:
 
-- The root `package.json` must exist and declare a `version` field. release-kit reports a clear error at config-load time if either is missing.
+- The root `package.json` must exist and declare a `version` field. release-kit reports an error at config-load time if either is missing.
 - `project.tagPrefix` must not collide with any active workspace's derived `tagPrefix`, any `workspaces[].legacyIdentities[].tagPrefix`, or any `retiredPackages[].tagPrefix`. The collision check is strict-prefix: a project prefix `'v'` collides with a workspace prefix `'vue-helpers-v'` because `git describe --match=v*` would return tags from both.
 - The `project` block is rejected in single-package mode (the implicit "all non-excluded workspaces contribute" rule is meaningless in a single-package repo).
 - Unknown fields inside `project` are rejected.
@@ -223,8 +223,8 @@ CLI flag interactions:
 - `--dry-run` previews project artifacts alongside workspace artifacts; no files are written.
 - `--bump=major|minor|patch` propagates to the project release.
 - `--force` combined with `--bump` runs the project release even with no commits since the last project tag.
-- `--only` is **rejected with a clear error** when `project` is configured. `--only` is a surgical, single-workspace operation; combining it with a project release that rolls up every contributing workspace would create ambiguous semantics. To release a single workspace, use a config without a `project` block, or run a full `prepare` (no `--only`) to include the project release.
-- `--set-version` cannot co-exist with a configured project block, since `--set-version` requires `--only` in monorepo mode (and `--only` is rejected when `project` is configured).
+- `--only` is rejected with an error when `project` is configured. `--only` is a surgical, single-workspace operation; combining it with a project release that rolls up every contributing workspace would create ambiguous semantics. To release a single workspace, use a config without a `project` block, or run a full `prepare` (no `--only`) to include the project release.
+- `--set-version` is rejected with an error when `project` is configured. `--set-version` operates on a single workspace, but a project release rolls up every contributing workspace; the two semantics don't compose. To use `--set-version`, run on a config without a `project` block.
 
 ### `VersionPatterns`
 

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -405,7 +405,7 @@ describe(readRootPackageVersion, () => {
     expect(readRootPackageVersion()).toStrictEqual({ exists: true, version: undefined });
   });
 
-  it('throws a clear error when the root package.json contains invalid JSON', () => {
+  it('throws an error when the root package.json contains invalid JSON', () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue('{ not valid json');
     expect(() => readRootPackageVersion()).toThrow(/Failed to parse root package\.json/);

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -455,7 +455,7 @@ describe(prepareCommand, () => {
     expect(callArgs).not.toHaveProperty('withReleaseNotes');
   });
 
-  describe('--only with project block', () => {
+  describe('--only and --set-version interactions with project block', () => {
     beforeEach(() => {
       // Configure the mocks so the project block is loaded and the root package.json is valid.
       mockLoadConfig.mockResolvedValue({ project: {} });
@@ -472,7 +472,7 @@ describe(prepareCommand, () => {
       });
     });
 
-    it('rejects --only with a clear error before any release work runs', async () => {
+    it('rejects --only with an error before any release work runs', async () => {
       await expect(prepareCommand(['--only=arrays'])).rejects.toThrow(ExitError);
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('--only cannot be combined with a project release'),
@@ -483,6 +483,23 @@ describe(prepareCommand, () => {
     it('runs normally without --only when project is configured', async () => {
       await prepareCommand([]);
       expect(mockReleasePrepareMono).toHaveBeenCalled();
+    });
+
+    it('rejects --set-version with the project-aware error (not the transitive --only error)', async () => {
+      await expect(prepareCommand(['--set-version=1.2.3'])).rejects.toThrow(ExitError);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('--set-version cannot be combined with a project release'),
+      );
+      expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('requires --only'));
+      expect(mockReleasePrepareMono).not.toHaveBeenCalled();
+    });
+
+    it('rejects --set-version + --only with the project-aware error (project rule wins over --only rule)', async () => {
+      await expect(prepareCommand(['--set-version=1.2.3', '--only=arrays'])).rejects.toThrow(ExitError);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('--set-version cannot be combined with a project release'),
+      );
+      expect(mockReleasePrepareMono).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -44,7 +44,8 @@ Usage: npx @williamthorsen/release-kit prepare [options]
 Options:
   --dry-run             Run without modifying any files
   --bump=major|minor|patch  Override the bump type for all workspaces
-  --set-version=X.Y.Z   Set an explicit version; bypasses commit-derived bumps. Requires --only in monorepo mode.
+  --set-version=X.Y.Z   Set an explicit version; bypasses commit-derived bumps.
+                         Requires --only in monorepo mode (rejected when a 'project' block is configured).
   --force               Force a release even when there are no commits since the last tag (requires --bump)
   --no-git-checks, -n   Skip the clean-working-tree check
   --only=name1,name2    Only process the named workspaces (comma-separated, monorepo only;
@@ -252,6 +253,21 @@ function runMonorepoMode(
     config = mergeMonorepoConfig(discoveredPaths, userConfig, rootPackage);
   } catch (error: unknown) {
     console.error(`Error resolving workspaces: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  // Reject `--set-version` when a project block is configured. `--set-version` is a workspace
+  // operation; a project release rolls up every contributing workspace and derives its bump
+  // from commits in the contributing-paths window — there is no flag designed to override the
+  // project version directly, and the two semantics do not compose. Runs before the `--only`
+  // rejection so a user passing `--set-version` (the primary intent) sees the project-aware
+  // error rather than the secondary `--only` error when both flags are supplied.
+  if (setVersion !== undefined && config.project !== undefined) {
+    console.error(
+      'Error: --set-version cannot be combined with a project release. ' +
+        '--set-version operates on a single workspace; a project release rolls up every ' +
+        'contributing workspace. To use --set-version, run on a config without a `project` block.',
+    );
     process.exit(1);
   }
 


### PR DESCRIPTION
## What

Improves the error users see when invoking `release-kit prepare --set-version` with a `project` block configured. The combination is still rejected — as before — but now produces a single, project-aware message ("--set-version cannot be combined with a project release…") rather than the previous two-step chain (`--set-version requires --only`, then `--only cannot be combined with a project release` after the user added `--only`).

## Why

The rejection was previously incidental — emerging from two unrelated rules (`--set-version` requires `--only`, and `--only` is rejected when `project` is configured) whose composition happened to produce the right outcome. The error message reflected that composition rather than the actual rule, leaving users to puzzle through a misleading hint. Making the rejection deliberate also protects it from silently disappearing if a future ticket relaxes either of the underlying rules.

## Details

### Fixes

- `prepareCommand.runMonorepoMode` now rejects `--set-version` directly when `config.project !== undefined`, with a single project-aware error. The new guard runs before the `--only` + `project` rejection so the project-aware error wins regardless of whether `--only` is also passed.
- `--help` text for `--set-version` mentions the `project` incompatibility.
- README's CLI flag interactions section states the rule directly rather than describing it as a transitive consequence.
- Removes "clear error" phrasing from the README and two test names — self-congratulatory wording that adds no information.

### Tests

- Two regression tests pin the rejection: one for `--set-version` alone, one for `--set-version` combined with `--only`. Both assert that the project-aware error message wins, not the transitive `--set-version requires --only` message.
- The existing `--only with project block` describe block was renamed to cover both flag interactions.

Closes #312 