### PR TITLE
#230 Add status indicator to standing-issue title

### DIFF
--- a/.github/workflows/audit.reusable.yaml
+++ b/.github/workflows/audit.reusable.yaml
@@ -124,15 +124,49 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Run audit
+      # The bare audit-deps invocation drives the human-readable body and emits its own
+      # `-- 📦 prod --` and `-- 🔧 dev --` group headers, so the issue body intentionally
+      # omits the H3 "### Production dependencies" / "### Development dependencies"
+      # subsections that earlier two-command versions used.
+      - name: Run audit (text body)
         id: audit
         run: pnpm dlx @williamthorsen/audit-deps@latest 2>&1 | tee audit-output.txt
         continue-on-error: true
 
-      # The bare audit-deps invocation above emits its own `-- 📦 prod --` and
-      # `-- 🔧 dev --` group headers, so the issue body intentionally omits the
-      # H3 "### Production dependencies" / "### Development dependencies"
-      # subsections that earlier two-command versions used.
+      # Separate JSON invocation drives the title's status discriminant and count.
+      # Two invocations are simpler than reconstructing the human-readable text from JSON.
+      - name: Run audit (JSON summary)
+        run: pnpm dlx @williamthorsen/audit-deps@latest check --json > audit.json
+        continue-on-error: true
+
+      - name: Render issue title
+        id: title
+        run: |
+          STATUS=$(jq -r '.summary.status' audit.json)
+          COUNT=$(jq -r '.summary.count' audit.json)
+          case "$STATUS" in
+            none)
+              TITLE="🤖 Dependency audit status: no vulnerabilities ✅"
+              ;;
+            vulnerabilities-found)
+              NOUN=$([ "$COUNT" = "1" ] && echo "vulnerability" || echo "vulnerabilities")
+              TITLE="🤖 Dependency audit status: ${COUNT} ${NOUN} found 🚨"
+              ;;
+            suppressed-vulnerabilities)
+              NOUN=$([ "$COUNT" = "1" ] && echo "vulnerability" || echo "vulnerabilities")
+              TITLE="🤖 Dependency audit status: ${COUNT} suppressed ${NOUN} ⚠️"
+              ;;
+            stale-overrides)
+              NOUN=$([ "$COUNT" = "1" ] && echo "override" || echo "overrides")
+              TITLE="🤖 Dependency audit status: ${COUNT} stale ${NOUN} 🗑️"
+              ;;
+            *)
+              echo "::error::Unrecognized audit-deps summary status: '$STATUS'"
+              exit 1
+              ;;
+          esac
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+
       - name: Build issue body
         id: issue
         run: |
@@ -155,13 +189,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      # Lookup is by label, not title, so the title format change is safe for existing standing
+      # issues — they are matched by label and have their titles rewritten on the next update step.
       - name: Find or create standing issue
         id: find-issue
         run: |
           ISSUE_NUMBER=$(gh issue list --label audit-status --state open --json number --jq '.[0].number // empty')
           if [ -z "$ISSUE_NUMBER" ]; then
             ISSUE_NUMBER=$(gh issue create \
-              --title "Dependency audit status" \
+              --title "$TITLE" \
               --label "audit-status" \
               --body "Awaiting first audit run." | grep -oE '[0-9]+$')
           fi
@@ -172,10 +208,12 @@ jobs:
           echo "number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
+          TITLE: ${{ steps.title.outputs.title }}
 
-      - name: Update issue body
+      - name: Update issue title and body
         run: |
-          gh issue edit "${{ steps.find-issue.outputs.number }}" --body "$ISSUE_BODY"
+          gh issue edit "${{ steps.find-issue.outputs.number }}" --title "$TITLE" --body "$ISSUE_BODY"
         env:
           GH_TOKEN: ${{ github.token }}
+          TITLE: ${{ steps.title.outputs.title }}
           ISSUE_BODY: ${{ steps.issue.outputs.body }}

