### PR TITLE
#323 Label prepare errors with the failing stage

### DIFF
--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -257,6 +257,26 @@ describe(prepareCommand, () => {
     );
   });
 
+  it('prints stage-attributed errors verbatim without an outer "Error preparing release:" prefix', async () => {
+    mockReleasePrepareMono.mockImplementation(() => {
+      throw new Error("workspace 'arrays' release stage: bumpAllVersions failed: ENOENT");
+    });
+
+    await expect(prepareCommand([])).rejects.toThrow(ExitError);
+    expect(console.error).toHaveBeenCalledWith("workspace 'arrays' release stage: bumpAllVersions failed: ENOENT");
+    expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
+  });
+
+  it('prints validation errors verbatim without an outer "Error preparing release:" prefix', async () => {
+    mockReleasePrepareMono.mockImplementation(() => {
+      throw new Error('--set-version 0.3.0 is not greater than current version 0.5.0');
+    });
+
+    await expect(prepareCommand([])).rejects.toThrow(ExitError);
+    expect(console.error).toHaveBeenCalledWith('--set-version 0.3.0 is not greater than current version 0.5.0');
+    expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
+  });
+
   it('exits with a distinct error when writing release tags fails', async () => {
     mockWriteFileWithCheck.mockReturnValue({
       filePath: RELEASE_TAGS_FILE,

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -1667,4 +1667,135 @@ describe(releasePrepareMono, () => {
       );
     });
   });
+
+  describe('stage attribution', () => {
+    function makeArraysConfig(overrides?: Partial<MonorepoReleaseConfig>): MonorepoReleaseConfig {
+      return makeConfig({
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+        ],
+        ...overrides,
+      });
+    }
+
+    /** Run `fn` and return the thrown Error. Fails the test if no Error is thrown. */
+    function captureError(fn: () => unknown): Error {
+      try {
+        fn();
+      } catch (error) {
+        if (error instanceof Error) return error;
+        throw new Error(`Expected an Error to be thrown, got ${typeof error}: ${String(error)}`);
+      }
+      throw new Error('Expected fn to throw, but it returned normally');
+    }
+
+    it("wraps a Phase 1 (bump-determination) throw with the workspace's release-stage label", () => {
+      const config = makeArraysConfig();
+      // Make the very first git invocation (`getCommitsSinceTarget`) throw — this exercises
+      // the Phase 1 wrap inside `determineDirectBumps`.
+      const underlying = new Error('git describe failed: not a git repo');
+      mockExecFileSync.mockImplementation(() => {
+        throw underlying;
+      });
+
+      const wrapped = captureError(() => releasePrepareMono(config, { dryRun: false }));
+
+      expect(wrapped.message).toMatch(/^workspace 'arrays' release stage: .*git describe failed: not a git repo$/);
+      // `cause` is preserved through the chain — at minimum, an Error instance.
+      expect(wrapped.cause).toBeInstanceOf(Error);
+    });
+
+    it("wraps a Phase 3 (executeWorkspaceRelease) throw with the workspace's release-stage label", () => {
+      const config = makeArraysConfig();
+      // Phase 1 succeeds (git describe + git log succeed). The cliff invocation in
+      // `generateChangelog` (which `executeWorkspaceRelease` calls) throws — this exercises
+      // the Phase 3 wrap inside `executeReleaseSet`.
+      const underlying = new Error('git-cliff exited with status 1');
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'arrays-v1.0.0\n';
+        if (cmd === 'git' && args[0] === 'log') return 'feat: addabc123';
+        if (cmd === 'npx') throw underlying;
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+      const wrapped = captureError(() => releasePrepareMono(config, { dryRun: false }));
+
+      expect(wrapped.message).toMatch(/^workspace 'arrays' release stage: .*git-cliff exited with status 1$/);
+      // `cause` is preserved through the chain — at minimum, an Error instance.
+      expect(wrapped.cause).toBeInstanceOf(Error);
+    });
+
+    it('wraps a project-stage throw with the project release-stage label', () => {
+      const config = makeArraysConfig({ project: { tagPrefix: 'v' } });
+      // Workspace stage succeeds; the project stage's git-cliff call throws.
+      const underlying = new Error('cliff exploded on root');
+      let cliffCallCount = 0;
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          const matchArg = args.find((a: string) => a.startsWith('--match='));
+          if (matchArg === '--match=arrays-v*') return 'arrays-v1.0.0\n';
+          if (matchArg === '--match=v*') return 'v0.9.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') return `feat: shipabc123`;
+        if (cmd === 'npx') {
+          cliffCallCount += 1;
+          // First cliff call is the workspace's; second is the project's.
+          if (cliffCallCount >= 2) throw underlying;
+        }
+        return '';
+      });
+      mockReadFileSync.mockImplementation((filePath: string) => {
+        if (filePath === './package.json') return JSON.stringify({ name: 'root', version: '0.9.0' });
+        return JSON.stringify({ version: '1.0.0' });
+      });
+
+      const wrapped = captureError(() => releasePrepareMono(config, { dryRun: false }));
+
+      expect(wrapped.message).toMatch(/^project release stage: .*cliff exploded on root$/);
+      expect(wrapped.cause).toBeInstanceOf(Error);
+    });
+
+    it('wraps a format-stage throw with the format-stage label and the failing command', () => {
+      const config = makeArraysConfig({ formatCommand: 'npx prettier --write' });
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'arrays-v1.0.0\n';
+        if (cmd === 'git' && args[0] === 'log') return 'feat: addbarabc123';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+      const underlying = new Error('prettier exited 2');
+      mockExecSync.mockImplementation(() => {
+        throw underlying;
+      });
+
+      const wrapped = captureError(() => releasePrepareMono(config, { dryRun: false }));
+
+      expect(wrapped.message).toMatch(/^format stage: prettier exited 2 \(command: 'npx prettier --write .+'\)$/);
+      expect(wrapped.cause).toBe(underlying);
+    });
+
+    it('does not wrap --set-version validation throws with a stage label', () => {
+      const config = makeArraysConfig();
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'arrays-v0.5.0\n';
+        if (cmd === 'git' && args[0] === 'log') return '';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/arrays', version: '0.5.0' }));
+
+      const wrapped = captureError(() => releasePrepareMono(config, { dryRun: false, setVersion: '0.3.0' }));
+
+      expect(wrapped.message).toBe('--set-version 0.3.0 is not greater than current version 0.5.0');
+      expect(wrapped.message).not.toContain('stage:');
+    });
+  });
 });

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -386,7 +386,7 @@ function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
   try {
     result = execute();
   } catch (error: unknown) {
-    console.error('Error preparing release:', error instanceof Error ? error.message : String(error));
+    console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -144,9 +144,8 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
       try {
         execSync(fullCommand, { stdio: 'inherit' });
       } catch (error: unknown) {
-        throw new Error(
-          `Format command failed ('${fullCommand}'): ${error instanceof Error ? error.message : String(error)}`,
-        );
+        const baseMessage = error instanceof Error ? error.message : String(error);
+        throw new Error(`format stage: ${baseMessage} (command: '${fullCommand}')`, { cause: error });
       }
       formatCommand = { command: fullCommand, executed: true, files: modifiedFiles };
     }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -137,7 +137,7 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
   // a per-workspace narrowing guard here.
   let project: ProjectPrepareResult | undefined;
   if (config.project !== undefined) {
-    project = releasePrepareProject({ config, options, modifiedFiles, tags });
+    project = tryStage('project release stage', () => releasePrepareProject({ config, options, modifiedFiles, tags }));
   }
 
   // === Phase 4: Format ===
