### PR TITLE
#315 Cover untested project-release and config branches

### DIFF
--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -410,6 +410,14 @@ describe(readRootPackageVersion, () => {
     mockReadFileSync.mockReturnValue('{ not valid json');
     expect(() => readRootPackageVersion()).toThrow(/Failed to parse root package\.json/);
   });
+
+  it('throws an error when reading the root package.json fails (I/O error)', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('permission denied');
+    });
+    expect(() => readRootPackageVersion()).toThrow(/Failed to read root package\.json/);
+  });
 });
 
 describe('mergeMonorepoConfig project block', () => {

--- a/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
@@ -285,6 +285,27 @@ describe(releasePrepareProject, () => {
     expect(cliffArgs).toContain('v0.10.0');
   });
 
+  it('omits paths of workspaces absent from config.workspaces (e.g., excluded by discovery or --only)', () => {
+    setupDefaultGit();
+    const config = makeConfig({
+      workspaces: [makeWorkspace({ dir: 'arrays' })],
+    });
+
+    releasePrepareProject({
+      config,
+      options: { dryRun: false },
+      modifiedFiles: [],
+      tags: [],
+    });
+
+    const cliffCall = mockExecFileSync.mock.calls.find(
+      (call) => call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff'),
+    );
+    const cliffArgs = cliffCall?.[1] ?? [];
+    expect(cliffArgs).toContain('packages/arrays/**');
+    expect(cliffArgs).not.toContain('packages/legacy/**');
+  });
+
   it('uses bumpOverride instead of commit-derived bump type', () => {
     setupDefaultGit();
     // Use a 1.x baseline so the major bump is not collapsed by the pre-1.0 rule in `bumpVersion`.

--- a/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
@@ -729,6 +729,56 @@ describe(reportPrepare, () => {
       expect(output).not.toContain(sectionHeader('project'));
     });
 
+    it('renders "(no previous release found)" when project.previousTag is undefined on a released project', () => {
+      const result: PrepareResult = {
+        workspaces: [],
+        tags: ['v0.1.0'],
+        dryRun: false,
+        project: {
+          status: 'released',
+          previousTag: undefined,
+          commitCount: 1,
+          parsedCommitCount: 1,
+          releaseType: 'minor',
+          currentVersion: '0.0.0',
+          newVersion: '0.1.0',
+          tag: 'v0.1.0',
+          bumpedFiles: ['./package.json'],
+          changelogFiles: ['./CHANGELOG.md'],
+        },
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain(dim('  Found 1 commits (no previous release found)'));
+    });
+
+    it('renders the unparseable-commit warning block in a released project section', () => {
+      const result: PrepareResult = {
+        workspaces: [],
+        tags: ['v0.9.1'],
+        dryRun: false,
+        project: {
+          status: 'released',
+          previousTag: 'v0.9.0',
+          commitCount: 1,
+          parsedCommitCount: 0,
+          releaseType: 'patch',
+          currentVersion: '0.9.0',
+          newVersion: '0.9.1',
+          tag: 'v0.9.1',
+          bumpedFiles: ['./package.json'],
+          changelogFiles: ['./CHANGELOG.md'],
+          unparseableCommits: [{ message: 'wip: undocumented', hash: 'abc1234def' }],
+        },
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('⚠️  1 commit could not be parsed (defaulting to patch bump)');
+      expect(output).toContain('· abc1234 wip: undocumented');
+    });
+
     it('renders a skipped project section as a header + commit count + skipReason', () => {
       // Mirrors the per-workspace skipped rendering: section header, "Found N commits"
       // line, and the skipReason — no bump-override line, no version line, no tag.


### PR DESCRIPTION
## What

Closes four mechanical test-coverage gaps in the project-level release surfaces flagged in the test review of #308. New cases exercise the `(no previous release found)` rendering for released projects, the unparseable-commit warning block on the released-project rendering path, the `readFileSync` I/O failure path in `readRootPackageVersion`, and the contributing-paths invariant in `releasePrepareProject`. No production code changes — these are pure-render and pure-derivation branches that previously had no test exercising them.

## Why

The project-level release feature (#308) landed with several uncovered branches that were identified by the test review but deferred. Recent prepare-API changes (#313, `--force` and `--bump` orthogonal) reshaped the `ProjectPrepareResult` and the rendering rules but did not fill these specific gaps. Closing them tightens coverage on the project rendering and config-load paths and documents an invariant that future refactors might otherwise silently break.

## Details

### Tests

- `reportPrepare.unit.test.ts`: adds two cases inside the `project release section` describe block.
  - `previousTag === undefined` on a released project asserts the `(no previous release found)` rendering.
  - A released-project fixture with `parsedCommitCount: 0`, `releaseType: 'patch'`, and a single unparseable commit asserts the `⚠️` warning, the `(defaulting to patch bump)` suffix, and the shortened-hash rendering. This exercises `formatProjectUnparseable`, which the existing skipped-project tests intentionally skip.
- `loadConfig.unit.test.ts`: adds one case inside the `readRootPackageVersion` describe block. Mocks `readFileSync` to throw and asserts the error matches `/Failed to read root package\.json/`. Covers the I/O failure throw path alongside the existing `JSON.parse` failure test.
- `releasePrepareProject.unit.test.ts`: adds one case asserting the contributing-paths invariant. Configures a single workspace and asserts the captured `git-cliff --include-path` args contain that workspace's glob but do not contain a glob for any workspace absent from `config.workspaces`. Documents the rule that contributing paths are derived purely from `config.workspaces.flatMap(w => w.paths)`.

Coverage moved as expected: `releasePrepareProject.ts` reaches 100% statement coverage, and the previously uncovered branches in `loadConfig.ts` and `reportPrepare.ts` are now exercised.

Closes #315
