### PR TITLE
#332 Order prerelease versions correctly in changelog sort

### DIFF
--- a/packages/release-kit/package.json
+++ b/packages/release-kit/package.json
@@ -44,10 +44,12 @@
     "glob": "13.0.6",
     "jiti": "2.6.1",
     "js-yaml": "4.1.1",
-    "json-stringify-pretty-compact": "4.0.0"
+    "json-stringify-pretty-compact": "4.0.0",
+    "semver": "7.7.4"
   },
   "devDependencies": {
     "@types/js-yaml": "4.0.9",
+    "@types/semver": "7.7.1",
     "smol-toml": "1.6.1"
   },
   "engines": {

--- a/packages/release-kit/src/__tests__/changelogJsonFile.unit.test.ts
+++ b/packages/release-kit/src/__tests__/changelogJsonFile.unit.test.ts
@@ -108,6 +108,64 @@ describe(writeChangelogJson, () => {
   });
 });
 
+describe('writeChangelogJson — version sort semantics', () => {
+  let tempDir: string;
+  let outputPath: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `test-sort-changelog-json-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+    outputPath = join(tempDir, '.meta', 'changelog.json');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeAndReadVersions(versions: string[]): string[] {
+    const entries: ChangelogEntry[] = versions.map((version) => ({ version, date: '2024-01-01', sections: [] }));
+    writeChangelogJson(outputPath, entries);
+    const written: ChangelogEntry[] = JSON.parse(readFileSync(outputPath, 'utf8'));
+    return written.map((e) => e.version);
+  }
+
+  it('orders releases by SemVer numeric precedence, not lexical (1.10.0 > 1.2.0)', () => {
+    expect(writeAndReadVersions(['1.2.0', '0.9.0', '1.10.0'])).toStrictEqual(['1.10.0', '1.2.0', '0.9.0']);
+  });
+
+  it('places a prerelease before its corresponding release per SemVer §11', () => {
+    expect(writeAndReadVersions(['1.2.3-alpha', '1.2.3-rc.1', '1.2.3'])).toStrictEqual([
+      '1.2.3',
+      '1.2.3-rc.1',
+      '1.2.3-alpha',
+    ]);
+  });
+
+  it('orders same-base prereleases lexically (alpha < beta)', () => {
+    expect(writeAndReadVersions(['1.2.3-beta', '1.2.3-alpha'])).toStrictEqual(['1.2.3-beta', '1.2.3-alpha']);
+  });
+
+  it('compares numeric prerelease identifiers numerically (rc.10 > rc.2)', () => {
+    expect(writeAndReadVersions(['1.2.3-rc.2', '1.2.3-rc.10'])).toStrictEqual(['1.2.3-rc.10', '1.2.3-rc.2']);
+  });
+
+  it('ignores build metadata for ordering — build-metadata variants of the same version rank equally', () => {
+    const result = writeAndReadVersions(['1.0.0', '1.2.3+build.2', '1.2.3+build.1', '0.9.0']);
+    // Both 1.2.3+build.* versions outrank 1.0.0 and 0.9.0 and stay together (their order
+    // relative to each other is implementation-defined; stable sort preserves input order).
+    expect(result.slice(2)).toStrictEqual(['1.0.0', '0.9.0']);
+    expect(new Set(result.slice(0, 2))).toStrictEqual(new Set(['1.2.3+build.1', '1.2.3+build.2']));
+  });
+
+  it('sorts a single malformed version to the bottom', () => {
+    expect(writeAndReadVersions(['1.0.0', 'garbage', '1.2.3'])).toStrictEqual(['1.2.3', '1.0.0', 'garbage']);
+  });
+
+  it('orders multiple malformed versions lexically descending at the bottom', () => {
+    expect(writeAndReadVersions(['aaa', '1.0.0', 'zzz'])).toStrictEqual(['1.0.0', 'zzz', 'aaa']);
+  });
+});
+
 describe(upsertChangelogJson, () => {
   let tempDir: string;
   let outputPath: string;

--- a/packages/release-kit/src/changelogJsonFile.ts
+++ b/packages/release-kit/src/changelogJsonFile.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import stringify from 'json-stringify-pretty-compact';
+import semver from 'semver';
 
 import { isChangelogEntry } from './changelogJsonUtils.ts';
 import { isUnknownArray } from './typeGuards.ts';
@@ -39,7 +40,7 @@ export function upsertChangelogJson(filePath: string, entries: ChangelogEntry[])
   return filePath;
 }
 
-/** Sort changelog entries newest-first by parsed version parts. */
+/** Sort changelog entries newest-first by SemVer-aware version comparison. */
 function sortNewestFirst(entries: Iterable<ChangelogEntry>): ChangelogEntry[] {
   // eslint-disable-next-line unicorn/no-array-sort -- spread already creates a fresh copy; toSorted requires Node >=20
   return [...entries].sort((a, b) => compareVersionsDescending(a.version, b.version));
@@ -85,21 +86,21 @@ function mergeEntries(newEntries: ChangelogEntry[], existingEntries: ChangelogEn
   return sortNewestFirst(versionMap.values());
 }
 
-/** Parse a version string into numeric parts for comparison. */
-function parseVersionParts(version: string): number[] {
-  return version.split('.').map((s) => {
-    const n = Number(s);
-    return Number.isNaN(n) ? 0 : n;
-  });
-}
-
-/** Compare two version strings in descending order (newest first). */
+/**
+ * Compare two version strings in descending order (newest first).
+ *
+ * Valid SemVer inputs are ordered per SemVer §11 (delegated to `semver.rcompare`): prerelease
+ * versions precede the corresponding release (`1.2.3-alpha < 1.2.3`), and build metadata is
+ * ignored for ordering. Inputs that fail `semver.valid` sort to the bottom of the descending
+ * list, ordered lexically among themselves. The comparator never throws.
+ */
 function compareVersionsDescending(a: string, b: string): number {
-  const partsA = parseVersionParts(a);
-  const partsB = parseVersionParts(b);
-  for (let i = 0; i < 3; i++) {
-    const diff = (partsB[i] ?? 0) - (partsA[i] ?? 0);
-    if (diff !== 0) return diff;
-  }
+  const aValid = semver.valid(a);
+  const bValid = semver.valid(b);
+  if (aValid && bValid) return semver.rcompare(aValid, bValid);
+  if (aValid) return -1;
+  if (bValid) return 1;
+  if (a > b) return -1;
+  if (a < b) return 1;
   return 0;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,10 +130,16 @@ importers:
       json-stringify-pretty-compact:
         specifier: 4.0.0
         version: 4.0.0
+      semver:
+        specifier: 7.7.4
+        version: 7.7.4
     devDependencies:
       '@types/js-yaml':
         specifier: 4.0.9
         version: 4.0.9
+      '@types/semver':
+        specifier: 7.7.1
+        version: 7.7.1
       smol-toml:
         specifier: 1.6.1
         version: 1.6.1
@@ -776,6 +782,9 @@ packages:
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@typescript-eslint/eslint-plugin@8.57.2':
     resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
@@ -3203,6 +3212,8 @@ snapshots:
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/semver@7.7.1': {}
 
   '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
## What

Fixes a latent issue in `@williamthorsen/release-kit` where prerelease version tags (e.g., `1.2.3-alpha`, `1.2.3-rc.1`) were sorted as if their prerelease component were absent, causing them to appear in the wrong position relative to releases sharing the same base version. Changelog entries are now ordered per SemVer §11: prerelease versions precede the corresponding release (`1.2.3-alpha < 1.2.3`), build metadata is ignored for ordering, and entries that fail SemVer validation sort deterministically to the bottom of the list rather than collapsing into mid-list positions.

## Why

The previous comparator parsed each version segment with `Number(s)` and silently coerced any non-numeric segment to `0`. As a result, `1.2.3-alpha` parsed to `[1, 2, 0]` and sorted as if it were `1.2.0`. The behavior was latent because every active call path runs through `extractVersion`, which currently produces only clean `N.N.N` strings — but it would activate the moment any caller seeded the changelog with a prerelease tag (e.g., from prerelease publishing, or external consumers feeding entries in directly).

## Details

### Fixes

- Replaces the hand-rolled `compareVersionsDescending` in `packages/release-kit/src/changelogJsonFile.ts` with a thin wrapper around `semver.rcompare`. Inputs are pre-validated with `semver.valid`; valid SemVer pairs delegate to `rcompare`; invalid inputs sort to the bottom of the descending list, ordered lexically among themselves. The comparator never throws.
- Removes the dead `parseVersionParts` helper.
- Updates JSDoc on `compareVersionsDescending` to document the SemVer §11 ordering and the malformed-input fallback rule.

### Tests

- Adds a `describe('writeChangelogJson — version sort semantics')` block in `packages/release-kit/src/__tests__/changelogJsonFile.unit.test.ts` covering: numeric vs. lexical release ordering (`1.10.0 > 1.2.0`), prerelease-precedes-release per SemVer §11, same-base prerelease alphabetical ordering, numeric vs. alphanumeric prerelease identifier comparison (`rc.10 > rc.2`), build-metadata equality for ordering, single-malformed-version fallback, and lexical ordering among multiple malformed versions.

### Dependencies

- Promotes `semver` from a transitive dependency to a direct dependency of `@williamthorsen/release-kit` (pinned to `7.7.4`, the version already resolved in the lockfile — install footprint is unchanged).
- Adds `@types/semver@7.7.1` as a devDependency for TypeScript types.


Closes #332
