### PR TITLE
#360 Skip npx registry revalidation when running git-cliff

### DIFF
--- a/packages/release-kit/src/__tests__/buildChangelogEntries.unit.test.ts
+++ b/packages/release-kit/src/__tests__/buildChangelogEntries.unit.test.ts
@@ -4,21 +4,16 @@ import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_WORK_TYPES } from '../defaults.t
 import { matchesAudience, renderReleaseNotesSingle } from '../renderReleaseNotes.ts';
 import type { ChangelogEntry, ChangelogJsonConfig, ReleaseConfig } from '../types.ts';
 
-// Mock execFileSync to avoid actually running git-cliff.
-vi.mock('node:child_process', () => ({
-  execFileSync: vi.fn(),
-}));
-
-// Mock filesystem so the `.template` path's tempdir handling is exercised without touching disk.
-const mockMkdtempSync = vi.hoisted(() => vi.fn());
-const mockCopyFileSync = vi.hoisted(() => vi.fn());
-const mockRmSync = vi.hoisted(() => vi.fn());
+// Mock the runGitCliff helper so the test exercises buildChangelogEntries' transformation logic
+// without spawning any subprocess. Assertions on the helper's input shape live in runGitCliff.unit.test.ts.
+const mockRunGitCliff = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
 
+vi.mock('../runGitCliff.ts', () => ({
+  runGitCliff: mockRunGitCliff,
+}));
+
 vi.mock('node:fs', () => ({
-  copyFileSync: mockCopyFileSync,
-  mkdtempSync: mockMkdtempSync,
-  rmSync: mockRmSync,
   writeFileSync: mockWriteFileSync,
 }));
 
@@ -27,10 +22,7 @@ vi.mock('../resolveCliffConfigPath.ts', () => ({
   resolveCliffConfigPath: () => '/fake/cliff.toml',
 }));
 
-const { execFileSync } = await import('node:child_process');
-const { buildChangelogEntries } = await import('../buildChangelogEntries.ts');
-
-const mockedExecFileSync = vi.mocked(execFileSync);
+import { buildChangelogEntries } from '../buildChangelogEntries.ts';
 
 const defaultChangelogJsonConfig: ChangelogJsonConfig = {
   enabled: true,
@@ -48,10 +40,7 @@ function makeConfig(
 
 describe(buildChangelogEntries, () => {
   beforeEach(() => {
-    mockedExecFileSync.mockReset();
-    mockMkdtempSync.mockReset();
-    mockCopyFileSync.mockReset();
-    mockRmSync.mockReset();
+    mockRunGitCliff.mockReset();
     mockWriteFileSync.mockReset();
   });
 
@@ -72,7 +61,7 @@ describe(buildChangelogEntries, () => {
       },
     ];
 
-    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+    mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
 
     const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
 
@@ -98,7 +87,7 @@ describe(buildChangelogEntries, () => {
       },
     ];
 
-    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+    mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
 
     const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
 
@@ -120,7 +109,7 @@ describe(buildChangelogEntries, () => {
       },
     ];
 
-    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+    mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
 
     const entries = buildChangelogEntries(makeConfig(), 'v2.0.0');
 
@@ -149,7 +138,7 @@ describe(buildChangelogEntries, () => {
       },
     ];
 
-    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+    mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
 
     const entries = buildChangelogEntries(makeConfig({ devOnlySections: ['Internal', 'Dependencies'] }), 'v1.0.0');
 
@@ -180,7 +169,7 @@ describe(buildChangelogEntries, () => {
         ],
       },
     ];
-    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+    mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
 
     const entries = buildChangelogEntries(makeConfig(), 'v3.0.0');
 
@@ -197,7 +186,7 @@ describe(buildChangelogEntries, () => {
       },
     ];
 
-    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+    mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
 
     const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
 
@@ -208,7 +197,7 @@ describe(buildChangelogEntries, () => {
     // Pins the intentional dry-run behavioral change: `buildChangelogEntries` does not short-
     // circuit. The caller's `dryRun` controls only the persistence step (writeChangelogJson /
     // upsertChangelogJson), not the cliff invocation. This test asserts:
-    //   1. execFileSync IS called (git-cliff runs).
+    //   1. runGitCliff IS called (git-cliff runs).
     //   2. writeFileSync is NOT called (no file is written by this helper).
     const cliffContext = [
       {
@@ -217,13 +206,42 @@ describe(buildChangelogEntries, () => {
         commits: [{ message: '#1 feat: Add widget', group: 'Features' }],
       },
     ];
-    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+    mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
 
     const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
 
-    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockRunGitCliff).toHaveBeenCalledTimes(1);
     expect(mockWriteFileSync).not.toHaveBeenCalled();
     expect(entries).toHaveLength(1);
+  });
+
+  it('passes the resolved config path, --context/--tag args, and capture stdio to runGitCliff', () => {
+    const cliffContext = [
+      {
+        version: 'v1.0.0',
+        timestamp: 1_700_000_000,
+        commits: [{ message: '#1 feat: Add widget', group: 'Features' }],
+      },
+    ];
+    mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
+
+    buildChangelogEntries(makeConfig(), 'v1.0.0', { tagPattern: 'v[0-9].*', includePaths: ['packages/foo'] });
+
+    expect(mockRunGitCliff).toHaveBeenCalledWith(
+      '/fake/cliff.toml',
+      ['--context', '--tag', 'v1.0.0', '--tag-pattern', 'v[0-9].*', '--include-path', 'packages/foo'],
+      ['pipe', 'pipe', 'inherit'],
+    );
+  });
+
+  it('wraps thrown errors from the helper with site-specific context', () => {
+    mockRunGitCliff.mockImplementationOnce(() => {
+      throw new Error('npx exited with code 1');
+    });
+
+    expect(() => buildChangelogEntries(makeConfig(), 'v9.9.9')).toThrow(
+      'Failed to build changelog entries for tag v9.9.9: npx exited with code 1',
+    );
   });
 
   describe('breaking marker', () => {
@@ -235,7 +253,7 @@ describe(buildChangelogEntries, () => {
           commits: [{ message: '#1 feat!: Redesign API', group: 'Features' }],
         },
       ];
-      mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+      mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
       const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
       expect(entries[0]?.sections[0]?.items[0]?.breaking).toBe(true);
     });
@@ -248,7 +266,7 @@ describe(buildChangelogEntries, () => {
           commits: [{ message: '#1 feat: Add widget', group: 'Features' }],
         },
       ];
-      mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+      mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
       const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
       expect(entries[0]?.sections[0]?.items[0]).not.toHaveProperty('breaking');
     });
@@ -261,7 +279,7 @@ describe(buildChangelogEntries, () => {
           commits: [{ message: '#1 drop!: Remove legacy endpoint', group: 'Removed' }],
         },
       ];
-      mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+      mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
       const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
       expect(entries[0]?.sections[0]?.items[0]?.breaking).toBe(true);
     });
