### PR TITLE
#192 Add :pre and :post hook conventions to nmr commands

### DIFF
--- a/.agents/nmr/AGENTS.md
+++ b/.agents/nmr/AGENTS.md
@@ -36,6 +36,42 @@ In `.config/nmr.config.ts` or a package's `package.json`, override values have s
 - `":"` — no-op; exit 0. Prefer this over `""` if your repo enforces non-empty script values.
 - Any other string — runs in place of the default.
 
+## Pre and post hooks
+
+Every `nmr X` invocation auto-wraps as the equivalent of `nmr X:pre && nmr X && nmr X:post`. Hooks are first-class scripts that resolve through the same 3-tier registry (built-in defaults → `.config/nmr.config.ts` → per-package `package.json`). Wrapping is uniform; nested invocations from composite expansion get their own hook treatment. Hook failure short-circuits the chain via shell `&&` semantics, propagating the failing exit code.
+
+Behaviors worth knowing:
+
+- **Silent when absent** — missing hooks produce no error and no output.
+- **Skip overrides apply to hooks** — a hook value of `""` or `":"` is treated the same as not defining the hook. No console message.
+- **Skipping the main command skips its hooks** — when `X` is overridden to `""` or `":"`, neither `X:pre` nor `X:post` fires.
+- **Recursion guard** — direct invocation of a hook (e.g., `nmr build:pre`) is treated as a leaf operation. It does NOT itself attempt to resolve `build:pre:pre` or `build:pre:post`.
+- **Passthrough args attach only to the main command** — `nmr X --flag value` runs hooks without `--flag value`.
+
+Worked examples:
+
+```ts
+// .config/nmr.config.ts — extend `nmr build` with a pre-build compile step
+import { defineConfig } from '@williamthorsen/nmr';
+
+export default defineConfig({
+  workspaceScripts: {
+    'build:pre': 'npx rdy compile',
+  },
+});
+```
+
+```jsonc
+// packages/nmr/package.json — re-stamp .agents/nmr/AGENTS.md after every build
+{
+  "scripts": {
+    "build:post": "nmr-sync-agent-files",
+  },
+}
+```
+
+The second example calls the bin directly to sidestep the workspace-vs-root registry distinction.
+
 ## Agent-file sync
 
 The presence and version stamp of `.agents/nmr/AGENTS.md` is verified by `check:agent-files`, which is part of the default root `check:strict` composite. If it fails, run `nmr sync-agent-files`.

--- a/.config/nmr.config.ts
+++ b/.config/nmr.config.ts
@@ -3,8 +3,7 @@ import { defineConfig } from '@williamthorsen/nmr';
 /** nmr configuration for this monorepo. */
 export default defineConfig({
   rootScripts: {
-    build: ['build:workspaces', 'build:rdy'],
-    'build:workspaces': 'pnpm --recursive exec nmr build',
-    'build:rdy': 'rdy compile',
+    build: 'pnpm --recursive exec nmr build',
+    'build:post': 'rdy compile',
   },
 });

--- a/packages/nmr/AGENTS.md
+++ b/packages/nmr/AGENTS.md
@@ -36,6 +36,42 @@ In `.config/nmr.config.ts` or a package's `package.json`, override values have s
 - `":"` — no-op; exit 0. Prefer this over `""` if your repo enforces non-empty script values.
 - Any other string — runs in place of the default.
 
+## Pre and post hooks
+
+Every `nmr X` invocation auto-wraps as the equivalent of `nmr X:pre && nmr X && nmr X:post`. Hooks are first-class scripts that resolve through the same 3-tier registry (built-in defaults → `.config/nmr.config.ts` → per-package `package.json`). Wrapping is uniform; nested invocations from composite expansion get their own hook treatment. Hook failure short-circuits the chain via shell `&&` semantics, propagating the failing exit code.
+
+Behaviors worth knowing:
+
+- **Silent when absent** — missing hooks produce no error and no output.
+- **Skip overrides apply to hooks** — a hook value of `""` or `":"` is treated the same as not defining the hook. No console message.
+- **Skipping the main command skips its hooks** — when `X` is overridden to `""` or `":"`, neither `X:pre` nor `X:post` fires.
+- **Recursion guard** — direct invocation of a hook (e.g., `nmr build:pre`) is treated as a leaf operation. It does NOT itself attempt to resolve `build:pre:pre` or `build:pre:post`.
+- **Passthrough args attach only to the main command** — `nmr X --flag value` runs hooks without `--flag value`.
+
+Worked examples:
+
+```ts
+// .config/nmr.config.ts — extend `nmr build` with a pre-build compile step
+import { defineConfig } from '@williamthorsen/nmr';
+
+export default defineConfig({
+  workspaceScripts: {
+    'build:pre': 'npx rdy compile',
+  },
+});
+```
+
+```jsonc
+// packages/nmr/package.json — re-stamp .agents/nmr/AGENTS.md after every build
+{
+  "scripts": {
+    "build:post": "nmr-sync-agent-files",
+  },
+}
+```
+
+The second example calls the bin directly to sidestep the workspace-vs-root registry distinction.
+
 ## Agent-file sync
 
 The presence and version stamp of `.agents/nmr/AGENTS.md` is verified by `check:agent-files`, which is part of the default root `check:strict` composite. If it fails, run `nmr sync-agent-files`.

