### PR TITLE
#343 Filter `nmr --help` to nmr commands

### DIFF
--- a/packages/nmr/__tests__/help.test.ts
+++ b/packages/nmr/__tests__/help.test.ts
@@ -8,12 +8,12 @@ import { generateHelp } from '../src/help.js';
 
 describe(generateHelp, () => {
   it('includes usage line', () => {
-    const help = generateHelp({});
+    const help = generateHelp({}, undefined, false);
     expect(help).toContain('Usage: nmr [flags] <command> [args...]');
   });
 
   it('includes all flag descriptions', () => {
-    const help = generateHelp({});
+    const help = generateHelp({}, undefined, false);
     expect(help).toContain('-F, --filter');
     expect(help).toContain('-R, --recursive');
     expect(help).toContain('-w, --workspace-root');
@@ -22,7 +22,7 @@ describe(generateHelp, () => {
   });
 
   it('includes workspace commands section', () => {
-    const help = generateHelp({});
+    const help = generateHelp({}, undefined, false);
     expect(help).toContain('Workspace commands:');
     expect(help).toContain('build');
     expect(help).toContain('test');
@@ -30,32 +30,58 @@ describe(generateHelp, () => {
   });
 
   it('includes root commands section', () => {
-    const help = generateHelp({});
+    const help = generateHelp({}, undefined, false);
     expect(help).toContain('Root commands:');
     expect(help).toContain('ci');
     expect(help).toContain('report-overrides');
   });
 
   it('includes config-defined scripts', () => {
-    const help = generateHelp({
-      workspaceScripts: { 'copy-content': 'tsx scripts/copy-content.ts' },
-      rootScripts: { 'demo:catwalk': 'pnpx http-server' },
-    });
+    const help = generateHelp(
+      {
+        workspaceScripts: { 'copy-content': 'tsx scripts/copy-content.ts' },
+        rootScripts: { 'demo:catwalk': 'pnpx http-server' },
+      },
+      undefined,
+      false,
+    );
 
     expect(help).toContain('copy-content');
     expect(help).toContain('demo:catwalk');
   });
 
-  it('includes config-defined hook in workspace commands', () => {
-    const help = generateHelp({
-      workspaceScripts: { 'build:pre': 'npx rdy compile' },
-    });
+  it('omits config-defined hooks from the workspace section', () => {
+    const help = generateHelp(
+      {
+        workspaceScripts: { 'build:pre': 'npx rdy compile' },
+      },
+      undefined,
+      false,
+    );
 
-    expect(help).toContain('build:pre');
-    expect(help).toContain('npx rdy compile');
+    expect(help).not.toContain('build:pre');
+    expect(help).not.toContain('npx rdy compile');
   });
 
-  describe('package scripts section', () => {
+  it('omits config-defined hooks from the root section', () => {
+    const help = generateHelp(
+      {
+        rootScripts: { 'build:post': 'echo built' },
+      },
+      undefined,
+      true,
+    );
+
+    expect(help).not.toContain('build:post');
+    expect(help).not.toContain('echo built');
+  });
+
+  it('omits the package scripts section regardless of packageDir', () => {
+    const help = generateHelp({}, undefined, false);
+    expect(help).not.toContain('Package scripts:');
+  });
+
+  describe('overrides section behavior', () => {
     let tmpDir: string;
 
     beforeEach(() => {
@@ -66,65 +92,164 @@ describe(generateHelp, () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it('omits package scripts section when packageDir is not provided', () => {
-      const help = generateHelp({});
+    it('omits the package scripts section even when packageDir has scripts', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({
+          name: 'pkg',
+          scripts: { something: 'echo something' },
+        }),
+      );
+
+      const help = generateHelp({}, tmpDir, false);
       expect(help).not.toContain('Package scripts:');
     });
 
-    it('omits package scripts section when package has no scripts', () => {
-      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'empty-pkg' }));
-
-      const help = generateHelp({}, tmpDir);
-      expect(help).not.toContain('Package scripts:');
-    });
-
-    it('lists tier-3 hook scripts in package scripts section', () => {
+    it('omits hook entries from a subpackage package.json', () => {
+      // Use a sentinel value that is not present in any default registry entry,
+      // so we can detect leakage of the package-script value distinctly from
+      // unrelated registry rows.
       fs.writeFileSync(
         path.join(tmpDir, 'package.json'),
         JSON.stringify({
           name: 'pkg-with-hook',
-          scripts: { 'build:post': 'nmr-sync-agent-files' },
+          scripts: { 'build:post': 'sentinel-hook-value' },
         }),
       );
 
-      const help = generateHelp({}, tmpDir);
-      expect(help).toContain('Package scripts:');
-      expect(help).toContain('build:post');
-      expect(help).toContain('nmr-sync-agent-files');
+      const help = generateHelp({}, tmpDir, false);
+      expect(help).not.toContain('build:post');
+      expect(help).not.toContain('sentinel-hook-value');
     });
 
-    it('lists tier-3 non-hook overrides in package scripts section', () => {
+    it('omits non-override (tier-3-only) entries from a subpackage package.json', () => {
       fs.writeFileSync(
         path.join(tmpDir, 'package.json'),
         JSON.stringify({
-          name: 'pkg-with-override',
-          scripts: { build: 'tsc -p tsconfig.custom.json' },
+          name: 'pkg-with-extra',
+          scripts: { 'custom-task': 'echo custom' },
         }),
       );
 
-      const help = generateHelp({}, tmpDir);
-      expect(help).toContain('Package scripts:');
-      expect(help).toContain('tsc -p tsconfig.custom.json');
+      const help = generateHelp({}, tmpDir, false);
+      expect(help).not.toContain('custom-task');
+      expect(help).not.toContain('echo custom');
     });
 
-    it('omits self-referential package scripts', () => {
+    it('omits generic pnpm lifecycle entries from a subpackage package.json', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({
+          name: 'pkg-lifecycle',
+          scripts: { prepare: 'echo prepare', postinstall: 'echo postinstall' },
+        }),
+      );
+
+      const help = generateHelp({}, tmpDir, false);
+      expect(help).not.toContain('prepare');
+      expect(help).not.toContain('postinstall');
+    });
+
+    it('inlines workspace overrides with `*` marker and footnote when useRoot=false', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({
+          name: 'pkg-override',
+          scripts: { lint: 'pkg-linter' },
+        }),
+      );
+
+      const help = generateHelp({}, tmpDir, false);
+      const workspaceSection = sectionOf(help, 'Workspace commands:', 'Root commands:');
+      expect(workspaceSection).toContain('lint*');
+      expect(workspaceSection).toContain('pkg-linter');
+      expect(help).toContain('* Overridden by package.json');
+
+      const rootSection = sectionOf(help, 'Root commands:', '* Overridden by package.json');
+      expect(rootSection).not.toContain('pkg-linter');
+    });
+
+    it('inlines root overrides with `*` marker and footnote when useRoot=true', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({
+          name: 'root-override',
+          scripts: { lint: 'custom-linter' },
+        }),
+      );
+
+      const help = generateHelp({}, tmpDir, true);
+      const rootSection = sectionOf(help, 'Root commands:', '* Overridden by package.json');
+      expect(rootSection).toContain('lint*');
+      expect(rootSection).toContain('custom-linter');
+      expect(help).toContain('* Overridden by package.json');
+
+      const workspaceSection = sectionOf(help, 'Workspace commands:', 'Root commands:');
+      expect(workspaceSection).not.toContain('custom-linter');
+    });
+
+    it('does not mark or override self-referential entries', () => {
       fs.writeFileSync(
         path.join(tmpDir, 'package.json'),
         JSON.stringify({
           name: 'pkg-self-ref',
-          scripts: {
-            build: 'nmr build',
-            'build:post': 'nmr-sync-agent-files',
-          },
+          scripts: { build: 'nmr build' },
         }),
       );
 
-      const help = generateHelp({}, tmpDir);
-      expect(help).toContain('Package scripts:');
-      expect(help).toContain('build:post');
-      // The self-referential `"build": "nmr build"` should not appear as a package script
-      const packageSection = help.slice(help.indexOf('Package scripts:'));
-      expect(packageSection).not.toContain('nmr build\n');
+      const help = generateHelp({}, tmpDir, false);
+      expect(help).not.toContain('build*');
+      expect(help).not.toContain('* Overridden by package.json');
+    });
+
+    it('omits the footnote when no overrides are present', () => {
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'plain-pkg' }));
+
+      const help = generateHelp({}, tmpDir, false);
+      expect(help).not.toContain('* Overridden by package.json');
+    });
+
+    it('aligns the value column for marked and unmarked rows in the same section', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({
+          name: 'align-pkg',
+          scripts: { lint: 'custom-linter' },
+        }),
+      );
+
+      const help = generateHelp({}, tmpDir, true);
+      const rootSection = sectionOf(help, 'Root commands:', '* Overridden by package.json');
+      const rows = rootSection.split('\n').filter((line) => line.startsWith('  ') && line.trim().length > 0);
+      // All rendered rows in the root section should share the same value-column offset
+      const valueColumns = new Set(rows.map((line) => findValueColumn(line)));
+      expect(valueColumns.size).toBe(1);
     });
   });
 });
+
+/**
+ * Extracts the substring between two markers (exclusive of the end marker).
+ * Returns the portion of `help` from `start` up to (but not including) `end`.
+ */
+function sectionOf(help: string, start: string, end: string): string {
+  const startIdx = help.indexOf(start);
+  const endIdx = help.indexOf(end, startIdx + start.length);
+  if (startIdx === -1) return '';
+  if (endIdx === -1) return help.slice(startIdx);
+  return help.slice(startIdx, endIdx);
+}
+
+/**
+ * Returns the column index where the value starts on a registry row.
+ * A row looks like `  <key><marker>   <value>`; the value begins at the
+ * first non-space character following the column padding after the key.
+ */
+function findValueColumn(line: string): number {
+  // Skip the leading `  ` indent, then skip past the key+marker text, then
+  // find the next non-space character which is where the value starts.
+  let i = 2;
+  while (i < line.length && line[i] !== ' ') i++;
+  while (i < line.length && line[i] === ' ') i++;
+  return i;
+}

--- a/packages/nmr/__tests__/helpers/hook-name.test.ts
+++ b/packages/nmr/__tests__/helpers/hook-name.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { isHookName } from '../../src/helpers/hook-name.js';
+
+describe(isHookName, () => {
+  it.each(['build:pre', 'build:post', 'test:pre', 'test:post', 'some:nested:post', 'x:pre', 'x:post'])(
+    'returns true for hook name %s',
+    (key) => {
+      expect(isHookName(key)).toBe(true);
+    },
+  );
+
+  it.each(['build', 'test', 'lint:check', 'root:test', 'prepare', 'postinstall', ':pre', ':post', ''])(
+    'returns false for non-hook name %s',
+    (key) => {
+      expect(isHookName(key)).toBe(false);
+    },
+  );
+});

--- a/packages/nmr/src/cli.ts
+++ b/packages/nmr/src/cli.ts
@@ -8,6 +8,7 @@ import { readPackageVersion } from '@williamthorsen/nmr-core';
 
 import { resolveContext } from './context.js';
 import { generateHelp } from './help.js';
+import { isHookName } from './helpers/hook-name.js';
 import type { ScriptRegistry } from './resolve-scripts.js';
 import { applyDevBin, buildRootRegistry, buildWorkspaceRegistry, resolveScript } from './resolver.js';
 import { runCommand } from './runner.js';
@@ -112,8 +113,17 @@ async function main(): Promise<void> {
 
   const context = await resolveContext();
 
+  // Determine which registry to use
+  const useRoot = parsed.workspaceRoot || context.isRoot;
+
+  // packageDir for tier-3 (package.json) lookups follows useRoot so that `-w`
+  // is fully root-contextual: an override or hook defined in the monorepo
+  // root's package.json resolves under `nmr -w X` from any cwd, mirroring
+  // how it resolves under `nmr X` from root cwd.
+  const packageDir = useRoot ? context.monorepoRoot : (context.packageDir ?? context.monorepoRoot);
+
   if (parsed.help || !parsed.command) {
-    console.info(generateHelp(context.config, context.packageDir));
+    console.info(generateHelp(context.config, packageDir, useRoot));
     process.exit(0);
   }
 
@@ -136,15 +146,7 @@ async function main(): Promise<void> {
     process.exit(code);
   }
 
-  // Determine which registry to use
-  const useRoot = parsed.workspaceRoot || context.isRoot;
   const registry = useRoot ? buildRootRegistry(context.config) : buildWorkspaceRegistry(context.config, parsed.intTest);
-
-  // packageDir for tier-3 (package.json) lookups follows useRoot so that `-w`
-  // is fully root-contextual: an override or hook defined in the monorepo
-  // root's package.json resolves under `nmr -w X` from any cwd, mirroring
-  // how it resolves under `nmr X` from root cwd.
-  const packageDir = useRoot ? context.monorepoRoot : (context.packageDir ?? context.monorepoRoot);
   const resolved = resolveScript(command, registry, packageDir, parsed.workspaceRoot);
 
   if (!resolved) {
@@ -169,7 +171,7 @@ async function main(): Promise<void> {
 
   // Hook recursion guard: commands ending in :pre or :post are leaf operations
   // and are not themselves wrapped in additional hook lookups.
-  const isHookInvocation = command.endsWith(':pre') || command.endsWith(':post');
+  const isHookInvocation = isHookName(command);
   const fullCommand = isHookInvocation
     ? mainCommand
     : wrapWithHooks(command, mainCommand, registry, packageDir, parsed.workspaceRoot);

--- a/packages/nmr/src/help.ts
+++ b/packages/nmr/src/help.ts
@@ -1,4 +1,5 @@
 import type { NmrConfig } from './config.js';
+import { isHookName } from './helpers/hook-name.js';
 import type { ScriptRegistry } from './resolve-scripts.js';
 import {
   buildRootRegistry,
@@ -9,12 +10,19 @@ import {
 } from './resolver.js';
 
 /**
- * Generates the help text for the `nmr` CLI, showing commands
- * from both workspace and root script registries. When `packageDir`
- * is provided, also lists non-self-referential scripts from that
- * package's `package.json` under a "Package scripts:" section.
+ * Generates the help text for the `nmr` CLI. Renders only nmr commands —
+ * names from the workspace and root registries, excluding hooks (`*:pre`,
+ * `*:post`).
+ *
+ * When `packageDir` is provided, tier-3 entries from that package's
+ * `package.json:scripts` that match a registry name in the active section
+ * are inlined as overrides: the registry value is replaced with the
+ * override value and the row's command name is suffixed with `*`. The
+ * active section is the root section when `useRoot` is true (root cwd
+ * or `-w`), otherwise the workspace section. A footnote is appended once
+ * if any override marker was rendered.
  */
-export function generateHelp(config: NmrConfig, packageDir?: string): string {
+export function generateHelp(config: NmrConfig, packageDir: string | undefined, useRoot: boolean): string {
   const lines: string[] = [
     'Usage: nmr [flags] <command> [args...]',
     '',
@@ -29,44 +37,93 @@ export function generateHelp(config: NmrConfig, packageDir?: string): string {
     'Workspace commands:',
   ];
 
-  formatRegistry(buildWorkspaceRegistry(config, false), lines);
-  lines.push('', 'Root commands:');
-  formatRegistry(buildRootRegistry(config), lines);
+  const overrides = packageDir === undefined ? {} : collectOverrides(packageDir);
 
-  if (packageDir !== undefined) {
-    const packageScripts = collectPackageScripts(packageDir);
-    if (Object.keys(packageScripts).length > 0) {
-      lines.push('', 'Package scripts:');
-      formatRegistry(packageScripts, lines);
-    }
+  let hadOverride = false;
+
+  const workspaceRegistry = filterHooks(buildWorkspaceRegistry(config, false));
+  const workspaceMarked = !useRoot ? applyOverrides(workspaceRegistry, overrides) : new Set<string>();
+  if (workspaceMarked.size > 0) hadOverride = true;
+  formatRegistry(workspaceRegistry, workspaceMarked, lines);
+
+  lines.push('', 'Root commands:');
+  const rootRegistry = filterHooks(buildRootRegistry(config));
+  const rootMarked = useRoot ? applyOverrides(rootRegistry, overrides) : new Set<string>();
+  if (rootMarked.size > 0) hadOverride = true;
+  formatRegistry(rootRegistry, rootMarked, lines);
+
+  if (hadOverride) {
+    lines.push('', '* Overridden by package.json');
   }
 
   return lines.join('\n');
 }
 
 /**
- * Loads a package's `package.json` scripts and removes self-referential entries
- * (e.g., `"build": "nmr build"`) which would appear as redundant duplicates of
- * the workspace command. Returns an empty object when no scripts are present.
+ * Loads `packageDir`'s `package.json:scripts`, dropping self-referential
+ * entries and hook names. The result is a candidate map of overrides;
+ * `applyOverrides` decides which entries actually match a registry name
+ * in the section being rendered.
  */
-function collectPackageScripts(packageDir: string): Record<string, string> {
+function collectOverrides(packageDir: string): Record<string, string> {
   const scripts = readPackageJsonScripts(packageDir);
   if (!scripts) return {};
 
   const filtered: Record<string, string> = {};
   for (const [name, value] of Object.entries(scripts)) {
-    if (!isSelfReferential(value, name)) {
-      filtered[name] = value;
-    }
+    if (isHookName(name)) continue;
+    if (isSelfReferential(value, name)) continue;
+    filtered[name] = value;
   }
   return filtered;
 }
 
-function formatRegistry(registry: ScriptRegistry, lines: string[]): void {
-  const maxKeyLen = Math.max(...Object.keys(registry).map((k) => k.length));
-  const pad = Math.max(maxKeyLen + 2, 20);
+/**
+ * Applies tier-3 overrides to a section registry in place: for each candidate
+ * override whose name matches a registry entry, replaces the registry value
+ * with the override value and records the name. Returns the set of marked
+ * names so the renderer can attach the `*` marker.
+ */
+function applyOverrides(registry: ScriptRegistry, overrides: Record<string, string>): Set<string> {
+  const marked = new Set<string>();
+  for (const [name, value] of Object.entries(overrides)) {
+    if (name in registry) {
+      registry[name] = value;
+      marked.add(name);
+    }
+  }
+  return marked;
+}
+
+/**
+ * Returns a copy of `registry` with hook entries (`*:pre`, `*:post`) removed.
+ */
+function filterHooks(registry: ScriptRegistry): ScriptRegistry {
+  const filtered: ScriptRegistry = {};
+  for (const [key, value] of Object.entries(registry)) {
+    if (!isHookName(key)) filtered[key] = value;
+  }
+  return filtered;
+}
+
+/**
+ * Renders each registry entry as `  <key><marker>  <value>`, where `marker`
+ * is `*` for entries in `marked` and a space otherwise. The combined
+ * `key + marker` is padded so the value column lines up across marked and
+ * unmarked rows.
+ */
+function formatRegistry(registry: ScriptRegistry, marked: Set<string>, lines: string[]): void {
+  const keys = Object.keys(registry);
+  if (keys.length === 0) return;
+
+  const maxKeyLen = Math.max(...keys.map((k) => k.length));
+  // +1 so there is room for the `*` marker character on every row, +2 to
+  // preserve the prior gap before the value column. The minimum (20) keeps
+  // narrow registries from collapsing.
+  const pad = Math.max(maxKeyLen + 1 + 2, 20);
 
   for (const [key, value] of Object.entries(registry)) {
-    lines.push(`  ${key.padEnd(pad)} ${describeScript(value)}`);
+    const marker = marked.has(key) ? '*' : ' ';
+    lines.push(`  ${(key + marker).padEnd(pad)} ${describeScript(value)}`);
   }
 }

--- a/packages/nmr/src/helpers/hook-name.ts
+++ b/packages/nmr/src/helpers/hook-name.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns true when `key` is a hook script name — that is, ends with the
+ * `:pre` or `:post` suffix preceded by at least one character.
+ *
+ * Bare `:pre` and `:post` (no parent name) return false. The predicate is
+ * purely about suffix shape; it does not consult the registry or care
+ * whether the parent command exists.
+ */
+export function isHookName(key: string): boolean {
+  return (key.length > 4 && key.endsWith(':pre')) || (key.length > 5 && key.endsWith(':post'));
+}


### PR DESCRIPTION
## What

Restricts `nmr --help` to nmr commands only. Hook scripts (names ending in `:pre` or `:post`) are now hidden from help, and generic `package.json` lifecycle scripts (`prepare`, `postinstall`, `bootstrap`) no longer appear. When a `package.json` script overrides a built-in nmr command, the override is shown inline alongside the command name with a `*` marker, and a single `* Overridden by package.json` footnote is appended whenever any marker is rendered. Help also now reflects the active resolution context: invoked from a subpackage you see workspace-level overrides; invoked from the repo root (or with `-w`) you see root-level overrides.

## Why

`nmr --help` was inconsistent with what `nmr <name>` actually resolves: at root cwd, scripted overrides were silently omitted; at a subpackage, the entire `package.json:scripts` block — including pnpm lifecycle scripts that are not nmr commands — was dumped into a separate section. Help should faithfully answer "what nmr commands does this repo expose?"

## Details

### Features

- Hook entries (`*:pre`, `*:post`) are excluded from help in both workspace and root sections, regardless of tier.
- `package.json:scripts` entries that override registry commands are inlined into the active section with a `*` marker and a single shared footnote.
- Help and command resolution share the same registry context — `useRoot` is now passed into `generateHelp` so help output matches what `nmr <name>` would resolve from the current cwd.

### Refactoring

- New `isHookName(key)` predicate in `packages/nmr/src/helpers/hook-name.ts` centralizes the hook-suffix convention. Replaces the inline `endsWith(':pre') || endsWith(':post')` check at the cli's recursion guard.
- The standalone `Package scripts:` section in help has been removed; tier-3 entries are now visible exclusively as inline overrides on registry rows.

### Tests

- Parameterized tests for `isHookName` covering all true/false cases.
- Help-test rewrite covering hook filtering, override inlining for both `useRoot` modes, footnote presence/absence, self-referential entries not marked, lifecycle scripts hidden, and value-column alignment across marked and unmarked rows.

Closes #343
