### PR TITLE
Reject `--only` that would strand excluded dependents

### DIFF
--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mockAssertCleanWorkingTree = vi.hoisted(() => vi.fn());
 const mockBuildReleaseSummary = vi.hoisted(() => vi.fn());
 const mockDiscoverWorkspaces = vi.hoisted(() => vi.fn());
+const mockGetCommitsSinceTarget = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockReadFileSync = vi.hoisted(() => vi.fn());
@@ -25,6 +26,10 @@ vi.mock('../buildReleaseSummary.ts', () => ({
 
 vi.mock('../discoverWorkspaces.ts', () => ({
   discoverWorkspaces: mockDiscoverWorkspaces,
+}));
+
+vi.mock('../getCommitsSinceTarget.ts', () => ({
+  getCommitsSinceTarget: mockGetCommitsSinceTarget,
 }));
 
 vi.mock('../loadConfig.ts', async (importOriginal) => {
@@ -54,23 +59,6 @@ vi.mock(import('@williamthorsen/nmr-core'), async (importOriginal) => {
 import { parseArgs, prepareCommand, RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from '../prepareCommand.ts';
 import type { PrepareResult } from '../types.ts';
 
-/** Sentinel error thrown by the mocked process.exit. */
-class ExitError extends Error {
-  constructor(public readonly code: number | undefined) {
-    super(`process.exit(${code})`);
-  }
-}
-
-/** Build a minimal PrepareResult for mocking. */
-function makePrepareResult(overrides?: Partial<PrepareResult>): PrepareResult {
-  return {
-    workspaces: [],
-    tags: [],
-    dryRun: false,
-    ...overrides,
-  };
-}
-
 describe(prepareCommand, () => {
   beforeEach(() => {
     mockBuildReleaseSummary.mockReturnValue('');
@@ -90,6 +78,8 @@ describe(prepareCommand, () => {
     });
     mockReleasePrepareMono.mockReturnValue(makePrepareResult());
     mockReleasePrepare.mockReturnValue(makePrepareResult());
+    // Default: no commits anywhere, so the stranded-dependents validator stays silent.
+    mockGetCommitsSinceTarget.mockReturnValue({ tag: undefined, commits: [] });
     mockWriteFileWithCheck.mockReturnValue({ filePath: RELEASE_TAGS_FILE, outcome: 'created' });
     vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
@@ -108,6 +98,7 @@ describe(prepareCommand, () => {
     mockReadFileSync.mockReset();
     mockReleasePrepareMono.mockReset();
     mockReleasePrepare.mockReset();
+    mockGetCommitsSinceTarget.mockReset();
     mockWriteFileWithCheck.mockReset();
     vi.restoreAllMocks();
   });
@@ -184,6 +175,32 @@ describe(prepareCommand, () => {
   it('exits with error for --only with an unknown workspace name in monorepo mode', async () => {
     await expect(prepareCommand(['--only=arrays,nonexistent'])).rejects.toThrow(ExitError);
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('nonexistent'));
+    expect(mockReleasePrepareMono).not.toHaveBeenCalled();
+  });
+
+  it('rejects --only when an excluded internal dependent has its own changes', async () => {
+    // Arrange a graph where strings depends on arrays, and both have commits since their last tag.
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath === 'packages/arrays/package.json') {
+        return JSON.stringify({ name: '@scope/arrays' });
+      }
+      if (filePath === 'packages/strings/package.json') {
+        return JSON.stringify({ name: '@scope/strings', dependencies: { '@scope/arrays': 'workspace:*' } });
+      }
+      throw new Error(`Unexpected readFileSync call for path: ${filePath}`);
+    });
+    mockGetCommitsSinceTarget.mockImplementation((tagPrefixes: readonly string[]) => {
+      if (tagPrefixes.includes('arrays-v'))
+        return { tag: 'arrays-v1.0.0', commits: [{ message: 'feat: x', hash: 'h1' }] };
+      if (tagPrefixes.includes('strings-v'))
+        return { tag: 'strings-v1.0.0', commits: [{ message: 'feat: y', hash: 'h2' }] };
+      return { tag: undefined, commits: [] };
+    });
+
+    await expect(prepareCommand(['--only=arrays'])).rejects.toThrow(ExitError);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('stranded by the release'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('strings'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('downstream of arrays'));
     expect(mockReleasePrepareMono).not.toHaveBeenCalled();
   });
 
@@ -612,3 +629,22 @@ describe('RELEASE_SUMMARY_FILE', () => {
     expect(RELEASE_SUMMARY_FILE).toBe('tmp/.release-summary');
   });
 });
+
+// region | Helpers
+/** Sentinel error thrown by the mocked process.exit. */
+class ExitError extends Error {
+  constructor(public readonly code: number | undefined) {
+    super(`process.exit(${code})`);
+  }
+}
+
+/** Build a minimal PrepareResult for mocking. */
+function makePrepareResult(overrides?: Partial<PrepareResult>): PrepareResult {
+  return {
+    workspaces: [],
+    tags: [],
+    dryRun: false,
+    ...overrides,
+  };
+}
+// endregion | Helpers

--- a/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
+++ b/packages/release-kit/src/__tests__/propagateBumps.unit.test.ts
@@ -5,31 +5,6 @@ import type { ReleaseEntry } from '../propagateBumps.ts';
 import { propagateBumps } from '../propagateBumps.ts';
 import type { WorkspaceConfig } from '../types.ts';
 
-function makeWorkspace(dir: string): WorkspaceConfig {
-  return {
-    dir,
-    name: `@test/${dir}`,
-    tagPrefix: `${dir}-v`,
-    workspacePath: `packages/${dir}`,
-    packageFiles: [`packages/${dir}/package.json`],
-    changelogPaths: [`packages/${dir}`],
-    paths: [`packages/${dir}/**`],
-  };
-}
-
-function makeGraph(
-  nameToDir: Record<string, string>,
-  dependentsOf: Record<string, WorkspaceConfig[]>,
-): DependencyGraph {
-  const packageNameToDir = new Map(Object.entries(nameToDir));
-  const dirToPackageName = new Map(Object.entries(nameToDir).map(([name, dir]) => [dir, name]));
-  return {
-    packageNameToDir,
-    dirToPackageName,
-    dependentsOf: new Map(Object.entries(dependentsOf)),
-  };
-}
-
 describe(propagateBumps, () => {
   it('propagates a patch bump to a single dependent', () => {
     const dependent = makeWorkspace('release-kit');
@@ -227,3 +202,31 @@ describe(propagateBumps, () => {
     });
   });
 });
+
+// region | Helpers
+function makeGraph(
+  nameToDir: Record<string, string>,
+  dependentsOf: Record<string, WorkspaceConfig[]>,
+): DependencyGraph {
+  const packageNameToDir = new Map(Object.entries(nameToDir));
+  const dirToPackageName = new Map(Object.entries(nameToDir).map(([name, dir]) => [dir, name]));
+  return {
+    packageNameToDir,
+    dirToPackageName,
+    dependentsOf: new Map(Object.entries(dependentsOf)),
+    dependenciesOf: new Map(),
+  };
+}
+
+function makeWorkspace(dir: string): WorkspaceConfig {
+  return {
+    dir,
+    name: `@test/${dir}`,
+    tagPrefix: `${dir}-v`,
+    workspacePath: `packages/${dir}`,
+    packageFiles: [`packages/${dir}/package.json`],
+    changelogPaths: [`packages/${dir}`],
+    paths: [`packages/${dir}/**`],
+  };
+}
+// endregion | Helpers

--- a/packages/release-kit/src/__tests__/validateOnlyExcludesStrandedDependents.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateOnlyExcludesStrandedDependents.unit.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DependencyGraph } from '../buildDependencyGraph.ts';
+import type { WorkspaceConfig } from '../types.ts';
+import {
+  type CommitsProbeResult,
+  validateOnlyExcludesStrandedDependents,
+} from '../validateOnlyExcludesStrandedDependents.ts';
+
+describe(validateOnlyExcludesStrandedDependents, () => {
+  it('returns undefined when the targeted workspace has no internal dependents (case A)', () => {
+    const a = makeWorkspace('a');
+    const graph = makeGraph([a], {});
+    const probe = makeProbe({ a: { has: true, tag: 'a-v1.0.0' } });
+
+    const result = validateOnlyExcludesStrandedDependents([a], ['a'], graph, probe);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when a dependent has no commits (case B)', () => {
+    const a = makeWorkspace('a');
+    const b = makeWorkspace('b');
+    const graph = makeGraph([a, b], { b: ['a'] });
+    const probe = makeProbe({ a: { has: true, tag: 'a-v1.0.0' } });
+
+    const result = validateOnlyExcludesStrandedDependents([a, b], ['a'], graph, probe);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('stops at an excluded no-commit dependent (case-3 barrier)', () => {
+    // a (--only, has commits) <- b (excluded, no commits) <- c (excluded, has commits).
+    // c must NOT be flagged: b is a barrier because excluded no-commit workspaces don't republish.
+    const a = makeWorkspace('a');
+    const b = makeWorkspace('b');
+    const c = makeWorkspace('c');
+    const graph = makeGraph([a, b, c], { b: ['a'], c: ['b'] });
+    const probe = makeProbe({
+      a: { has: true, tag: 'a-v1.0.0' },
+      c: { has: true, tag: 'c-v1.0.0' },
+    });
+
+    const result = validateOnlyExcludesStrandedDependents([a, b, c], ['a'], graph, probe);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('flags a single excluded dependent with own commits (case C, direct)', () => {
+    const a = makeWorkspace('a');
+    const b = makeWorkspace('b');
+    const graph = makeGraph([a, b], { b: ['a'] });
+    const probe = makeProbe({
+      a: { has: true, tag: 'a-v1.0.0' },
+      b: { has: true, tag: 'b-v1.0.0' },
+    });
+
+    const result = validateOnlyExcludesStrandedDependents([a, b], ['a'], graph, probe);
+
+    expect(result).toEqual([{ dir: 'b', downstreamOf: 'a', tag: 'b-v1.0.0' }]);
+  });
+
+  it('flags multiple excluded dependents at the same depth, sorted by dir', () => {
+    const a = makeWorkspace('a');
+    const b = makeWorkspace('b');
+    const c = makeWorkspace('c');
+    const graph = makeGraph([a, b, c], { b: ['a'], c: ['a'] });
+    const probe = makeProbe({
+      a: { has: true, tag: 'a-v1.0.0' },
+      b: { has: true, tag: 'b-v1.0.0' },
+      c: { has: true, tag: 'c-v1.0.0' },
+    });
+
+    const result = validateOnlyExcludesStrandedDependents([a, b, c], ['a'], graph, probe);
+
+    expect(result).toEqual([
+      { dir: 'b', downstreamOf: 'a', tag: 'b-v1.0.0' },
+      { dir: 'c', downstreamOf: 'a', tag: 'c-v1.0.0' },
+    ]);
+  });
+
+  it('catches the transitive case where B in --only bridges A to excluded D', () => {
+    // --only=[a, b]. a has commits. b has none but depends on a (joins R via fixpoint).
+    // c depends on b, c excluded with own commits → flagged as downstream of b.
+    const a = makeWorkspace('a');
+    const b = makeWorkspace('b');
+    const c = makeWorkspace('c');
+    const graph = makeGraph([a, b, c], { b: ['a'], c: ['b'] });
+    const probe = makeProbe({
+      a: { has: true, tag: 'a-v1.0.0' },
+      c: { has: true, tag: 'c-v1.0.0' },
+    });
+
+    const result = validateOnlyExcludesStrandedDependents([a, b, c], ['a', 'b'], graph, probe);
+
+    expect(result).toEqual([{ dir: 'c', downstreamOf: 'b', tag: 'c-v1.0.0' }]);
+  });
+
+  it('walks through anticipated-fix dependents to surface deeper footguns in one pass', () => {
+    // a (--only, has commits) <- b (excluded, has commits) <- c (excluded, has commits).
+    // Both b and c must be flagged in a single pass.
+    const a = makeWorkspace('a');
+    const b = makeWorkspace('b');
+    const c = makeWorkspace('c');
+    const graph = makeGraph([a, b, c], { b: ['a'], c: ['b'] });
+    const probe = makeProbe({
+      a: { has: true, tag: 'a-v1.0.0' },
+      b: { has: true, tag: 'b-v1.0.0' },
+      c: { has: true, tag: 'c-v1.0.0' },
+    });
+
+    const result = validateOnlyExcludesStrandedDependents([a, b, c], ['a'], graph, probe);
+
+    expect(result).toEqual([
+      { dir: 'b', downstreamOf: 'a', tag: 'b-v1.0.0' },
+      { dir: 'c', downstreamOf: 'b', tag: 'c-v1.0.0' },
+    ]);
+  });
+
+  it('returns undefined when no --only workspace has commits and none gain entry via propagation', () => {
+    const a = makeWorkspace('a');
+    const x = makeWorkspace('x');
+    const graph = makeGraph([a, x], {});
+    const probe = makeProbe({}); // neither has commits
+
+    const result = validateOnlyExcludesStrandedDependents([a, x], ['a', 'x'], graph, probe);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('does not walk through --only workspaces that are not in R', () => {
+    // a (--only, no commits), b (--only, no commits but depends on nothing in R), c (excluded with commits, depends on b).
+    // Neither a nor b joins R (no source of commits). c must not be flagged.
+    const a = makeWorkspace('a');
+    const b = makeWorkspace('b');
+    const c = makeWorkspace('c');
+    const graph = makeGraph([a, b, c], { c: ['b'] });
+    const probe = makeProbe({ c: { has: true, tag: 'c-v1.0.0' } });
+
+    const result = validateOnlyExcludesStrandedDependents([a, b, c], ['a', 'b'], graph, probe);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('preserves the tag value (including undefined) from the probe', () => {
+    const a = makeWorkspace('a');
+    const b = makeWorkspace('b');
+    const graph = makeGraph([a, b], { b: ['a'] });
+    const probe = makeProbe({
+      a: { has: true, tag: 'a-v1.0.0' },
+      b: { has: true, tag: undefined },
+    });
+
+    const result = validateOnlyExcludesStrandedDependents([a, b], ['a'], graph, probe);
+
+    expect(result).toEqual([{ dir: 'b', downstreamOf: 'a', tag: undefined }]);
+  });
+
+  it('memoizes hasCommits — each workspace is probed at most once', () => {
+    const a = makeWorkspace('a');
+    const b = makeWorkspace('b');
+    const c = makeWorkspace('c');
+    const graph = makeGraph([a, b, c], { b: ['a'], c: ['a'] });
+    const calls = new Map<string, number>();
+    const spy = vi.fn((workspace: WorkspaceConfig): CommitsProbeResult => {
+      calls.set(workspace.dir, (calls.get(workspace.dir) ?? 0) + 1);
+      if (workspace.dir === 'a') return { has: true, tag: 'a-v1.0.0' };
+      if (workspace.dir === 'b') return { has: true, tag: 'b-v1.0.0' };
+      return { has: true, tag: 'c-v1.0.0' };
+    });
+
+    validateOnlyExcludesStrandedDependents([a, b, c], ['a'], graph, spy);
+
+    expect(calls.get('a')).toBe(1);
+    expect(calls.get('b')).toBe(1);
+    expect(calls.get('c')).toBe(1);
+  });
+});
+
+// region | Helpers
+/**
+ * Build a `DependencyGraph` from a textual edge spec without touching the filesystem.
+ *
+ * `edges` maps each workspace `dir` to the set of workspace `dir`s it depends on. The
+ * returned graph mirrors the shape produced by `buildDependencyGraph` so the validator
+ * sees identical structure.
+ */
+function makeGraph(workspaces: WorkspaceConfig[], edges: Record<string, string[]>): DependencyGraph {
+  const packageNameToDir = new Map<string, string>();
+  const dirToPackageName = new Map<string, string>();
+  for (const w of workspaces) {
+    packageNameToDir.set(w.name, w.dir);
+    dirToPackageName.set(w.dir, w.name);
+  }
+
+  const dependentsOf = new Map<string, WorkspaceConfig[]>();
+  const dependenciesOf = new Map<string, Set<string>>();
+  const workspaceByDir = new Map(workspaces.map((w) => [w.dir, w] as const));
+
+  for (const [dir, deps] of Object.entries(edges)) {
+    const forward = new Set<string>();
+    for (const depDir of deps) {
+      const depWorkspace = workspaceByDir.get(depDir);
+      if (depWorkspace === undefined) {
+        throw new Error(`makeGraph: ${dir} depends on unknown ${depDir}`);
+      }
+      forward.add(depWorkspace.name);
+      const dependentWorkspace = workspaceByDir.get(dir);
+      if (dependentWorkspace === undefined) {
+        throw new Error(`makeGraph: unknown dependent ${dir}`);
+      }
+      const list = dependentsOf.get(depWorkspace.name);
+      if (list === undefined) {
+        dependentsOf.set(depWorkspace.name, [dependentWorkspace]);
+      } else {
+        list.push(dependentWorkspace);
+      }
+    }
+    if (forward.size > 0) {
+      dependenciesOf.set(dir, forward);
+    }
+  }
+
+  return { packageNameToDir, dirToPackageName, dependentsOf, dependenciesOf };
+}
+
+/** Build a `hasCommits` probe from a map of `dir` to `{ has, tag }`. Defaults to no commits. */
+function makeProbe(map: Record<string, CommitsProbeResult>): (workspace: WorkspaceConfig) => CommitsProbeResult {
+  return (workspace) => map[workspace.dir] ?? { has: false, tag: undefined };
+}
+
+/** Build a minimal `WorkspaceConfig` keyed by `dir` (and a matching `name` derived from it). */
+function makeWorkspace(dir: string): WorkspaceConfig {
+  return {
+    dir,
+    name: `@scope/${dir}`,
+    tagPrefix: `${dir}-v`,
+    workspacePath: `packages/${dir}`,
+    packageFiles: [`packages/${dir}/package.json`],
+    changelogPaths: [`packages/${dir}`],
+    paths: [`packages/${dir}`],
+  };
+}
+// endregion | Helpers

--- a/packages/release-kit/src/buildDependencyGraph.ts
+++ b/packages/release-kit/src/buildDependencyGraph.ts
@@ -10,6 +10,11 @@ export interface DependencyGraph {
   dirToPackageName: Map<string, string>;
   /** Map a package name to the workspaces that depend on it. */
   dependentsOf: Map<string, WorkspaceConfig[]>;
+  /**
+   * Forward adjacency: map a workspace `dir` to the set of `workspace:`-protocol package
+   * names it declares in `dependencies` or `peerDependencies`. Complement of `dependentsOf`.
+   */
+  dependenciesOf: Map<string, Set<string>>;
 }
 
 interface PackageJsonSubset {
@@ -34,6 +39,7 @@ export function buildDependencyGraph(workspaces: readonly WorkspaceConfig[]): De
   const packageNameToDir = new Map<string, string>();
   const dirToPackageName = new Map<string, string>();
   const dependentsOf = new Map<string, WorkspaceConfig[]>();
+  const dependenciesOf = new Map<string, Set<string>>();
 
   // First pass: read each workspace's package.json, cache the result, and register its name.
   const workspacePackages = new Map<WorkspaceConfig, PackageJsonSubset>();
@@ -54,7 +60,7 @@ export function buildDependencyGraph(workspaces: readonly WorkspaceConfig[]): De
     dirToPackageName.set(workspace.dir, pkg.name);
   }
 
-  // Second pass: build the reverse adjacency map using cached package data.
+  // Second pass: build the reverse and forward adjacency maps using cached package data.
   for (const [workspace, pkg] of workspacePackages) {
     const allDeps = { ...pkg.dependencies, ...pkg.peerDependencies };
 
@@ -69,10 +75,17 @@ export function buildDependencyGraph(workspaces: readonly WorkspaceConfig[]): De
       } else {
         existing.push(workspace);
       }
+
+      const forward = dependenciesOf.get(workspace.dir);
+      if (forward === undefined) {
+        dependenciesOf.set(workspace.dir, new Set([depName]));
+      } else {
+        forward.add(depName);
+      }
     }
   }
 
-  return { packageNameToDir, dirToPackageName, dependentsOf };
+  return { packageNameToDir, dirToPackageName, dependentsOf, dependenciesOf };
 }
 
 /** Read and parse a package.json file, returning only the fields needed for graph building. */

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -5,15 +5,18 @@ import type { WriteResult } from '@williamthorsen/nmr-core';
 import { parseArgs as coreParseArgs, translateParseError, writeFileWithCheck } from '@williamthorsen/nmr-core';
 
 import { assertCleanWorkingTree } from './assertCleanWorkingTree.ts';
+import { buildDependencyGraph } from './buildDependencyGraph.ts';
 import { buildReleaseSummary } from './buildReleaseSummary.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
 import { dim } from './format.ts';
+import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig, readRootPackageVersion } from './loadConfig.ts';
 import { releasePrepare } from './releasePrepare.ts';
 import { releasePrepareMono } from './releasePrepareMono.ts';
 import { reportPrepare } from './reportPrepare.ts';
 import type { MonorepoReleaseConfig, PrepareResult, ReleaseKitConfig, ReleaseType } from './types.ts';
 import { validateConfig } from './validateConfig.ts';
+import { validateOnlyExcludesStrandedDependents } from './validateOnlyExcludesStrandedDependents.ts';
 
 /**
  * File written by the release preparation step, containing one tag per line.
@@ -293,6 +296,30 @@ function runMonorepoMode(
         console.error(`Error: Unknown workspace "${name}". Known workspaces: ${knownNames.join(', ')}`);
         process.exit(1);
       }
+    }
+
+    // Reject `--only` invocations that would silently strand changes in excluded internal
+    // dependents. Runs before the filter mutates `config.workspaces` so the validator sees
+    // the full pre-filter graph.
+    const graph = buildDependencyGraph(config.workspaces);
+    const violations = validateOnlyExcludesStrandedDependents(config.workspaces, only, graph, (workspace) => {
+      const tagPrefixes = [
+        workspace.tagPrefix,
+        ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? []),
+      ];
+      const result = getCommitsSinceTarget(tagPrefixes, workspace.paths);
+      return { has: result.commits.length > 0, tag: result.tag };
+    });
+
+    if (violations !== undefined) {
+      console.error('Error: --only excludes packages with changes that would be stranded by the release.');
+      console.error('The following packages must be added to --only or have their dependencies removed:');
+      for (const violation of violations) {
+        const since = violation.tag ?? 'the beginning';
+        console.error(`  - ${violation.dir} (downstream of ${violation.downstreamOf}; has commits since ${since})`);
+      }
+      console.error('Alternatively, run `release-kit prepare` without --only to release everything.');
+      process.exit(1);
     }
 
     config.workspaces = config.workspaces.filter((w) => only.includes(w.dir));

--- a/packages/release-kit/src/validateOnlyExcludesStrandedDependents.ts
+++ b/packages/release-kit/src/validateOnlyExcludesStrandedDependents.ts
@@ -1,0 +1,207 @@
+import type { DependencyGraph } from './buildDependencyGraph.ts';
+import type { WorkspaceConfig } from './types.ts';
+
+/** Result of probing a workspace's commits since its last tag. */
+export interface CommitsProbeResult {
+  /** Whether the workspace has any commits since its last tag (excluding `release:` commits). */
+  has: boolean;
+  /** The baseline tag the commits were measured from; `undefined` when no prior tag exists. */
+  tag: string | undefined;
+}
+
+/** A single excluded workspace whose changes would be stranded by the `--only` invocation. */
+export interface StrandedDependentViolation {
+  /** The excluded workspace's `dir`. */
+  dir: string;
+  /** The released workspace's `dir` whose release would have triggered D's republication. */
+  downstreamOf: string;
+  /** The baseline tag from which D's commits were counted; `undefined` if no prior tag. */
+  tag: string | undefined;
+}
+
+/** Probe callback that returns whether a workspace has commits since its last tag. */
+type CommitsProbe = (workspace: WorkspaceConfig) => CommitsProbeResult;
+
+/**
+ * Detect `--only` invocations that would silently strand changes in excluded internal dependents.
+ *
+ * Runs in two steps. First, compute the released `--only` set R via fixpoint: start with `--only`
+ * workspaces that have own commits, then iteratively add `--only` workspaces whose `workspace:`
+ * deps land in R (those will release via propagation). Second, BFS through the reverse-dep graph
+ * starting from R, recording each excluded workspace with own commits as a violation. The walk
+ * continues *through* such workspaces (anticipating that the user will add them to `--only`,
+ * surfacing deeper footguns in one pass), but stops at excluded workspaces with no commits
+ * (case-3 barriers — they don't republish, so their downstream dependents aren't affected by R).
+ *
+ * Returns `undefined` when no violations are found, or a sorted list otherwise.
+ */
+export function validateOnlyExcludesStrandedDependents(
+  workspaces: readonly WorkspaceConfig[],
+  only: readonly string[],
+  graph: DependencyGraph,
+  hasCommits: CommitsProbe,
+): StrandedDependentViolation[] | undefined {
+  const probeCommits = memoizeCommitsProbe(hasCommits);
+  const workspaceByDir = new Map(workspaces.map((w) => [w.dir, w] as const));
+
+  const released = computeReleasedSet(only, workspaceByDir, graph, probeCommits);
+  const violations = collectStrandedViolations(released, new Set(only), graph, probeCommits);
+
+  if (violations.length === 0) return undefined;
+  violations.sort((a, b) => a.dir.localeCompare(b.dir));
+  return violations;
+}
+
+// region | Helpers
+
+/** Wrap a commits probe with a per-workspace cache so each workspace is queried at most once. */
+function memoizeCommitsProbe(probe: CommitsProbe): CommitsProbe {
+  const cache = new Map<string, CommitsProbeResult>();
+  return (workspace) => {
+    const cached = cache.get(workspace.dir);
+    if (cached !== undefined) return cached;
+    const result = probe(workspace);
+    cache.set(workspace.dir, result);
+    return result;
+  };
+}
+
+/**
+ * Compute R: the set of `--only` workspaces that will release.
+ *
+ * Initial members are `--only` workspaces with their own commits since their last tag. The fixpoint
+ * adds `--only` workspaces whose internal deps land in R, since those will release via propagation.
+ */
+function computeReleasedSet(
+  only: readonly string[],
+  workspaceByDir: ReadonlyMap<string, WorkspaceConfig>,
+  graph: DependencyGraph,
+  probeCommits: CommitsProbe,
+): Set<string> {
+  const released = new Set<string>();
+  for (const dir of only) {
+    const workspace = workspaceByDir.get(dir);
+    if (workspace !== undefined && probeCommits(workspace).has) {
+      released.add(dir);
+    }
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const dir of only) {
+      if (released.has(dir)) continue;
+      if (hasDependencyIn(dir, graph, released)) {
+        released.add(dir);
+        changed = true;
+      }
+    }
+  }
+  return released;
+}
+
+/** Whether `dir` declares a `workspace:` dep on any workspace in `released`. */
+function hasDependencyIn(dir: string, graph: DependencyGraph, released: ReadonlySet<string>): boolean {
+  const forwardDeps = graph.dependenciesOf.get(dir);
+  if (forwardDeps === undefined) return false;
+  for (const depPackageName of forwardDeps) {
+    const depDir = graph.packageNameToDir.get(depPackageName);
+    if (depDir !== undefined && released.has(depDir)) return true;
+  }
+  return false;
+}
+
+/**
+ * BFS through the reverse-dep graph starting from R; record excluded changed dependents as
+ * violations. Walks *through* recorded violations (anticipated user fix), but stops at excluded
+ * no-commit dependents (case-3 barriers).
+ */
+function collectStrandedViolations(
+  released: ReadonlySet<string>,
+  onlySet: ReadonlySet<string>,
+  graph: DependencyGraph,
+  probeCommits: CommitsProbe,
+): StrandedDependentViolation[] {
+  const violations: StrandedDependentViolation[] = [];
+  const violationDirs = new Set<string>();
+  const visited = new Set<string>();
+  const queue: { packageName: string; releasedAncestor: string }[] = [];
+
+  for (const dir of released) {
+    const packageName = graph.dirToPackageName.get(dir);
+    if (packageName !== undefined) {
+      queue.push({ packageName, releasedAncestor: dir });
+    }
+  }
+
+  while (queue.length > 0) {
+    const item = queue.shift();
+    if (item === undefined) break;
+    if (visited.has(item.packageName)) continue;
+    visited.add(item.packageName);
+
+    const dependents = graph.dependentsOf.get(item.packageName);
+    if (dependents === undefined) continue;
+
+    for (const dependent of dependents) {
+      visitDependent(dependent, item.releasedAncestor, {
+        released,
+        onlySet,
+        graph,
+        probeCommits,
+        queue,
+        violations,
+        violationDirs,
+      });
+    }
+  }
+
+  return violations;
+}
+
+interface VisitDependentContext {
+  released: ReadonlySet<string>;
+  onlySet: ReadonlySet<string>;
+  graph: DependencyGraph;
+  probeCommits: CommitsProbe;
+  queue: { packageName: string; releasedAncestor: string }[];
+  violations: StrandedDependentViolation[];
+  violationDirs: Set<string>;
+}
+
+/** Classify a single dependent: skip, walk-through, or record as a violation (and walk through). */
+function visitDependent(dependent: WorkspaceConfig, releasedAncestor: string, ctx: VisitDependentContext): void {
+  if (ctx.onlySet.has(dependent.dir)) {
+    // Walk through `--only` dependents only when they will actually release (i.e., are in R).
+    // A `--only` workspace not in R has no commits and no propagation source — it doesn't
+    // release, so we should not propagate the walk through it.
+    if (ctx.released.has(dependent.dir)) {
+      enqueueDependent(dependent, dependent.dir, ctx);
+    }
+    return;
+  }
+
+  const probe = ctx.probeCommits(dependent);
+  if (!probe.has) return; // Case-3 barrier: excluded with no commits.
+
+  if (!ctx.violationDirs.has(dependent.dir)) {
+    ctx.violationDirs.add(dependent.dir);
+    ctx.violations.push({
+      dir: dependent.dir,
+      downstreamOf: releasedAncestor,
+      tag: probe.tag,
+    });
+  }
+
+  // Walk through the violating dependent: anticipate the user adding it to `--only`,
+  // which would put it in R and surface any deeper footguns in this same pass.
+  enqueueDependent(dependent, dependent.dir, ctx);
+}
+
+/** Push the dependent onto the BFS queue using its package name as the new frontier key. */
+function enqueueDependent(dependent: WorkspaceConfig, releasedAncestor: string, ctx: VisitDependentContext): void {
+  const packageName = ctx.graph.dirToPackageName.get(dependent.dir);
+  if (packageName !== undefined) {
+    ctx.queue.push({ packageName, releasedAncestor });
+  }
+}

--- a/packages/release-kit/src/validateOnlyExcludesStrandedDependents.ts
+++ b/packages/release-kit/src/validateOnlyExcludesStrandedDependents.ts
@@ -125,12 +125,12 @@ function collectStrandedViolations(
   const violations: StrandedDependentViolation[] = [];
   const violationDirs = new Set<string>();
   const visited = new Set<string>();
-  const queue: { packageName: string; releasedAncestor: string }[] = [];
+  const queue: BfsFrontierItem[] = [];
 
   for (const dir of released) {
     const packageName = graph.dirToPackageName.get(dir);
     if (packageName !== undefined) {
-      queue.push({ packageName, releasedAncestor: dir });
+      queue.push({ packageName, attributionRoot: dir });
     }
   }
 
@@ -144,7 +144,7 @@ function collectStrandedViolations(
     if (dependents === undefined) continue;
 
     for (const dependent of dependents) {
-      visitDependent(dependent, item.releasedAncestor, {
+      visitDependent(dependent, item.attributionRoot, {
         released,
         onlySet,
         graph,
@@ -159,24 +159,37 @@ function collectStrandedViolations(
   return violations;
 }
 
+/**
+ * One node in the BFS frontier. `attributionRoot` is the workspace whose release (or anticipated
+ * release) propagation reached this node — the value that downstream violations cite as their
+ * `downstreamOf`. When the BFS walks past a node N (either an `--only` ∩ R member or an excluded
+ * would-release violation that the user is expected to add to `--only`), the next frontier item's
+ * `attributionRoot` becomes N — that node is now the most proximate release point to anything
+ * deeper in the chain.
+ */
+interface BfsFrontierItem {
+  packageName: string;
+  attributionRoot: string;
+}
+
 interface VisitDependentContext {
   released: ReadonlySet<string>;
   onlySet: ReadonlySet<string>;
   graph: DependencyGraph;
   probeCommits: CommitsProbe;
-  queue: { packageName: string; releasedAncestor: string }[];
+  queue: BfsFrontierItem[];
   violations: StrandedDependentViolation[];
   violationDirs: Set<string>;
 }
 
 /** Classify a single dependent: skip, walk-through, or record as a violation (and walk through). */
-function visitDependent(dependent: WorkspaceConfig, releasedAncestor: string, ctx: VisitDependentContext): void {
+function visitDependent(dependent: WorkspaceConfig, attributionRoot: string, ctx: VisitDependentContext): void {
   if (ctx.onlySet.has(dependent.dir)) {
     // Walk through `--only` dependents only when they will actually release (i.e., are in R).
     // A `--only` workspace not in R has no commits and no propagation source — it doesn't
     // release, so we should not propagate the walk through it.
     if (ctx.released.has(dependent.dir)) {
-      enqueueDependent(dependent, dependent.dir, ctx);
+      enqueueDependent(dependent, ctx);
     }
     return;
   }
@@ -188,20 +201,23 @@ function visitDependent(dependent: WorkspaceConfig, releasedAncestor: string, ct
     ctx.violationDirs.add(dependent.dir);
     ctx.violations.push({
       dir: dependent.dir,
-      downstreamOf: releasedAncestor,
+      downstreamOf: attributionRoot,
       tag: probe.tag,
     });
   }
 
   // Walk through the violating dependent: anticipate the user adding it to `--only`,
   // which would put it in R and surface any deeper footguns in this same pass.
-  enqueueDependent(dependent, dependent.dir, ctx);
+  enqueueDependent(dependent, ctx);
 }
 
-/** Push the dependent onto the BFS queue using its package name as the new frontier key. */
-function enqueueDependent(dependent: WorkspaceConfig, releasedAncestor: string, ctx: VisitDependentContext): void {
+/**
+ * Push the dependent onto the BFS queue, using its `dir` as the new `attributionRoot` for any
+ * deeper violations the BFS uncovers through it.
+ */
+function enqueueDependent(dependent: WorkspaceConfig, ctx: VisitDependentContext): void {
   const packageName = ctx.graph.dirToPackageName.get(dependent.dir);
   if (packageName !== undefined) {
-    ctx.queue.push({ packageName, releasedAncestor });
+    ctx.queue.push({ packageName, attributionRoot: dependent.dir });
   }
 }


### PR DESCRIPTION
## What

Fixes a silent footgun in `release-kit prepare --only=...`: an excluded internal dependent with its own changes would be left unreleased with no runtime signal, even though the targeted workspace it depends on was being released. The command now rejects such invocations up front, naming every excluded dependent whose changes would be stranded.

The error message lists each offender along with the released workspace it depends on and the baseline tag from which its commits were counted, so the user can fix the invocation in a single step. Existing rejection paths (unknown workspace name, `--only` combined with a project release) continue to behave as before.

## Why

Filtering `config.workspaces` to the `--only` set built the dependency graph from the filtered list, so propagation could not reach any workspace not in `--only`. If `B` depended on `A`, both had release-worthy commits, and the user ran `--only=A`, the run released `A` and silently dropped `B`'s changes — easy to forget about, especially in CI. The user's intent ("come back for B later") was right in spirit but had no enforcement.

## Details

### Fixes

- A new validator runs in `prepareCommand.runMonorepoMode` after the unknown-name check and before the `--only` filter mutates `config.workspaces`. It builds the dependency graph from the full pre-filter workspace list.
- The validator computes the released `--only` set `R` via fixpoint: starts with `--only` workspaces that have their own commits since their last tag, then iteratively adds `--only` workspaces whose internal deps land in `R` (these will release via propagation).
- A BFS walks the reverse-dep graph from `R`. Excluded dependents with their own commits are recorded as violations and walked through (so deeper footguns in a chain surface in one pass). Excluded dependents with no commits act as case-3 barriers: they don't republish, so the walk stops at them. `--only` workspaces not in `R` are also barriers, since they don't release.
- All violations are reported in a single rejection that names each offender, the released workspace it depends on, and the baseline tag, with an alternative ("run without `--only`") spelled out in the message.

### Refactoring

- `DependencyGraph` is extended with a forward `dependenciesOf: Map<string, Set<string>>` map alongside the existing reverse `dependentsOf`. Both are populated in the same `package.json` second pass — no extra reads.
- The validator is split into a primary `validateOnlyExcludesStrandedDependents` orchestrator with named helpers (`memoizeCommitsProbe`, `computeReleasedSet`, `hasDependencyIn`, `collectStrandedViolations`, `visitDependent`, `enqueueDependent`). The BFS frontier shape is captured in a named `BfsFrontierItem` interface; its `attributionRoot` field documents the role the value plays as the workspace downstream violations cite as their `downstreamOf`.

### Tests

- A new validator unit test file covers eleven cases: cases A and B from the ticket, the case-3 barrier, single direct violation, multiple at the same depth, the transitive-via-fixpoint case, the deep-chain anticipated-fix walk-through, the empty-`R` short-circuit, the `--only`-not-in-`R` barrier, undefined-tag preservation, and probe memoization.
- One integration test in `prepareCommand.unit.test.ts` verifies the wiring fires when `strings` declares a `workspace:*` dep on `arrays` and both have commits, and that `releasePrepareMono` is not invoked when the validator rejects.
- Helper definitions in `propagateBumps.unit.test.ts` and `prepareCommand.unit.test.ts` were moved to the bottom of each file under `// region | Helpers` markers, matching the project's "primary logic first" convention. The `propagateBumps` test fixture's `makeGraph` was updated to include `dependenciesOf: new Map()` for the extended interface.

Closes #318