@@ -274,7 +292,7 @@ describe(buildChangelogEntries, () => {
           commits: [{ message: '#1 feat(api)!: Redesign endpoint', group: 'Features' }],
         },
       ];
-      mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+      mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
       const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
       expect(entries[0]?.sections[0]?.items[0]?.breaking).toBe(true);
     });
@@ -287,7 +305,7 @@ describe(buildChangelogEntries, () => {
           commits: [{ message: '#1 web|feat!: Reshape API', group: 'Features' }],
         },
       ];
-      mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+      mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
       const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
       expect(entries[0]?.sections[0]?.items[0]?.breaking).toBe(true);
     });
@@ -300,7 +318,7 @@ describe(buildChangelogEntries, () => {
           commits: [{ message: '#1 feat: Add widget\n\nBREAKING CHANGE: removes /v1 path', group: 'Features' }],
         },
       ];
-      mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+      mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
       const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
       expect(entries[0]?.sections[0]?.items[0]).not.toHaveProperty('breaking');
     });
@@ -315,7 +333,7 @@ describe(buildChangelogEntries, () => {
           commits: [{ message, group: 'Features' }],
         },
       ];
-      mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+      mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
       const entries = buildChangelogEntries(makeConfig(), 'v1.0.0');
       return entries[0]?.sections[0]?.items ?? [];
     }
