### PR TITLE
#364 Soft-skip tags with no changelog entry under --tags

### DIFF
--- a/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
@@ -199,7 +199,10 @@ describe(createGithubReleaseCommand, () => {
     expect(console.error).toHaveBeenCalledWith('Error discovering workspaces: discovery failed');
   });
 
-  it('exits with code 1 when --tags is explicit and any requested tag has no changelog entry', async () => {
+  it('does not exit when --tags is explicit and every skip is no-entry', async () => {
+    // Typo protection lives upstream in resolveCommandTags (which exits 1 on unknown --tags
+    // values), so a no-entry skip reaching here is a legitimate "no releasable content"
+    // outcome — same as no-audience-content and empty-body.
     mockDiscoverWorkspaces.mockResolvedValue(['packages/core', 'packages/extra']);
     mockResolveReleaseTags.mockReturnValue([
       { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
@@ -213,20 +216,11 @@ describe(createGithubReleaseCommand, () => {
       ],
     });
 
-    let thrown: ExitError | undefined;
-    try {
-      await createGithubReleaseCommand(['--tags=core-v1.3.0,extra-v0.1.0']);
-    } catch (error: unknown) {
-      if (error instanceof ExitError) {
-        thrown = error;
-      }
-    }
+    await createGithubReleaseCommand(['--tags=core-v1.3.0,extra-v0.1.0']);
 
-    expect(thrown).toBeInstanceOf(ExitError);
-    expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith(
-      'Error: requested tags have no changelog entry: core-v1.3.0, extra-v0.1.0. ' +
-        'Verify the tag names match a published changelog version.',
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledWith(
+      'Skipped 2 tag(s) with no releasable content: core-v1.3.0 (no-entry), extra-v0.1.0 (no-entry).',
     );
   });
 
@@ -260,9 +254,9 @@ describe(createGithubReleaseCommand, () => {
     expect(console.info).toHaveBeenCalledWith('Skipped 1 tag(s) with no releasable content: core-v1.3.0 (empty-body).');
   });
 
-  it('exits 1 when --tags has mixed outcomes including a no-entry skip, naming only the no-entry tags', async () => {
-    // A typoed tag is still a typo even when other requested tags succeed. The error message
-    // names only the no-entry tags so the user knows which to investigate.
+  it('logs an info summary when --tags has mixed outcomes including a no-entry skip', async () => {
+    // Mirrors the no-audience-content mixed-outcome test below: no-entry is no longer
+    // discriminated at this layer because resolveCommandTags already rejects unknown tags.
     mockDiscoverWorkspaces.mockResolvedValue(['packages/core', 'packages/extra']);
     mockResolveReleaseTags.mockReturnValue([
       { tag: 'core-v1.3.0', dir: 'core', workspacePath: 'packages/core' },
@@ -273,21 +267,10 @@ describe(createGithubReleaseCommand, () => {
       skipped: [{ tag: 'extra-v0.1.0', reason: 'no-entry' }],
     });
 
-    let thrown: ExitError | undefined;
-    try {
-      await createGithubReleaseCommand(['--tags=core-v1.3.0,extra-v0.1.0']);
-    } catch (error: unknown) {
-      if (error instanceof ExitError) {
-        thrown = error;
-      }
-    }
+    await createGithubReleaseCommand(['--tags=core-v1.3.0,extra-v0.1.0']);
 
-    expect(thrown).toBeInstanceOf(ExitError);
-    expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith(
-      'Error: requested tags have no changelog entry: extra-v0.1.0. ' +
-        'Verify the tag names match a published changelog version.',
-    );
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledWith('Skipped 1 tag(s) with no releasable content: extra-v0.1.0 (no-entry).');
   });
 
   it('does not exit when --tags is omitted and every tag is skipped', async () => {

--- a/packages/release-kit/src/createGithubReleaseCommand.ts
+++ b/packages/release-kit/src/createGithubReleaseCommand.ts
@@ -41,23 +41,11 @@ export async function createGithubReleaseCommand(argv: string[]): Promise<void> 
     process.exit(1);
   }
 
-  // Fail visibly when the user explicitly requested tags via --tags and any requested tag has no
-  // changelog entry: that's a typo or misconfiguration worth surfacing, even if other requested
-  // tags succeeded. Other skip reasons (`no-audience-content`, `empty-body`) are intentional
-  // outcomes of release-kit's rendering rules — a tooling-only release has nothing user-facing
-  // to announce, and that's a normal state, not a failure. Omitted --tags (operate on all HEAD
-  // tags) keeps the legacy soft-skip behavior since the user did not single out specific tags.
-  if (requestedTags !== undefined) {
-    const noEntryTags = outcome.skipped.filter((s) => s.reason === 'no-entry').map((s) => s.tag);
-    if (noEntryTags.length > 0) {
-      console.error(
-        `Error: requested tags have no changelog entry: ${noEntryTags.join(', ')}. ` +
-          `Verify the tag names match a published changelog version.`,
-      );
-      process.exit(1);
-    }
-  }
-
+  // Treat every per-tag skip reason (`no-entry`, `no-audience-content`, `empty-body`) as
+  // informational. Typo protection for `--tags` lives upstream in `resolveCommandTags`, which
+  // exits 1 with `Error: Unknown tag "..."` before any tag reaches `createGithubReleases`.
+  // By the time a tag's outcome is `no-entry` here, its existence in git is guaranteed and the
+  // missing entry is a legitimate "no releasable content" outcome — same as the other reasons.
   if (outcome.skipped.length > 0) {
     const formatted = outcome.skipped.map((s) => `${s.tag} (${s.reason})`).join(', ');
     console.info(`Skipped ${outcome.skipped.length} tag(s) with no releasable content: ${formatted}.`);


### PR DESCRIPTION
## What

Fixes an issue where `release-kit create-github-release --tags <tag>` exited 1 — failing the calling CI workflow — when the requested tag had no changelog entry. Tooling-only releases (those whose changelog generator legitimately omits an entry) are now soft-skipped with an info-level summary, the same as releases skipped because their entry has no audience-relevant content. Typo protection is preserved: passing an unknown tag to `--tags` still exits 1.

## Why

A tag that legitimately has no changelog content was breaking CI workflows that publish releases on every push — a tooling-only release with nothing to announce should be a normal outcome, not a failure. The hard-fail was a leftover safeguard from when this command was the only typo guard, but tag validation has since moved upstream.

## Details

### Fixes

- Removes the `--tags` + missing-changelog-entry hard-fail in `create-github-release`. All three skip reasons (`no-entry`, `no-audience-content`, `empty-body`) now behave uniformly as soft-skips, completing the work begun in #347.
- The existing `Skipped N tag(s) with no releasable content: ...` info summary continues to name each skipped tag and its reason, so CI logs still surface why a tag was skipped.

### Tests

- Replaces the two unit tests that asserted the old hard-fail with tests that assert the new soft-skip behavior, covering both the "all skipped" and "mixed outcome" cases for the `no-entry` reason. Existing tests for `no-audience-content` and `empty-body` are unchanged.

Closes #364
