### PR TITLE
#368 Suppress git-cliff stale-version warnings on prepare

### DIFF
--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -327,8 +327,11 @@ describe(releasePrepare, () => {
     const workspace = result.workspaces[0];
     if (workspace?.status !== 'released') throw new Error('expected released');
     expect(workspace.changelogFiles).toStrictEqual(['./CHANGELOG.md']);
+    // Filter on `--config` to count only real cliff *work* invocations and exclude the
+    // once-per-run cache-refresh call (`npx --yes git-cliff --version`, no `--config`).
     const cliffCalls = mockExecFileSync.mock.calls.filter(
-      (call: unknown[]) => call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff'),
+      (call: unknown[]) =>
+        call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff') && call[1].includes('--config'),
     );
     expect(cliffCalls).toHaveLength(1);
   });
@@ -568,6 +571,85 @@ describe(releasePrepare, () => {
 
       expect(result.workspaces[0]?.status).toBe('released');
       expect(result.workspaces[0]?.policyViolations).toHaveLength(1);
+    });
+  });
+
+  describe('git-cliff cache refresh', () => {
+    /** Identify the warmup call: `npx --yes git-cliff --version`, no `--config`, no `--prefer-offline`. */
+    function findWarmupCallIndices(): number[] {
+      const indices: number[] = [];
+      mockExecFileSync.mock.calls.forEach((call: unknown[], index: number) => {
+        if (
+          call[0] === 'npx' &&
+          Array.isArray(call[1]) &&
+          call[1].includes('git-cliff') &&
+          call[1].includes('--version') &&
+          !call[1].includes('--config') &&
+          !call[1].includes('--prefer-offline')
+        ) {
+          indices.push(index);
+        }
+      });
+      return indices;
+    }
+
+    /** Identify cliff *work* calls (those that pass `--config`) and return their call indices. */
+    function findCliffWorkCallIndices(): number[] {
+      const indices: number[] = [];
+      mockExecFileSync.mock.calls.forEach((call: unknown[], index: number) => {
+        if (
+          call[0] === 'npx' &&
+          Array.isArray(call[1]) &&
+          call[1].includes('git-cliff') &&
+          call[1].includes('--config')
+        ) {
+          indices.push(index);
+        }
+      });
+      return indices;
+    }
+
+    it('refreshes the git-cliff cache exactly once on a non-skip release run, before any cliff work call', () => {
+      setupFeatCommit();
+
+      releasePrepare(makeConfig(), { dryRun: false });
+
+      const warmupIndices = findWarmupCallIndices();
+      const workIndices = findCliffWorkCallIndices();
+      expect(warmupIndices).toHaveLength(1);
+      expect(workIndices.length).toBeGreaterThan(0);
+      const firstWarmup = warmupIndices[0] ?? Number.POSITIVE_INFINITY;
+      const firstWork = workIndices[0] ?? Number.NEGATIVE_INFINITY;
+      expect(firstWarmup).toBeLessThan(firstWork);
+    });
+
+    it('refreshes the git-cliff cache even in dry-run mode (cliff is invoked under dry-run for changelog.json)', () => {
+      setupFeatCommit();
+
+      releasePrepare(makeConfig(), { dryRun: true });
+
+      expect(findWarmupCallIndices()).toHaveLength(1);
+    });
+
+    it('does not refresh the cache when no commits exist and no override is given (skip path)', () => {
+      // Tag exists but no commits since → releaseType stays undefined → skip path → no cliff
+      // work needed → no warmup.
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          return 'v1.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          return '';
+        }
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+      const result = releasePrepare(makeConfig(), { dryRun: false });
+
+      // Sanity: confirm the test actually exercised the skip path.
+      expect(result.workspaces[0]?.status).toBe('skipped');
+      expect(findWarmupCallIndices()).toHaveLength(0);
     });
   });
 });

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -77,21 +77,68 @@ function makeConfig(overrides?: Partial<MonorepoReleaseConfig>): MonorepoRelease
   };
 }
 
-/** Count how many npx git-cliff calls occurred. */
+/** Count how many npx git-cliff *work* calls occurred (excludes the once-per-run cache refresh). */
 function countCliffCalls(): number {
   return mockExecFileSync.mock.calls.filter(
-    (call: unknown[]) => call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff'),
+    (call: unknown[]) =>
+      call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff') && call[1].includes('--config'),
   ).length;
 }
 
