### PR TITLE
#340 Honor -w flag in composite-script step subprocesses

### DIFF
--- a/packages/nmr/__tests__/cli.test.ts
+++ b/packages/nmr/__tests__/cli.test.ts
@@ -545,6 +545,9 @@ export default defineConfig({
     'wroot-cmd': 'echo wroot-main >> ${configLogFile}',
     'wroot-cmd:pre': 'echo wroot-pre >> ${configLogFile}',
     'wroot-cmd:post': 'echo wroot-post >> ${configLogFile}',
+    'wroot-composite': ['wroot-step1', 'wroot-step2'],
+    'wroot-step1': 'echo wroot-step1 >> ${configLogFile}',
+    'wroot-step2': 'echo wroot-step2 >> ${configLogFile}',
   },
 });
 `;
@@ -584,6 +587,17 @@ export default defineConfig({
         const { exitCode } = runNmr('-w wroot-cmd', { cwd: configPkgDir });
         expect(exitCode).toBe(0);
         expect(readConfigLog()).toStrictEqual(['wroot-pre', 'wroot-main', 'wroot-post']);
+      });
+
+      it('propagates -w through composite-script step subprocesses', () => {
+        clearConfigLog();
+        // wroot-composite and its steps live only in rootScripts. The composite expands
+        // to `nmr -w wroot-step1 && nmr -w wroot-step2` so each child resolves via the
+        // root registry. Without -w propagation in expandScript, the children re-derive
+        // a workspace registry from the package cwd and fail with "Unknown command".
+        const { exitCode } = runNmr('-w wroot-composite', { cwd: configPkgDir });
+        expect(exitCode).toBe(0);
+        expect(readConfigLog()).toStrictEqual(['wroot-step1', 'wroot-step2']);
       });
 
       it('resolves tier-3 (root package.json) scripts under -w from a subpackage', () => {

--- a/packages/nmr/__tests__/resolver.test.ts
+++ b/packages/nmr/__tests__/resolver.test.ts
@@ -66,15 +66,27 @@ describe(applyDevBin, () => {
 
 describe('expandScript', () => {
   it('returns a string script unchanged', () => {
-    expect(expandScript('vitest')).toBe('vitest');
+    expect(expandScript('vitest', false)).toBe('vitest');
+  });
+
+  it('returns a string script unchanged regardless of workspaceRoot', () => {
+    expect(expandScript('vitest', true)).toBe('vitest');
   });
 
   it('expands an array to chained nmr invocations', () => {
-    expect(expandScript(['compile', 'generate-typings'])).toBe('nmr compile && nmr generate-typings');
+    expect(expandScript(['compile', 'generate-typings'], false)).toBe('nmr compile && nmr generate-typings');
   });
 
   it('expands a single-element array', () => {
-    expect(expandScript(['test'])).toBe('nmr test');
+    expect(expandScript(['test'], false)).toBe('nmr test');
+  });
+
+  it('propagates -w to each step when workspaceRoot is true', () => {
+    expect(expandScript(['compile', 'generate-typings'], true)).toBe('nmr -w compile && nmr -w generate-typings');
+  });
+
+  it('propagates -w to a single-element array when workspaceRoot is true', () => {
+    expect(expandScript(['test'], true)).toBe('nmr -w test');
   });
 });
 
@@ -130,14 +142,14 @@ describe('resolveScript', () => {
 
   it('resolves from the registry when no package override exists', () => {
     const registry = { test: 'vitest' };
-    const result = resolveScript('test', registry);
+    const result = resolveScript('test', registry, undefined, false);
 
     expect(result).toStrictEqual({ command: 'vitest', source: 'default' });
   });
 
   it('expands array scripts from the registry', () => {
     const registry = { build: ['compile', 'generate-typings'] };
-    const result = resolveScript('build', registry);
+    const result = resolveScript('build', registry, undefined, false);
 
     expect(result).toStrictEqual({
       command: 'nmr compile && nmr generate-typings',
@@ -145,9 +157,19 @@ describe('resolveScript', () => {
     });
   });
 
+  it('propagates -w through composite expansion when workspaceRoot is true', () => {
+    const registry = { build: ['compile', 'generate-typings'] };
+    const result = resolveScript('build', registry, undefined, true);
+
+    expect(result).toStrictEqual({
+      command: 'nmr -w compile && nmr -w generate-typings',
+      source: 'default',
+    });
+  });
+
   it('returns undefined for unknown commands', () => {
     const registry = { test: 'vitest' };
-    expect(resolveScript('unknown', registry)).toBeUndefined();
+    expect(resolveScript('unknown', registry, undefined, false)).toBeUndefined();
   });
 
   it('uses package.json override when present (tier 3)', () => {
@@ -157,16 +179,30 @@ describe('resolveScript', () => {
     );
 
     const registry = { test: 'vitest' };
-    const result = resolveScript('test', registry, tmpDir);
+    const result = resolveScript('test', registry, tmpDir, false);
 
     expect(result).toStrictEqual({ command: 'jest', source: 'package' });
+  });
+
+  it('does not rewrite tier-3 override strings when workspaceRoot is true', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'test-pkg', scripts: { build: 'nmr compile' } }),
+    );
+
+    const registry = { build: ['compile', 'generate-typings'] };
+    const result = resolveScript('build', registry, tmpDir, true);
+
+    // User-authored override strings pass through untouched; only generated
+    // chains receive the -w flag.
+    expect(result).toStrictEqual({ command: 'nmr compile', source: 'package' });
   });
 
   it('skips execution when package.json override is empty string', () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'test-pkg', scripts: { lint: '' } }));
 
     const registry = { lint: 'eslint .' };
-    const result = resolveScript('lint', registry, tmpDir);
+    const result = resolveScript('lint', registry, tmpDir, false);
 
     expect(result).toStrictEqual({ command: '', source: 'package' });
   });
@@ -178,7 +214,7 @@ describe('resolveScript', () => {
     );
 
     const registry = { build: ['compile', 'generate-typings'] };
-    const result = resolveScript('build', registry, tmpDir);
+    const result = resolveScript('build', registry, tmpDir, false);
 
     expect(result).toStrictEqual({
       command: 'nmr compile && nmr generate-typings',
@@ -193,7 +229,7 @@ describe('resolveScript', () => {
     );
 
     const registry = { build: ['compile', 'generate-typings'] };
-    const result = resolveScript('build', registry, tmpDir);
+    const result = resolveScript('build', registry, tmpDir, false);
 
     expect(result).toStrictEqual({
       command: 'nmr compile && nmr generate-typings',
@@ -208,7 +244,7 @@ describe('resolveScript', () => {
     );
 
     const registry = { build: ['compile', 'generate-typings'] };
-    const result = resolveScript('build', registry, tmpDir);
+    const result = resolveScript('build', registry, tmpDir, false);
 
     expect(result).toStrictEqual({ command: 'nmr compile', source: 'package' });
   });
@@ -220,7 +256,7 @@ describe('resolveScript', () => {
     );
 
     const registry = { test: 'vitest' };
-    const result = resolveScript('test', registry, tmpDir);
+    const result = resolveScript('test', registry, tmpDir, false);
 
     expect(result).toStrictEqual({ command: 'vitest', source: 'default' });
   });

--- a/packages/nmr/src/cli.ts
+++ b/packages/nmr/src/cli.ts
@@ -145,7 +145,7 @@ async function main(): Promise<void> {
   // root's package.json resolves under `nmr -w X` from any cwd, mirroring
   // how it resolves under `nmr X` from root cwd.
   const packageDir = useRoot ? context.monorepoRoot : (context.packageDir ?? context.monorepoRoot);
-  const resolved = resolveScript(command, registry, packageDir);
+  const resolved = resolveScript(command, registry, packageDir, parsed.workspaceRoot);
 
   if (!resolved) {
     if (process.env.NMR_RUN_IF_PRESENT === '1') {
@@ -224,11 +224,11 @@ function wrapWithHooks(
   const segments: string[] = [];
   const flag = workspaceRoot ? '-w ' : '';
 
-  if (hasRunnableHook(`${command}:pre`, registry, packageDir)) {
+  if (hasRunnableHook(`${command}:pre`, registry, packageDir, workspaceRoot)) {
     segments.push(`nmr ${flag}${command}:pre`);
   }
   segments.push(mainCommand);
-  if (hasRunnableHook(`${command}:post`, registry, packageDir)) {
+  if (hasRunnableHook(`${command}:post`, registry, packageDir, workspaceRoot)) {
     segments.push(`nmr ${flag}${command}:post`);
   }
 
@@ -240,8 +240,13 @@ function wrapWithHooks(
  * A hook is runnable when it resolves and the resolved value is neither
  * `""` nor `":"` (both of which mean "skip").
  */
-function hasRunnableHook(hookName: string, registry: ScriptRegistry, packageDir: string): boolean {
-  const resolved = resolveScript(hookName, registry, packageDir);
+function hasRunnableHook(
+  hookName: string,
+  registry: ScriptRegistry,
+  packageDir: string,
+  workspaceRoot: boolean,
+): boolean {
+  const resolved = resolveScript(hookName, registry, packageDir, workspaceRoot);
   if (!resolved) return false;
   return resolved.command !== '' && resolved.command !== ':';
 }

--- a/packages/nmr/src/resolver.ts
+++ b/packages/nmr/src/resolver.ts
@@ -58,12 +58,20 @@ export interface ResolvedScript {
 /**
  * Expands a script value into an executable command string.
  * Arrays are expanded to `nmr {step1} && nmr {step2}`.
+ *
+ * When `workspaceRoot` is true, the parent's `-w` flag is propagated to each
+ * step's subprocess invocation (`nmr -w {step1} && nmr -w {step2}`) so children
+ * resolve against the same root registry the parent used. Without this, a step
+ * defined only in `rootScripts` would fail to resolve when the child re-derives
+ * its registry from the package cwd. Mirrors the convention `wrapWithHooks`
+ * uses for hook subprocess invocations.
  */
-export function expandScript(script: ScriptValue): string {
+export function expandScript(script: ScriptValue, workspaceRoot: boolean): string {
   if (typeof script === 'string') {
     return script;
   }
-  return script.map((s) => `nmr ${s}`).join(' && ');
+  const flag = workspaceRoot ? '-w ' : '';
+  return script.map((s) => `nmr ${flag}${s}`).join(' && ');
 }
 
 /**
@@ -142,7 +150,8 @@ export function isSelfReferential(script: string, commandName: string): boolean 
 export function resolveScript(
   commandName: string,
   registry: ScriptRegistry,
-  packageDir?: string,
+  packageDir: string | undefined,
+  workspaceRoot: boolean,
 ): ResolvedScript | undefined {
   // Check tier 3: per-package package.json overrides
   if (packageDir) {
@@ -161,5 +170,5 @@ export function resolveScript(
     return undefined;
   }
 
-  return { command: expandScript(registryEntry), source: 'default' };
+  return { command: expandScript(registryEntry, workspaceRoot), source: 'default' };
 }


### PR DESCRIPTION
## What

Fixes an issue where invoking `nmr -w <command>` from inside a workspace package, with `<command>` resolving to a composite (multi-step) script defined at the root level, failed with `Unknown command` for any step that was reachable only via the root script registry. The `-w` flag is now propagated to every step's subprocess invocation, so composite scripts run end-to-end regardless of which directory they are invoked from.

## Why

Composite scripts are arrays of step names that nmr expands into a chained `nmr step1 && nmr step2` shell command. The chain previously dropped the parent's `-w` flag, so each child subprocess re-derived its registry from the package cwd instead of the root, breaking any step that lived only at the root level. The same flag-dropping pattern was closed for hook subprocesses in the prior release; this change closes it on the composite-expansion surface.

## Details

### Fixes

- Threads an explicit `workspaceRoot` parameter through `resolveScript` and `expandScript` so composite chains emit `nmr -w step1 && nmr -w step2` when the parent invocation used `-w`.
- String registry entries and user-authored package.json override strings pass through untouched; only generated chains receive the flag.

### Tests

- Adds an end-to-end test that invokes a root-only composite via `nmr -w` from a subpackage and asserts each step ran.
- Extends unit coverage for `expandScript` and `resolveScript` to exercise the new parameter, including the explicit non-rewrite of tier-3 override strings.

Closes #340
