### PR TITLE
#357 Surface bang violations in release prepare reports

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -107,16 +107,17 @@ The config file supports both `export default config` and `export const config =
 
 ### `ReleaseKitConfig` reference
 
-| Field             | Type                             | Description                                                                                                                   |
-| ----------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `cliffConfigPath` | `string`                         | Explicit path to cliff config. If omitted, resolved automatically: `.config/git-cliff.toml` → `cliff.toml` → bundled template |
-| `workspaces`      | `WorkspaceOverride[]`            | Override or exclude discovered workspaces (matched by `dir`)                                                                  |
-| `formatCommand`   | `string`                         | Shell command to run after changelog generation; modified file paths are appended as arguments                                |
-| `versionPatterns` | `VersionPatterns`                | Rules for which commit types trigger major/minor bumps                                                                        |
-| `scopeAliases`    | `Record<string, string>`         | Maps shorthand scope names to canonical names in commits                                                                      |
-| `workTypes`       | `Record<string, WorkTypeConfig>` | Work type definitions, merged with defaults by key                                                                            |
-| `retiredPackages` | `RetiredPackage[]`               | Packages that once lived in this repo but have been extracted or removed; suppresses undeclared-tag-prefix warnings           |
-| `project`         | `ProjectConfig`                  | Opt-in project-level release block. Declaring `project: {}` (even empty) enables a project-release stage in `prepare`         |
+| Field              | Type                                                      | Description                                                                                                                                          |
+| ------------------ | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cliffConfigPath`  | `string`                                                  | Explicit path to cliff config. If omitted, resolved automatically: `.config/git-cliff.toml` → `cliff.toml` → bundled template                        |
+| `workspaces`       | `WorkspaceOverride[]`                                     | Override or exclude discovered workspaces (matched by `dir`)                                                                                         |
+| `formatCommand`    | `string`                                                  | Shell command to run after changelog generation; modified file paths are appended as arguments                                                       |
+| `versionPatterns`  | `VersionPatterns`                                         | Rules for which commit types trigger major/minor bumps                                                                                               |
+| `scopeAliases`     | `Record<string, string>`                                  | Maps shorthand scope names to canonical names in commits                                                                                             |
+| `workTypes`        | `Record<string, WorkTypeConfig>`                          | Work type definitions, merged with defaults by key                                                                                                   |
+| `breakingPolicies` | `Record<string, 'forbidden' \| 'optional' \| 'required'>` | Per-type `!`-policy lookup. Defaults to `DEFAULT_BREAKING_POLICIES`. Replaces the default entirely when provided. Set to `{}` to disable enforcement |
+| `retiredPackages`  | `RetiredPackage[]`                                        | Packages that once lived in this repo but have been extracted or removed; suppresses undeclared-tag-prefix warnings                                  |
+| `project`          | `ProjectConfig`                                           | Opt-in project-level release block. Declaring `project: {}` (even empty) enables a project-release stage in `prepare`                                |
 
 All fields are optional.
 
@@ -323,6 +324,19 @@ The `!` policy operates at two distinct levels with different semantics:
 - **Release-time** (`parseCommitMessage`) — tolerant warn-and-continue. Commits already in the log cannot be rewritten, so a policy-violating commit is parsed using its canonical type with `breaking: false` (the `!` is dropped from the parse) and a `onPolicyViolation` callback fires. Callers (`decideRelease` etc.) can collect these warnings and surface them in the release report. A single legacy `internal!` in a year-old log does not block releases.
 
 A `BREAKING CHANGE:` body footer on a `forbidden`-policy type triggers the same warning path as the prefix `!` does — the spirit of the policy is "internal/perf/etc. cannot be breaking", which must apply to both surfaces.
+
+The release-prepare orchestrators (`releasePrepare`, `releasePrepareMono`, `releasePrepareProject`) apply `DEFAULT_BREAKING_POLICIES` automatically. Violations encountered while parsing each workspace's or project's commit window are collected onto the corresponding result's `policyViolations` field and rendered under the section in the prepare report:
+
+```
+arrays
+  Found 1 commits since arrays-v1.0.0
+  ⚠️  1 policy violation:
+      · def5678 'internal!: refactor cache' — type 'internal' at prefix surface
+  Bumping versions (patch)...
+  📦 1.0.0 → 1.0.1 (patch)
+```
+
+To customize, set `breakingPolicies` in `release-kit.config.ts` — provide a partial map to override individual types, or `{}` to disable enforcement entirely (the parser falls back to `'optional'` for any missing type). Violations remain warnings, never failures.
 
 #### `🚨 **Breaking:**` bullet marker
 

--- a/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/loadConfig.unit.test.ts
@@ -231,6 +231,20 @@ describe(mergeMonorepoConfig, () => {
     expect(result.scopeAliases).toStrictEqual({ api: 'backend-api' });
   });
 
+  it('passes through breakingPolicies from config', () => {
+    const result = mergeMonorepoConfig(discoveredPaths, {
+      breakingPolicies: { feat: 'forbidden', drop: 'required' },
+    });
+
+    expect(result.breakingPolicies).toStrictEqual({ feat: 'forbidden', drop: 'required' });
+  });
+
+  it('omits breakingPolicies when not configured', () => {
+    const result = mergeMonorepoConfig(discoveredPaths, {});
+
+    expect(result.breakingPolicies).toBeUndefined();
+  });
+
   it('throws when two workspaces produce the same tagPrefix', () => {
     mockPackageNames({
       'packages/a-foo': '@a/foo',
@@ -581,5 +595,19 @@ describe(mergeSinglePackageConfig, () => {
     expect(result.formatCommand).toBe('pnpm run fmt');
     expect(result.cliffConfigPath).toBe('custom/cliff.toml');
     expect(result.scopeAliases).toStrictEqual({ api: 'backend-api' });
+  });
+
+  it('passes through breakingPolicies from config', () => {
+    const result = mergeSinglePackageConfig({
+      breakingPolicies: { feat: 'forbidden', drop: 'required' },
+    });
+
+    expect(result.breakingPolicies).toStrictEqual({ feat: 'forbidden', drop: 'required' });
+  });
+
+  it('omits breakingPolicies when not configured', () => {
+    const result = mergeSinglePackageConfig({});
+
+    expect(result.breakingPolicies).toBeUndefined();
   });
 });

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -45,7 +45,7 @@ vi.mock('../changelogJsonFile.ts', () => ({
   upsertChangelogJson: mockUpsertChangelogJson,
 }));
 
-import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG } from '../defaults.ts';
+import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG, DEFAULT_WORK_TYPES } from '../defaults.ts';
 import { releasePrepare } from '../releasePrepare.ts';
 import type { ReleaseConfig, WorkTypeConfig } from '../types.ts';
 