@@ -178,7 +178,11 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
 
   for (const workspace of config.workspaces) {
     const name = workspace.dir;
-    const { tag, commits } = getCommitsSinceTarget(getAllTagPrefixes(workspace), workspace.paths);
+    const stageLabel = workspaceStageLabel(workspace.dir);
+
+    const { tag, commits } = tryStage(stageLabel, () =>
+      getCommitsSinceTarget(getAllTagPrefixes(workspace), workspace.paths),
+    );
     const since = tag === undefined ? '(no previous release found)' : `since ${tag}`;
 
     if (tag === undefined) {
@@ -190,7 +194,7 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
     // pre-write current version.
     const primaryPackageFile = workspace.packageFiles[0];
     if (primaryPackageFile !== undefined) {
-      const currentVersion = readCurrentVersion(primaryPackageFile);
+      const currentVersion = tryStage(stageLabel, () => readCurrentVersion(primaryPackageFile));
       if (currentVersion !== undefined) {
         currentVersions.set(workspace.dir, currentVersion);
       }
@@ -243,7 +247,9 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
     let unparseableCommits: Commit[] | undefined;
 
     if (bumpOverride === undefined) {
-      const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.scopeAliases);
+      const determination = tryStage(stageLabel, () =>
+        determineBumpFromCommits(commits, workTypes, versionPatterns, config.scopeAliases),
+      );
       parsedCommitCount = determination.parsedCommitCount;
       unparseableCommits = determination.unparseableCommits;
       releaseType = determination.releaseType;
@@ -336,20 +342,22 @@ function executeReleaseSet(
       continue;
     }
 
-    executeWorkspaceRelease({
-      dir,
-      workspace,
-      releaseEntry,
-      directResult: directResults.get(dir),
-      previousTags,
-      config,
-      dryRun,
-      today,
-      tags,
-      modifiedFiles,
-      workspaces,
-      previewOptions,
-    });
+    tryStage(workspaceStageLabel(dir), () =>
+      executeWorkspaceRelease({
+        dir,
+        workspace,
+        releaseEntry,
+        directResult: directResults.get(dir),
+        previousTags,
+        config,
+        dryRun,
+        today,
+        tags,
+        modifiedFiles,
+        workspaces,
+        previewOptions,
+      }),
+    );
   }
 
   return { tags, modifiedFiles };
@@ -569,9 +577,8 @@ function runFormatCommand(
   try {
     execSync(fullCommand, { stdio: 'inherit' });
   } catch (error: unknown) {
-    throw new Error(
-      `Format command failed ('${fullCommand}'): ${error instanceof Error ? error.message : String(error)}`,
-    );
+    const baseMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`format stage: ${baseMessage} (command: '${fullCommand}')`, { cause: error });
   }
 
   return { command: fullCommand, executed: true, files: modifiedFiles };
@@ -580,6 +587,30 @@ function runFormatCommand(
 /** Find a workspace by its `dir` in the workspaces array. */
 function findWorkspace(workspaces: readonly WorkspaceConfig[], dir: string): WorkspaceConfig | undefined {
   return workspaces.find((w) => w.dir === dir);
+}
+
+/**
+ * Wrap an unknown thrown value with a stage label, preserving the original via `Error.cause`.
+ * The resulting message starts with `<stageLabel>:` so the outer CLI boundary can recognize
+ * stage-attributed errors.
+ */
+function wrapStageError(stageLabel: string, error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  return new Error(`${stageLabel}: ${message}`, { cause: error });
+}
+
+/** Run `fn` and rethrow any thrown value wrapped with a stage label via `wrapStageError`. */
+function tryStage<T>(stageLabel: string, fn: () => T): T {
+  try {
+    return fn();
+  } catch (error) {
+    throw wrapStageError(stageLabel, error);
+  }
+}
+
+/** Build the per-workspace stage label used for both Phase 1 and Phase 3 attribution. */
+function workspaceStageLabel(dir: string): string {
+  return `workspace '${dir}' release stage`;
 }
 
 /** Shared single-fire flag so multiple no-baseline workspaces trigger at most one hint per run. */


### PR DESCRIPTION
## What

Identifies which stage of the `release-kit prepare` pipeline is responsible when an error surfaces. Errors thrown during per-workspace bumps and changelog generation, the project release stage, or the post-release format command now begin with a stage label that names the failing stage and (where relevant) the affected workspace, so a user reading stderr no longer has to infer the source from path hints in the underlying message.

The new shapes:

- Per-workspace errors: `workspace '<dir>' release stage: <message>`
- Project errors: `project release stage: <message>`
- Format-command errors: `format stage: <message> (command: '<full command>')`

The original error is preserved via `Error.cause`, so stack traces and downstream debugging tooling continue to see the underlying cause.

The outer `Error preparing release:` prefix that `runAndReport` previously prepended to every caught error has been removed. The CLI command name in the user's terminal already provides framing, and stage labels carry stage-level attribution. Validation throws (e.g., `--set-version` checks) keep their bare, self-describing format and now surface verbatim instead of being doubly prefixed.

## Why

`release-kit prepare` runs across many workspaces and orchestrates several distinct stages (per-workspace bumps and changelogs, an optional project-level release, and a final format pass). When any of those stages threw, the outer boundary caught the error and emitted `Error preparing release: <opaque message>` with no indication of which stage or workspace was responsible. For a monorepo with many packages, this turned stderr into a guessing game — the user had to read the underlying message body and infer the source from filesystem path hints, when present.

This change replaces the opaque framing with explicit stage attribution at every entrypoint that can throw, mirroring the symmetric pattern proposed for the project-stage spike (#316).

## Details

### Features

- Adds a small `wrapStageError` helper and a `tryStage` wrapper in `releasePrepareMono.ts` that produce the new error shape and preserve `Error.cause`. Per-workspace iterations in both `determineDirectBumps` (Phase 1) and `executeReleaseSet` (Phase 3) now flow their throws through `tryStage` with a `workspace '<dir>' release stage` label; the `releasePrepareProject` call site uses `project release stage`; and `runFormatCommand` builds a `format stage: <message> (command: '<cmd>')` error inline so the failing command stays in the diagnostic.
- Aligns the single-package `releasePrepare.ts` format-command error to the same `format stage:` shape so both monorepo and single-package modes produce consistent output.
- Removes the unconditional `Error preparing release:` prefix from `runAndReport` in `prepareCommand.ts`. Every caught error now surfaces verbatim — stage-attributed errors keep their stage label, and `--set-version` validation throws (which sit outside the wrapped regions) keep their existing self-describing wording.

### Tests

- Adds five new tests in `releasePrepareMono.unit.test.ts` covering the four wrapped sites: a Phase 1 `getCommitsSinceTarget` failure, a Phase 3 `git-cliff` failure, a project-stage failure, a format-stage `execSync` failure (asserting `Error.cause` is preserved), and a `--set-version` validation throw (asserting the unwrapped path remains untouched).
- Adds two new tests in `prepareCommand.unit.test.ts` confirming that both stage-attributed errors and validation throws surface bare in `console.error`, with no `Error preparing release:` prefix.

Closes #323