--- a/packages/audit-deps/README.md
+++ b/packages/audit-deps/README.md
@@ -68,7 +68,7 @@ Usage: audit-deps [options]
        audit-deps <command> [options]
 
 Commands:
-  (default)            Grouped vulnerability check with severity indicators
+  check (default)      Grouped vulnerability check with severity indicators
   sync                 Synchronize allowlists with current audit findings
   init                 Scaffold a starter config file and GitHub Actions workflow
 
@@ -91,6 +91,29 @@ Other options:
   --dry-run, -n   Preview changes without writing files
   --force, -f     Overwrite existing files
 ```
+
+### JSON output shape
+
+`--json` emits one object per requested scope plus a top-level `summary` block:
+
+```jsonc
+{
+  "prod": { "allowed": [...], "belowThreshold": [...], "stale": [...], "unallowed": [...] },
+  "dev":  { "allowed": [...], "belowThreshold": [...], "stale": [...], "unallowed": [...] },
+  "summary": { "status": "vulnerabilities-found", "count": 3 }
+}
+```
+
+`summary.status` is the highest-severity finding category present across the requested scopes. Below-threshold findings never affect it.
+
+| `status`                     | When                                              |
+| ---------------------------- | ------------------------------------------------- |
+| `vulnerabilities-found`      | At least one unallowed advisory                   |
+| `suppressed-vulnerabilities` | No unallowed; at least one allowlisted advisory   |
+| `stale-overrides`            | No advisories; at least one stale allowlist entry |
+| `none`                       | No findings                                       |
+
+`summary.count` is the total across the requested scopes for the active category. It is `0` when `status` is `none`.
 
 ## Scaffolded GitHub Actions workflow
 

--- a/packages/audit-deps/__tests__/format-check.test.ts
+++ b/packages/audit-deps/__tests__/format-check.test.ts
@@ -605,6 +605,7 @@ describe(formatCheckJson, () => {
         stale: [{ id: 'GHSA-old' }],
         unallowed: [],
       },
+      summary: { status: 'suppressed-vulnerabilities', count: 1 },
     });
   });
 
@@ -677,5 +678,52 @@ describe(formatCheckJson, () => {
     const parsed: unknown = JSON.parse(formatCheckJson(result, ['dev']));
     expect(parsed).toHaveProperty('dev');
     expect(parsed).not.toHaveProperty('prod');
+  });
+
+  it('includes a top-level summary block derived from the result', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [],
+        belowThreshold: [],
+        stale: [],
+        unallowed: [
+          { id: 'GHSA-1', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/1' },
+          { id: 'GHSA-2', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/2' },
+        ],
+      },
+    });
+
+    const parsed: unknown = JSON.parse(formatCheckJson(result, ['prod', 'dev']));
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        summary: { status: 'vulnerabilities-found', count: 2 },
+      }),
+    );
+  });
+
+  it('emits summary { status: "none", count: 0 } for a clean result', () => {
+    const parsed: unknown = JSON.parse(formatCheckJson(makeCheckResult(), ['prod', 'dev']));
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        summary: { status: 'none', count: 0 },
+      }),
+    );
+  });
+
+  it('derives the summary across only the requested scopes', () => {
+    const result = makeCheckResult({
+      dev: {
+        allowed: [],
+        belowThreshold: [],
+        stale: [],
+        unallowed: [{ id: 'GHSA-dev', path: 'pkg', paths: ['pkg'], severity: 'high', url: 'https://example.com/d' }],
+      },
+    });
+
+    const prodOnly: unknown = JSON.parse(formatCheckJson(result, ['prod']));
+    expect(prodOnly).toEqual(expect.objectContaining({ summary: { status: 'none', count: 0 } }));
+
+    const devOnly: unknown = JSON.parse(formatCheckJson(result, ['dev']));
+    expect(devOnly).toEqual(expect.objectContaining({ summary: { status: 'vulnerabilities-found', count: 1 } }));
   });
 });

--- a/packages/audit-deps/__tests__/format-summary.test.ts
+++ b/packages/audit-deps/__tests__/format-summary.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CheckResult, ScopeCheckResult } from '../src/format-check.ts';
+import { deriveSummary } from '../src/format-summary.ts';
+import type { AuditResult } from '../src/types.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emptyScopeResult(): ScopeCheckResult {
+  return { allowed: [], belowThreshold: [], stale: [], unallowed: [] };
+}
+
+function makeCheckResult(overrides?: Partial<CheckResult>): CheckResult {
+  return {
+    dev: emptyScopeResult(),
+    prod: emptyScopeResult(),
+    ...overrides,
+  };
+}
+
+function fakeAdvisory(id: string): AuditResult {
+  return { id, path: 'pkg', paths: ['pkg'], severity: 'high', url: `https://example.com/${id}` };
+}
+
+// ---------------------------------------------------------------------------
+// deriveSummary
+// ---------------------------------------------------------------------------
+
+describe(deriveSummary, () => {
+  it('returns status "none" with count 0 when both scopes are empty', () => {
+    const result = makeCheckResult();
+    expect(deriveSummary(result, ['prod', 'dev'])).toEqual({ status: 'none', count: 0 });
+  });
+
+  it('returns "vulnerabilities-found" with the total unallowed count across scopes', () => {
+    const result = makeCheckResult({
+      dev: { ...emptyScopeResult(), unallowed: [fakeAdvisory('GHSA-1')] },
+      prod: { ...emptyScopeResult(), unallowed: [fakeAdvisory('GHSA-2'), fakeAdvisory('GHSA-3')] },
+    });
+    expect(deriveSummary(result, ['prod', 'dev'])).toEqual({ status: 'vulnerabilities-found', count: 3 });
+  });
+
+  it('returns "suppressed-vulnerabilities" with the total allowed count when no unallowed exist', () => {
+    const result = makeCheckResult({
+      prod: {
+        ...emptyScopeResult(),
+        allowed: [
+          { id: 'GHSA-a', path: 'pkg', paths: ['pkg'], url: 'https://example.com/a' },
+          { id: 'GHSA-b', path: 'pkg', paths: ['pkg'], url: 'https://example.com/b' },
+        ],
+      },
+    });
+    expect(deriveSummary(result, ['prod', 'dev'])).toEqual({ status: 'suppressed-vulnerabilities', count: 2 });
+  });
+
+  it('returns "stale-overrides" with the total stale count when no vulnerabilities exist', () => {
+    const result = makeCheckResult({
+      prod: { ...emptyScopeResult(), stale: [{ id: 'GHSA-old' }] },
+    });
+    expect(deriveSummary(result, ['prod', 'dev'])).toEqual({ status: 'stale-overrides', count: 1 });
+  });
+
+  it('prioritizes unallowed over allowed and stale, and reports only the unallowed count', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [{ id: 'GHSA-allowed', path: 'pkg', paths: ['pkg'], url: 'https://example.com/allowed' }],
+        belowThreshold: [],
+        stale: [{ id: 'GHSA-old' }, { id: 'GHSA-old2' }],
+        unallowed: [fakeAdvisory('GHSA-new')],
+      },
+    });
+    expect(deriveSummary(result, ['prod', 'dev'])).toEqual({ status: 'vulnerabilities-found', count: 1 });
+  });
+
+  it('prioritizes allowed over stale when no unallowed exist, and reports only the allowed count', () => {
+    const result = makeCheckResult({
+      prod: {
+        allowed: [{ id: 'GHSA-allowed', path: 'pkg', paths: ['pkg'], url: 'https://example.com/allowed' }],
+        belowThreshold: [],
+        stale: [{ id: 'GHSA-old' }],
+        unallowed: [],
+      },
+    });
+    expect(deriveSummary(result, ['prod', 'dev'])).toEqual({ status: 'suppressed-vulnerabilities', count: 1 });
+  });
+
+  it('ignores below-threshold findings when classifying status', () => {
+    const result = makeCheckResult({
+      prod: {
+        ...emptyScopeResult(),
+        belowThreshold: [
+          { id: 'GHSA-bt', path: 'pkg', paths: ['pkg'], severity: 'low', url: 'https://example.com/bt' },
+        ],
+      },
+    });
+    expect(deriveSummary(result, ['prod', 'dev'])).toEqual({ status: 'none', count: 0 });
+  });
+
+  it('only considers requested scopes', () => {
+    const result = makeCheckResult({
+      dev: { ...emptyScopeResult(), unallowed: [fakeAdvisory('GHSA-dev-only')] },
+      prod: emptyScopeResult(),
+    });
+    expect(deriveSummary(result, ['prod'])).toEqual({ status: 'none', count: 0 });
+    expect(deriveSummary(result, ['dev'])).toEqual({ status: 'vulnerabilities-found', count: 1 });
+  });
+});