@@ -433,5 +433,87 @@ describe(releasePrepare, () => {
     expect(result.tags).toStrictEqual(['v1.0.0']);
     expect(result.dryRun).toBe(true);
     expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  describe('policy violations', () => {
+    /** Stub git log to return a single commit message paired with a hash. */
+    function stubLog(message: string, hash: string): void {
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'v1.0.0\n';
+        if (cmd === 'git' && args[0] === 'log') return `${message}${hash}`;
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+    }
+
+    function configWithDefaultWorkTypes(overrides?: Partial<ReleaseConfig>): ReleaseConfig {
+      return makeConfig({ workTypes: DEFAULT_WORK_TYPES, ...overrides });
+    }
+
+    it('omits policyViolations when a clean feat! commit obeys the optional policy', () => {
+      stubLog('feat!: drop legacy export', 'abc1234');
+
+      const result = releasePrepare(configWithDefaultWorkTypes(), { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toBeUndefined();
+    });
+
+    it('records a prefix-surface violation for an internal! commit (forbidden policy)', () => {
+      stubLog('internal!: refactor cache', 'def5678');
+
+      const result = releasePrepare(configWithDefaultWorkTypes(), { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toStrictEqual([
+        {
+          commitHash: 'def5678',
+          commitSubject: 'internal!: refactor cache',
+          type: 'internal',
+          surface: 'prefix',
+        },
+      ]);
+    });
+
+    it('records a prefix-surface violation for a bare drop commit (required policy)', () => {
+      stubLog('drop: remove deprecated API', '9abc012');
+
+      const result = releasePrepare(configWithDefaultWorkTypes(), { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toStrictEqual([
+        {
+          commitHash: '9abc012',
+          commitSubject: 'drop: remove deprecated API',
+          type: 'drop',
+          surface: 'prefix',
+        },
+      ]);
+    });
+
+    it('produces no violations when breakingPolicies is set to {} (opt-out)', () => {
+      stubLog('internal!: refactor cache', 'def5678');
+
+      const result = releasePrepare(configWithDefaultWorkTypes({ breakingPolicies: {} }), { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toBeUndefined();
+    });
+
+    it('propagates policyViolations through the patch-floor release path', () => {
+      // A bare `drop:` is a policy violation AND parses with breaking=false; the
+      // single-package legacy path then applies a patch floor since at least one commit
+      // exists. The result is `released` (not `skipped`) — verify that policyViolations
+      // still propagates onto the released workspace result.
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'v1.0.0\n';
+        if (cmd === 'git' && args[0] === 'log') return 'drop: remove APIxyz9999';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+      // The single-package legacy path applies a patch floor when commits exist, so this
+      // releases (status: 'released') with policyViolations attached. Verify that path.
+      const result = releasePrepare(configWithDefaultWorkTypes(), { dryRun: false });
+
+      expect(result.workspaces[0]?.status).toBe('released');
+      expect(result.workspaces[0]?.policyViolations).toHaveLength(1);
+    });
   });
 });

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -45,7 +45,12 @@ vi.mock('../changelogJsonFile.ts', () => ({
   upsertChangelogJson: mockUpsertChangelogJson,
 }));
 
-import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG, DEFAULT_WORK_TYPES } from '../defaults.ts';
+import {
+  DEFAULT_BREAKING_POLICIES,
+  DEFAULT_CHANGELOG_JSON_CONFIG,
+  DEFAULT_RELEASE_NOTES_CONFIG,
+  DEFAULT_WORK_TYPES,
+} from '../defaults.ts';
 import { releasePrepare } from '../releasePrepare.ts';
 import type { ReleaseConfig, WorkTypeConfig } from '../types.ts';
 
@@ -494,6 +499,55 @@ describe(releasePrepare, () => {
       const result = releasePrepare(configWithDefaultWorkTypes({ breakingPolicies: {} }), { dryRun: false });
 
       expect(result.workspaces[0]?.policyViolations).toBeUndefined();
+    });
+
+    it('records a body-surface violation when BREAKING CHANGE: appears under a custom forbidden feat policy', () => {
+      // The parser invokes `message.includes('BREAKING CHANGE:')` on the raw commit message;
+      // any commit whose `.message` contains that literal triggers the body-surface code path.
+      // Real git-log subjects (--pretty=format:%s) don't carry body footers, but the wiring still
+      // needs to surface body-surface violations correctly when they appear (here: a subject
+      // that itself contains the literal string).
+      const config = configWithDefaultWorkTypes({
+        breakingPolicies: { ...DEFAULT_BREAKING_POLICIES, feat: 'forbidden' },
+      });
+      stubLog('feat: rework auth (BREAKING CHANGE: removes /v1)', 'body0001');
+
+      const result = releasePrepare(config, { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toStrictEqual([
+        {
+          commitHash: 'body0001',
+          commitSubject: 'feat: rework auth (BREAKING CHANGE: removes /v1)',
+          type: 'feat',
+          surface: 'body',
+        },
+      ]);
+    });
+
+    it('records both prefix and body violations when a forbidden feat carries ! and BREAKING CHANGE:', () => {
+      // A `forbidden`-policy commit with both `!` AND `BREAKING CHANGE:` fires
+      // `onPolicyViolation` twice — once for the prefix, once for the body.
+      const config = configWithDefaultWorkTypes({
+        breakingPolicies: { ...DEFAULT_BREAKING_POLICIES, feat: 'forbidden' },
+      });
+      stubLog('feat!: rework auth (BREAKING CHANGE: removes /v1)', 'dual0001');
+
+      const result = releasePrepare(config, { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toStrictEqual([
+        {
+          commitHash: 'dual0001',
+          commitSubject: 'feat!: rework auth (BREAKING CHANGE: removes /v1)',
+          type: 'feat',
+          surface: 'prefix',
+        },
+        {
+          commitHash: 'dual0001',
+          commitSubject: 'feat!: rework auth (BREAKING CHANGE: removes /v1)',
+          type: 'feat',
+          surface: 'body',
+        },
+      ]);
     });
 
     it('propagates policyViolations through the patch-floor release path', () => {

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -53,9 +53,9 @@ vi.mock('../changelogJsonFile.ts', () => ({
   upsertChangelogJson: mockUpsertChangelogJson,
 }));
 
-import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG } from '../defaults.ts';
+import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG, DEFAULT_WORK_TYPES } from '../defaults.ts';
 import { releasePrepareMono } from '../releasePrepareMono.ts';
-import type { MonorepoReleaseConfig, WorkTypeConfig } from '../types.ts';
+import type { MonorepoReleaseConfig, WorkspaceConfig, WorkTypeConfig } from '../types.ts';
 
 const workTypes: Record<string, WorkTypeConfig> = {
   feat: { header: 'Features' },
@@ -2054,5 +2054,138 @@ describe(releasePrepareMono, () => {
       expect(wrapped.message).toBe('--set-version 0.3.0 is not greater than current version 0.5.0');
       expect(wrapped.message).not.toContain('stage:');
     });
+  });
+
+  describe('policy violations', () => {
+    /** ASCII unit separator (U+001F) used by `git log --pretty=format` to delimit subject from hash. */
+    const SEP = String.fromCodePoint(0x1f);
+
+    function makeWorkspace(overrides?: Partial<WorkspaceConfig>): WorkspaceConfig {
+      return {
+        dir: 'arrays',
+        name: '@test/arrays',
+        tagPrefix: 'arrays-v',
+        workspacePath: 'packages/arrays',
+        isPublishable: true,
+        packageFiles: ['packages/arrays/package.json'],
+        changelogPaths: ['packages/arrays'],
+        paths: ['packages/arrays/**'],
+        ...overrides,
+      };
+    }
+
+    /** Format a single commit log line as the `getCommitsSinceTarget` parser expects. */
+    function logLine(subject: string, hash: string): string {
+      return `${subject}${SEP}${hash}`;
+    }
+
+    /** Stub git output for a single workspace with one log line per commit. */
+    function stubLog(tag: string, logBody: string): void {
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return `${tag}\n`;
+        if (cmd === 'git' && args[0] === 'log') return logBody;
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+    }
+
+    it('omits policyViolations on a workspace whose only commit is a clean feat!', () => {
+      const config = makeConfig({ workspaces: [makeWorkspace()], workTypes: DEFAULT_WORK_TYPES });
+      stubLog('arrays-v1.0.0', logLine('feat!: drop legacy export', 'abc1234'));
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toBeUndefined();
+    });
+
+    it('records a prefix-surface violation for an internal! commit (forbidden policy)', () => {
+      const config = makeConfig({ workspaces: [makeWorkspace()], workTypes: DEFAULT_WORK_TYPES });
+      stubLog('arrays-v1.0.0', logLine('internal!: refactor cache', 'def5678'));
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toStrictEqual([
+        {
+          commitHash: 'def5678',
+          commitSubject: 'internal!: refactor cache',
+          type: 'internal',
+          surface: 'prefix',
+        },
+      ]);
+    });
+
+    it('records a prefix-surface violation for a bare drop commit (required policy)', () => {
+      const config = makeConfig({ workspaces: [makeWorkspace()], workTypes: DEFAULT_WORK_TYPES });
+      stubLog('arrays-v1.0.0', logLine('drop: remove deprecated API', '9abc012'));
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toStrictEqual([
+        {
+          commitHash: '9abc012',
+          commitSubject: 'drop: remove deprecated API',
+          type: 'drop',
+          surface: 'prefix',
+        },
+      ]);
+    });
+
+    it('produces no violations when breakingPolicies is set to {} (opt-out)', () => {
+      const config = makeConfig({
+        workspaces: [makeWorkspace()],
+        workTypes: DEFAULT_WORK_TYPES,
+        breakingPolicies: {},
+      });
+      stubLog('arrays-v1.0.0', logLine('internal!: refactor cache', 'def5678'));
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toBeUndefined();
+    });
+
+    it('attaches violations only to the workspace whose commits triggered them', () => {
+      // Two workspaces; one has an internal! commit (violation), the other has a clean feat.
+      const cleanWorkspace = makeWorkspace({
+        dir: 'core',
+        name: '@test/core',
+        tagPrefix: 'core-v',
+        workspacePath: 'packages/core',
+        packageFiles: ['packages/core/package.json'],
+        changelogPaths: ['packages/core'],
+        paths: ['packages/core/**'],
+      });
+      const config = makeConfig({
+        workspaces: [makeWorkspace(), cleanWorkspace],
+        workTypes: DEFAULT_WORK_TYPES,
+      });
+
+      // Per-workspace describe + log responses keyed by --match flags.
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd !== 'git') return '';
+        if (args[0] === 'describe') {
+          if (args.some((a) => a.includes('arrays-v'))) return 'arrays-v1.0.0\n';
+          if (args.some((a) => a.includes('core-v'))) return 'core-v1.0.0\n';
+        }
+        if (args[0] === 'log') {
+          if (args.includes('packages/arrays/**')) return logLine('internal!: refactor cache', 'def5678');
+          if (args.includes('packages/core/**')) return logLine('feat: add helper', 'aaa1111');
+        }
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      const arraysResult = result.workspaces.find((w) => w.name === 'arrays');
+      const coreResult = result.workspaces.find((w) => w.name === 'core');
+      expect(arraysResult?.policyViolations).toHaveLength(1);
+      expect(coreResult?.policyViolations).toBeUndefined();
+    });
+
+    // Note: there is no orchestrator-reachable path where a SkippedWorkspaceResult also
+    // carries policyViolations — the unified `decideRelease` algorithm only enters the skip
+    // branch when zero commits parsed, which means no violation could have fired. The
+    // `SkippedResult.policyViolations` field is wired defensively for parity with the
+    // released path but not exercised here.
   });
 });

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -53,7 +53,12 @@ vi.mock('../changelogJsonFile.ts', () => ({
   upsertChangelogJson: mockUpsertChangelogJson,
 }));
 
-import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG, DEFAULT_WORK_TYPES } from '../defaults.ts';
+import {
+  DEFAULT_BREAKING_POLICIES,
+  DEFAULT_CHANGELOG_JSON_CONFIG,
+  DEFAULT_RELEASE_NOTES_CONFIG,
+  DEFAULT_WORK_TYPES,
+} from '../defaults.ts';
 import { releasePrepareMono } from '../releasePrepareMono.ts';
 import type { MonorepoReleaseConfig, WorkspaceConfig, WorkTypeConfig } from '../types.ts';
 
@@ -2180,6 +2185,31 @@ describe(releasePrepareMono, () => {
       const coreResult = result.workspaces.find((w) => w.name === 'core');
       expect(arraysResult?.policyViolations).toHaveLength(1);
       expect(coreResult?.policyViolations).toBeUndefined();
+    });
+
+    it('records a body-surface violation when BREAKING CHANGE: appears under a custom forbidden feat policy', () => {
+      // The parser invokes `message.includes('BREAKING CHANGE:')` on the raw commit message;
+      // any commit whose `.message` contains that literal triggers the body-surface code path.
+      // Real git-log subjects (--pretty=format:%s) don't carry body footers, but the wiring still
+      // needs to surface body-surface violations correctly when they appear (here: a subject
+      // that itself contains the literal string).
+      const config = makeConfig({
+        workspaces: [makeWorkspace()],
+        workTypes: DEFAULT_WORK_TYPES,
+        breakingPolicies: { ...DEFAULT_BREAKING_POLICIES, feat: 'forbidden' },
+      });
+      stubLog('arrays-v1.0.0', logLine('feat: rework auth (BREAKING CHANGE: removes /v1)', 'body0001'));
+
+      const result = releasePrepareMono(config, { dryRun: false });
+
+      expect(result.workspaces[0]?.policyViolations).toStrictEqual([
+        {
+          commitHash: 'body0001',
+          commitSubject: 'feat: rework auth (BREAKING CHANGE: removes /v1)',
+          type: 'feat',
+          surface: 'body',
+        },
+      ]);
     });
 
     // Note: there is no orchestrator-reachable path where a SkippedWorkspaceResult also

--- a/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
@@ -45,7 +45,12 @@ vi.mock('../writeReleaseNotesPreviews.ts', () => ({
   writeReleaseNotesPreviews: mockWriteReleaseNotesPreviews,
 }));
 
-import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG, DEFAULT_WORK_TYPES } from '../defaults.ts';
+import {
+  DEFAULT_BREAKING_POLICIES,
+  DEFAULT_CHANGELOG_JSON_CONFIG,
+  DEFAULT_RELEASE_NOTES_CONFIG,
+  DEFAULT_WORK_TYPES,
+} from '../defaults.ts';
 import { releasePrepareProject } from '../releasePrepareProject.ts';
 import type { MonorepoReleaseConfig, WorkspaceConfig } from '../types.ts';
 
@@ -606,6 +611,30 @@ describe(releasePrepareProject, () => {
       const result = releasePrepareProject({ config, options: { dryRun: false }, modifiedFiles: [], tags: [] });
 
       expect(result.policyViolations).toBeUndefined();
+    });
+
+    it('records a body-surface violation when BREAKING CHANGE: appears under a custom forbidden feat policy', () => {
+      // The parser invokes `message.includes('BREAKING CHANGE:')` on the raw commit message;
+      // any commit whose `.message` contains that literal triggers the body-surface code path.
+      // Real git-log subjects (--pretty=format:%s) don't carry body footers, but the wiring still
+      // needs to surface body-surface violations correctly when they appear (here: a subject
+      // that itself contains the literal string).
+      const config = makeConfig({
+        workTypes: DEFAULT_WORK_TYPES,
+        breakingPolicies: { ...DEFAULT_BREAKING_POLICIES, feat: 'forbidden' },
+      });
+      stubLog('v1.0.0', logLine('feat: rework auth (BREAKING CHANGE: removes /v1)', 'body0001'));
+
+      const result = releasePrepareProject({ config, options: { dryRun: false }, modifiedFiles: [], tags: [] });
+
+      expect(result.policyViolations).toStrictEqual([
+        {
+          commitHash: 'body0001',
+          commitSubject: 'feat: rework auth (BREAKING CHANGE: removes /v1)',
+          type: 'feat',
+          surface: 'body',
+        },
+      ]);
     });
   });
 });

--- a/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
@@ -45,7 +45,7 @@ vi.mock('../writeReleaseNotesPreviews.ts', () => ({
   writeReleaseNotesPreviews: mockWriteReleaseNotesPreviews,
 }));
 
-import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG } from '../defaults.ts';
+import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG, DEFAULT_WORK_TYPES } from '../defaults.ts';
 import { releasePrepareProject } from '../releasePrepareProject.ts';
 import type { MonorepoReleaseConfig, WorkspaceConfig } from '../types.ts';
 