--- a/packages/nmr/__tests__/cli.test.ts
+++ b/packages/nmr/__tests__/cli.test.ts
@@ -496,6 +496,7 @@ describe('nmr CLI', () => {
         writeFileSync(configLogFile, '');
 
         // Composite hook (array) — only allowed in tier 1+2, so requires .config/nmr.config.ts
+        // rootScripts entries also live here; they are reachable only via -w from a package cwd.
         const configContent = `import { defineConfig } from '${NMR_PACKAGE_DIR}/dist/esm/index.js';
 export default defineConfig({
   workspaceScripts: {
@@ -503,6 +504,11 @@ export default defineConfig({
     'cfg-pre-step1': 'echo step1 >> ${configLogFile}',
     'cfg-pre-step2': 'echo step2 >> ${configLogFile}',
     'clean:post': 'echo cfg-post >> ${configLogFile}',
+  },
+  rootScripts: {
+    'wroot-cmd': 'echo wroot-main >> ${configLogFile}',
+    'wroot-cmd:pre': 'echo wroot-pre >> ${configLogFile}',
+    'wroot-cmd:post': 'echo wroot-post >> ${configLogFile}',
   },
 });
 `;
@@ -531,6 +537,17 @@ export default defineConfig({
         expect(exitCode).toBe(0);
         // composite pre-hook expands to nmr cfg-pre-step1 && nmr cfg-pre-step2
         expect(readConfigLog()).toStrictEqual(['step1', 'step2', 'main', 'cfg-post']);
+      });
+
+      it('propagates -w to hook subprocesses so they resolve via root registry', () => {
+        clearConfigLog();
+        // wroot-cmd and its hooks live only in rootScripts. Without -w propagation,
+        // the parent's `useRoot=true` decision is lost in the subprocess `nmr X:pre` call,
+        // and the child re-derives a workspace registry from the package cwd, failing to
+        // resolve the hook.
+        const { exitCode } = runNmr('-w wroot-cmd', { cwd: configPkgDir });
+        expect(exitCode).toBe(0);
+        expect(readConfigLog()).toStrictEqual(['wroot-pre', 'wroot-main', 'wroot-post']);
       });
     });
   });

--- a/packages/nmr/__tests__/cli.test.ts
+++ b/packages/nmr/__tests__/cli.test.ts
@@ -1,9 +1,24 @@
 import { execSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+function makeLogHelpers(getPath: () => string): { read: () => string[]; clear: () => void } {
+  return {
+    read: () => {
+      try {
+        return readFileSync(getPath(), 'utf8')
+          .split('\n')
+          .filter((line) => line.length > 0);
+      } catch {
+        return [];
+      }
+    },
+    clear: () => writeFileSync(getPath(), ''),
+  };
+}
 
 const MONOREPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
 const NMR_PACKAGE_DIR = path.resolve(MONOREPO_ROOT, 'packages', 'nmr');
@@ -182,19 +197,7 @@ describe('nmr CLI', () => {
       writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ name: packageName, scripts }));
     }
 