-/** Find the first npx git-cliff call's args from the mock call history. */
+/** Find the first npx git-cliff *work* call's args (skips the cache-refresh `--version` call). */
 function findCliffCallArgs(): readonly unknown[] {
   for (const call of mockExecFileSync.mock.calls) {
-    if (call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff')) {
+    if (call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff') && call[1].includes('--config')) {
       return call[1];
     }
   }
-  throw new Error('No npx git-cliff call found in mock history');
+  throw new Error('No npx git-cliff work call found in mock history');
+}
+
+/** Count how many cache-refresh warmup calls occurred (`npx --yes git-cliff --version`). */
+function countCacheRefreshCalls(): number {
+  return mockExecFileSync.mock.calls.filter(
+    (call: unknown[]) =>
+      call[0] === 'npx' &&
+      Array.isArray(call[1]) &&
+      call[1].includes('git-cliff') &&
+      call[1].includes('--version') &&
+      !call[1].includes('--config'),
+  ).length;
+}
+
+/**
+ * Return the index of the first cache-refresh call, or `+Infinity` if none.
+ * Sentinel chosen so `firstCacheRefreshCallIndex() < firstCliffWorkCallIndex()` only
+ * passes when both are present.
+ */
+function firstCacheRefreshCallIndex(): number {
+  let index = 0;
+  for (const call of mockExecFileSync.mock.calls) {
+    if (
+      call[0] === 'npx' &&
+      Array.isArray(call[1]) &&
+      call[1].includes('git-cliff') &&
+      call[1].includes('--version') &&
+      !call[1].includes('--config')
+    ) {
+      return index;
+    }
+    index += 1;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+/** Return the index of the first cliff work call, or `-Infinity` if none. */
+function firstCliffWorkCallIndex(): number {
+  let index = 0;
+  for (const call of mockExecFileSync.mock.calls) {
+    if (call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff') && call[1].includes('--config')) {
+      return index;
+    }
+    index += 1;
+  }
+  return Number.NEGATIVE_INFINITY;
 }
 
 /** Collect the --output path from every npx git-cliff call. */
@@ -1984,7 +2031,9 @@ describe(releasePrepareMono, () => {
       mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
         if (cmd === 'git' && args[0] === 'describe') return 'arrays-v1.0.0\n';
         if (cmd === 'git' && args[0] === 'log') return 'feat: addabc123';
-        if (cmd === 'npx') throw underlying;
+        // Only throw on cliff *work* calls (those carrying `--config`); the once-per-run
+        // cache-refresh warmup call (`--version`, no `--config`) succeeds.
+        if (cmd === 'npx' && Array.isArray(args) && args.includes('--config')) throw underlying;
         return '';
       });
       mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
@@ -2008,9 +2057,10 @@ describe(releasePrepareMono, () => {
           if (matchArg === '--match=v*') return 'v0.9.0\n';
         }
         if (cmd === 'git' && args[0] === 'log') return `feat: shipabc123`;
-        if (cmd === 'npx') {
+        // Count only cliff *work* calls (those carrying `--config`); ignore the once-per-run
+        // cache-refresh warmup. First work call is the workspace's; second is the project's.
+        if (cmd === 'npx' && Array.isArray(args) && args.includes('--config')) {
           cliffCallCount += 1;
-          // First cliff call is the workspace's; second is the project's.
           if (cliffCallCount >= 2) throw underlying;
         }
         return '';
@@ -2217,5 +2267,90 @@ describe(releasePrepareMono, () => {
     // branch when zero commits parsed, which means no violation could have fired. The
     // `SkippedResult.policyViolations` field is wired defensively for parity with the
     // released path but not exercised here.
+  });
+
+  describe('git-cliff cache refresh', () => {
+    it('refreshes the git-cliff cache exactly once before any per-workspace cliff work call', () => {
+      const config = makeConfig({
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            isPublishable: true,
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+          {
+            dir: 'strings',
+            name: '@test/strings',
+            tagPrefix: 'strings-v',
+            workspacePath: 'packages/strings',
+            isPublishable: true,
+            packageFiles: ['packages/strings/package.json'],
+            changelogPaths: ['packages/strings'],
+            paths: ['packages/strings/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          const matchArg = args.find((a: string) => a.startsWith('--match='));
+          if (matchArg?.includes('arrays-v')) {
+            return 'arrays-v1.0.0\n';
+          }
+          if (matchArg?.includes('strings-v')) {
+            return 'strings-v2.0.0\n';
+          }
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          return 'feat: changeabc123';
+        }
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+      releasePrepareMono(config, { dryRun: false });
+
+      expect(countCacheRefreshCalls()).toBe(1);
+      // The single warmup must precede every per-workspace cliff work invocation.
+      expect(firstCacheRefreshCallIndex()).toBeLessThan(firstCliffWorkCallIndex());
+    });
+
+    it('does not refresh the cache when every workspace skips (no cliff work to warm)', () => {
+      const config = makeConfig({
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            isPublishable: true,
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          return 'arrays-v1.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          return '';
+        }
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/arrays', version: '1.0.0' }));
+
+      releasePrepareMono(config, { dryRun: false });
+
+      expect(countCacheRefreshCalls()).toBe(0);
+      expect(countCliffCalls()).toBe(0);
+    });
   });
 });

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -2320,6 +2320,34 @@ describe(releasePrepareMono, () => {
       expect(firstCacheRefreshCallIndex()).toBeLessThan(firstCliffWorkCallIndex());
     });
 
+    it('refreshes the git-cliff cache even in dry-run mode (cliff is invoked under dry-run for changelog.json)', () => {
+      const config = makeConfig({
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            isPublishable: true,
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'arrays-v1.0.0\n';
+        if (cmd === 'git' && args[0] === 'log') return 'feat: changeabc123';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+
+      releasePrepareMono(config, { dryRun: true });
+
+      expect(countCacheRefreshCalls()).toBe(1);
+    });
+
     it('does not refresh the cache when every workspace skips (no cliff work to warm)', () => {
       const config = makeConfig({
         workspaces: [

--- a/packages/release-kit/src/__tests__/runGitCliff.unit.test.ts
+++ b/packages/release-kit/src/__tests__/runGitCliff.unit.test.ts
@@ -10,7 +10,7 @@ vi.mock('node:child_process', () => ({ execFileSync: mockExecFileSync }));
 vi.mock('node:fs', () => ({ copyFileSync: mockCopyFileSync, mkdtempSync: mockMkdtempSync, rmSync: mockRmSync }));
 vi.mock('node:os', () => ({ tmpdir: mockTmpdir }));
 
-import { runGitCliff } from '../runGitCliff.ts';
+import { refreshGitCliffCache, runGitCliff } from '../runGitCliff.ts';
 
 describe(runGitCliff, () => {
   afterEach(() => {
@@ -155,5 +155,64 @@ describe(runGitCliff, () => {
 
     expect(() => runGitCliff('/explicit/cliff.toml', [], 'inherit')).toThrow('git-cliff failed');
     expect(mockRmSync).not.toHaveBeenCalled();
+  });
+});
+
+describe(refreshGitCliffCache, () => {
+  afterEach(() => {
+    mockExecFileSync.mockReset();
+  });
+
+  it('invokes npx --yes git-cliff --version without --prefer-offline', () => {
+    mockExecFileSync.mockReturnValueOnce('');
+
+    refreshGitCliffCache();
+
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockExecFileSync).toHaveBeenCalledWith('npx', ['--yes', 'git-cliff', '--version'], expect.any(Object));
+    // The omission of --prefer-offline is the whole point of this helper.
+    const [, args] = mockExecFileSync.mock.calls[0] ?? [];
+    expect(args).not.toContain('--prefer-offline');
+    // No --config: the warmup does not need a cliff config to revalidate the cache.
+    expect(args).not.toContain('--config');
+  });
+
+  it('uses stdio ["ignore", "pipe", "inherit"] so the version line is suppressed but errors surface', () => {
+    mockExecFileSync.mockReturnValueOnce('');
+
+    refreshGitCliffCache();
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      expect.any(Array),
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'inherit'] }),
+    );
+  });
+
+  it('sets npm_config_progress=false in the spawned env while preserving inherited variables', () => {
+    mockExecFileSync.mockReturnValueOnce('');
+    const previousPath = process.env.PATH;
+
+    refreshGitCliffCache();
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'npx',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          npm_config_progress: 'false',
+          PATH: previousPath,
+        }),
+      }),
+    );
+  });
+
+  it('rethrows the underlying execFileSync error without wrapping it', () => {
+    const underlying = new Error('npx exited with code 1');
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw underlying;
+    });
+
+    expect(() => refreshGitCliffCache()).toThrow(underlying);
   });
 });

--- a/packages/release-kit/src/__tests__/runGitCliff.unit.test.ts
+++ b/packages/release-kit/src/__tests__/runGitCliff.unit.test.ts
@@ -213,6 +213,15 @@ describe(refreshGitCliffCache, () => {
       throw underlying;
     });
 
-    expect(() => refreshGitCliffCache()).toThrow(underlying);
+    // Capture and assert reference identity; `toThrow(underlying)` matches by message/class
+    // and would pass even if the helper wrapped the error in a fresh Error with the same
+    // message string.
+    let caught: unknown;
+    try {
+      refreshGitCliffCache();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBe(underlying);
   });
 });

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -13,6 +13,7 @@ import { hasPrettierConfig } from './hasPrettierConfig.ts';
 import { resolveWorkTypes } from './loadConfig.ts';
 import { readCurrentVersion } from './readCurrentVersion.ts';
 import { deriveSectionOrder } from './resolveReleaseNotesConfig.ts';
+import { refreshGitCliffCache } from './runGitCliff.ts';
 import type {
   BumpResult,
   Commit,
@@ -127,6 +128,10 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
   }
 
   const newTag = `${config.tagPrefix}${bump.newVersion}`;
+
+  // Revalidate npx's git-cliff cache once before any cliff invocation in this run, so the
+  // per-call --prefer-offline flag in `runGitCliff` does not pin the cached binary forever.
+  refreshGitCliffCache();
 
   // 4. Generate changelogs
   const changelogFiles = generateChangelogs(config, newTag, dryRun);

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -94,6 +94,9 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
     if (!isForwardVersion(currentVersion, setVersion)) {
       throw new Error(`--set-version ${setVersion} is not greater than current version ${currentVersion}`);
     }
+    // Warm the git-cliff cache *before* writing any package.json bumps so a refresh failure
+    // leaves the working tree unchanged.
+    refreshGitCliffCache();
     bump = setAllVersions(config.packageFiles, setVersion, dryRun);
   } else {
     if (bumpOverride === undefined) {
@@ -123,15 +126,15 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
       };
     }
 