@@ -403,10 +421,7 @@ describe(buildChangelogEntries, () => {
 
 describe('buildChangelogEntries + renderReleaseNotesSingle integration', () => {
   beforeEach(() => {
-    mockedExecFileSync.mockReset();
-    mockMkdtempSync.mockReset();
-    mockCopyFileSync.mockReset();
-    mockRmSync.mockReset();
+    mockRunGitCliff.mockReset();
     mockWriteFileSync.mockReset();
   });
 
@@ -438,7 +453,7 @@ describe('buildChangelogEntries + renderReleaseNotesSingle integration', () => {
         ],
       },
     ];
-    mockedExecFileSync.mockReturnValueOnce(JSON.stringify(cliffContext));
+    mockRunGitCliff.mockReturnValueOnce(JSON.stringify(cliffContext));
 
     const entries = buildChangelogEntries(
       makeConfig({ devOnlySections: DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections }),

--- a/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
+++ b/packages/release-kit/src/__tests__/generateChangelog.unit.test.ts
@@ -1,19 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const mockExecFileSync = vi.hoisted(() => vi.fn());
+const mockRunGitCliff = vi.hoisted(() => vi.fn());
 const mockResolveCliffConfigPath = vi.hoisted(() => vi.fn());
-const mockCopyFileSync = vi.hoisted(() => vi.fn());
-const mockMkdtempSync = vi.hoisted(() => vi.fn(() => '/tmp/cliff-abc123'));
-const mockRmSync = vi.hoisted(() => vi.fn());
 
-vi.mock('node:child_process', () => ({
-  execFileSync: mockExecFileSync,
-}));
-
-vi.mock('node:fs', () => ({
-  copyFileSync: mockCopyFileSync,
-  mkdtempSync: mockMkdtempSync,
-  rmSync: mockRmSync,
+vi.mock('../runGitCliff.ts', () => ({
+  runGitCliff: mockRunGitCliff,
 }));
 
 vi.mock('../resolveCliffConfigPath.ts', () => ({
@@ -48,24 +39,21 @@ describe(buildTagPattern, () => {
 
 describe(generateChangelog, () => {
   afterEach(() => {
-    mockExecFileSync.mockReset();
+    mockRunGitCliff.mockReset();
     mockResolveCliffConfigPath.mockReset();
-    mockCopyFileSync.mockReset();
-    mockMkdtempSync.mockReset().mockReturnValue('/tmp/cliff-abc123');
-    mockRmSync.mockReset();
   });
 
-  it('calls git-cliff with base args when no includePaths are provided', () => {
+  it('calls runGitCliff with base args when no includePaths are provided', () => {
     mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
     const config = { cliffConfigPath: 'cliff.toml' };
 
     const result = generateChangelog(config, 'packages/arrays', 'v1.0.0', false);
 
     expect(result).toStrictEqual(['packages/arrays/CHANGELOG.md']);
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'npx',
-      ['--yes', 'git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
-      { stdio: 'inherit' },
+    expect(mockRunGitCliff).toHaveBeenCalledWith(
+      'cliff.toml',
+      ['--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      'inherit',
     );
   });
 
@@ -78,21 +66,10 @@ describe(generateChangelog, () => {
     });
 
     expect(result).toStrictEqual(['packages/arrays/CHANGELOG.md']);
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'npx',
-      [
-        '--yes',
-        'git-cliff',
-        '--config',
-        'cliff.toml',
-        '--output',
-        'packages/arrays/CHANGELOG.md',
-        '--tag',
-        'arrays-v1.0.0',
-        '--include-path',
-        'packages/arrays',
-      ],
-      { stdio: 'inherit' },
+    expect(mockRunGitCliff).toHaveBeenCalledWith(
+      'cliff.toml',
+      ['--output', 'packages/arrays/CHANGELOG.md', '--tag', 'arrays-v1.0.0', '--include-path', 'packages/arrays'],
+      'inherit',
     );
   });
 
@@ -105,13 +82,9 @@ describe(generateChangelog, () => {
     });
 
     expect(result).toStrictEqual(['./CHANGELOG.md']);
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'npx',
+    expect(mockRunGitCliff).toHaveBeenCalledWith(
+      'cliff.toml',
       [
-        '--yes',
-        'git-cliff',
-        '--config',
-        'cliff.toml',
         '--output',
         './CHANGELOG.md',
         '--tag',
@@ -121,7 +94,7 @@ describe(generateChangelog, () => {
         '--include-path',
         'packages/strings',
       ],
-      { stdio: 'inherit' },
+      'inherit',
     );
   });
 
@@ -134,13 +107,9 @@ describe(generateChangelog, () => {
       includePaths: ['packages/arrays'],
     });
 
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'npx',
+    expect(mockRunGitCliff).toHaveBeenCalledWith(
+      'cliff.toml',
       [
-        '--yes',
-        'git-cliff',
-        '--config',
-        'cliff.toml',
         '--output',
         'packages/arrays/CHANGELOG.md',
         '--tag',
@@ -150,7 +119,7 @@ describe(generateChangelog, () => {
         '--include-path',
         'packages/arrays',
       ],
-      { stdio: 'inherit' },
+      'inherit',
     );
   });
 
@@ -160,10 +129,10 @@ describe(generateChangelog, () => {
 
     generateChangelog(config, 'packages/arrays', 'v1.0.0', false);
 
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'npx',
-      ['--yes', 'git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
-      { stdio: 'inherit' },
+    expect(mockRunGitCliff).toHaveBeenCalledWith(
+      'cliff.toml',
+      ['--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      'inherit',
     );
   });
 
@@ -173,24 +142,34 @@ describe(generateChangelog, () => {
 
     generateChangelog(config, 'packages/arrays', 'v1.0.0', false, { includePaths: [] });
 
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'npx',
-      ['--yes', 'git-cliff', '--config', 'cliff.toml', '--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
-      { stdio: 'inherit' },
+    expect(mockRunGitCliff).toHaveBeenCalledWith(
+      'cliff.toml',
+      ['--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      'inherit',
     );
   });
 
-  it('returns the output file path without calling execFileSync when dryRun is true', () => {
+  it('returns the output file path without invoking runGitCliff when dryRun is true', () => {
     mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
     const config = { cliffConfigPath: 'cliff.toml' };
 
     const result = generateChangelog(config, 'packages/arrays', 'v1.0.0', true);
 
     expect(result).toStrictEqual(['packages/arrays/CHANGELOG.md']);
-    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(mockRunGitCliff).not.toHaveBeenCalled();
   });
 
-  it('copies .template files to a temp .toml before passing to git-cliff', () => {
+  it('does not resolve the cliff config path when dryRun is true', () => {
+    // Dry-run skips both helper invocation and the resolveCliffConfigPath call, so a missing
+    // bundled template (or a transient resolution failure) does not block dry-run output.
+    const config = { cliffConfigPath: 'cliff.toml' };
+
+    generateChangelog(config, 'packages/arrays', 'v1.0.0', true);
+
+    expect(mockResolveCliffConfigPath).not.toHaveBeenCalled();
+  });
+
+  it('forwards the resolved config path to runGitCliff (e.g. a .template path)', () => {
     mockResolveCliffConfigPath.mockReturnValue('/bundled/cliff.toml.template');
     const config = {};
 
@@ -198,28 +177,29 @@ describe(generateChangelog, () => {
 
     expect(result).toStrictEqual(['packages/arrays/CHANGELOG.md']);
     expect(mockResolveCliffConfigPath).toHaveBeenCalledWith(undefined, expect.any(String));
-    expect(mockCopyFileSync).toHaveBeenCalledWith('/bundled/cliff.toml.template', '/tmp/cliff-abc123/cliff.toml');
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'npx',
-      [
-        '--yes',
-        'git-cliff',
-        '--config',
-        '/tmp/cliff-abc123/cliff.toml',
-        '--output',
-        'packages/arrays/CHANGELOG.md',
-        '--tag',
-        'v1.0.0',
-      ],
-      { stdio: 'inherit' },
+    expect(mockRunGitCliff).toHaveBeenCalledWith(
+      '/bundled/cliff.toml.template',
+      ['--output', 'packages/arrays/CHANGELOG.md', '--tag', 'v1.0.0'],
+      'inherit',
     );
-    expect(mockRmSync).toHaveBeenCalledWith('/tmp/cliff-abc123', { recursive: true, force: true });
+  });
+
+  it('wraps thrown errors from the helper with site-specific context', () => {
+    mockResolveCliffConfigPath.mockReturnValue('cliff.toml');
+    mockRunGitCliff.mockImplementationOnce(() => {
+      throw new Error('npx exited with code 1');
+    });
+    const config = { cliffConfigPath: 'cliff.toml' };
+
+    expect(() => generateChangelog(config, 'packages/arrays', 'v1.0.0', false)).toThrow(
+      'Failed to generate changelog for packages/arrays/CHANGELOG.md: npx exited with code 1',
+    );
   });
 });
 
 describe(generateChangelogs, () => {
   afterEach(() => {
-    mockExecFileSync.mockReset();
+    mockRunGitCliff.mockReset();
     mockResolveCliffConfigPath.mockReset();
   });
 
@@ -238,7 +218,7 @@ describe(generateChangelogs, () => {
     const result = generateChangelogs(config, 'v1.0.0', false);
 
     expect(result).toStrictEqual(['packages/arrays/CHANGELOG.md', 'packages/strings/CHANGELOG.md']);
-    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+    expect(mockRunGitCliff).toHaveBeenCalledTimes(2);
   });
 
   it('passes --tag-pattern derived from tagPrefix', () => {
@@ -255,13 +235,9 @@ describe(generateChangelogs, () => {
 
     generateChangelogs(config, 'release-kit-v2.3.0', false);
 
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'npx',
+    expect(mockRunGitCliff).toHaveBeenCalledWith(
+      'cliff.toml',
       [
-        '--yes',
-        'git-cliff',
-        '--config',
-        'cliff.toml',
         '--output',
         'packages/release-kit/CHANGELOG.md',
         '--tag',
@@ -269,7 +245,7 @@ describe(generateChangelogs, () => {
         '--tag-pattern',
         'release-kit-v[0-9].*',
       ],
-      { stdio: 'inherit' },
+      'inherit',
     );
   });
 });

--- a/packages/release-kit/src/__tests__/runGitCliff.unit.test.ts
+++ b/packages/release-kit/src/__tests__/runGitCliff.unit.test.ts
@@ -128,6 +128,17 @@ describe(runGitCliff, () => {
     expect(mockRmSync).toHaveBeenCalledWith('/tmp/cliff-abc123', { recursive: true, force: true });
   });
 
+  it('removes the temp dir when copyFileSync throws after mkdtempSync succeeds', () => {
+    mockCopyFileSync.mockImplementationOnce(() => {
+      throw new Error('template unreadable');
+    });
+
+    expect(() => runGitCliff('/bundled/cliff.toml.template', [], 'inherit')).toThrow('template unreadable');
+    expect(mockMkdtempSync).toHaveBeenCalledWith('/tmp/cliff-');
+    expect(mockRmSync).toHaveBeenCalledWith('/tmp/cliff-abc123', { recursive: true, force: true });
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
   it('rethrows the underlying execFileSync error without wrapping it', () => {
     const underlying = new Error('npx exited with code 1');
     mockExecFileSync.mockImplementationOnce(() => {

--- a/packages/release-kit/src/__tests__/runGitCliff.unit.test.ts
+++ b/packages/release-kit/src/__tests__/runGitCliff.unit.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+const mockCopyFileSync = vi.hoisted(() => vi.fn());
+const mockMkdtempSync = vi.hoisted(() => vi.fn(() => '/tmp/cliff-abc123'));
+const mockRmSync = vi.hoisted(() => vi.fn());
+const mockTmpdir = vi.hoisted(() => vi.fn(() => '/tmp'));
+
+vi.mock('node:child_process', () => ({ execFileSync: mockExecFileSync }));
+vi.mock('node:fs', () => ({ copyFileSync: mockCopyFileSync, mkdtempSync: mockMkdtempSync, rmSync: mockRmSync }));
+vi.mock('node:os', () => ({ tmpdir: mockTmpdir }));
+
+import { runGitCliff } from '../runGitCliff.ts';
+
+describe(runGitCliff, () => {
+  afterEach(() => {
+    mockExecFileSync.mockReset();
+    mockCopyFileSync.mockReset();
+    mockMkdtempSync.mockReset().mockReturnValue('/tmp/cliff-abc123');
+    mockRmSync.mockReset();
+    mockTmpdir.mockReset().mockReturnValue('/tmp');
+  });
+
+  it('passes --prefer-offline and --yes to npx ahead of git-cliff', () => {
+    mockExecFileSync.mockReturnValueOnce('');
+
+    runGitCliff('cliff.toml', ['--tag', 'v1.0.0'], 'inherit');
+
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      ['--prefer-offline', '--yes', 'git-cliff', '--config', 'cliff.toml', '--tag', 'v1.0.0'],
+      expect.any(Object),
+    );
+  });
+
+  it('sets npm_config_progress=false in the spawned env while preserving inherited variables', () => {
+    mockExecFileSync.mockReturnValueOnce('');
+    const previousPath = process.env.PATH;
+
+    runGitCliff('cliff.toml', [], 'inherit');
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          npm_config_progress: 'false',
+          // Sanity: an arbitrary inherited variable is still present (env merge does not clobber the inherited environment).
+          PATH: previousPath,
+        }),
+      }),
+    );
+  });
+
+  it('forces utf8 encoding so the return type is string', () => {
+    mockExecFileSync.mockReturnValueOnce('cliff stdout');
+
+    const result = runGitCliff('cliff.toml', [], ['pipe', 'pipe', 'inherit']);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      expect.any(Array),
+      expect.objectContaining({ encoding: 'utf8' }),
+    );
+    expect(result).toBe('cliff stdout');
+  });
+
+  it('passes the caller-supplied stdio value through to execFileSync', () => {
+    mockExecFileSync.mockReturnValueOnce('');
+
+    runGitCliff('cliff.toml', [], ['pipe', 'pipe', 'inherit']);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      expect.any(Array),
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'inherit'] }),
+    );
+  });
+
+  it('copies a .template config to a temp .toml and uses the temp path as --config', () => {
+    mockExecFileSync.mockReturnValueOnce('');
+
+    runGitCliff('/bundled/cliff.toml.template', ['--tag', 'v1.0.0'], 'inherit');
+
+    expect(mockMkdtempSync).toHaveBeenCalledWith('/tmp/cliff-');
+    expect(mockCopyFileSync).toHaveBeenCalledWith('/bundled/cliff.toml.template', '/tmp/cliff-abc123/cliff.toml');
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      expect.arrayContaining(['/tmp/cliff-abc123/cliff.toml']),
+      expect.any(Object),
+    );
+    expect(mockExecFileSync).not.toHaveBeenCalledWith(
+      'npx',
+      expect.arrayContaining(['/bundled/cliff.toml.template']),
+      expect.any(Object),
+    );
+  });
+
+  it('passes a non-.template config path through unchanged without creating a temp dir', () => {
+    mockExecFileSync.mockReturnValueOnce('');
+
+    runGitCliff('/explicit/cliff.toml', [], 'inherit');
+
+    expect(mockMkdtempSync).not.toHaveBeenCalled();
+    expect(mockCopyFileSync).not.toHaveBeenCalled();
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      expect.arrayContaining(['/explicit/cliff.toml']),
+      expect.any(Object),
+    );
+  });
+
+  it('removes the temp dir after a successful invocation when a .template was used', () => {
+    mockExecFileSync.mockReturnValueOnce('');
+
+    runGitCliff('/bundled/cliff.toml.template', [], 'inherit');
+
+    expect(mockRmSync).toHaveBeenCalledWith('/tmp/cliff-abc123', { recursive: true, force: true });
+  });
+
+  it('removes the temp dir even when execFileSync throws', () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error('git-cliff failed');
+    });
+
+    expect(() => runGitCliff('/bundled/cliff.toml.template', [], 'inherit')).toThrow('git-cliff failed');
+    expect(mockRmSync).toHaveBeenCalledWith('/tmp/cliff-abc123', { recursive: true, force: true });
+  });
+
+  it('rethrows the underlying execFileSync error without wrapping it', () => {
+    const underlying = new Error('npx exited with code 1');
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw underlying;
+    });
+
+    expect(() => runGitCliff('cliff.toml', [], 'inherit')).toThrow(underlying);
+  });
+
+  it('does not invoke rmSync when no temp dir was created (non-.template path)', () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error('git-cliff failed');
+    });
+
+    expect(() => runGitCliff('/explicit/cliff.toml', [], 'inherit')).toThrow('git-cliff failed');
+    expect(mockRmSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/release-kit/src/buildChangelogEntries.ts
+++ b/packages/release-kit/src/buildChangelogEntries.ts
@@ -1,13 +1,9 @@
-import { execFileSync } from 'node:child_process';
-import { copyFileSync, mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
 import { extractVersion } from './changelogJsonUtils.ts';
 import { DEFAULT_WORK_TYPES } from './defaults.ts';
 import type { GenerateChangelogOptions } from './generateChangelogs.ts';
 import { COMMIT_PREPROCESSOR_PATTERNS } from './parseCommitMessage.ts';
 import { resolveCliffConfigPath } from './resolveCliffConfigPath.ts';
+import { runGitCliff } from './runGitCliff.ts';
 import { stripEmojiPrefix } from './stripEmojiPrefix.ts';
 import { isRecord, isUnknownArray } from './typeGuards.ts';
 import type { ChangelogEntry, ChangelogItem, ChangelogSection, ReleaseConfig } from './types.ts';
@@ -86,29 +82,18 @@ export function buildChangelogEntries(
 ): ChangelogEntry[] {
   const resolvedConfigPath = resolveCliffConfigPath(config.cliffConfigPath, import.meta.url);
 
-  let cliffConfigPath = resolvedConfigPath;
-  let tempDir: string | undefined;
-  if (resolvedConfigPath.endsWith('.template')) {
-    tempDir = mkdtempSync(join(tmpdir(), 'cliff-'));
-    cliffConfigPath = join(tempDir, 'cliff.toml');
-    copyFileSync(resolvedConfigPath, cliffConfigPath);
-  }
-
-  const args = ['--config', cliffConfigPath, '--context', '--tag', tag];
+  const cliffArgs = ['--context', '--tag', tag];
 
   if (options?.tagPattern !== undefined) {
-    args.push('--tag-pattern', options.tagPattern);
+    cliffArgs.push('--tag-pattern', options.tagPattern);
   }
 
   for (const includePath of options?.includePaths ?? []) {
-    args.push('--include-path', includePath);
+    cliffArgs.push('--include-path', includePath);
   }
 
   try {
-    const contextJson = execFileSync('npx', ['--yes', 'git-cliff', ...args], {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'inherit'],
-    });
+    const contextJson = runGitCliff(resolvedConfigPath, cliffArgs, ['pipe', 'pipe', 'inherit']);
 
     const releases = parseCliffContext(contextJson);
     const devOnlySections = new Set(config.changelogJson.devOnlySections);
@@ -117,10 +102,6 @@ export function buildChangelogEntries(
     throw new Error(
       `Failed to build changelog entries for tag ${tag}: ${error instanceof Error ? error.message : String(error)}`,
     );
-  } finally {
-    if (tempDir !== undefined) {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
   }
 }
 

--- a/packages/release-kit/src/generateChangelogs.ts
+++ b/packages/release-kit/src/generateChangelogs.ts
@@ -65,12 +65,10 @@ export function generateChangelog(
   const resolvedConfigPath = resolveCliffConfigPath(config.cliffConfigPath, import.meta.url);
   const cliffArgs = ['--output', outputFile, '--tag', tag];
 
-  // Append --tag-pattern flag when a tag pattern is provided.
   if (options?.tagPattern !== undefined) {
     cliffArgs.push('--tag-pattern', options.tagPattern);
   }
 
-  // Append --include-path flags when path filtering is requested.
   for (const includePath of options?.includePaths ?? []) {
     cliffArgs.push('--include-path', includePath);
   }

--- a/packages/release-kit/src/generateChangelogs.ts
+++ b/packages/release-kit/src/generateChangelogs.ts
@@ -1,9 +1,5 @@
-import { execFileSync } from 'node:child_process';
-import { copyFileSync, mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
 import { resolveCliffConfigPath } from './resolveCliffConfigPath.ts';
+import { runGitCliff } from './runGitCliff.ts';
 import type { ReleaseConfig } from './types.ts';
 
 /**
@@ -49,9 +45,9 @@ export interface GenerateChangelogOptions {
 /**
  * Generate a single changelog using git-cliff.
  *
- * Invokes `git-cliff` via `npx --yes` using `execFileSync` with an argument array,
- * avoiding shell interpretation of paths. Returns the output file path as a
- * single-element array for consistency with `generateChangelogs`.
+ * Invokes `git-cliff` via the shared `runGitCliff` helper (which spawns `npx`). Returns
+ * the output file path as a single-element array for consistency with `generateChangelogs`.
+ * In dry-run mode the helper is not invoked at all — no subprocess, no temp dir.
  */
 export function generateChangelog(
   config: Pick<ReleaseConfig, 'cliffConfigPath'>,
@@ -60,47 +56,34 @@ export function generateChangelog(
   dryRun: boolean,
   options?: GenerateChangelogOptions,
 ): string[] {
-  const resolvedConfigPath = resolveCliffConfigPath(config.cliffConfigPath, import.meta.url);
+  const outputFile = `${changelogPath}/CHANGELOG.md`;
 
-  // git-cliff rejects non-.toml extensions. Copy bundled .template files to a temp .toml file.
-  let cliffConfigPath = resolvedConfigPath;
-  let tempDir: string | undefined;
-  if (resolvedConfigPath.endsWith('.template')) {
-    tempDir = mkdtempSync(join(tmpdir(), 'cliff-'));
-    cliffConfigPath = join(tempDir, 'cliff.toml');
-    copyFileSync(resolvedConfigPath, cliffConfigPath);
+  if (dryRun) {
+    return [outputFile];
   }
 
-  const outputFile = `${changelogPath}/CHANGELOG.md`;
-  const args = ['--config', cliffConfigPath, '--output', outputFile, '--tag', tag];
+  const resolvedConfigPath = resolveCliffConfigPath(config.cliffConfigPath, import.meta.url);
+  const cliffArgs = ['--output', outputFile, '--tag', tag];
 
   // Append --tag-pattern flag when a tag pattern is provided.
   if (options?.tagPattern !== undefined) {
-    args.push('--tag-pattern', options.tagPattern);
+    cliffArgs.push('--tag-pattern', options.tagPattern);
   }
 
   // Append --include-path flags when path filtering is requested.
   for (const includePath of options?.includePaths ?? []) {
-    args.push('--include-path', includePath);
+    cliffArgs.push('--include-path', includePath);
   }
 
   try {
-    if (!dryRun) {
-      try {
-        execFileSync('npx', ['--yes', 'git-cliff', ...args], { stdio: 'inherit' });
-      } catch (error: unknown) {
-        throw new Error(
-          `Failed to generate changelog for ${outputFile}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    }
-
-    return [outputFile];
-  } finally {
-    if (tempDir !== undefined) {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    runGitCliff(resolvedConfigPath, cliffArgs, 'inherit');
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to generate changelog for ${outputFile}: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
+
+  return [outputFile];
 }
 
 /**

--- a/packages/release-kit/src/runGitCliff.ts
+++ b/packages/release-kit/src/runGitCliff.ts
@@ -1,0 +1,47 @@
+import { execFileSync, type StdioOptions } from 'node:child_process';
+import { copyFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Invoke `git-cliff` via `npx`, returning its stdout as a string.
+ *
+ * Single entry point for `git-cliff` invocations from `release-kit`. Owns three pieces of
+ * shared lifecycle that would otherwise duplicate (and silently drift) across call sites:
+ * the npx flags, the spawned-process environment, and the `.template`→temp `.toml` copy.
+ *
+ * The `--prefer-offline` flag and `npm_config_progress=false` env entry are deliberate:
+ * `--prefer-offline` skips npx's per-call npm-registry revalidation HTTP round-trip
+ * (~2.5 s per invocation on a warm cache), and `npm_config_progress=false` suppresses
+ * npx's animated stderr spinner, which otherwise renders as a transient flicker.
+ *
+ * The helper injects `--config <path>` itself — callers must NOT include `--config` in
+ * `cliffArgs`. The caller is responsible for resolving the cliff config path (via
+ * `resolveCliffConfigPath`) before calling, since the resolution depends on the caller's
+ * `import.meta.url`.
+ *
+ * Errors from `execFileSync` are not caught: callers wrap with site-specific messages.
+ * The temp-dir cleanup runs in a `finally` so it still happens on throw.
+ */
+export function runGitCliff(cliffConfigPath: string, cliffArgs: readonly string[], stdio: StdioOptions): string {
+  let configPath = cliffConfigPath;
+  let tempDir: string | undefined;
+  // git-cliff rejects non-.toml extensions. Copy bundled .template files to a temp .toml file.
+  if (cliffConfigPath.endsWith('.template')) {
+    tempDir = mkdtempSync(join(tmpdir(), 'cliff-'));
+    configPath = join(tempDir, 'cliff.toml');
+    copyFileSync(cliffConfigPath, configPath);
+  }
+
+  try {
+    return execFileSync('npx', ['--prefer-offline', '--yes', 'git-cliff', '--config', configPath, ...cliffArgs], {
+      encoding: 'utf8',
+      stdio,
+      env: { ...process.env, npm_config_progress: 'false' },
+    });
+  } finally {
+    if (tempDir !== undefined) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+}

--- a/packages/release-kit/src/runGitCliff.ts
+++ b/packages/release-kit/src/runGitCliff.ts
@@ -26,14 +26,14 @@ import { join } from 'node:path';
 export function runGitCliff(cliffConfigPath: string, cliffArgs: readonly string[], stdio: StdioOptions): string {
   let configPath = cliffConfigPath;
   let tempDir: string | undefined;
-  // git-cliff rejects non-.toml extensions. Copy bundled .template files to a temp .toml file.
-  if (cliffConfigPath.endsWith('.template')) {
-    tempDir = mkdtempSync(join(tmpdir(), 'cliff-'));
-    configPath = join(tempDir, 'cliff.toml');
-    copyFileSync(cliffConfigPath, configPath);
-  }
-
   try {
+    // git-cliff rejects non-.toml extensions. Copy bundled .template files to a temp .toml file.
+    if (cliffConfigPath.endsWith('.template')) {
+      tempDir = mkdtempSync(join(tmpdir(), 'cliff-'));
+      configPath = join(tempDir, 'cliff.toml');
+      copyFileSync(cliffConfigPath, configPath);
+    }
+
     return execFileSync('npx', ['--prefer-offline', '--yes', 'git-cliff', '--config', configPath, ...cliffArgs], {
       encoding: 'utf8',
       stdio,


### PR DESCRIPTION
## What

Speeds up `release-kit prepare` by skipping the npm registry cache-revalidation HTTP request that ran on every `git-cliff` invocation. Per-invocation overhead drops from ~4.6 s to ~2.0 s; in a four-workspace monorepo this saves about 10 seconds per run. Also suppresses a transient stderr spinner that briefly appeared during package resolution and looked like a half-complete log message. Network fallback is preserved — runs on machines with an empty npx cache still resolve `git-cliff` over the network.

## Why

`release-kit prepare` invokes `git-cliff` once per workspace (twice in some configurations), and most of each call's wall time was npm overhead — a registry revalidation request on every cache hit, plus an animated spinner reaching the user's terminal — not actual changelog work. The cost was visible enough on multi-workspace runs to be worth eliminating.

## Details

### Performance

- Adds `--prefer-offline` to the `npx` invocation so cached `git-cliff` packages are reused without revalidation, while still falling back to the network on a true cache miss.
- Sets `npm_config_progress=false` in the spawned process's environment so the npx Braille spinner no longer reaches stderr during the brief moment of package resolution.

### Refactoring

- Centralizes the `git-cliff` invocation lifecycle in a new internal helper so the npx flag set, the env override, and the `.template`→temp-`.toml` copy/cleanup all live in one place. Both prior call sites delegate to the helper, eliminating a duplicated block at each site and making it impossible for a future call site to silently regress the speed or the spinner suppression. Site-specific error context (e.g., "Failed to build changelog entries for tag X") is preserved at each caller.
- As an incidental improvement, the `--dry-run` path no longer creates a temp directory at all — the dry-run short-circuit now precedes the config-path resolution it gated.

### Tests

- Adds a unit test suite for the new helper that pins the contract: the npx flags are present, the spawned env sets the progress override, `.template` paths are copied to a temp `.toml` and cleaned up, non-`.template` paths are passed through unchanged, and the temp dir is removed on success and on throw at any step.
- Retargets both call-site test suites to mock the helper directly, removing low-level subprocess assertions from those suites and keeping flag-pinning assertions in one place.

Closes #360
