### PR TITLE
#342 Skip tooling-only releases instead of failing

### DIFF
--- a/.github/workflows/create-github-release.reusable.yaml
+++ b/.github/workflows/create-github-release.reusable.yaml
@@ -7,6 +7,8 @@ name: Create GitHub Release
 # `release-kit create-github-release --tags <tag>` via `npx`, which prefers the
 # consumer's workspace-linked release-kit over a registry fetch. Independent of
 # `npm publish`: consumers that do not publish to npm can still use this workflow.
+# Releases whose changelog has no all-audience content (e.g., tooling-only)
+# succeed silently — the workflow does not fail.
 # When running in the `williamthorsen/node-monorepo-tools` repo itself (checked
 # via `github.repository`), release-kit is additionally built from source so
 # the workspace-linked binary is ready.

--- a/packages/release-kit/src/__tests__/createGithubRelease.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubRelease.unit.test.ts
@@ -155,6 +155,7 @@ describe(createGithubRelease, () => {
 
   it('skips release with reason no-audience-content when entry has only dev-audience sections', () => {
     mockedExecFileSync.mockClear();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const devOnlyEntries: ChangelogEntry[] = [
       {
         version: '2.0.0',
@@ -175,10 +176,14 @@ describe(createGithubRelease, () => {
 
     expect(result).toEqual({ status: 'skipped', reason: 'no-audience-content' });
     expect(mockedExecFileSync).not.toHaveBeenCalled();
+    // Intentional skips must stay silent at the lib layer; the per-tag info summary is the
+    // command's responsibility and does not run through console.warn.
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('skips release with reason empty-body when rendered all-audience body is empty', () => {
     mockedExecFileSync.mockClear();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     writeFileSync(changelogJsonPath, JSON.stringify(sampleEntries), 'utf8');
     mockedRenderReleaseNotesSingle.mockReturnValueOnce('   \n   ');
 
@@ -190,6 +195,7 @@ describe(createGithubRelease, () => {
 
     expect(result).toEqual({ status: 'skipped', reason: 'empty-body' });
     expect(mockedExecFileSync).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('extracts version from prefixed tags and matches correct entry', () => {

--- a/packages/release-kit/src/__tests__/createGithubRelease.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubRelease.unit.test.ts
@@ -52,18 +52,31 @@ describe(createGithubRelease, () => {
     vi.restoreAllMocks();
   });
 
-  it('returns false and warns when changelog.json does not exist', () => {
+  it('returns no-entry skip and warns when changelog.json does not exist', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = createGithubRelease({
       tag: 'v1.0.0',
       changelogJsonPath: join(tempDir, 'nonexistent.json'),
       dryRun: false,
     });
-    expect(result).toBe(false);
+    expect(result).toEqual({ status: 'skipped', reason: 'no-entry' });
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not found'));
   });
 
-  it('returns false and warns when version is not in changelog.json', () => {
+  it('returns no-entry skip and warns when changelog.json cannot be parsed', () => {
+    writeFileSync(changelogJsonPath, 'not valid json{{{', 'utf8');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = createGithubRelease({
+      tag: 'v1.0.0',
+      changelogJsonPath,
+      dryRun: false,
+    });
+    expect(result).toEqual({ status: 'skipped', reason: 'no-entry' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('could not parse'));
+  });
+
+  it('returns no-entry skip and warns when version is not in changelog.json', () => {
     writeFileSync(changelogJsonPath, JSON.stringify(sampleEntries), 'utf8');
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -72,7 +85,7 @@ describe(createGithubRelease, () => {
       changelogJsonPath,
       dryRun: false,
     });
-    expect(result).toBe(false);
+    expect(result).toEqual({ status: 'skipped', reason: 'no-entry' });
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no changelog entry'));
   });
 
@@ -85,7 +98,7 @@ describe(createGithubRelease, () => {
       changelogJsonPath,
       dryRun: true,
     });
-    expect(result).toBe(true);
+    expect(result).toEqual({ status: 'created' });
     expect(mockedExecFileSync).not.toHaveBeenCalled();
     expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('[dry-run]'));
   });
@@ -140,7 +153,7 @@ describe(createGithubRelease, () => {
     ).toThrow('gh failed');
   });
 
-  it('skips release when entry has only dev-audience sections', () => {
+  it('skips release with reason no-audience-content when entry has only dev-audience sections', () => {
     mockedExecFileSync.mockClear();
     const devOnlyEntries: ChangelogEntry[] = [
       {
@@ -160,7 +173,22 @@ describe(createGithubRelease, () => {
       dryRun: false,
     });
 
-    expect(result).toBe(false);
+    expect(result).toEqual({ status: 'skipped', reason: 'no-audience-content' });
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('skips release with reason empty-body when rendered all-audience body is empty', () => {
+    mockedExecFileSync.mockClear();
+    writeFileSync(changelogJsonPath, JSON.stringify(sampleEntries), 'utf8');
+    mockedRenderReleaseNotesSingle.mockReturnValueOnce('   \n   ');
+
+    const result = createGithubRelease({
+      tag: 'v1.0.0',
+      changelogJsonPath,
+      dryRun: false,
+    });
+
+    expect(result).toEqual({ status: 'skipped', reason: 'empty-body' });
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
 

--- a/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
@@ -199,13 +199,19 @@ describe(createGithubReleaseCommand, () => {
     expect(console.error).toHaveBeenCalledWith('Error discovering workspaces: discovery failed');
   });
 
-  it('exits with code 1 when --tags is explicit and all requested tags produce no Release', async () => {
+  it('exits with code 1 when --tags is explicit and any requested tag has no changelog entry', async () => {
     mockDiscoverWorkspaces.mockResolvedValue(['packages/core', 'packages/extra']);
     mockResolveReleaseTags.mockReturnValue([
       { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
       { tag: 'extra-v0.1.0', dir: 'extra', workspacePath: 'packages/extra' },
     ]);
-    mockCreateGithubReleases.mockReturnValue({ created: [], skipped: ['core-v1.3.0', 'extra-v0.1.0'] });
+    mockCreateGithubReleases.mockReturnValue({
+      created: [],
+      skipped: [
+        { tag: 'core-v1.3.0', reason: 'no-entry' },
+        { tag: 'extra-v0.1.0', reason: 'no-entry' },
+      ],
+    });
 
     let thrown: ExitError | undefined;
     try {
@@ -219,31 +225,102 @@ describe(createGithubReleaseCommand, () => {
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
     expect(console.error).toHaveBeenCalledWith(
-      'Error: no GitHub Releases were created for requested tags: core-v1.3.0, extra-v0.1.0. ' +
-        'Each was skipped (missing changelog entry, no all-audience content, or empty rendered body).',
+      'Error: requested tags have no changelog entry: core-v1.3.0, extra-v0.1.0. ' +
+        'Verify the tag names match a published changelog version.',
     );
   });
 
-  it('does not exit when --tags is omitted and every tag is skipped', async () => {
-    // When the user did not single out tags, an all-skipped outcome is informational, not a failure.
-    mockCreateGithubReleases.mockReturnValue({ created: [], skipped: ['v1.0.0'] });
+  it('exits 0 when --tags is explicit and every skip is no-audience-content', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue(['packages/core']);
+    mockResolveReleaseTags.mockReturnValue([{ tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' }]);
+    mockCreateGithubReleases.mockReturnValue({
+      created: [],
+      skipped: [{ tag: 'core-v1.3.0', reason: 'no-audience-content' }],
+    });
 
-    await createGithubReleaseCommand([]);
+    await createGithubReleaseCommand(['--tags=core-v1.3.0']);
 
-    expect(console.info).toHaveBeenCalledWith('Skipped 1 tag(s) with no releasable content: v1.0.0.');
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledWith(
+      'Skipped 1 tag(s) with no releasable content: core-v1.3.0 (no-audience-content).',
+    );
   });
 
-  it('logs an info summary when some tags are skipped but others succeed', async () => {
+  it('exits 0 when --tags is explicit and the only skip reason is empty-body', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue(['packages/core']);
+    mockResolveReleaseTags.mockReturnValue([{ tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' }]);
+    mockCreateGithubReleases.mockReturnValue({
+      created: [],
+      skipped: [{ tag: 'core-v1.3.0', reason: 'empty-body' }],
+    });
+
+    await createGithubReleaseCommand(['--tags=core-v1.3.0']);
+
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledWith('Skipped 1 tag(s) with no releasable content: core-v1.3.0 (empty-body).');
+  });
+
+  it('exits 1 when --tags has mixed outcomes including a no-entry skip, naming only the no-entry tags', async () => {
+    // A typoed tag is still a typo even when other requested tags succeed. The error message
+    // names only the no-entry tags so the user knows which to investigate.
     mockDiscoverWorkspaces.mockResolvedValue(['packages/core', 'packages/extra']);
     mockResolveReleaseTags.mockReturnValue([
       { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
       { tag: 'extra-v0.1.0', dir: 'extra', workspacePath: 'packages/extra' },
     ]);
-    mockCreateGithubReleases.mockReturnValue({ created: ['core-v1.3.0'], skipped: ['extra-v0.1.0'] });
+    mockCreateGithubReleases.mockReturnValue({
+      created: ['core-v1.3.0'],
+      skipped: [{ tag: 'extra-v0.1.0', reason: 'no-entry' }],
+    });
+
+    let thrown: ExitError | undefined;
+    try {
+      await createGithubReleaseCommand(['--tags=core-v1.3.0,extra-v0.1.0']);
+    } catch (error: unknown) {
+      if (error instanceof ExitError) {
+        thrown = error;
+      }
+    }
+
+    expect(thrown).toBeInstanceOf(ExitError);
+    expect(thrown?.code).toBe(1);
+    expect(console.error).toHaveBeenCalledWith(
+      'Error: requested tags have no changelog entry: extra-v0.1.0. ' +
+        'Verify the tag names match a published changelog version.',
+    );
+  });
+
+  it('does not exit when --tags is omitted and every tag is skipped', async () => {
+    // When the user did not single out tags, an all-skipped outcome is informational, not a failure.
+    mockCreateGithubReleases.mockReturnValue({
+      created: [],
+      skipped: [{ tag: 'v1.0.0', reason: 'no-audience-content' }],
+    });
+
+    await createGithubReleaseCommand([]);
+
+    expect(console.info).toHaveBeenCalledWith(
+      'Skipped 1 tag(s) with no releasable content: v1.0.0 (no-audience-content).',
+    );
+  });
+
+  it('logs an info summary when some tags are skipped (intentional reasons) but others succeed', async () => {
+    mockDiscoverWorkspaces.mockResolvedValue(['packages/core', 'packages/extra']);
+    mockResolveReleaseTags.mockReturnValue([
+      { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
+      { tag: 'extra-v0.1.0', dir: 'extra', workspacePath: 'packages/extra' },
+    ]);
+    mockCreateGithubReleases.mockReturnValue({
+      created: ['core-v1.3.0'],
+      skipped: [{ tag: 'extra-v0.1.0', reason: 'no-audience-content' }],
+    });
 
     await createGithubReleaseCommand(['--tags=core-v1.3.0,extra-v0.1.0']);
 
-    expect(console.info).toHaveBeenCalledWith('Skipped 1 tag(s) with no releasable content: extra-v0.1.0.');
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledWith(
+      'Skipped 1 tag(s) with no releasable content: extra-v0.1.0 (no-audience-content).',
+    );
   });
 
   it('exits with code 1 when createGithubReleases throws', async () => {

--- a/packages/release-kit/src/createGithubRelease.ts
+++ b/packages/release-kit/src/createGithubRelease.ts
@@ -15,19 +15,33 @@ export interface CreateGithubReleaseOptions {
 }
 
 /**
+ * Discriminated reason a single tag was skipped.
+ *
+ * `'no-entry'` is the umbrella for all "data missing" sub-cases (changelog file not found,
+ * JSON unparseable, version not in changelog) — distinguishing them programmatically adds no
+ * value to the consumer, while the existing `console.warn` messages already discriminate them
+ * for human diagnostics.
+ */
+export type CreateReleaseSkipReason = 'no-entry' | 'no-audience-content' | 'empty-body';
+
+/** Discriminated outcome of attempting to create a single GitHub Release. */
+export type CreateReleaseResult = { status: 'created' } | { status: 'skipped'; reason: CreateReleaseSkipReason };
+
+/**
  * Create a GitHub Release from changelog.json using the `gh` CLI.
  *
  * Reads the changelog JSON, finds the entry matching the tag's version, renders all-audience
- * release notes, and creates the release. Returns `false` (with a warning) when the changelog
- * entry is missing, unparseable, or contains no all-audience content. Throws when the `gh` CLI
- * invocation itself fails so callers can surface the failure rather than exit 0 silently.
+ * release notes, and creates the release. Returns a discriminated `{status: 'skipped', reason}`
+ * (with a warning) when the changelog entry is missing, the entry has no all-audience content,
+ * or the rendered body is empty. Throws when the `gh` CLI invocation itself fails so callers
+ * can surface the failure rather than exit 0 silently.
  */
-export function createGithubRelease(options: CreateGithubReleaseOptions): boolean {
+export function createGithubRelease(options: CreateGithubReleaseOptions): CreateReleaseResult {
   const { tag, changelogJsonPath, dryRun, sectionOrder } = options;
 
   if (!existsSync(changelogJsonPath)) {
     console.warn(`Warning: ${changelogJsonPath} not found; skipping GitHub Release creation`);
-    return false;
+    return { status: 'skipped', reason: 'no-entry' };
   }
 
   const version = extractVersion(tag);
@@ -35,17 +49,17 @@ export function createGithubRelease(options: CreateGithubReleaseOptions): boolea
 
   if (entries === undefined) {
     console.warn(`Warning: could not parse ${changelogJsonPath}; skipping GitHub Release creation`);
-    return false;
+    return { status: 'skipped', reason: 'no-entry' };
   }
 
   const entry = entries.find((e) => e.version === version);
   if (entry === undefined) {
     console.warn(`Warning: no changelog entry for version ${version}; skipping GitHub Release creation`);
-    return false;
+    return { status: 'skipped', reason: 'no-entry' };
   }
 
   if (!entry.sections.some(matchesAudience('all'))) {
-    return false;
+    return { status: 'skipped', reason: 'no-audience-content' };
   }
 
   const body = renderReleaseNotesSingle(entry, {
@@ -55,34 +69,34 @@ export function createGithubRelease(options: CreateGithubReleaseOptions): boolea
   });
 
   if (body.trim() === '') {
-    return false;
+    return { status: 'skipped', reason: 'empty-body' };
   }
 
   const args = ['release', 'create', tag, '--title', tag, '--notes', body];
 
   if (dryRun) {
     console.info(`[dry-run] Would run: gh ${args.join(' ')}`);
-    return true;
+    return { status: 'created' };
   }
 
   execFileSync('gh', args, { stdio: 'inherit' });
-  return true;
+  return { status: 'created' };
 }
 
 /** Outcome of a `createGithubReleases` invocation. */
 export interface CreateGithubReleasesOutcome {
   /** Tags for which a Release was created (or would be, under `--dry-run`). */
   created: string[];
-  /** Tags that were skipped with a soft-fail (missing changelog entry, no all-audience content, etc.). */
-  skipped: string[];
+  /** Tags that were skipped, paired with the discriminated reason for each skip. */
+  skipped: Array<{ tag: string; reason: CreateReleaseSkipReason }>;
 }
 
 /**
  * Create GitHub Releases for each provided tag.
  *
  * Per-tag soft-fails (missing changelog entry, no all-audience content, empty rendered body) are
- * recorded in `skipped` and do not throw. Hard failures from the `gh` CLI itself throw and
- * short-circuit the loop so callers can surface them.
+ * recorded in `skipped` with their discriminated reason and do not throw. Hard failures from the
+ * `gh` CLI itself throw and short-circuit the loop so callers can surface them.
  */
 export function createGithubReleases(
   tags: Array<{ tag: string; workspacePath: string }>,
@@ -91,7 +105,7 @@ export function createGithubReleases(
   sectionOrder?: string[],
 ): CreateGithubReleasesOutcome {
   const created: string[] = [];
-  const skipped: string[] = [];
+  const skipped: Array<{ tag: string; reason: CreateReleaseSkipReason }> = [];
   for (const { tag, workspacePath } of tags) {
     const changelogJsonPath = join(workspacePath, changelogJsonOutputPath);
     const result = createGithubRelease({
@@ -100,7 +114,11 @@ export function createGithubReleases(
       dryRun,
       ...(sectionOrder === undefined ? {} : { sectionOrder }),
     });
-    (result ? created : skipped).push(tag);
+    if (result.status === 'created') {
+      created.push(tag);
+    } else {
+      skipped.push({ tag, reason: result.reason });
+    }
   }
   return { created, skipped };
 }

--- a/packages/release-kit/src/createGithubReleaseCommand.ts
+++ b/packages/release-kit/src/createGithubReleaseCommand.ts
@@ -41,19 +41,25 @@ export async function createGithubReleaseCommand(argv: string[]): Promise<void> 
     process.exit(1);
   }
 
-  // Fail visibly when the user explicitly requested tags via --tags and no Release was created.
-  // A soft-skip across every requested tag is a silent-success gap for this command, whose whole
-  // purpose is failure visibility. Omitted --tags (operate on all HEAD tags) keeps the legacy
-  // soft-skip behavior since the user did not single out specific tags.
-  if (requestedTags !== undefined && outcome.created.length === 0) {
-    console.error(
-      `Error: no GitHub Releases were created for requested tags: ${outcome.skipped.join(', ')}. ` +
-        `Each was skipped (missing changelog entry, no all-audience content, or empty rendered body).`,
-    );
-    process.exit(1);
+  // Fail visibly when the user explicitly requested tags via --tags and any requested tag has no
+  // changelog entry: that's a typo or misconfiguration worth surfacing, even if other requested
+  // tags succeeded. Other skip reasons (`no-audience-content`, `empty-body`) are intentional
+  // outcomes of release-kit's rendering rules — a tooling-only release has nothing user-facing
+  // to announce, and that's a normal state, not a failure. Omitted --tags (operate on all HEAD
+  // tags) keeps the legacy soft-skip behavior since the user did not single out specific tags.
+  if (requestedTags !== undefined) {
+    const noEntryTags = outcome.skipped.filter((s) => s.reason === 'no-entry').map((s) => s.tag);
+    if (noEntryTags.length > 0) {
+      console.error(
+        `Error: requested tags have no changelog entry: ${noEntryTags.join(', ')}. ` +
+          `Verify the tag names match a published changelog version.`,
+      );
+      process.exit(1);
+    }
   }
 
   if (outcome.skipped.length > 0) {
-    console.info(`Skipped ${outcome.skipped.length} tag(s) with no releasable content: ${outcome.skipped.join(', ')}.`);
+    const formatted = outcome.skipped.map((s) => `${s.tag} (${s.reason})`).join(', ');
+    console.info(`Skipped ${outcome.skipped.length} tag(s) with no releasable content: ${formatted}.`);
   }
 }


### PR DESCRIPTION
## What

Fixes an issue where `release-kit create-github-release --tags <tag>` exited 1 whenever the tag's changelog had no all-audience content. The reusable `create-github-release.reusable.yaml` workflow forwards `github.ref_name` into `--tags`, so tooling-only releases consistently produced failed workflow runs even though no failure occurred. The command now exits 1 only when a requested tag has no changelog entry; intentional skip reasons (`no-audience-content`, `empty-body`) are informational. A typoed tag still surfaces an error even when batched alongside successful tags, and the info summary reports the per-tag skip reason for diagnostic visibility.

## Why

A repository whose release lacked all-audience content (e.g., a `Tooling`-only release section) would see every tag-push workflow run fail, despite the underlying release-kit behavior being correct: there was simply nothing user-facing to publish. The conflated exit-code policy turned a normal "no announcement needed" outcome into a red CI run, eroding signal value of the workflow status. Distinguishing the three skip reasons restores the failure signal to its intended meaning — a typoed or missing tag — while letting designed silences pass through cleanly.

## Details

### Fixes

- `createGithubRelease()` now returns a discriminated `{status: 'created'} | {status: 'skipped'; reason: 'no-entry' | 'no-audience-content' | 'empty-body'}` result instead of a `boolean`. `'no-entry'` is the umbrella for the three "data missing" sub-cases (changelog file not found, JSON unparseable, version not in the changelog); the existing `console.warn` messages still discriminate them for human diagnostics.
- `createGithubReleases()` aggregates the per-tag reason into `skipped: Array<{tag, reason}>`.
- The CLI's exit logic exits 1 when `--tags` is explicit and any requested tag has reason `'no-entry'`, regardless of whether other requested tags succeeded. Intentional skip reasons no longer affect the exit code.
- The error message names only the no-entry tags, so users can isolate the typo or missing entry rather than scanning a list that mixes typos with intentional skips.
- The info summary surfaces the per-tag reason: `Skipped 1 tag(s) with no releasable content: foo-v1.0.0 (no-audience-content).`
- The reusable `create-github-release.reusable.yaml` workflow header documents that tooling-only releases succeed silently.

### Tests

- Coverage for each of the three skip-reason variants in `createGithubRelease.unit.test.ts`, including the JSON-parse-failure sub-case of `'no-entry'`.
- Coverage for every row of the behavior matrix in `createGithubReleaseCommand.unit.test.ts`: exit 0 for `no-audience-content` and `empty-body` skips; exit 1 for `no-entry` skips alone or mixed with successful tags; the info-summary format including the per-tag reason.
- Negative `console.warn` assertions on the `'no-audience-content'` and `'empty-body'` tests, pinning the contract that intentional skips stay silent at the lib layer (the per-tag info summary remains the command's responsibility).

Closes #342