-    function readLog(): string[] {
-      try {
-        return execSync(`cat ${logFile}`, { encoding: 'utf8' })
-          .split('\n')
-          .filter((line) => line.length > 0);
-      } catch {
-        return [];
-      }
-    }
-
-    function clearLog(): void {
-      writeFileSync(logFile, '');
-    }
+    const { read: readLog, clear: clearLog } = makeLogHelpers(() => logFile);
 
     beforeAll(() => {
       tempRoot = mkdtempSync(path.join(tmpdir(), 'nmr-hooks-test-'));
@@ -520,15 +523,7 @@ export default defineConfig({
         rmSync(configRoot, { recursive: true, force: true });
       });
 
-      function readConfigLog(): string[] {
-        return execSync(`cat ${configLogFile}`, { encoding: 'utf8' })
-          .split('\n')
-          .filter((line) => line.length > 0);
-      }
-
-      function clearConfigLog(): void {
-        writeFileSync(configLogFile, '');
-      }
+      const { read: readConfigLog, clear: clearConfigLog } = makeLogHelpers(() => configLogFile);
 
       it('runs hooks when main command is overridden in package.json (composite pre)', () => {
         clearConfigLog();

--- a/packages/nmr/__tests__/cli.test.ts
+++ b/packages/nmr/__tests__/cli.test.ts
@@ -166,4 +166,377 @@ describe('nmr CLI', () => {
       expect(stderr).toContain('Unknown command');
     });
   });
+
+  describe('pre/post hooks', () => {
+    let tempRoot: string;
+    let logFile: string;
+
+    /**
+     * Writes a workspace package whose scripts append a marker line to a log file
+     * when invoked. The `clean` script is overridden because clean is in the default
+     * registry (so resolving it triggers the override path), and we layer hook
+     * scripts on top in tier-3 (package.json) where appropriate.
+     */
+    function writePackage(packageDir: string, scripts: Record<string, string>, packageName = 'hook-pkg'): void {
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ name: packageName, scripts }));
+    }
+
+    function readLog(): string[] {
+      try {
+        return execSync(`cat ${logFile}`, { encoding: 'utf8' })
+          .split('\n')
+          .filter((line) => line.length > 0);
+      } catch {
+        return [];
+      }
+    }
+
+    function clearLog(): void {
+      writeFileSync(logFile, '');
+    }
+
+    beforeAll(() => {
+      tempRoot = mkdtempSync(path.join(tmpdir(), 'nmr-hooks-test-'));
+      writeFileSync(path.join(tempRoot, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
+      writeFileSync(path.join(tempRoot, 'package.json'), JSON.stringify({ name: 'temp-root', private: true }));
+      mkdirSync(path.join(tempRoot, 'packages'), { recursive: true });
+      logFile = path.join(tempRoot, 'log.txt');
+      writeFileSync(logFile, '');
+    });
+
+    afterAll(() => {
+      rmSync(tempRoot, { recursive: true, force: true });
+    });
+
+    it('runs pre and post hooks around the main command', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'both-hooks');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main >> ${logFile}`,
+          'clean:pre': `echo pre >> ${logFile}`,
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'both-hooks',
+      );
+      clearLog();
+
+      const { exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual(['pre', 'main', 'post']);
+    });
+
+    it('runs pre-only hook when post is undefined', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'pre-only');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main >> ${logFile}`,
+          'clean:pre': `echo pre >> ${logFile}`,
+        },
+        'pre-only',
+      );
+      clearLog();
+
+      const { exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual(['pre', 'main']);
+    });
+
+    it('runs post-only hook when pre is undefined', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'post-only');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main >> ${logFile}`,
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'post-only',
+      );
+      clearLog();
+
+      const { exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual(['main', 'post']);
+    });
+
+    it('is a silent no-op when no hooks are defined', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'no-hooks');
+      writePackage(pkgDir, { clean: `echo main >> ${logFile}` }, 'no-hooks');
+      clearLog();
+
+      const { exitCode, stderr } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual(['main']);
+      expect(stderr).toBe('');
+    });
+
+    it('short-circuits when pre-hook fails — main and post do not run', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'pre-fails');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main >> ${logFile}`,
+          'clean:pre': `echo pre >> ${logFile} && exit 7`,
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'pre-fails',
+      );
+      clearLog();
+
+      const { exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(7);
+      expect(readLog()).toStrictEqual(['pre']);
+    });
+
+    it('short-circuits when main fails — post does not run', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'main-fails');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main >> ${logFile} && exit 5`,
+          'clean:pre': `echo pre >> ${logFile}`,
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'main-fails',
+      );
+      clearLog();
+
+      const { exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(5);
+      expect(readLog()).toStrictEqual(['pre', 'main']);
+    });
+
+    it('propagates the exit code when post-hook fails', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'post-fails');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main >> ${logFile}`,
+          'clean:pre': `echo pre >> ${logFile}`,
+          'clean:post': `echo post >> ${logFile} && exit 9`,
+        },
+        'post-fails',
+      );
+      clearLog();
+
+      const { exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(9);
+      expect(readLog()).toStrictEqual(['pre', 'main', 'post']);
+    });
+
+    it('runs hooks when the main command is overridden in package.json', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'override-main');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo override-main >> ${logFile}`,
+          'clean:pre': `echo pre >> ${logFile}`,
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'override-main',
+      );
+      clearLog();
+
+      const { exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual(['pre', 'override-main', 'post']);
+    });
+
+    it('directly invokes the pre hook without cascading', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'direct-pre');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main >> ${logFile}`,
+          'clean:pre': `echo pre >> ${logFile}`,
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'direct-pre',
+      );
+      clearLog();
+
+      const { exitCode, stderr } = runNmr('clean:pre', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      // Only the pre hook itself should run — no cascading attempt to find pre:pre/pre:post
+      expect(readLog()).toStrictEqual(['pre']);
+      expect(stderr).not.toContain('Unknown command');
+    });
+
+    it('directly invokes the post hook without cascading', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'direct-post');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main >> ${logFile}`,
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'direct-post',
+      );
+      clearLog();
+
+      const { exitCode, stderr } = runNmr('clean:post', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual(['post']);
+      expect(stderr).not.toContain('Unknown command');
+    });
+
+    it('attaches passthrough args to the main command only', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'passthrough');
+      // Use a wrapper script so we can capture argv without shell-redirection
+      // ambiguities (where `>> file --flag` would parse as redirect + extra args).
+      const captureScript = path.join(pkgDir, 'capture.sh');
+      writePackage(
+        pkgDir,
+        {
+          clean: `bash ${captureScript} main`,
+          'clean:pre': `bash ${captureScript} pre`,
+          'clean:post': `bash ${captureScript} post`,
+        },
+        'passthrough',
+      );
+      writeFileSync(captureScript, `#!/bin/bash\nlabel="$1"\nshift\necho "$label args=$*" >> ${logFile}\n`);
+      clearLog();
+
+      const { exitCode } = runNmr('clean --flag value', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual(['pre args=', 'main args=--flag value', 'post args=']);
+    });
+
+    it('skips hooks when main command is overridden to empty string', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'main-skip-empty');
+      writePackage(
+        pkgDir,
+        {
+          clean: '',
+          'clean:pre': `echo pre >> ${logFile}`,
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'main-skip-empty',
+      );
+      clearLog();
+
+      const { exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual([]);
+    });
+
+    it('skips hooks when main command is overridden to colon', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'main-skip-colon');
+      writePackage(
+        pkgDir,
+        {
+          clean: ':',
+          'clean:pre': `echo pre >> ${logFile}`,
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'main-skip-colon',
+      );
+      clearLog();
+
+      const { exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual([]);
+    });
+
+    it('treats empty-string hook as silent no-op', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'hook-skip-empty');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main >> ${logFile}`,
+          'clean:pre': '',
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'hook-skip-empty',
+      );
+      clearLog();
+
+      const { stdout, exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual(['main', 'post']);
+      // No "Skipping" message should appear for the hook
+      expect(stdout).not.toContain('Skipping');
+    });
+
+    it('treats colon-valued hook as silent no-op', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'hook-skip-colon');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main >> ${logFile}`,
+          'clean:pre': ':',
+          'clean:post': `echo post >> ${logFile}`,
+        },
+        'hook-skip-colon',
+      );
+      clearLog();
+
+      const { stdout, exitCode } = runNmr('clean', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      expect(readLog()).toStrictEqual(['main', 'post']);
+      expect(stdout).not.toContain('no-op');
+    });
+
+    describe('config-defined hooks', () => {
+      let configRoot: string;
+      let configPkgDir: string;
+      let configLogFile: string;
+
+      beforeAll(() => {
+        configRoot = mkdtempSync(path.join(tmpdir(), 'nmr-hooks-cfg-'));
+        writeFileSync(path.join(configRoot, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
+        writeFileSync(path.join(configRoot, 'package.json'), JSON.stringify({ name: 'cfg-root', private: true }));
+        mkdirSync(path.join(configRoot, '.config'), { recursive: true });
+        configLogFile = path.join(configRoot, 'log.txt');
+        writeFileSync(configLogFile, '');
+
+        // Composite hook (array) — only allowed in tier 1+2, so requires .config/nmr.config.ts
+        const configContent = `import { defineConfig } from '${NMR_PACKAGE_DIR}/dist/esm/index.js';
+export default defineConfig({
+  workspaceScripts: {
+    'clean:pre': ['cfg-pre-step1', 'cfg-pre-step2'],
+    'cfg-pre-step1': 'echo step1 >> ${configLogFile}',
+    'cfg-pre-step2': 'echo step2 >> ${configLogFile}',
+    'clean:post': 'echo cfg-post >> ${configLogFile}',
+  },
+});
+`;
+        writeFileSync(path.join(configRoot, '.config', 'nmr.config.ts'), configContent);
+
+        configPkgDir = path.join(configRoot, 'packages', 'cfg-pkg');
+        mkdirSync(configPkgDir, { recursive: true });
+        writeFileSync(
+          path.join(configPkgDir, 'package.json'),
+          JSON.stringify({
+            name: 'cfg-pkg',
+            scripts: { clean: `echo main >> ${configLogFile}` },
+          }),
+        );
+      });
+
+      afterAll(() => {
+        rmSync(configRoot, { recursive: true, force: true });
+      });
+
+      function readConfigLog(): string[] {
+        return execSync(`cat ${configLogFile}`, { encoding: 'utf8' })
+          .split('\n')
+          .filter((line) => line.length > 0);
+      }
+
+      function clearConfigLog(): void {
+        writeFileSync(configLogFile, '');
+      }
+
+      it('runs hooks when main command is overridden in package.json (composite pre)', () => {
+        clearConfigLog();
+        const { exitCode } = runNmr('clean', { cwd: configPkgDir });
+        expect(exitCode).toBe(0);
+        // composite pre-hook expands to nmr cfg-pre-step1 && nmr cfg-pre-step2
+        expect(readConfigLog()).toStrictEqual(['step1', 'step2', 'main', 'cfg-post']);
+      });
+    });
+  });
 });