@@ -535,5 +535,77 @@ describe(releasePrepareProject, () => {
         tags: [],
       }),
     ).toThrow(/without a configured project block/);
+  });
+
+  describe('policy violations', () => {
+    /** ASCII unit separator (U+001F) used by `git log --pretty=format` to delimit subject from hash. */
+    const SEP = String.fromCodePoint(0x1f);
+
+    /** Format a single commit log line as the `getCommitsSinceTarget` parser expects. */
+    function logLine(subject: string, hash: string): string {
+      return `${subject}${SEP}${hash}`;
+    }
+
+    /** Stub git output for the project window with one log line per commit. */
+    function stubLog(tag: string, logBody: string): void {
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return `${tag}\n`;
+        if (cmd === 'git' && args[0] === 'log') return logBody;
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'root', version: '1.0.0' }));
+    }
+
+    it('omits policyViolations on a project release whose only commit is a clean feat!', () => {
+      const config = makeConfig({ workTypes: DEFAULT_WORK_TYPES });
+      stubLog('v1.0.0', logLine('feat!: drop legacy export', 'abc1234'));
+
+      const result = releasePrepareProject({ config, options: { dryRun: false }, modifiedFiles: [], tags: [] });
+
+      expect(result.status).toBe('released');
+      if (result.status !== 'released') throw new Error('expected released');
+      expect(result.policyViolations).toBeUndefined();
+    });
+
+    it('records a prefix-surface violation for an internal! commit (forbidden policy)', () => {
+      const config = makeConfig({ workTypes: DEFAULT_WORK_TYPES });
+      stubLog('v1.0.0', logLine('internal!: refactor cache', 'def5678'));
+
+      const result = releasePrepareProject({ config, options: { dryRun: false }, modifiedFiles: [], tags: [] });
+
+      expect(result.policyViolations).toStrictEqual([
+        {
+          commitHash: 'def5678',
+          commitSubject: 'internal!: refactor cache',
+          type: 'internal',
+          surface: 'prefix',
+        },
+      ]);
+    });
+
+    it('records a prefix-surface violation for a bare drop commit (required policy)', () => {
+      const config = makeConfig({ workTypes: DEFAULT_WORK_TYPES });
+      stubLog('v1.0.0', logLine('drop: remove deprecated API', '9abc012'));
+
+      const result = releasePrepareProject({ config, options: { dryRun: false }, modifiedFiles: [], tags: [] });
+
+      expect(result.policyViolations).toStrictEqual([
+        {
+          commitHash: '9abc012',
+          commitSubject: 'drop: remove deprecated API',
+          type: 'drop',
+          surface: 'prefix',
+        },
+      ]);
+    });
+
+    it('produces no violations when breakingPolicies is set to {} (opt-out)', () => {
+      const config = makeConfig({ workTypes: DEFAULT_WORK_TYPES, breakingPolicies: {} });
+      stubLog('v1.0.0', logLine('internal!: refactor cache', 'def5678'));
+
+      const result = releasePrepareProject({ config, options: { dryRun: false }, modifiedFiles: [], tags: [] });
+
+      expect(result.policyViolations).toBeUndefined();
+    });
   });
 });

