### PR TITLE
#362 Clarify which vulnerabilities `audit-deps sync` adds

### DIFF
--- a/packages/audit-deps/__tests__/format-actions.test.ts
+++ b/packages/audit-deps/__tests__/format-actions.test.ts
@@ -34,7 +34,7 @@ describe(formatActionHints, () => {
     const output = formatActionHints(result, ['prod']);
     expect(output).toContain('Actions:');
     expect(output).toContain('  \u{2022} Run `audit-deps --prod --verbose` for full report');
-    expect(output).toContain('  \u{2022} Run `audit-deps sync` to add vulnerabilities to the allowlist.');
+    expect(output).toContain('  \u{2022} Run `audit-deps sync` to add the listed vulnerabilities to the allowlist.');
   });
 
   it('returns remove-only hint without verbose hint when only stale entries exist', () => {
@@ -69,7 +69,7 @@ describe(formatActionHints, () => {
     });
 
     const output = formatActionHints(result, ['prod', 'dev']);
-    expect(output).toContain('add vulnerabilities to the allowlist and remove stale entries');
+    expect(output).toContain('add the listed vulnerabilities to the allowlist and remove stale entries');
   });
 
   it('only considers scopes included in the scopes array', () => {

--- a/packages/audit-deps/__tests__/format-check.test.ts
+++ b/packages/audit-deps/__tests__/format-check.test.ts
@@ -345,7 +345,7 @@ describe(formatCheckText, () => {
     const output = formatCheckText(result, ['prod'], FIXED_NOW);
     expect(output).toContain('Actions:');
     expect(output).toContain('Run `audit-deps --prod --verbose` for full report');
-    expect(output).toContain('Run `audit-deps sync` to add vulnerabilities to the allowlist.');
+    expect(output).toContain('Run `audit-deps sync` to add the listed vulnerabilities to the allowlist.');
   });
 
   it('appends an Actions footer with the remove-only hint when only stale entries exist', () => {
@@ -377,7 +377,7 @@ describe(formatCheckText, () => {
 
     const output = formatCheckText(result, ['prod'], FIXED_NOW);
     expect(output).toContain('Actions:');
-    expect(output).toContain('add vulnerabilities to the allowlist and remove stale entries');
+    expect(output).toContain('add the listed vulnerabilities to the allowlist and remove stale entries');
   });
 
   it('omits the Actions footer when the allowlist is fully current', () => {
@@ -410,7 +410,7 @@ describe(formatCheckText, () => {
     const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW);
     expect(output).toContain('Actions:');
     expect(output).toContain('Run `audit-deps --verbose` for full report');
-    expect(output).toContain('Run `audit-deps sync` to add vulnerabilities to the allowlist.');
+    expect(output).toContain('Run `audit-deps sync` to add the listed vulnerabilities to the allowlist.');
   });
 
   it('appends Actions footer with remove-only sync hint when multi-scope has only stale entries', () => {
@@ -456,7 +456,7 @@ describe(formatCheckText, () => {
 
     const output = formatCheckText(result, ['prod', 'dev'], FIXED_NOW);
     expect(output).toContain('Actions:');
-    expect(output).toContain('add vulnerabilities to the allowlist and remove stale entries');
+    expect(output).toContain('add the listed vulnerabilities to the allowlist and remove stale entries');
     expect(output).toContain('Run `audit-deps --verbose` for full report');
   });
 

--- a/packages/audit-deps/__tests__/format-verbose.test.ts
+++ b/packages/audit-deps/__tests__/format-verbose.test.ts
@@ -399,7 +399,7 @@ describe(formatCheckVerboseText, () => {
 
     const output = formatCheckVerboseText(result, ['prod'], FIXED_NOW);
     expect(output).toContain('Actions:');
-    expect(output).toContain('add vulnerabilities to the allowlist and remove stale entries');
+    expect(output).toContain('add the listed vulnerabilities to the allowlist and remove stale entries');
   });
 
   it('omits the Actions footer when the allowlist is fully current', () => {

--- a/packages/audit-deps/src/format-actions.ts
+++ b/packages/audit-deps/src/format-actions.ts
@@ -1,9 +1,9 @@
 import type { CheckResult } from './format-check.ts';
 import type { AuditScope } from './types.ts';
 
-const HINT_ADD = 'Run `audit-deps sync` to add vulnerabilities to the allowlist.';
+const HINT_ADD = 'Run `audit-deps sync` to add the listed vulnerabilities to the allowlist.';
 const HINT_REMOVE = 'Run `audit-deps sync` to remove stale allowlist entries.';
-const HINT_BOTH = 'Run `audit-deps sync` to add vulnerabilities to the allowlist and remove stale entries.';
+const HINT_BOTH = 'Run `audit-deps sync` to add the listed vulnerabilities to the allowlist and remove stale entries.';
 
 /** Build the `--verbose` flag string reflecting the original scope flags. */
 function buildVerboseFlag(scopes: AuditScope[]): string {


### PR DESCRIPTION
## What

Clarifies the action hints printed by `audit-deps check` so users understand exactly which vulnerabilities `audit-deps sync` will allowlist. The hints now read "add **the listed** vulnerabilities to the allowlist", tying the action to the report shown immediately above. The previous wording — "add vulnerabilities to the allowlist" — could imply that `sync` is selective or interactive, when in fact it non-interactively allowlists every unallowed vulnerability in the report.

## Why

A user noted that the existing hint invites the misreading that `audit-deps sync` lets them choose which vulnerabilities to allowlist. The command is non-interactive: it adds every unallowed vulnerability in the report. The wording change makes the antecedent explicit and removes the ambiguity without any behavior change.

## Details

### Fixes

- Updates `HINT_ADD` and `HINT_BOTH` in `packages/audit-deps/src/format-actions.ts` to qualify "vulnerabilities" as "the listed vulnerabilities".
- Updates the corresponding assertions in `format-actions.test.ts`, `format-check.test.ts`, and `format-verbose.test.ts` to match the new wording.

`HINT_REMOVE` is left as-is — "stale" already names a specific category, so adding "listed" would not improve clarity.

Closes #362