--- a/packages/nmr/__tests__/cli.test.ts
+++ b/packages/nmr/__tests__/cli.test.ts
@@ -482,6 +482,27 @@ describe('nmr CLI', () => {
       expect(stdout).not.toContain('no-op');
     });
 
+    it('suppresses hook chain output under --quiet', () => {
+      const pkgDir = path.join(tempRoot, 'packages', 'quiet-hooks');
+      writePackage(
+        pkgDir,
+        {
+          clean: `echo main-noise && echo main >> ${logFile}`,
+          'clean:pre': `echo pre-noise && echo pre >> ${logFile}`,
+          'clean:post': `echo post-noise && echo post >> ${logFile}`,
+        },
+        'quiet-hooks',
+      );
+      clearLog();
+
+      const { stdout, exitCode } = runNmr('-q clean', { cwd: pkgDir });
+      expect(exitCode).toBe(0);
+      // Log proves the full chain ran
+      expect(readLog()).toStrictEqual(['pre', 'main', 'post']);
+      // -q suppresses all stdout from the chain
+      expect(stdout).toBe('');
+    });
+
     describe('config-defined hooks', () => {
       let configRoot: string;
       let configPkgDir: string;

--- a/packages/nmr/__tests__/cli.test.ts
+++ b/packages/nmr/__tests__/cli.test.ts
@@ -511,10 +511,25 @@ describe('nmr CLI', () => {
       beforeAll(() => {
         configRoot = mkdtempSync(path.join(tmpdir(), 'nmr-hooks-cfg-'));
         writeFileSync(path.join(configRoot, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
-        writeFileSync(path.join(configRoot, 'package.json'), JSON.stringify({ name: 'cfg-root', private: true }));
         mkdirSync(path.join(configRoot, '.config'), { recursive: true });
         configLogFile = path.join(configRoot, 'log.txt');
         writeFileSync(configLogFile, '');
+
+        // Root package.json scripts are tier 3 from root cwd; under -w from a
+        // subpackage they should resolve via root's package.json, not the
+        // subpackage's. Defining wpkg-cmd here exercises that path.
+        writeFileSync(
+          path.join(configRoot, 'package.json'),
+          JSON.stringify({
+            name: 'cfg-root',
+            private: true,
+            scripts: {
+              'wpkg-cmd': `echo wpkg-main >> ${configLogFile}`,
+              'wpkg-cmd:pre': `echo wpkg-pre >> ${configLogFile}`,
+              'wpkg-cmd:post': `echo wpkg-post >> ${configLogFile}`,
+            },
+          }),
+        );
 
         // Composite hook (array) — only allowed in tier 1+2, so requires .config/nmr.config.ts
         // rootScripts entries also live here; they are reachable only via -w from a package cwd.
@@ -569,6 +584,17 @@ export default defineConfig({
         const { exitCode } = runNmr('-w wroot-cmd', { cwd: configPkgDir });
         expect(exitCode).toBe(0);
         expect(readConfigLog()).toStrictEqual(['wroot-pre', 'wroot-main', 'wroot-post']);
+      });
+
+      it('resolves tier-3 (root package.json) scripts under -w from a subpackage', () => {
+        clearConfigLog();
+        // wpkg-cmd and its hooks live only in the root package.json scripts (tier 3
+        // from root cwd). Under -w from a subpackage, packageDir must follow useRoot
+        // so the resolver consults root's package.json instead of the subpackage's,
+        // otherwise the command and its hooks fail with "Unknown command".
+        const { exitCode } = runNmr('-w wpkg-cmd', { cwd: configPkgDir });
+        expect(exitCode).toBe(0);
+        expect(readConfigLog()).toStrictEqual(['wpkg-pre', 'wpkg-main', 'wpkg-post']);
       });
     });
   });

--- a/packages/nmr/__tests__/help.test.ts
+++ b/packages/nmr/__tests__/help.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { generateHelp } from '../src/help.js';
 
-describe('generateHelp', () => {
+describe(generateHelp, () => {
   it('includes usage line', () => {
     const help = generateHelp({});
     expect(help).toContain('Usage: nmr [flags] <command> [args...]');
@@ -40,5 +44,87 @@ describe('generateHelp', () => {
 
     expect(help).toContain('copy-content');
     expect(help).toContain('demo:catwalk');
+  });
+
+  it('includes config-defined hook in workspace commands', () => {
+    const help = generateHelp({
+      workspaceScripts: { 'build:pre': 'npx rdy compile' },
+    });
+
+    expect(help).toContain('build:pre');
+    expect(help).toContain('npx rdy compile');
+  });
+
+  describe('package scripts section', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nmr-help-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('omits package scripts section when packageDir is not provided', () => {
+      const help = generateHelp({});
+      expect(help).not.toContain('Package scripts:');
+    });
+
+    it('omits package scripts section when package has no scripts', () => {
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'empty-pkg' }));
+
+      const help = generateHelp({}, tmpDir);
+      expect(help).not.toContain('Package scripts:');
+    });
+
+    it('lists tier-3 hook scripts in package scripts section', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({
+          name: 'pkg-with-hook',
+          scripts: { 'build:post': 'nmr-sync-agent-files' },
+        }),
+      );
+
+      const help = generateHelp({}, tmpDir);
+      expect(help).toContain('Package scripts:');
+      expect(help).toContain('build:post');
+      expect(help).toContain('nmr-sync-agent-files');
+    });
+
+    it('lists tier-3 non-hook overrides in package scripts section', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({
+          name: 'pkg-with-override',
+          scripts: { build: 'tsc -p tsconfig.custom.json' },
+        }),
+      );
+
+      const help = generateHelp({}, tmpDir);
+      expect(help).toContain('Package scripts:');
+      expect(help).toContain('tsc -p tsconfig.custom.json');
+    });
+
+    it('omits self-referential package scripts', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({
+          name: 'pkg-self-ref',
+          scripts: {
+            build: 'nmr build',
+            'build:post': 'nmr-sync-agent-files',
+          },
+        }),
+      );
+
+      const help = generateHelp({}, tmpDir);
+      expect(help).toContain('Package scripts:');
+      expect(help).toContain('build:post');
+      // The self-referential `"build": "nmr build"` should not appear as a package script
+      const packageSection = help.slice(help.indexOf('Package scripts:'));
+      expect(packageSection).not.toContain('nmr build\n');
+    });
   });
 });