--- a/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/reportPrepare.unit.test.ts
@@ -830,4 +830,205 @@ describe(reportPrepare, () => {
       expect(output).not.toContain('Parsed 0 typed commits');
     });
   });
+
+  describe('policy violations rendering', () => {
+    it('renders a single-package result with one policy violation', () => {
+      const result: PrepareResult = {
+        workspaces: [
+          {
+            status: 'released',
+            previousTag: 'v1.0.0',
+            commitCount: 1,
+            parsedCommitCount: 1,
+            releaseType: 'patch',
+            currentVersion: '1.0.0',
+            newVersion: '1.0.1',
+            tag: 'v1.0.1',
+            bumpedFiles: ['package.json'],
+            changelogFiles: ['./CHANGELOG.md'],
+            policyViolations: [
+              {
+                commitHash: 'def5678',
+                commitSubject: 'internal!: refactor cache',
+                type: 'internal',
+                surface: 'prefix',
+              },
+            ],
+          },
+        ],
+        tags: ['v1.0.1'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('1 policy violation:');
+      expect(output).toContain("· def5678 'internal!: refactor cache' — type 'internal' at prefix surface");
+    });
+
+    it('renders multiple policy violations with plural header', () => {
+      const result: PrepareResult = {
+        workspaces: [
+          {
+            status: 'released',
+            commitCount: 2,
+            parsedCommitCount: 2,
+            releaseType: 'patch',
+            currentVersion: '1.0.0',
+            newVersion: '1.0.1',
+            tag: 'v1.0.1',
+            bumpedFiles: ['package.json'],
+            changelogFiles: ['./CHANGELOG.md'],
+            policyViolations: [
+              {
+                commitHash: 'aaa1111',
+                commitSubject: 'internal!: refactor X',
+                type: 'internal',
+                surface: 'prefix',
+              },
+              {
+                commitHash: 'bbb2222',
+                commitSubject: 'drop: remove Y',
+                type: 'drop',
+                surface: 'prefix',
+              },
+            ],
+          },
+        ],
+        tags: ['v1.0.1'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('2 policy violations:');
+      expect(output).toContain("· aaa1111 'internal!: refactor X' — type 'internal' at prefix surface");
+      expect(output).toContain("· bbb2222 'drop: remove Y' — type 'drop' at prefix surface");
+    });
+
+    it('renders a workspace section in multi-workspace mode with policy violations', () => {
+      const result: PrepareResult = {
+        workspaces: [
+          {
+            name: 'arrays',
+            status: 'released',
+            commitCount: 1,
+            parsedCommitCount: 1,
+            releaseType: 'patch',
+            currentVersion: '1.0.0',
+            newVersion: '1.0.1',
+            tag: 'arrays-v1.0.1',
+            bumpedFiles: ['packages/arrays/package.json'],
+            changelogFiles: ['packages/arrays/CHANGELOG.md'],
+            policyViolations: [
+              {
+                commitHash: 'def5678',
+                commitSubject: 'internal!: refactor cache',
+                type: 'internal',
+                surface: 'prefix',
+              },
+            ],
+          },
+        ],
+        tags: ['arrays-v1.0.1'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('1 policy violation:');
+      expect(output).toContain("· def5678 'internal!: refactor cache' — type 'internal' at prefix surface");
+    });
+
+    it('renders a project section with policy violations', () => {
+      const result: PrepareResult = {
+        workspaces: [],
+        tags: ['v1.0.1'],
+        dryRun: false,
+        project: {
+          status: 'released',
+          previousTag: 'v1.0.0',
+          commitCount: 1,
+          parsedCommitCount: 1,
+          releaseType: 'patch',
+          currentVersion: '1.0.0',
+          newVersion: '1.0.1',
+          tag: 'v1.0.1',
+          bumpedFiles: ['./package.json'],
+          changelogFiles: ['./CHANGELOG.md'],
+          commits: [{ message: 'internal!: refactor cache', hash: 'def5678' }],
+          policyViolations: [
+            {
+              commitHash: 'def5678',
+              commitSubject: 'internal!: refactor cache',
+              type: 'internal',
+              surface: 'prefix',
+            },
+          ],
+        },
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain('1 policy violation:');
+      expect(output).toContain("· def5678 'internal!: refactor cache' — type 'internal' at prefix surface");
+    });
+
+    it('omits the policy-violation block when policyViolations is undefined', () => {
+      const result: PrepareResult = {
+        workspaces: [
+          {
+            status: 'released',
+            commitCount: 1,
+            parsedCommitCount: 1,
+            releaseType: 'minor',
+            currentVersion: '1.0.0',
+            newVersion: '1.1.0',
+            tag: 'v1.1.0',
+            bumpedFiles: ['package.json'],
+            changelogFiles: ['./CHANGELOG.md'],
+          },
+        ],
+        tags: ['v1.1.0'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).not.toContain('policy violation');
+    });
+
+    it('truncates long commit subjects to 72 characters with ellipsis at 69', () => {
+      const longSubject = `internal!: ${'x'.repeat(80)}`;
+      const result: PrepareResult = {
+        workspaces: [
+          {
+            status: 'released',
+            commitCount: 1,
+            parsedCommitCount: 1,
+            releaseType: 'patch',
+            currentVersion: '1.0.0',
+            newVersion: '1.0.1',
+            tag: 'v1.0.1',
+            bumpedFiles: ['package.json'],
+            changelogFiles: ['./CHANGELOG.md'],
+            policyViolations: [
+              {
+                commitHash: 'def5678',
+                commitSubject: longSubject,
+                type: 'internal',
+                surface: 'prefix',
+              },
+            ],
+          },
+        ],
+        tags: ['v1.0.1'],
+        dryRun: false,
+      };
+
+      const output = reportPrepare(result);
+
+      expect(output).toContain(`'${longSubject.slice(0, 69)}...'`);
+    });
+  });
 });

--- a/packages/release-kit/src/collectPolicyViolations.ts
+++ b/packages/release-kit/src/collectPolicyViolations.ts
@@ -1,0 +1,27 @@
+import type { PolicyViolationHandler } from './parseCommitMessage.ts';
+import type { PolicyViolation } from './types.ts';
+
+/**
+ * Build a fresh `policyViolations` accumulator paired with the `onPolicyViolation` callback
+ * that pushes structured entries into it.
+ *
+ * Used by all three release-prepare orchestrators (`releasePrepare`, `releasePrepareMono`,
+ * `releasePrepareProject`) to collect parser-side `!`-policy violations into a result-attachable
+ * array. Centralizing the callback shape keeps the `commitSubject` extraction rule (`firstLine
+ * post-split`) consistent across orchestrators.
+ */
+export function createPolicyViolationCollector(): {
+  violations: PolicyViolation[];
+  onPolicyViolation: PolicyViolationHandler;
+} {
+  const violations: PolicyViolation[] = [];
+  const onPolicyViolation: PolicyViolationHandler = (commit, type, surface) => {
+    violations.push({
+      commitHash: commit.hash,
+      commitSubject: commit.message.split('\n', 1)[0] ?? '',
+      type,
+      surface,
+    });
+  };
+  return { violations, onPolicyViolation };
+}

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -187,22 +187,42 @@ export function mergeMonorepoConfig(
     result.project = project;
   }
 
-  const formatCommand = userConfig?.formatCommand;
-  if (formatCommand !== undefined) {
-    result.formatCommand = formatCommand;
-  }
-
-  const cliffConfigPath = userConfig?.cliffConfigPath;
-  if (cliffConfigPath !== undefined) {
-    result.cliffConfigPath = cliffConfigPath;
-  }
-
-  const scopeAliases = userConfig?.scopeAliases;
-  if (scopeAliases !== undefined) {
-    result.scopeAliases = scopeAliases;
-  }
+  applyOptionalPassthroughFields(result, userConfig);
 
   return result;
+}
+
+/**
+ * Copy optional pass-through fields (`formatCommand`, `cliffConfigPath`, `scopeAliases`,
+ * `breakingPolicies`) from `userConfig` onto `result`, omitting any that are absent.
+ *
+ * Extracted from both `mergeMonorepoConfig` and `mergeSinglePackageConfig` to keep their
+ * cyclomatic complexity below the project ceiling — each conditional spread contributes a
+ * branch to the host's complexity, and inlining all four tipped both functions over.
+ * `breakingPolicies` is deep-cloned (`{ ...value }`) for parity with how monorepo config
+ * defends against later mutation of nested config objects.
+ */
+function applyOptionalPassthroughFields(
+  result: {
+    formatCommand?: string;
+    cliffConfigPath?: string;
+    scopeAliases?: Record<string, string>;
+    breakingPolicies?: Record<string, 'forbidden' | 'optional' | 'required'>;
+  },
+  userConfig: ReleaseKitConfig | undefined,
+): void {
+  if (userConfig?.formatCommand !== undefined) {
+    result.formatCommand = userConfig.formatCommand;
+  }
+  if (userConfig?.cliffConfigPath !== undefined) {
+    result.cliffConfigPath = userConfig.cliffConfigPath;
+  }
+  if (userConfig?.scopeAliases !== undefined) {
+    result.scopeAliases = userConfig.scopeAliases;
+  }
+  if (userConfig?.breakingPolicies !== undefined) {
+    result.breakingPolicies = { ...userConfig.breakingPolicies };
+  }
 }
 
 /**
@@ -235,20 +255,7 @@ export function mergeSinglePackageConfig(userConfig: ReleaseKitConfig | undefine
     releaseNotes,
   };
 
-  const formatCommand = userConfig?.formatCommand;
-  if (formatCommand !== undefined) {
-    result.formatCommand = formatCommand;
-  }
-
-  const cliffConfigPath = userConfig?.cliffConfigPath;
-  if (cliffConfigPath !== undefined) {
-    result.cliffConfigPath = cliffConfigPath;
-  }
-
-  const scopeAliases = userConfig?.scopeAliases;
-  if (scopeAliases !== undefined) {
-    result.scopeAliases = scopeAliases;
-  }
+  applyOptionalPassthroughFields(result, userConfig);
 
   return result;
 }

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -199,8 +199,8 @@ export function mergeMonorepoConfig(
  * Extracted from both `mergeMonorepoConfig` and `mergeSinglePackageConfig` to keep their
  * cyclomatic complexity below the project ceiling — each conditional spread contributes a
  * branch to the host's complexity, and inlining all four tipped both functions over.
- * `breakingPolicies` is deep-cloned (`{ ...value }`) for parity with how monorepo config
- * defends against later mutation of nested config objects.
+ * Object-typed fields (`scopeAliases`, `breakingPolicies`) are stored by reference, matching
+ * how `scopeAliases` is handled elsewhere in this module.
  */
 function applyOptionalPassthroughFields(
   result: {
@@ -221,7 +221,7 @@ function applyOptionalPassthroughFields(
     result.scopeAliases = userConfig.scopeAliases;
   }
   if (userConfig?.breakingPolicies !== undefined) {
-    result.breakingPolicies = { ...userConfig.breakingPolicies };
+    result.breakingPolicies = userConfig.breakingPolicies;
   }
 }
 

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -3,8 +3,9 @@ import { execSync } from 'node:child_process';
 import { buildChangelogEntries } from './buildChangelogEntries.ts';
 import { bumpAllVersions, setAllVersions } from './bumpAllVersions.ts';
 import { resolveChangelogJsonPath, upsertChangelogJson } from './changelogJsonFile.ts';
+import { createPolicyViolationCollector } from './collectPolicyViolations.ts';
 import { isForwardVersion } from './compareVersions.ts';
-import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
+import { DEFAULT_BREAKING_POLICIES, DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { determineBumpFromCommits } from './determineBumpFromCommits.ts';
 import { generateChangelogs } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
@@ -15,6 +16,7 @@ import { deriveSectionOrder } from './resolveReleaseNotesConfig.ts';
 import type {
   BumpResult,
   Commit,
+  PolicyViolation,
   PrepareResult,
   ReleaseConfig,
   ReleasedWorkspaceResult,
@@ -65,6 +67,7 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   const { dryRun, bumpOverride, setVersion, withReleaseNotes } = options;
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
+  const breakingPolicies = config.breakingPolicies ?? DEFAULT_BREAKING_POLICIES;
 
   // 1. Get commits since last tag
   const { tag, commits } = getCommitsSinceTarget([config.tagPrefix]);
@@ -73,6 +76,7 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   let releaseType: ReleaseType | undefined;
   let parsedCommitCount: number | undefined;
   let unparseableCommits: Commit[] | undefined;
+  const collector = createPolicyViolationCollector();
   let bump: BumpResult;
 
   if (setVersion !== undefined) {
@@ -92,7 +96,10 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
     bump = setAllVersions(config.packageFiles, setVersion, dryRun);
   } else {
     if (bumpOverride === undefined) {
-      const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.scopeAliases);
+      const determination = determineBumpFromCommits(commits, workTypes, versionPatterns, config.scopeAliases, {
+        breakingPolicies,
+        onPolicyViolation: collector.onPolicyViolation,
+      });
       parsedCommitCount = determination.parsedCommitCount;
       unparseableCommits = determination.unparseableCommits;
       releaseType = determination.releaseType;
@@ -101,20 +108,13 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
     }
 
     if (releaseType === undefined) {
-      const skipped: SkippedWorkspaceResult = {
-        status: 'skipped',
+      const skipped = buildSkippedSinglePackage({
         commitCount: commits.length,
-        skipReason: 'No release-worthy changes found. Skipping.',
-      };
-      if (tag !== undefined) {
-        skipped.previousTag = tag;
-      }
-      if (parsedCommitCount !== undefined) {
-        skipped.parsedCommitCount = parsedCommitCount;
-      }
-      if (unparseableCommits !== undefined) {
-        skipped.unparseableCommits = unparseableCommits;
-      }
+        previousTag: tag,
+        parsedCommitCount,
+        unparseableCommits,
+        policyViolations: collector.violations.length > 0 ? collector.violations : undefined,
+      });
       return {
         workspaces: [skipped],
         tags: [],
@@ -171,6 +171,7 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
     parsedCommitCount,
     releaseType,
     unparseableCommits,
+    policyViolations: collector.violations.length > 0 ? collector.violations : undefined,
     setVersion,
   });
 
@@ -180,6 +181,42 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
     formatCommand,
     dryRun,
   };
+}
+
+/** Inputs to {@link buildSkippedSinglePackage}. */
+interface BuildSkippedSinglePackageArgs {
+  commitCount: number;
+  previousTag: string | undefined;
+  parsedCommitCount: number | undefined;
+  unparseableCommits: Commit[] | undefined;
+  policyViolations: PolicyViolation[] | undefined;
+}
+
+/**
+ * Build a `SkippedWorkspaceResult` for the single-package "no release-worthy changes" path,
+ * attaching only defined optional fields. Extracted from `releasePrepare` so the host stays
+ * within the project's cyclomatic-complexity ceiling — each conditional optional-field
+ * assignment is one branch.
+ */
+function buildSkippedSinglePackage(args: BuildSkippedSinglePackageArgs): SkippedWorkspaceResult {
+  const skipped: SkippedWorkspaceResult = {
+    status: 'skipped',
+    commitCount: args.commitCount,
+    skipReason: 'No release-worthy changes found. Skipping.',
+  };
+  if (args.previousTag !== undefined) {
+    skipped.previousTag = args.previousTag;
+  }
+  if (args.parsedCommitCount !== undefined) {
+    skipped.parsedCommitCount = args.parsedCommitCount;
+  }
+  if (args.unparseableCommits !== undefined) {
+    skipped.unparseableCommits = args.unparseableCommits;
+  }
+  if (args.policyViolations !== undefined) {
+    skipped.policyViolations = args.policyViolations;
+  }
+  return skipped;
 }
 
 /** Inputs to {@link buildReleasedSinglePackage}. */
@@ -192,6 +229,7 @@ interface BuildReleasedSinglePackageArgs {
   parsedCommitCount: number | undefined;
   releaseType: ReleaseType | undefined;
   unparseableCommits: Commit[] | undefined;
+  policyViolations: PolicyViolation[] | undefined;
   setVersion: string | undefined;
 }
 
@@ -211,6 +249,7 @@ function buildReleasedSinglePackage(args: BuildReleasedSinglePackageArgs): Relea
     parsedCommitCount,
     releaseType,
     unparseableCommits,
+    policyViolations,
     setVersion,
   } = args;
   const released: ReleasedWorkspaceResult = {
@@ -234,6 +273,9 @@ function buildReleasedSinglePackage(args: BuildReleasedSinglePackageArgs): Relea
   }
   if (unparseableCommits !== undefined) {
     released.unparseableCommits = unparseableCommits;
+  }
+  if (policyViolations !== undefined) {
+    released.policyViolations = policyViolations;
   }
   if (setVersion !== undefined) {
     released.setVersion = setVersion;

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -456,9 +456,8 @@ function executeWorkspaceRelease(args: ExecuteWorkspaceReleaseArgs): void {
     changelogFiles,
   };
   attachReleasedWorkspaceOptionals(released, {
-    dir,
+    previousTag: directResult?.tag ?? previousTags.get(dir),
     directResult,
-    previousTags,
     releaseEntry,
     setVersionTarget,
   });
@@ -467,9 +466,8 @@ function executeWorkspaceRelease(args: ExecuteWorkspaceReleaseArgs): void {
 
 /** Inputs to {@link attachReleasedWorkspaceOptionals}. */
 interface AttachReleasedOptionalsArgs {
-  dir: string;
+  previousTag: string | undefined;
   directResult: DirectBumpResult | undefined;
-  previousTags: Map<string, string | undefined>;
   releaseEntry: ReleaseEntry;
   setVersionTarget: string | undefined;
 }
@@ -484,9 +482,8 @@ interface AttachReleasedOptionalsArgs {
  * version pushes the host past the project's complexity ceiling.
  */
 function attachReleasedWorkspaceOptionals(released: ReleasedWorkspaceResult, args: AttachReleasedOptionalsArgs): void {
-  const { dir, directResult, previousTags, releaseEntry, setVersionTarget } = args;
+  const { previousTag, directResult, releaseEntry, setVersionTarget } = args;
 
-  const previousTag = directResult?.tag ?? previousTags.get(dir);
   if (previousTag !== undefined) {
     released.previousTag = previousTag;
   }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -6,9 +6,10 @@ import { buildDependencyGraph } from './buildDependencyGraph.ts';
 import { buildSyntheticChangelogEntry } from './buildSyntheticChangelogEntry.ts';
 import { bumpAllVersions, setAllVersions } from './bumpAllVersions.ts';
 import { resolveChangelogJsonPath, upsertChangelogJson } from './changelogJsonFile.ts';
+import { createPolicyViolationCollector } from './collectPolicyViolations.ts';
 import { isForwardVersion } from './compareVersions.ts';
 import { decideRelease } from './decideRelease.ts';
-import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
+import { DEFAULT_BREAKING_POLICIES, DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { detectUndeclaredTagPrefixes } from './detectUndeclaredTagPrefixes.ts';
 import { buildTagPattern, generateChangelog } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
@@ -23,6 +24,7 @@ import { deriveSectionOrder } from './resolveReleaseNotesConfig.ts';
 import type {
   Commit,
   MonorepoReleaseConfig,
+  PolicyViolation,
   PrepareResult,
   ProjectPrepareResult,
   ReleasedWorkspaceResult,
@@ -43,6 +45,8 @@ interface DirectBumpResult {
   releaseType: ReleaseType | undefined;
   parsedCommitCount: number | undefined;
   unparseableCommits: Commit[] | undefined;
+  /** Policy violations collected while parsing this workspace's commits; undefined when none. */
+  policyViolations: PolicyViolation[] | undefined;
   /** Set when `--bump=X` was supplied for this workspace's direct release; surfaced to renderer. */
   bumpOverride: ReleaseType | undefined;
   /** Explicit version from `--set-version`, present only for the overridden workspace. */
@@ -56,6 +60,8 @@ interface SkippedResult {
   commitCount: number;
   parsedCommitCount: number | undefined;
   unparseableCommits: Commit[] | undefined;
+  /** Policy violations collected while parsing this workspace's commits; undefined when none. */
+  policyViolations: PolicyViolation[] | undefined;
   skipReason: string;
 }
 
@@ -175,6 +181,7 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
 
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
+  const breakingPolicies = config.breakingPolicies ?? DEFAULT_BREAKING_POLICIES;
 
   const directBumps = new Map<string, ReleaseEntry>();
   const directResults = new Map<string, DirectBumpResult>();
@@ -232,6 +239,7 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
         releaseType: undefined,
         parsedCommitCount: undefined,
         unparseableCommits: undefined,
+        policyViolations: undefined,
         bumpOverride: undefined,
         setVersion,
       });
@@ -242,6 +250,7 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
     // `--force` is purely a release trigger that defaults to patch when no level is given.
     // Always parses commits so `parsedCommitCount` and `unparseableCommits` are populated for
     // diagnostic surfacing regardless of whether `bumpOverride` was supplied.
+    const collector = createPolicyViolationCollector();
     const decision = tryStage(stageLabel, () =>
       decideRelease({
         commits,
@@ -250,12 +259,16 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
         workTypes,
         versionPatterns,
         scopeAliases: config.scopeAliases,
+        breakingPolicies,
+        onPolicyViolation: collector.onPolicyViolation,
         skipReasons: {
           noCommits: `No commits for ${name} ${since}. Pass --force to release at patch. Skipping.`,
           noBumpWorthy: `No bump-worthy commits for ${name} ${since}. Pass --force to release at patch (or --force --bump=X for a different level). Skipping.`,
         },
       }),
     );
+
+    const policyViolations = collector.violations.length > 0 ? collector.violations : undefined;
 
     if (decision.outcome === 'skip') {
       skippedResults.push({
@@ -264,6 +277,7 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
         commitCount: commits.length,
         parsedCommitCount: decision.parsedCommitCount,
         unparseableCommits: decision.unparseableCommits,
+        policyViolations,
         skipReason: decision.skipReason,
       });
       continue;
@@ -277,6 +291,7 @@ function determineDirectBumps(config: MonorepoReleaseConfig, options: ReleasePre
       releaseType: decision.releaseType,
       parsedCommitCount: decision.parsedCommitCount,
       unparseableCommits: decision.unparseableCommits,
+      policyViolations,
       bumpOverride,
     });
   }
@@ -308,6 +323,9 @@ function collectSkippedWorkspaces(
     }
     if (skipped.unparseableCommits !== undefined) {
       result.unparseableCommits = skipped.unparseableCommits;
+    }
+    if (skipped.policyViolations !== undefined) {
+      result.policyViolations = skipped.policyViolations;
     }
     workspaces.push(result);
   }
@@ -437,6 +455,37 @@ function executeWorkspaceRelease(args: ExecuteWorkspaceReleaseArgs): void {
     bumpedFiles: bump.files,
     changelogFiles,
   };
+  attachReleasedWorkspaceOptionals(released, {
+    dir,
+    directResult,
+    previousTags,
+    releaseEntry,
+    setVersionTarget,
+  });
+  workspaces.push(released);
+}
+
+/** Inputs to {@link attachReleasedWorkspaceOptionals}. */
+interface AttachReleasedOptionalsArgs {
+  dir: string;
+  directResult: DirectBumpResult | undefined;
+  previousTags: Map<string, string | undefined>;
+  releaseEntry: ReleaseEntry;
+  setVersionTarget: string | undefined;
+}
+
+/**
+ * Attach the optional fields of a `ReleasedWorkspaceResult` (previousTag, parsedCommitCount,
+ * releaseType, commits, unparseableCommits, policyViolations, propagatedFrom, bumpOverride,
+ * setVersion) using the conditional-assignment rules from the surrounding executor.
+ *
+ * Extracted from `executeWorkspaceRelease` so each conditional branch lives outside the host
+ * function's cyclomatic-complexity budget; with the addition of `policyViolations` the inline
+ * version pushes the host past the project's complexity ceiling.
+ */
+function attachReleasedWorkspaceOptionals(released: ReleasedWorkspaceResult, args: AttachReleasedOptionalsArgs): void {
+  const { dir, directResult, previousTags, releaseEntry, setVersionTarget } = args;
+
   const previousTag = directResult?.tag ?? previousTags.get(dir);
   if (previousTag !== undefined) {
     released.previousTag = previousTag;
@@ -455,6 +504,9 @@ function executeWorkspaceRelease(args: ExecuteWorkspaceReleaseArgs): void {
   if (directResult?.unparseableCommits !== undefined) {
     released.unparseableCommits = directResult.unparseableCommits;
   }
+  if (directResult?.policyViolations !== undefined) {
+    released.policyViolations = directResult.policyViolations;
+  }
   if (releaseEntry.propagatedFrom !== undefined) {
     released.propagatedFrom = releaseEntry.propagatedFrom;
   }
@@ -464,7 +516,6 @@ function executeWorkspaceRelease(args: ExecuteWorkspaceReleaseArgs): void {
   if (setVersionTarget !== undefined) {
     released.setVersion = setVersionTarget;
   }
-  workspaces.push(released);
 }
 
 /** Arguments for generating changelog files for a single workspace. */

--- a/packages/release-kit/src/releasePrepareProject.ts
+++ b/packages/release-kit/src/releasePrepareProject.ts
@@ -1,8 +1,9 @@
 import { buildChangelogEntries } from './buildChangelogEntries.ts';
 import { bumpAllVersions } from './bumpAllVersions.ts';
 import { resolveChangelogJsonPath, writeChangelogJson } from './changelogJsonFile.ts';
+import { createPolicyViolationCollector } from './collectPolicyViolations.ts';
 import { decideRelease } from './decideRelease.ts';
-import { DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
+import { DEFAULT_BREAKING_POLICIES, DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { buildTagPattern, generateChangelog } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
@@ -53,6 +54,7 @@ export function releasePrepareProject(args: ReleasePrepareProjectArgs): ProjectP
 
   const workTypes = config.workTypes ?? { ...DEFAULT_WORK_TYPES };
   const versionPatterns = config.versionPatterns ?? { ...DEFAULT_VERSION_PATTERNS };
+  const breakingPolicies = config.breakingPolicies ?? DEFAULT_BREAKING_POLICIES;
 
   // 1. Compute contributing paths (union of every non-excluded workspace's paths).
   const contributingPaths = config.workspaces.flatMap((workspace) => workspace.paths);
@@ -63,6 +65,7 @@ export function releasePrepareProject(args: ReleasePrepareProjectArgs): ProjectP
 
   // 3. Apply the unified release-decision algorithm. `--bump=X` is purely a level chooser;
   //    `--force` is purely a release trigger that defaults to patch when no level is given.
+  const collector = createPolicyViolationCollector();
   const decision = decideRelease({
     commits,
     force,
@@ -70,11 +73,15 @@ export function releasePrepareProject(args: ReleasePrepareProjectArgs): ProjectP
     workTypes,
     versionPatterns,
     scopeAliases: config.scopeAliases,
+    breakingPolicies,
+    onPolicyViolation: collector.onPolicyViolation,
     skipReasons: {
       noCommits: `No commits ${since}. Pass --force to release at patch. Skipping.`,
       noBumpWorthy: `No bump-worthy commits ${since}. Pass --force to release at patch (or --force --bump=X for a different level). Skipping.`,
     },
   });
+
+  const policyViolations = collector.violations.length > 0 ? collector.violations : undefined;
 
   if (decision.outcome === 'skip') {
     const skipped: SkippedProjectResult = {
@@ -88,6 +95,9 @@ export function releasePrepareProject(args: ReleasePrepareProjectArgs): ProjectP
     }
     if (decision.unparseableCommits !== undefined) {
       skipped.unparseableCommits = decision.unparseableCommits;
+    }
+    if (policyViolations !== undefined) {
+      skipped.policyViolations = policyViolations;
     }
     return skipped;
   }
@@ -160,6 +170,9 @@ export function releasePrepareProject(args: ReleasePrepareProjectArgs): ProjectP
   }
   if (unparseableCommits !== undefined) {
     result.unparseableCommits = unparseableCommits;
+  }
+  if (policyViolations !== undefined) {
+    result.policyViolations = policyViolations;
   }
   if (bumpOverride !== undefined) {
     result.bumpOverride = bumpOverride;

--- a/packages/release-kit/src/reportPrepare.ts
+++ b/packages/release-kit/src/reportPrepare.ts
@@ -299,7 +299,14 @@ function formatChangelogFiles(lines: string[], workspace: ReleasedWorkspaceResul
   }
 }
 
-/** Append unparseable commit warning lines when applicable. */
+/**
+ * Append unparseable commit warning lines when applicable.
+ *
+ * `indent` is an additional outer indent prepended to both the header and bullet lines; base
+ * spacing (2 spaces for the header, 4 for bullets) is encoded in the format strings, so the
+ * caller passes only the section-level indent (e.g., `''` for single-package, `'  '` for
+ * multi-workspace).
+ */
 function formatUnparseableWarning(lines: string[], workspace: WorkspacePrepareResult, indent = ''): void {
   const unparseable = workspace.unparseableCommits;
   if (unparseable === undefined || unparseable.length === 0) {
@@ -324,6 +331,11 @@ function formatUnparseableWarning(lines: string[], workspace: WorkspacePrepareRe
  * Renders one header line plus one bullet per violation. Subject truncation matches
  * `formatUnparseableWarning`'s 72-char convention. Returns early when no violations
  * were collected, leaving the lines array unchanged.
+ *
+ * `indent` is an additional outer indent prepended to both the header and bullet lines; base
+ * spacing (2 spaces for the header, 4 for bullets) is encoded in the format strings, so the
+ * caller passes only the section-level indent (e.g., `''` for single-package, `'  '` for
+ * multi-workspace).
  */
 function formatPolicyViolations(lines: string[], violations: PolicyViolation[] | undefined, indent = ''): void {
   if (violations === undefined || violations.length === 0) {

--- a/packages/release-kit/src/reportPrepare.ts
+++ b/packages/release-kit/src/reportPrepare.ts
@@ -1,5 +1,6 @@
 import { bold, dim, sectionHeader } from './format.ts';
 import type {
+  PolicyViolation,
   PrepareResult,
   ProjectPrepareResult,
   PropagationSource,
@@ -44,6 +45,7 @@ function formatSingleWorkspace(result: PrepareResult): string {
   }
 
   formatUnparseableWarning(lines, workspace);
+  formatPolicyViolations(lines, workspace.policyViolations);
 
   if (workspace.status === 'skipped') {
     lines.push(`⏭️  ${workspace.skipReason}`);
@@ -135,6 +137,8 @@ function formatProjectSection(lines: string[], project: ProjectPrepareResult, dr
   const since = project.previousTag === undefined ? '(no previous release found)' : `since ${project.previousTag}`;
   lines.push(dim(`  Found ${project.commitCount} commits ${since}`));
 
+  formatPolicyViolations(lines, project.policyViolations, '  ');
+
   if (project.status === 'skipped') {
     lines.push(`  ⏭️  ${project.skipReason}`);
     return;
@@ -215,6 +219,7 @@ function formatWorkspaceSection(lines: string[], workspace: WorkspacePrepareResu
 
   formatCommitSummary(lines, workspace, propagatedFrom, isPropagatedOnly);
   formatUnparseableWarning(lines, workspace, '  ');
+  formatPolicyViolations(lines, workspace.policyViolations, '  ');
   formatBumpLabels(lines, workspace, isPropagatedOnly);
   formatVersionLine(lines, workspace, propagatedFrom, isPropagatedOnly);
 
@@ -310,6 +315,30 @@ function formatUnparseableWarning(lines: string[], workspace: WorkspacePrepareRe
     const shortHash = commit.hash.slice(0, 7);
     const truncatedMessage = commit.message.length > 72 ? `${commit.message.slice(0, 69)}...` : commit.message;
     lines.push(`${indent}    · ${shortHash} ${truncatedMessage}`);
+  }
+}
+
+/**
+ * Append policy-violation lines when applicable.
+ *
+ * Renders one header line plus one bullet per violation. Subject truncation matches
+ * `formatUnparseableWarning`'s 72-char convention. Returns early when no violations
+ * were collected, leaving the lines array unchanged.
+ */
+function formatPolicyViolations(lines: string[], violations: PolicyViolation[] | undefined, indent = ''): void {
+  if (violations === undefined || violations.length === 0) {
+    return;
+  }
+
+  const count = violations.length;
+  lines.push(`${indent}  ⚠️  ${count} policy violation${count === 1 ? '' : 's'}:`);
+  for (const violation of violations) {
+    const shortHash = violation.commitHash.slice(0, 7);
+    const subject = violation.commitSubject;
+    const truncatedSubject = subject.length > 72 ? `${subject.slice(0, 69)}...` : subject;
+    lines.push(
+      `${indent}    · ${shortHash} '${truncatedSubject}' — type '${violation.type}' at ${violation.surface} surface`,
+    );
   }
 }
 

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -88,6 +88,24 @@ export interface BumpResult {
 }
 
 /**
+ * A `!`-policy violation detected while parsing commits during release preparation.
+ *
+ * Surfaces from `releasePrepare`, `releasePrepareMono`, and `releasePrepareProject` via the
+ * `policyViolations` field on each per-workspace/project result. The policy itself is enforced
+ * tolerantly at release time — violations are collected and reported, never fail the release.
+ */
+export interface PolicyViolation {
+  /** Full hash of the offending commit. */
+  commitHash: string;
+  /** First line of the commit message (raw, including any ticket prefix). */
+  commitSubject: string;
+  /** Resolved canonical work type whose policy was violated. */
+  type: string;
+  /** Where the violation was detected: `'prefix'` for `!`, `'body'` for `BREAKING CHANGE:` footer. */
+  surface: 'prefix' | 'body';
+}
+
+/**
  * Result of preparing a single workspace (package) for release when a release was produced.
  *
  * `currentVersion`, `newVersion`, `tag`, `bumpedFiles`, and `changelogFiles` are always
@@ -113,6 +131,8 @@ export interface ReleasedWorkspaceResult {
   parsedCommitCount?: number;
   /** Commits that could not be parsed into a recognized work type. */
   unparseableCommits?: Commit[];
+  /** Policy violations detected while parsing this workspace's commits; omitted when none. */
+  policyViolations?: PolicyViolation[];
   releaseType?: ReleaseType;
   currentVersion: string;
   newVersion: string;
@@ -152,6 +172,8 @@ export interface SkippedWorkspaceResult {
   parsedCommitCount?: number;
   /** Commits that could not be parsed into a recognized work type. */
   unparseableCommits?: Commit[];
+  /** Policy violations detected while parsing this workspace's commits; omitted when none. */
+  policyViolations?: PolicyViolation[];
   skipReason: string;
 }
 
@@ -184,6 +206,8 @@ export interface ReleasedProjectResult {
   parsedCommitCount: number;
   /** Commits that could not be parsed into a recognized work type. */
   unparseableCommits?: Commit[];
+  /** Policy violations detected while parsing the project's commits; omitted when none. */
+  policyViolations?: PolicyViolation[];
   releaseType: ReleaseType;
   currentVersion: string;
   newVersion: string;
@@ -218,6 +242,8 @@ export interface SkippedProjectResult {
   parsedCommitCount: number;
   /** Commits that could not be parsed into a recognized work type. */
   unparseableCommits?: Commit[];
+  /** Policy violations detected while parsing the project's commits; omitted when none. */
+  policyViolations?: PolicyViolation[];
   skipReason: string;
 }
 
@@ -283,6 +309,15 @@ export interface ReleaseKitConfig {
   versionPatterns?: VersionPatterns;
   /** Work type overrides. Merged with defaults by key. */
   workTypes?: Record<string, WorkTypeConfig>;
+  /**
+   * Per-canonical-type breaking-policy lookup driving release-time `!`-policy enforcement.
+   *
+   * When omitted, release-prepare flows apply `DEFAULT_BREAKING_POLICIES`. When provided, the
+   * map replaces the default entirely (no merge). To disable enforcement, pass `{}` — the
+   * parser falls back to `'optional'` for any type missing from the map. Individual entries
+   * can be overridden (e.g., make `feat` `'forbidden'` for a stricter dialect).
+   */
+  breakingPolicies?: Record<string, 'forbidden' | 'optional' | 'required'>;
   /**
    * Shell command to run after all changelogs are generated (e.g., 'pnpm run fmt').
    * Modified file paths (package.json files and CHANGELOGs) are appended as space-separated
@@ -434,6 +469,12 @@ export interface MonorepoReleaseConfig {
   /** Version bump patterns. Defaults to `DEFAULT_VERSION_PATTERNS`. */
   versionPatterns?: VersionPatterns;
   /**
+   * Per-canonical-type breaking-policy lookup. Defaults to `DEFAULT_BREAKING_POLICIES`. When
+   * provided, replaces the default entirely. Pass `{}` to disable enforcement (parser falls
+   * back to `'optional'` for missing types).
+   */
+  breakingPolicies?: Record<string, 'forbidden' | 'optional' | 'required'>;
+  /**
    * Shell command to run after all changelogs are generated (e.g., 'pnpm run fmt').
    * Modified file paths (package.json files and CHANGELOGs) are appended as space-separated
    * arguments. Paths are repo-relative; file paths containing spaces are not supported.
@@ -471,6 +512,12 @@ export interface ReleaseConfig {
   workTypes?: Record<string, WorkTypeConfig>;
   /** Version bump patterns. Defaults to `DEFAULT_VERSION_PATTERNS`. */
   versionPatterns?: VersionPatterns;
+  /**
+   * Per-canonical-type breaking-policy lookup. Defaults to `DEFAULT_BREAKING_POLICIES`. When
+   * provided, replaces the default entirely. Pass `{}` to disable enforcement (parser falls
+   * back to `'optional'` for missing types).
+   */
+  breakingPolicies?: Record<string, 'forbidden' | 'optional' | 'required'>;
   /**
    * Shell command to run after changelog generation (e.g., 'pnpm run fmt').
    * Modified file paths (package.json files and CHANGELOGs) are appended as space-separated


### PR DESCRIPTION
## What

Release-prepare flows now surface `!`-policy violations as warnings in the prepare report. Each workspace's and project's commit window is parsed against the default policy table — `internal!` is rejected as contradictory, bare `drop:` is rejected for missing the required `!`, and so on — and any violations appear under the workspace's section in the report alongside short hash, truncated subject, type, and surface (prefix or body). A new `breakingPolicies` config field lets consumers override individual entries or pass `{}` to disable enforcement entirely. Release-time enforcement remains tolerant: violations are warnings, never failures, so a single legacy commit cannot block a release.

## Why

The parser-side `!`-policy primitives shipped in #355, but the orchestrator-side wiring was deliberately deferred. Without this change, the standard release flows did not opt in to policy enforcement, so policy-violating commits parsed silently with `breaking: false` — the policy machinery was effectively inert in production runs. Surfacing violations in the release report closes the contract introduced by #355 and gives release authors the signal they need to clean up commit hygiene before tag time.

## Details

### Features

- New `PolicyViolation` interface (`commitHash`, `commitSubject`, `type`, `surface`) on `release-kit`'s public types surface.
- New optional `policyViolations?: PolicyViolation[]` field on every per-workspace and per-project result variant, populated when at least one violation was detected and omitted otherwise (matching the existing `unparseableCommits` convention).
- New optional `breakingPolicies?: Record<string, 'forbidden' | 'optional' | 'required'>` field on `ReleaseKitConfig`, `MonorepoReleaseConfig`, and `ReleaseConfig`. Defaults to `DEFAULT_BREAKING_POLICIES`; `{}` disables enforcement; partial maps override specific types.
- Prepare report now renders a per-section `⚠️  N policy violations:` block with one bullet per violation, using the same 72-char truncation convention as the existing unparseable-commits warning.

### Refactoring

- Shared `createPolicyViolationCollector` helper centralizes the `commitSubject` extraction rule (`commit.message.split('\n', 1)[0]` — raw, pre-strip) so all three orchestrators stay consistent.
- Extracted four helpers (`buildSkippedSinglePackage`, `attachReleasedWorkspaceOptionals`, `applyOptionalPassthroughFields`, plus the existing `buildReleasedSinglePackage` extended) to keep host functions within the project's cyclomatic-complexity ceiling — each new optional-field assignment counts as a branch, and the type-surface expansion would otherwise tip three functions over the limit.

### Tests

- 24 new test cases across four files: prefix-surface and body-surface violation emission per orchestrator, dual-emission (`!` + `BREAKING CHANGE:`), per-workspace attribution in monorepo mode, the patch-floor release path in single-package mode, the `{}`-disable opt-out, `breakingPolicies` config-merge pass-through for both `mergeMonorepoConfig` and `mergeSinglePackageConfig`, and the renderer's plural/singular header, single-package vs. multi-workspace vs. project sections, and 72-char truncation rule.

### Documentation

- README's consumer-config table gains a `breakingPolicies` row.
- "Two-tier policy enforcement" section gains a paragraph documenting the orchestrator-side behavior, with a rendered example excerpt.
- Sibling helpers `formatUnparseableWarning` and `formatPolicyViolations` now document the `indent` parameter contract (additional outer indent prepended to header and bullet lines; base 2/4-space spacing encoded in format strings).

Closes #357