--- a/packages/audit-deps/__tests__/route.test.ts
+++ b/packages/audit-deps/__tests__/route.test.ts
@@ -69,6 +69,21 @@ describe(routeCommand, () => {
     expect(exitCode).toBe(1);
   });
 
+  it('dispatches "check" to checkCommand', async () => {
+    await routeCommand(['check']);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: [] }));
+  });
+
+  it('dispatches "check --json" to checkCommand with json: true', async () => {
+    await routeCommand(['check', '--json']);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ json: true, scopes: [] }));
+  });
+
+  it('dispatches "check --dev" to checkCommand with scopes ["dev"]', async () => {
+    await routeCommand(['check', '--dev']);
+    expect(checkCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['dev'] }));
+  });
+
   it('dispatches "sync" to syncCommand', async () => {
     await routeCommand(['sync']);
     expect(syncCommand).toHaveBeenCalledWith(expect.objectContaining({ scopes: [] }));

--- a/packages/audit-deps/src/bin/route.ts
+++ b/packages/audit-deps/src/bin/route.ts
@@ -7,7 +7,7 @@ import { initCommand } from '../init/initCommand.ts';
 import type { AuditScope, CommandOptions } from '../types.ts';
 import { VERSION } from '../version.ts';
 
-const SUBCOMMANDS = ['init', 'sync'];
+const SUBCOMMANDS = ['check', 'init', 'sync'];
 const MIN_PREFIX_LENGTH = 3;
 
 function showHelp(): void {
@@ -16,7 +16,7 @@ Usage: audit-deps [options]
        audit-deps <command> [options]
 
 Commands:
-  (default)            Grouped vulnerability check with severity indicators
+  check (default)      Grouped vulnerability check with severity indicators
   sync                 Synchronize allowlists with current audit findings
   init                 Scaffold a starter config file and GitHub Actions workflow
 
@@ -121,6 +121,10 @@ export async function routeCommand(args: string[]): Promise<number> {
   if (command === '--version' || command === '-V') {
     console.info(VERSION);
     return 0;
+  }
+
+  if (command === 'check') {
+    return handleSubcommand(args.slice(1), checkCommand);
   }
 
   if (command === 'init') {

--- a/packages/audit-deps/src/format-check.ts
+++ b/packages/audit-deps/src/format-check.ts
@@ -1,4 +1,5 @@
 import { formatActionHints } from './format-actions.ts';
+import { deriveSummary } from './format-summary.ts';
 import { formatRelativeTime } from './format-time.ts';
 import type { AuditResult, AuditScope, SeverityThreshold } from './types.ts';
 
@@ -229,11 +230,12 @@ export function formatCheckText(
 // JSON formatter
 // ---------------------------------------------------------------------------
 
-/** Format check results as a JSON string. */
+/** Format check results as a JSON string with a top-level `summary` block derived from the result. */
 export function formatCheckJson(result: CheckResult, scopes: AuditScope[]): string {
-  const output: Record<string, ScopeCheckResult> = {};
+  const output: Record<string, unknown> = {};
   for (const scope of scopes) {
     output[scope] = result[scope];
   }
+  output.summary = deriveSummary(result, scopes);
   return JSON.stringify(output, null, 2) + '\n';
 }

--- a/packages/audit-deps/src/format-summary.ts
+++ b/packages/audit-deps/src/format-summary.ts
@@ -1,0 +1,31 @@
+import type { CheckResult } from './format-check.ts';
+import type { AuditScope } from './types.ts';
+
+/** Status discriminant exposing the most severe finding category in a check result. */
+export type CheckSummaryStatus = 'vulnerabilities-found' | 'suppressed-vulnerabilities' | 'stale-overrides' | 'none';
+
+/** Headline summary of a check run: status discriminant plus count for the active category. */
+export interface CheckSummary {
+  status: CheckSummaryStatus;
+  count: number;
+}
+
+/**
+ * Derive the headline summary from a check result.
+ *
+ * Priority is severity-driven: unallowed > allowed > stale > none. The count is the total across
+ * the requested scopes for the *active* category only; for `'none'` it is `0`. Below-threshold
+ * findings never affect the summary — the threshold already excludes them from pass/fail.
+ */
+export function deriveSummary(result: CheckResult, scopes: AuditScope[]): CheckSummary {
+  const unallowed = scopes.reduce((total, scope) => total + result[scope].unallowed.length, 0);
+  if (unallowed > 0) return { status: 'vulnerabilities-found', count: unallowed };
+
+  const allowed = scopes.reduce((total, scope) => total + result[scope].allowed.length, 0);
+  if (allowed > 0) return { status: 'suppressed-vulnerabilities', count: allowed };
+
+  const stale = scopes.reduce((total, scope) => total + result[scope].stale.length, 0);
+  if (stale > 0) return { status: 'stale-overrides', count: stale };
+
+  return { status: 'none', count: 0 };
+}


### PR DESCRIPTION
## What

Adds a status indicator and bot-origin emoji to the standing issue maintained by the dependency-audit workflow. The title now reflects the most severe finding category and is refreshed on every run — `🤖 Dependency audit status: 3 vulnerabilities found 🚨`, `🤖 Dependency audit status: no vulnerabilities ✅`, and so on. Status priority is severity-driven: unallowed vulnerabilities outrank suppressed entries, which outrank stale allowlist entries.

Adds a top-level `summary` block to `audit-deps check --json` containing a `status` discriminant (`vulnerabilities-found`, `suppressed-vulnerabilities`, `stale-overrides`, `none`) and a `count` for the active category. Below-threshold findings never affect the summary. Existing per-scope JSON keys are unchanged.

Adds an explicit `check` subcommand alongside `init` and `sync`. The bare invocation continues to run a check, so existing consumers are unaffected.

## Why

The standing issue created by the dependency-audit workflow was titled `Dependency audit status` with no visual cue that it was bot-maintained, and its title never changed regardless of state. To learn whether anything was wrong, a maintainer had to open the issue and read the body. Surfacing the status in the title turns the issue list itself into an at-a-glance signal.

## Details

### Features

- `audit-deps check --json` now emits a top-level `summary: { status, count }` block. `status` is one of `vulnerabilities-found`, `suppressed-vulnerabilities`, `stale-overrides`, or `none`; `count` is the total across the requested scopes for the active category, or `0` when status is `none`.
- The new `check` subcommand on the CLI is an explicit alias for the default audit-and-classify behavior. Bare invocation continues to run a check, so the change is purely additive for existing consumers.
- The reusable audit workflow at `workflow/audit-v1` now runs both text and JSON invocations of `audit-deps@latest`, derives the title via `jq` against the `summary` block, and updates issue title alongside body on every scheduled or dispatched run. Existing standing issues are matched by the `audit-status` label and have their titles rewritten on the next run.

## Test plan

- [ ] After merge, trigger the `Dependency audit` workflow via `workflow_dispatch` and confirm issue #214's title is rewritten to `🤖 Dependency audit status: 1 suppressed vulnerability ⚠️` (matches the repo's current allowlist state).
- [ ] Confirm no new `audit-status`-labeled issue is created (the existing #214 should be reused).

Closes #230