--- a/packages/nmr/package.json
+++ b/packages/nmr/package.json
@@ -39,6 +39,7 @@
     "dist"
   ],
   "scripts": {
+    "build:post": "nmr-sync-agent-files",
     "prepare": "tsx ../../config/build.ts && tsc --project tsconfig.generate-typings.json"
   },
   "dependencies": {

--- a/packages/nmr/src/cli.ts
+++ b/packages/nmr/src/cli.ts
@@ -8,6 +8,7 @@ import { readPackageVersion } from '@williamthorsen/nmr-core';
 
 import { resolveContext } from './context.js';
 import { generateHelp } from './help.js';
+import type { ScriptRegistry } from './resolve-scripts.js';
 import { applyDevBin, buildRootRegistry, buildWorkspaceRegistry, resolveScript } from './resolver.js';
 import { runCommand } from './runner.js';
 
@@ -112,7 +113,7 @@ async function main(): Promise<void> {
   const context = await resolveContext();
 
   if (parsed.help || !parsed.command) {
-    console.info(generateHelp(context.config));
+    console.info(generateHelp(context.config, context.packageDir));
     process.exit(0);
   }
 
@@ -150,30 +151,80 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const packageName = path.basename(packageDir);
-
-  if (resolved.command === '') {
-    if (!parsed.quiet) {
-      console.info(`⛔ ${packageName}: Override script is defined but empty. Skipping.`);
-    }
-    process.exit(0);
-  }
-
-  if (resolved.command === ':') {
-    if (!parsed.quiet) {
-      console.info(`⛔ ${packageName}: Override script is a no-op. Skipping.`);
-    }
-    process.exit(0);
+  const skipExitCode = handleSkipMessage(resolved.command, packageDir, parsed.quiet);
+  if (skipExitCode !== undefined) {
+    process.exit(skipExitCode);
   }
 
   if (resolved.source === 'package' && !parsed.quiet && registry[command] !== undefined) {
-    console.info(`📦 ${packageName}: Using override script: ${resolved.command}`);
+    console.info(`📦 ${path.basename(packageDir)}: Using override script: ${resolved.command}`);
   }
 
   const substitutedCommand = applyDevBin(resolved.command, context.config.devBin, context.monorepoRoot);
-  const fullCommand = substitutedCommand + passthrough;
+  const mainCommand = substitutedCommand + passthrough;
+
+  // Hook recursion guard: commands ending in :pre or :post are leaf operations
+  // and are not themselves wrapped in additional hook lookups.
+  const isHookInvocation = command.endsWith(':pre') || command.endsWith(':post');
+  const fullCommand = isHookInvocation ? mainCommand : wrapWithHooks(command, mainCommand, registry, packageDir);
+
   const code = runCommand(fullCommand, undefined, runOptions);
   process.exit(code);
+}
+
+/**
+ * Returns the exit code to use when a resolved command is an explicit skip
+ * (`""` or `":"`), printing the skip message unless quiet. Returns undefined
+ * when the command is not a skip, indicating execution should proceed.
+ */
+function handleSkipMessage(resolvedCommand: string, packageDir: string, quiet: boolean): number | undefined {
+  if (resolvedCommand === '') {
+    if (!quiet) {
+      console.info(`⛔ ${path.basename(packageDir)}: Override script is defined but empty. Skipping.`);
+    }
+    return 0;
+  }
+  if (resolvedCommand === ':') {
+    if (!quiet) {
+      console.info(`⛔ ${path.basename(packageDir)}: Override script is a no-op. Skipping.`);
+    }
+    return 0;
+  }
+  return undefined;
+}
+
+/**
+ * Wraps a resolved main command with `nmr <command>:pre` and `nmr <command>:post`
+ * invocations when the corresponding hooks resolve to non-skip values.
+ *
+ * Hooks are looked up via the same 3-tier registry as the main command. Missing
+ * hooks (and explicit `""`/`":"` skips) are silent — they do not appear in the
+ * chain and produce no output. Hook failure short-circuits the chain via shell
+ * `&&` semantics; the failing exit code propagates.
+ */
+function wrapWithHooks(command: string, mainCommand: string, registry: ScriptRegistry, packageDir: string): string {
+  const segments: string[] = [];
+
+  if (hasRunnableHook(`${command}:pre`, registry, packageDir)) {
+    segments.push(`nmr ${command}:pre`);
+  }
+  segments.push(mainCommand);
+  if (hasRunnableHook(`${command}:post`, registry, packageDir)) {
+    segments.push(`nmr ${command}:post`);
+  }
+
+  return segments.join(' && ');
+}
+
+/**
+ * Returns true when a hook script resolves to a runnable command.
+ * A hook is runnable when it resolves and the resolved value is neither
+ * `""` nor `":"` (both of which mean "skip").
+ */
+function hasRunnableHook(hookName: string, registry: ScriptRegistry, packageDir: string): boolean {
+  const resolved = resolveScript(hookName, registry, packageDir);
+  if (!resolved) return false;
+  return resolved.command !== '' && resolved.command !== ':';
 }
 
 try {

--- a/packages/nmr/src/cli.ts
+++ b/packages/nmr/src/cli.ts
@@ -140,7 +140,11 @@ async function main(): Promise<void> {
   const useRoot = parsed.workspaceRoot || context.isRoot;
   const registry = useRoot ? buildRootRegistry(context.config) : buildWorkspaceRegistry(context.config, parsed.intTest);
 
-  const packageDir = context.packageDir ?? context.monorepoRoot;
+  // packageDir for tier-3 (package.json) lookups follows useRoot so that `-w`
+  // is fully root-contextual: an override or hook defined in the monorepo
+  // root's package.json resolves under `nmr -w X` from any cwd, mirroring
+  // how it resolves under `nmr X` from root cwd.
+  const packageDir = useRoot ? context.monorepoRoot : (context.packageDir ?? context.monorepoRoot);
   const resolved = resolveScript(command, registry, packageDir);
 
   if (!resolved) {

--- a/packages/nmr/src/cli.ts
+++ b/packages/nmr/src/cli.ts
@@ -166,7 +166,9 @@ async function main(): Promise<void> {
   // Hook recursion guard: commands ending in :pre or :post are leaf operations
   // and are not themselves wrapped in additional hook lookups.
   const isHookInvocation = command.endsWith(':pre') || command.endsWith(':post');
-  const fullCommand = isHookInvocation ? mainCommand : wrapWithHooks(command, mainCommand, registry, packageDir);
+  const fullCommand = isHookInvocation
+    ? mainCommand
+    : wrapWithHooks(command, mainCommand, registry, packageDir, parsed.workspaceRoot);
 
   const code = runCommand(fullCommand, undefined, runOptions);
   process.exit(code);
@@ -201,16 +203,29 @@ function handleSkipMessage(resolvedCommand: string, packageDir: string, quiet: b
  * hooks (and explicit `""`/`":"` skips) are silent — they do not appear in the
  * chain and produce no output. Hook failure short-circuits the chain via shell
  * `&&` semantics; the failing exit code propagates.
+ *
+ * When the parent invocation used `-w`/`--workspace-root` to force root-registry
+ * resolution, the flag is propagated to hook subprocess invocations so the child
+ * resolves hooks against the same registry the parent used. Without this, a hook
+ * defined only in `rootScripts` would fail to resolve when the child re-derives
+ * its registry from the package cwd.
  */
-function wrapWithHooks(command: string, mainCommand: string, registry: ScriptRegistry, packageDir: string): string {
+function wrapWithHooks(
+  command: string,
+  mainCommand: string,
+  registry: ScriptRegistry,
+  packageDir: string,
+  workspaceRoot: boolean,
+): string {
   const segments: string[] = [];
+  const flag = workspaceRoot ? '-w ' : '';
 
   if (hasRunnableHook(`${command}:pre`, registry, packageDir)) {
-    segments.push(`nmr ${command}:pre`);
+    segments.push(`nmr ${flag}${command}:pre`);
   }
   segments.push(mainCommand);
   if (hasRunnableHook(`${command}:post`, registry, packageDir)) {
-    segments.push(`nmr ${command}:post`);
+    segments.push(`nmr ${flag}${command}:post`);
   }
 
   return segments.join(' && ');

--- a/packages/nmr/src/help.ts
+++ b/packages/nmr/src/help.ts
@@ -35,7 +35,7 @@ export function generateHelp(config: NmrConfig, packageDir?: string): string {
 
   if (packageDir !== undefined) {
     const packageScripts = collectPackageScripts(packageDir);
-    if (packageScripts && Object.keys(packageScripts).length > 0) {
+    if (Object.keys(packageScripts).length > 0) {
       lines.push('', 'Package scripts:');
       formatRegistry(packageScripts, lines);
     }
@@ -47,11 +47,11 @@ export function generateHelp(config: NmrConfig, packageDir?: string): string {
 /**
  * Loads a package's `package.json` scripts and removes self-referential entries
  * (e.g., `"build": "nmr build"`) which would appear as redundant duplicates of
- * the workspace command.
+ * the workspace command. Returns an empty object when no scripts are present.
  */
-function collectPackageScripts(packageDir: string): Record<string, string> | undefined {
+function collectPackageScripts(packageDir: string): Record<string, string> {
   const scripts = readPackageJsonScripts(packageDir);
-  if (!scripts) return undefined;
+  if (!scripts) return {};
 
   const filtered: Record<string, string> = {};
   for (const [name, value] of Object.entries(scripts)) {

--- a/packages/nmr/src/help.ts
+++ b/packages/nmr/src/help.ts
@@ -1,13 +1,20 @@
 import type { NmrConfig } from './config.js';
 import type { ScriptRegistry } from './resolve-scripts.js';
-import { buildRootRegistry, buildWorkspaceRegistry } from './resolver.js';
-import { describeScript } from './resolver.js';
+import {
+  buildRootRegistry,
+  buildWorkspaceRegistry,
+  describeScript,
+  isSelfReferential,
+  readPackageJsonScripts,
+} from './resolver.js';
 
 /**
  * Generates the help text for the `nmr` CLI, showing commands
- * from both workspace and root script registries.
+ * from both workspace and root script registries. When `packageDir`
+ * is provided, also lists non-self-referential scripts from that
+ * package's `package.json` under a "Package scripts:" section.
  */
-export function generateHelp(config: NmrConfig): string {
+export function generateHelp(config: NmrConfig, packageDir?: string): string {
   const lines: string[] = [
     'Usage: nmr [flags] <command> [args...]',
     '',
@@ -26,7 +33,33 @@ export function generateHelp(config: NmrConfig): string {
   lines.push('', 'Root commands:');
   formatRegistry(buildRootRegistry(config), lines);
 
+  if (packageDir !== undefined) {
+    const packageScripts = collectPackageScripts(packageDir);
+    if (packageScripts && Object.keys(packageScripts).length > 0) {
+      lines.push('', 'Package scripts:');
+      formatRegistry(packageScripts, lines);
+    }
+  }
+
   return lines.join('\n');
+}
+
+/**
+ * Loads a package's `package.json` scripts and removes self-referential entries
+ * (e.g., `"build": "nmr build"`) which would appear as redundant duplicates of
+ * the workspace command.
+ */
+function collectPackageScripts(packageDir: string): Record<string, string> | undefined {
+  const scripts = readPackageJsonScripts(packageDir);
+  if (!scripts) return undefined;
+
+  const filtered: Record<string, string> = {};
+  for (const [name, value] of Object.entries(scripts)) {
+    if (!isSelfReferential(value, name)) {
+      filtered[name] = value;
+    }
+  }
+  return filtered;
 }
 
 function formatRegistry(registry: ScriptRegistry, lines: string[]): void {

--- a/packages/nmr/src/resolver.ts
+++ b/packages/nmr/src/resolver.ts
@@ -76,7 +76,7 @@ export function describeScript(script: ScriptValue): string {
 /**
  * Reads a package.json file and returns the scripts object.
  */
-function readPackageJsonScripts(packageDir: string): Record<string, string> | undefined {
+export function readPackageJsonScripts(packageDir: string): Record<string, string> | undefined {
   try {
     const raw = readFileSync(path.join(packageDir, 'package.json'), 'utf8');
     const parsed: unknown = JSON.parse(raw);
@@ -124,7 +124,7 @@ export function buildRootRegistry(config: NmrConfig): ScriptRegistry {
  * Check whether a package.json script simply re-invokes the same nmr command,
  * e.g. `"build": "nmr build"` or `"build": "nmr build --verbose"`.
  */
-function isSelfReferential(script: string, commandName: string): boolean {
+export function isSelfReferential(script: string, commandName: string): boolean {
   const prefix = `nmr ${commandName}`;
   return script === prefix || script.startsWith(`${prefix} `);
 }


### PR DESCRIPTION
## What

Adds `:pre` and `:post` hook conventions to nmr's command runner. Consumers can declare `X:pre` or `X:post` scripts that nmr runs automatically before and after script `X`. The hook commands are optional and ignored if missing. Hooks fire even when the main command is overridden, and direct invocations like `nmr build:pre` are treated as leaf operations rather than recursively cascading into `build:pre:pre` lookups.

## Why

nmr's 3-tier resolution model replaces commands at each tier — there has been no way to extend a default script without rewriting it. Hooks are the smallest mechanism that lets consumers extend the standard chain at well-known points without replacing the underlying command.

## Details

### Features

- `nmr --help` from a package context now lists tier-3 scripts (hooks and non-hook overrides) under a new "Package scripts:" section, so consumers can see what's defined in the local `package.json` without opening the file.
- `packages/nmr/package.json` declares `"build:post": "nmr-sync-agent-files"` as the canonical hook consumer: `nmr build` from the nmr workspace re-stamps `.agents/nmr/AGENTS.md` after a version bump, eliminating a latent CI failure mode where a stale agent file could slip through local checks and break a release pipeline downstream.

### Fixes

- The `-w` flag now propagates fully to hook subprocess invocations *and* tier-3 (root `package.json`) lookups, so a hook or override defined only at root resolves correctly under `nmr -w X` from any cwd. Previously, `-w` selected the root registry but tier-3 still consulted the subpackage's `package.json` and hook subprocesses dropped the flag — both now closed.

### Refactoring

- Root build chain (`.config/nmr.config.ts`) now expresses `rdy compile` as a `build:post` hook on the root `build` script rather than a composite-chain step (`build = [build:workspaces, build:rdy]`). Eats the new hook system on the repo's own config; `nmr build:rdy` is replaced by `nmr build:post` for explicit invocation.

Closes #192
