### PR TITLE
#371 Expose workspace bins from any subdir and simplify nmr docs

### DIFF
--- a/.agents/nmr/AGENTS.md
+++ b/.agents/nmr/AGENTS.md
@@ -4,7 +4,7 @@ source: '@williamthorsen/nmr@0.13.0'
 
 # nmr: agent guidance
 
-This file is managed by `@williamthorsen/nmr`. Do not edit — re-run `pnpm exec nmr sync-agent-files` after an nmr upgrade to refresh it.
+This file is managed by `@williamthorsen/nmr`. Do not edit — re-run `nmr sync-agent-files` after an nmr upgrade to refresh it.
 
 ## Discover scripts by running nmr
 
@@ -13,8 +13,20 @@ Run `nmr` with no command (from the monorepo root or any workspace package) to l
 ## Invocation rules
 
 - Use `nmr <command>` for anything nmr provides. Do not use `pnpm run <command>`.
-- Use `pnpm exec nmr`, not `npx nmr`. Inside git worktrees, `npx` can resolve a different nmr binary from outside the working tree.
-- If `nmr` itself fails to run (fresh clone, missing build output), run `pnpm run bootstrap` from the repo root first.
+- You can invoke nmr from the monorepo root or any workspace package.
+
+### How to make `nmr` resolvable
+
+`nmr` ships as a workspace bin. The bare `nmr` command works only when your shell can find `<root>/node_modules/.bin/nmr`. Choose one:
+
+- **direnv** (recommended for contributors). With [direnv](https://direnv.net/) installed, the repo's `.envrc` adds `node_modules/.bin` to your `PATH` automatically. From any subdirectory, bare `nmr` works.
+- **`pnpm exec nmr <command>`** — works without setup. pnpm resolves the bin from the workspace root.
+
+Avoid `npx nmr`. Inside git worktrees, `npx` can resolve a different nmr binary from outside the working tree.
+
+### Bootstrap fallback
+
+If `nmr` itself fails to run (fresh clone, missing build output), run `pnpm run bootstrap` from the repo root first.
 
 ## Root vs. workspace context
 

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-export PATH="./node_modules/.bin:$PATH"
+PATH_add node_modules/.bin

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ asdf plugin add nodejs
 asdf install nodejs 18.12.1
 ```
 
+## Recommended setup
+
+Install [direnv](https://direnv.net/) and run `direnv allow` from the repo root. The repo's `.envrc` adds `node_modules/.bin` to your `PATH`, so workspace bins like `nmr`, `release-kit`, and `audit-deps` resolve directly from any subdirectory.
+
+Without direnv, prefix workspace bins with `pnpm exec` (e.g., `pnpm exec nmr <command>`).
+
 ## Scripts
 
 Install dependencies (this script has the same effect regardless of where it is run in the project):

--- a/packages/nmr/AGENTS.md
+++ b/packages/nmr/AGENTS.md
@@ -4,7 +4,7 @@ source: '@williamthorsen/nmr@0.0.0-source'
 
 # nmr: agent guidance
 
-This file is managed by `@williamthorsen/nmr`. Do not edit — re-run `pnpm exec nmr sync-agent-files` after an nmr upgrade to refresh it.
+This file is managed by `@williamthorsen/nmr`. Do not edit — re-run `nmr sync-agent-files` after an nmr upgrade to refresh it.
 
 ## Discover scripts by running nmr
 
@@ -13,8 +13,20 @@ Run `nmr` with no command (from the monorepo root or any workspace package) to l
 ## Invocation rules
 
 - Use `nmr <command>` for anything nmr provides. Do not use `pnpm run <command>`.
-- Use `pnpm exec nmr`, not `npx nmr`. Inside git worktrees, `npx` can resolve a different nmr binary from outside the working tree.
-- If `nmr` itself fails to run (fresh clone, missing build output), run `pnpm run bootstrap` from the repo root first.
+- You can invoke nmr from the monorepo root or any workspace package.
+
+### How to make `nmr` resolvable
+
+`nmr` ships as a workspace bin. The bare `nmr` command works only when your shell can find `<root>/node_modules/.bin/nmr`. Choose one:
+
+- **direnv** (recommended for contributors). With [direnv](https://direnv.net/) installed, the repo's `.envrc` adds `node_modules/.bin` to your `PATH` automatically. From any subdirectory, bare `nmr` works.
+- **`pnpm exec nmr <command>`** — works without setup. pnpm resolves the bin from the workspace root.
+
+Avoid `npx nmr`. Inside git worktrees, `npx` can resolve a different nmr binary from outside the working tree.
+
+### Bootstrap fallback
+
+If `nmr` itself fails to run (fresh clone, missing build output), run `pnpm run bootstrap` from the repo root first.
 
 ## Root vs. workspace context
 


### PR DESCRIPTION
## What

Workspace bins like `nmr`, `release-kit`, and `audit-deps` are now invocable from any subdirectory under the monorepo when direnv is active, replacing the previous root-only `.envrc` recipe. The nmr usage docs are restructured to present two unambiguous resolution modes — direnv (recommended) and `pnpm exec nmr` — and the repo's README now documents direnv as the recommended setup.

## Why

Contributors and AI agents working from subdirectories had to remember to prefix every nmr invocation with `pnpm exec` because the previous `.envrc` only exposed bins from the monorepo root. The friction discouraged adoption and pushed readers toward inconsistent invocation patterns across the codebase.

## Details

### Tooling

- Replaces the root `.envrc` with `PATH_add node_modules/.bin`, which prepends an absolute path computed against the `.envrc`'s own location. With direnv installed, bare `nmr`, `release-kit`, and `audit-deps` resolve from any subdirectory.

### Documentation

- Restructures the "Invocation rules" section of `packages/nmr/AGENTS.md` to present two unambiguous ways to make `nmr` resolvable: direnv (recommended) and `pnpm exec nmr`. Drops the bare `pnpm nmr` form because readers cannot tell whether the second word is a built-in command, a `package.json` script, or a binary.
- Regenerates `.agents/nmr/AGENTS.md` via `nmr sync-agent-files` so the bundled copy stays in sync with the source-of-truth template that ships in the `@williamthorsen/nmr` package.
- Adds a "Recommended setup" section to `README.md` flagging direnv as the recommended setup for contributors and showing the `pnpm exec` fallback for users without direnv.

Closes #371
