### PR TITLE
#314 Document tag prefix collisions as general rule

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -167,9 +167,20 @@ Validation rules:
 - `successor` is optional; if present, it must be a non-empty string.
 - Full-tuple `(name, tagPrefix)` duplicates within `retiredPackages` are rejected.
 - Two entries sharing the same `tagPrefix` but different `name`s are accepted — this documents a package renamed within the repo before being retired.
-- A `tagPrefix` that collides with an active workspace's derived prefix or any declared `workspaces[].legacyIdentities[].tagPrefix` is rejected. A retired prefix cannot also be current or legacy.
 
 `show-tag-prefixes` currently does not render a dedicated "Retired packages" section (deferred). Declaring a retired entry is verifiable by confirming that its `tagPrefix` stops appearing under "Undeclared tag prefixes" in the `show-tag-prefixes` output.
+
+### Tag prefix collisions
+
+Tag prefixes from distinct owners must not be identical or be a strict prefix of one another. An owner is one of:
+
+- An active workspace, comprising its derived `tagPrefix` plus any declared `legacyIdentities[].tagPrefix`. Identities of the same workspace are one owner, so their prefixes are allowed to overlap (this represents the same package across renames).
+- A `retiredPackages[]` entry (one owner per entry).
+- The `project` block, when configured.
+
+release-kit resolves baseline tags via `git describe --match=<prefix>*`, so a strict-prefix overlap between distinct owners would cause that glob to return cross-matches against the wrong owner's history. For example, a project prefix of `v` collides with a workspace prefix of `vue-helpers-v`, since `git describe --match=v*` would return both project tags and `vue-helpers` tags.
+
+The rule is enforced at config load; the resulting error identifies both colliding declarations.
 
 ### Project releases
 
@@ -214,7 +225,6 @@ Contributing workspaces are implicit: every non-excluded discovered workspace co
 Validation rules:
 
 - The root `package.json` must exist and declare a `version` field. release-kit reports an error at config-load time if either is missing.
-- `project.tagPrefix` must not collide with any active workspace's derived `tagPrefix`, any `workspaces[].legacyIdentities[].tagPrefix`, or any `retiredPackages[].tagPrefix`. The collision check is strict-prefix: a project prefix `'v'` collides with a workspace prefix `'vue-helpers-v'` because `git describe --match=v*` would return tags from both.
 - The `project` block is rejected in single-package mode (the implicit "all non-excluded workspaces contribute" rule is meaningless in a single-package repo).
 - Unknown fields inside `project` are rejected.
 


### PR DESCRIPTION
## What

Documents the strict-prefix tag-prefix collision rule as a general validation rule that applies to every release-kit consumer declaring more than one tag prefix — across active workspaces, declared legacy identities, retired packages, and the optional `project` block. Previously the rule appeared only inside the `Project releases` validation list, so readers scanning the `WorkspaceOverride` or `RetiredPackage` documentation had no signal that it applied to them. The underlying validation behavior is unchanged; this change is documentation only.

## Why

`assertNoTagPrefixCollisions` enforces the strict-prefix rule for every release-kit consumer at config load, but the README documented it only as a `project`-block concern. A reader who didn't declare a `project` block would not realize the rule covered their workspace prefixes, legacy identities, and retired-package prefixes. Promoting the rule to a top-level Configuration topic makes it discoverable for the consumers it actually constrains.

## Details

### Documentation

- Adds a new `### Tag prefix collisions` subsection under `## Configuration` in `packages/release-kit/README.md`, positioned between `### RetiredPackage` and `### Project releases`. The subsection states the rule once, defines an "owner" (an active workspace together with its declared `legacyIdentities[].tagPrefix`, each `retiredPackages[]` entry, and the optional `project` block), gives the `git describe --match=<prefix>*` rationale, and includes a concrete strict-prefix example (`v` vs `vue-helpers-v`).
- Removes the now-redundant strict-prefix bullet from `### Project releases → Validation rules`.
- Removes the partial cross-collision bullet from `### RetiredPackage` validation rules. The previous bullet was both incomplete (omitted `project.tagPrefix`) and imprecise (said "rejected" without naming the strict-prefix nature of the check); the new canonical section covers it accurately.

The underlying check in `assertNoTagPrefixCollisions` (`packages/release-kit/src/loadConfig.ts`) is unchanged.

Closes #314