-    // 3. Bump all versions
+    // 3. Bump all versions. Warm the git-cliff cache *before* writing any bumps so a
+    // refresh failure leaves the working tree unchanged. The `--prefer-offline` flag in
+    // `runGitCliff` would otherwise pin the cached binary forever; one warmup per run
+    // revalidates it without losing the per-call perf win.
+    refreshGitCliffCache();
     bump = bumpAllVersions(config.packageFiles, releaseType, dryRun);
   }
 
   const newTag = `${config.tagPrefix}${bump.newVersion}`;
-
-  // Revalidate npx's git-cliff cache once before any cliff invocation in this run, so the
-  // per-call --prefer-offline flag in `runGitCliff` does not pin the cached binary forever.
-  refreshGitCliffCache();
 
   // 4. Generate changelogs
   const changelogFiles = generateChangelogs(config, newTag, dryRun);

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -21,6 +21,7 @@ import { readCurrentVersion } from './readCurrentVersion.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
 import { releasePrepareProject } from './releasePrepareProject.ts';
 import { deriveSectionOrder } from './resolveReleaseNotesConfig.ts';
+import { refreshGitCliffCache } from './runGitCliff.ts';
 import type {
   Commit,
   MonorepoReleaseConfig,
@@ -123,6 +124,12 @@ export function releasePrepareMono(config: MonorepoReleaseConfig, options: Relea
     enabled: withReleaseNotes === true && config.changelogJson.enabled,
     sectionOrder,
   };
+  // Revalidate npx's git-cliff cache once before per-workspace cliff invocations begin, so
+  // the `--prefer-offline` flag in `runGitCliff` does not pin the cached binary forever
+  // across releases. Skipped only when no workspace will release (no cliff work to warm).
+  if (fullReleaseSet.size > 0) {
+    refreshGitCliffCache();
+  }
   const { tags, modifiedFiles } = executeReleaseSet(
     sortedDirs,
     fullReleaseSet,

--- a/packages/release-kit/src/runGitCliff.ts
+++ b/packages/release-kit/src/runGitCliff.ts
@@ -15,6 +15,13 @@ import { join } from 'node:path';
  * (~2.5 s per invocation on a warm cache), and `npm_config_progress=false` suppresses
  * npx's animated stderr spinner, which otherwise renders as a transient flicker.
  *
+ * Because `--prefer-offline` also suppresses npx's cache-staleness check, the cached
+ * `git-cliff` binary would otherwise drift further and further behind upstream, with each
+ * cliff invocation re-emitting the "A new version of git-cliff is available" notice and
+ * the local cache never updating. `refreshGitCliffCache` (below) revalidates the cache
+ * once at the top of each `prepare` run so subsequent `--prefer-offline` calls run against
+ * a current binary.
+ *
  * The helper injects `--config <path>` itself — callers must NOT include `--config` in
  * `cliffArgs`. The caller is responsible for resolving the cliff config path (via
  * `resolveCliffConfigPath`) before calling, since the resolution depends on the caller's
@@ -44,4 +51,26 @@ export function runGitCliff(cliffConfigPath: string, cliffArgs: readonly string[
       rmSync(tempDir, { recursive: true, force: true });
     }
   }
+}
+
+/**
+ * Revalidate npx's cache for `git-cliff` once per `prepare` run.
+ *
+ * Spawns `npx --yes git-cliff --version` *without* `--prefer-offline`, so npm performs its
+ * normal registry-staleness check and refreshes the cached binary if a newer version is
+ * available. Subsequent `runGitCliff` calls within the same run keep `--prefer-offline`
+ * (preserving the per-call perf win) but now run against an up-to-date cache, so
+ * git-cliff's own self-update notice no longer fires repeatedly.
+ *
+ * Stdio: stdin ignored, stdout piped (the version line is suppressed as noise), stderr
+ * inherited (npm errors and any rare upgrade notice surface, but only once per run).
+ *
+ * Errors propagate unchanged — a failed cache refresh fails the prepare run loudly rather
+ * than silently degrading.
+ */
+export function refreshGitCliffCache(): void {
+  execFileSync('npx', ['--yes', 'git-cliff', '--version'], {
+    stdio: ['ignore', 'pipe', 'inherit'],
+    env: { ...process.env, npm_config_progress: 'false' },
+  });
 }


### PR DESCRIPTION
## What

Fixes an issue where `release-kit prepare` repeatedly printed git-cliff's "A new version of git-cliff is available" notice — twice per release unit, so 2 × N times for an N-package monorepo run — while never updating the locally cached git-cliff binary. Each `prepare` run now revalidates the npm cache once before any cliff work, so the binary stays current with upstream releases and the notice no longer surfaces on every per-workspace invocation.

## Why

A prior performance change added `--prefer-offline` to the `npx git-cliff` invocation to skip per-call npm-registry revalidation, but that flag also suppressed npm's cache-staleness check. The cached binary was therefore pinned indefinitely while git-cliff's own self-update notice fired on every invocation — visible noise that never abated, on a tool the user had no path to actually upgrade.

## Details

### Fixes

Adds a `refreshGitCliffCache` helper alongside `runGitCliff` that performs a single `npx --yes git-cliff --version` *without* `--prefer-offline`. Both `releasePrepare` and `releasePrepareMono` call it once per run, gated to skip no-op paths (single-package skip path; mono `fullReleaseSet.size === 0`). The existing `runGitCliff` retains `--prefer-offline`, so the per-call performance benefit is preserved for the 2nd-through-Nth cliff invocations within the run.

### Refactoring

Aligns the single-package warmup placement with the mono pattern: `refreshGitCliffCache` runs *before* `package.json` bumps in `releasePrepare`, matching mono mode where the warmup precedes `executeReleaseSet` (which owns all bump-writes). A refresh failure now leaves the working tree unchanged in both modes.

### Tests

Pins the contract at both layers. Helper-level coverage asserts the spawned-command shape (no `--prefer-offline`, no `--config`, stdio `['ignore', 'pipe', 'inherit']`, env preserves `npm_config_progress=false`, errors propagate by reference). Orchestrator coverage asserts exactly-once invocation before any cliff work, dry-run parity in both modes, and zero-call behavior on no-op paths.

Closes #368
