### PR TITLE
#369 Use synthetic changelogs for forced empty-range releases

### DIFF
--- a/packages/release-kit/src/__tests__/buildEmptyReleaseEntry.unit.test.ts
+++ b/packages/release-kit/src/__tests__/buildEmptyReleaseEntry.unit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildEmptyReleaseEntry } from '../buildEmptyReleaseEntry.ts';
+
+describe(buildEmptyReleaseEntry, () => {
+  it('produces a ChangelogEntry with a single Notes section', () => {
+    const entry = buildEmptyReleaseEntry('1.0.1', '2026-05-06');
+
+    expect(entry.version).toBe('1.0.1');
+    expect(entry.date).toBe('2026-05-06');
+    expect(entry.sections).toHaveLength(1);
+    expect(entry.sections[0]?.title).toBe('Notes');
+    expect(entry.sections[0]?.audience).toBe('dev');
+  });
+
+  it('produces a single Forced version bump. item', () => {
+    const entry = buildEmptyReleaseEntry('2.0.0', '2026-05-06');
+
+    expect(entry.sections[0]?.items).toStrictEqual([{ description: 'Forced version bump.' }]);
+  });
+
+  it('returns no extra top-level keys (round-trip safe)', () => {
+    const entry = buildEmptyReleaseEntry('1.2.3', '2026-05-06');
+
+    // eslint-disable-next-line unicorn/no-array-sort -- toSorted() requires Node 20; project targets Node 18.17+
+    expect(Object.keys(entry).sort()).toStrictEqual(['date', 'sections', 'version']);
+  });
+});

--- a/packages/release-kit/src/__tests__/prependChangelogSection.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prependChangelogSection.unit.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+import { prependChangelogSection } from '../prependChangelogSection.ts';
+
+describe(prependChangelogSection, () => {
+  afterEach(() => {
+    mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
+  });
+
+  it('writes only the section followed by a newline when the file does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    prependChangelogSection('packages/app/CHANGELOG.md', '## 1.0.0 — 2026-05-06\n', false);
+
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).toHaveBeenCalledWith('packages/app/CHANGELOG.md', '## 1.0.0 — 2026-05-06\n\n', 'utf8');
+  });
+
+  it('prepends the section ahead of existing content separated by a blank line', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('## 0.9.0 — 2026-03-01\n\nPrevious release.\n');
+
+    prependChangelogSection('packages/app/CHANGELOG.md', '## 1.0.0 — 2026-05-06\n', false);
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      'packages/app/CHANGELOG.md',
+      '## 1.0.0 — 2026-05-06\n\n## 0.9.0 — 2026-03-01\n\nPrevious release.\n',
+      'utf8',
+    );
+  });
+
+  it('performs no I/O in dry-run mode', () => {
+    prependChangelogSection('packages/app/CHANGELOG.md', '## 1.0.0 — 2026-05-06\n', true);
+
+    expect(mockExistsSync).not.toHaveBeenCalled();
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepare.unit.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockExecFileSync = vi.hoisted(() => vi.fn());
 const mockExecSync = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
 const mockHasPrettierConfig = vi.hoisted(() => vi.fn());
@@ -13,6 +14,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
   readFileSync: mockReadFileSync,
   writeFileSync: mockWriteFileSync,
 }));
@@ -89,11 +91,15 @@ describe(releasePrepare, () => {
   beforeEach(() => {
     mockBuildChangelogEntries.mockReturnValue([]);
     mockUpsertChangelogJson.mockImplementation((filePath: string) => filePath);
+    // Default `existsSync` to false so synthetic-write paths skip the read-existing-file
+    // branch by default. Individual tests override per-call when they exercise prepend behavior.
+    mockExistsSync.mockReturnValue(false);
   });
 
   afterEach(() => {
     mockExecFileSync.mockReset();
     mockExecSync.mockReset();
+    mockExistsSync.mockReset();
     mockReadFileSync.mockReset();
     mockWriteFileSync.mockReset();
     mockHasPrettierConfig.mockReset();
@@ -310,7 +316,9 @@ describe(releasePrepare, () => {
     );
   });
 
-  it('still generates a changelog when using --set-version', () => {
+  it('writes a synthetic empty-range changelog when --set-version is used with zero commits', () => {
+    // `commits.length === 0` routes to `writeEmptyReleaseChangelog` instead of git-cliff,
+    // avoiding the `WARN  git_cliff > There is already a tag` noise (issue #369).
     mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === 'git' && args[0] === 'describe') {
         return 'v0.5.0\n';
@@ -327,13 +335,20 @@ describe(releasePrepare, () => {
     const workspace = result.workspaces[0];
     if (workspace?.status !== 'released') throw new Error('expected released');
     expect(workspace.changelogFiles).toStrictEqual(['./CHANGELOG.md']);
-    // Filter on `--config` to count only real cliff *work* invocations and exclude the
-    // once-per-run cache-refresh call (`npx --yes git-cliff --version`, no `--config`).
+
+    // Synthetic write to CHANGELOG.md: header + Notes section + bullet.
+    const changelogWrite = mockWriteFileSync.mock.calls.find((call: unknown[]) => call[0] === './CHANGELOG.md');
+    expect(changelogWrite).toBeDefined();
+    expect(changelogWrite?.[1]).toContain('## 1.0.0');
+    expect(changelogWrite?.[1]).toContain('### Notes');
+    expect(changelogWrite?.[1]).toContain('- Forced version bump.');
+
+    // No git-cliff *work* invocation (filter on `--config` to exclude the cache-refresh call).
     const cliffCalls = mockExecFileSync.mock.calls.filter(
       (call: unknown[]) =>
         call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff') && call[1].includes('--config'),
     );
-    expect(cliffCalls).toHaveLength(1);
+    expect(cliffCalls).toHaveLength(0);
   });
 
   it('throws when --set-version is not greater than the current version', () => {
@@ -422,6 +437,113 @@ describe(releasePrepare, () => {
     });
 
     expect(mockWriteReleaseNotesPreviews).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
+  });
+
+  describe('empty-range (--force / --bump / --set-version with zero commits)', () => {
+    /** Stub git to simulate a tag exists but there are no commits since it. */
+    function stubEmptyRange(): void {
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'v1.0.0\n';
+        if (cmd === 'git' && args[0] === 'log') return '';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+    }
+
+    /** Count git-cliff *work* invocations (those that pass `--config`). */
+    function countCliffWorkCalls(): number {
+      return mockExecFileSync.mock.calls.filter(
+        (call: unknown[]) =>
+          call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff') && call[1].includes('--config'),
+      ).length;
+    }
+
+    it('writes a synthetic Notes / Forced version bump entry when --force is used with no commits', () => {
+      stubEmptyRange();
+
+      const result = releasePrepare(makeConfig(), { dryRun: false, bumpOverride: 'patch' });
+
+      expect(result.tags).toStrictEqual(['v1.0.1']);
+      const workspace = result.workspaces[0];
+      if (workspace?.status !== 'released') throw new Error('expected released');
+      expect(workspace.changelogFiles).toStrictEqual(['./CHANGELOG.md']);
+
+      const changelogWrite = mockWriteFileSync.mock.calls.find((call: unknown[]) => call[0] === './CHANGELOG.md');
+      expect(changelogWrite?.[1]).toContain('## 1.0.1');
+      expect(changelogWrite?.[1]).toContain('### Notes');
+      expect(changelogWrite?.[1]).toContain('- Forced version bump.');
+    });
+
+    it('does not invoke git-cliff for empty-range releases', () => {
+      stubEmptyRange();
+
+      releasePrepare(makeConfig(), { dryRun: false, bumpOverride: 'minor' });
+
+      // Empty-range releases must bypass git-cliff entirely so consumers do not see
+      // `WARN  git_cliff > There is already a tag` lines (issue #369).
+      expect(countCliffWorkCalls()).toBe(0);
+    });
+
+    it('upserts a synthetic empty-range entry into changelog.json when enabled', () => {
+      stubEmptyRange();
+
+      releasePrepare(makeConfig({ changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true } }), {
+        dryRun: false,
+        bumpOverride: 'patch',
+      });
+
+      expect(mockUpsertChangelogJson).toHaveBeenCalledTimes(1);
+      const upsertEntries = mockUpsertChangelogJson.mock.calls[0]?.[1];
+      expect(upsertEntries).toMatchObject([
+        {
+          version: '1.0.1',
+          sections: [
+            {
+              title: 'Notes',
+              audience: 'dev',
+              items: [{ description: 'Forced version bump.' }],
+            },
+          ],
+        },
+      ]);
+      // Build-via-cliff path must not be exercised on the empty-range branch.
+      expect(mockBuildChangelogEntries).not.toHaveBeenCalled();
+    });
+
+    it('skips synthetic file writes in dry-run mode but still returns paths', () => {
+      stubEmptyRange();
+
+      const result = releasePrepare(
+        makeConfig({ changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true } }),
+        {
+          dryRun: true,
+          bumpOverride: 'patch',
+        },
+      );
+
+      expect(result.tags).toStrictEqual(['v1.0.1']);
+      // No CHANGELOG.md write under dry-run.
+      const changelogWrites = mockWriteFileSync.mock.calls.filter((call: unknown[]) => call[0] === './CHANGELOG.md');
+      expect(changelogWrites).toHaveLength(0);
+      // Upsert is also skipped under dry-run, but the path still flows into formatCommand.
+      expect(mockUpsertChangelogJson).not.toHaveBeenCalled();
+      const workspace = result.workspaces[0];
+      if (workspace?.status !== 'released') throw new Error('expected released');
+      expect(workspace.changelogFiles).toStrictEqual(['./CHANGELOG.md']);
+    });
+
+    it('appends synthetic CHANGELOG.md and changelog.json paths to formatCommand.files', () => {
+      stubEmptyRange();
+      const config = makeConfig({
+        formatCommand: 'npx prettier --write',
+        changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true },
+      });
+
+      const result = releasePrepare(config, { dryRun: true, bumpOverride: 'patch' });
+
+      expect(result.formatCommand?.files).toContain('./CHANGELOG.md');
+      expect(result.formatCommand?.files).toContain('./.meta/changelog.json');
+    });
   });
 
   it('does not write files in dry-run mode with --set-version', () => {

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -36,6 +36,7 @@ vi.mock('../writeReleaseNotesPreviews.ts', () => ({
 // invoking git-cliff or touching the filesystem.
 const mockBuildChangelogEntries = vi.hoisted(() => vi.fn());
 const mockBuildSyntheticChangelogEntry = vi.hoisted(() => vi.fn());
+const mockBuildEmptyReleaseEntry = vi.hoisted(() => vi.fn());
 const mockUpsertChangelogJson = vi.hoisted(() => vi.fn());
 
 vi.mock('../buildChangelogEntries.ts', () => ({
@@ -44,6 +45,10 @@ vi.mock('../buildChangelogEntries.ts', () => ({
 
 vi.mock('../buildSyntheticChangelogEntry.ts', () => ({
   buildSyntheticChangelogEntry: mockBuildSyntheticChangelogEntry,
+}));
+
+vi.mock('../buildEmptyReleaseEntry.ts', () => ({
+  buildEmptyReleaseEntry: mockBuildEmptyReleaseEntry,
 }));
 
 vi.mock('../changelogJsonFile.ts', () => ({
@@ -164,6 +169,11 @@ describe(releasePrepareMono, () => {
     // tests can override if needed.
     mockBuildChangelogEntries.mockReturnValue([]);
     mockBuildSyntheticChangelogEntry.mockReturnValue({ version: '0.0.0', date: '2024-01-01', sections: [] });
+    mockBuildEmptyReleaseEntry.mockReturnValue({
+      version: '0.0.0',
+      date: '2024-01-01',
+      sections: [{ title: 'Notes', audience: 'dev', items: [{ description: 'Forced version bump.' }] }],
+    });
     mockUpsertChangelogJson.mockImplementation((filePath: string) => filePath);
   });
 
@@ -177,6 +187,7 @@ describe(releasePrepareMono, () => {
     mockWriteReleaseNotesPreviews.mockReset();
     mockBuildChangelogEntries.mockReset();
     mockBuildSyntheticChangelogEntry.mockReset();
+    mockBuildEmptyReleaseEntry.mockReset();
     mockUpsertChangelogJson.mockReset();
   });
 
@@ -780,7 +791,9 @@ describe(releasePrepareMono, () => {
       expect.stringContaining('"version": "1.0.1"'),
       'utf8',
     );
-    expect(countCliffCalls()).toBe(1);
+    // Empty-range release: git-cliff is bypassed in favor of the synthetic
+    // "Notes / Forced version bump." entry (issue #369).
+    expect(countCliffCalls()).toBe(0);
   });
 
   it('force-bumps a workspace with no commits while also bumping one with commits', () => {
@@ -1429,6 +1442,252 @@ describe(releasePrepareMono, () => {
         releaseType: 'minor',
         propagatedFrom: [{ packageName: '@test/core', newVersion: '1.0.1' }],
       });
+    });
+  });
+
+  describe('empty-range releases', () => {
+    // When a workspace is forced to release (`--force`, `--bump=X`, or `--set-version`) with
+    // zero qualifying commits since its last tag, git-cliff is bypassed in favor of a
+    // synthetic "Notes / Forced version bump." entry. Without this branch, git-cliff emits
+    // 2 × N `WARN  git_cliff > There is already a tag` lines per prepare run (issue #369).
+
+    /** Helper config with one empty-range workspace. */
+    function singleWorkspaceConfig(overrides?: Partial<MonorepoReleaseConfig>): MonorepoReleaseConfig {
+      const workspace: WorkspaceConfig = {
+        dir: 'arrays',
+        name: '@test/arrays',
+        tagPrefix: 'arrays-v',
+        workspacePath: 'packages/arrays',
+        isPublishable: true,
+        packageFiles: ['packages/arrays/package.json'],
+        changelogPaths: ['packages/arrays'],
+        paths: ['packages/arrays/**'],
+      };
+      return makeConfig({ workspaces: [workspace], ...overrides });
+    }
+
+    /** Stub git so the workspace has a tag but no qualifying commits since it. */
+    function stubEmptyRange(): void {
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'arrays-v1.0.0\n';
+        if (cmd === 'git' && args[0] === 'log') return '';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/arrays', version: '1.0.0' }));
+      mockExistsSync.mockReturnValue(false);
+    }
+
+    it('writes a synthetic Notes / Forced version bump entry when --force is used with no commits', () => {
+      stubEmptyRange();
+
+      const result = releasePrepareMono(singleWorkspaceConfig(), { dryRun: false, force: true });
+
+      expect(result.tags).toStrictEqual(['arrays-v1.0.1']);
+
+      const changelogWrite = mockWriteFileSync.mock.calls.find(
+        (call: unknown[]) => call[0] === 'packages/arrays/CHANGELOG.md',
+      );
+      expect(changelogWrite).toBeDefined();
+      expect(changelogWrite?.[1]).toContain('## 1.0.1');
+      expect(changelogWrite?.[1]).toContain('### Notes');
+      expect(changelogWrite?.[1]).toContain('- Forced version bump.');
+    });
+
+    it('does not invoke git-cliff for an empty-range workspace', () => {
+      stubEmptyRange();
+
+      releasePrepareMono(singleWorkspaceConfig(), { dryRun: false, bumpOverride: 'minor' });
+
+      expect(countCliffCalls()).toBe(0);
+    });
+
+    it('upserts a synthetic empty-range entry into changelog.json when enabled', () => {
+      stubEmptyRange();
+
+      releasePrepareMono(
+        singleWorkspaceConfig({ changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true } }),
+        { dryRun: false, force: true },
+      );
+
+      expect(mockBuildEmptyReleaseEntry).toHaveBeenCalledTimes(1);
+      expect(mockBuildEmptyReleaseEntry).toHaveBeenCalledWith('1.0.1', expect.any(String));
+      expect(mockBuildChangelogEntries).not.toHaveBeenCalled();
+      expect(mockUpsertChangelogJson).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps propagation-only workspaces on the propagation path (no regression)', () => {
+      const config = makeConfig({
+        workspaces: [
+          {
+            dir: 'core',
+            name: '@test/core',
+            tagPrefix: 'core-v',
+            workspacePath: 'packages/core',
+            isPublishable: true,
+            packageFiles: ['packages/core/package.json'],
+            changelogPaths: ['packages/core'],
+            paths: ['packages/core/**'],
+          },
+          {
+            dir: 'app',
+            name: '@test/app',
+            tagPrefix: 'app-v',
+            workspacePath: 'packages/app',
+            isPublishable: true,
+            packageFiles: ['packages/app/package.json'],
+            changelogPaths: ['packages/app'],
+            paths: ['packages/app/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          const matchArg = args.find((a: string) => a.startsWith('--match='));
+          if (matchArg?.includes('core-v')) return 'core-v1.0.0\n';
+          if (matchArg?.includes('app-v')) return 'app-v1.0.0\n';
+        }
+        if (cmd === 'git' && args[0] === 'log') {
+          const hasCorePath = args.includes('packages/core/**');
+          if (hasCorePath) return 'fix: bug fixabc123';
+          return '';
+        }
+        return '';
+      });
+      mockReadFileSync.mockImplementation((filePath: string) => {
+        if (filePath.includes('core')) {
+          return JSON.stringify({ name: '@test/core', version: '1.0.0' });
+        }
+        if (filePath.includes('app')) {
+          return JSON.stringify({
+            name: '@test/app',
+            version: '1.0.0',
+            dependencies: { '@test/core': 'workspace:*' },
+          });
+        }
+        return '{}';
+      });
+      mockExistsSync.mockReturnValue(false);
+
+      releasePrepareMono(config, { dryRun: false });
+
+      // The propagation-only path writes a "Dependency updates" section, not the empty-range
+      // "Notes / Forced version bump." section.
+      const appWrite = mockWriteFileSync.mock.calls.find((call: unknown[]) => call[0] === 'packages/app/CHANGELOG.md');
+      expect(appWrite?.[1]).toContain('Dependency updates');
+      expect(appWrite?.[1]).not.toContain('Forced version bump.');
+    });
+
+    it('keeps workspaces with real commits on the cliff path (no regression)', () => {
+      const config = singleWorkspaceConfig();
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'arrays-v1.0.0\n';
+        if (cmd === 'git' && args[0] === 'log') return 'feat: new utilityabc123';
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '@test/arrays', version: '1.0.0' }));
+
+      releasePrepareMono(config, { dryRun: false });
+
+      // Real commits → cliff path runs.
+      expect(countCliffCalls()).toBe(1);
+    });
+
+    it('does not write synthetic entries for workspaces correctly skipped (no commits, no --force)', () => {
+      stubEmptyRange();
+
+      const result = releasePrepareMono(singleWorkspaceConfig(), { dryRun: false });
+
+      expect(result.tags).toStrictEqual([]);
+      expect(result.workspaces[0]).toMatchObject({ status: 'skipped' });
+      // No CHANGELOG.md write for the skipped workspace.
+      const changelogWrites = mockWriteFileSync.mock.calls.filter(
+        (call: unknown[]) => call[0] === 'packages/arrays/CHANGELOG.md',
+      );
+      expect(changelogWrites).toHaveLength(0);
+    });
+
+    it('skips synthetic file writes in dry-run mode but still returns tag and changelog path', () => {
+      stubEmptyRange();
+
+      const result = releasePrepareMono(
+        singleWorkspaceConfig({ changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true } }),
+        { dryRun: true, force: true },
+      );
+
+      expect(result.tags).toStrictEqual(['arrays-v1.0.1']);
+      const workspace = result.workspaces[0];
+      if (workspace?.status !== 'released') throw new Error('expected released');
+      expect(workspace.changelogFiles).toStrictEqual(['packages/arrays/CHANGELOG.md']);
+
+      // No CHANGELOG.md write under dry-run; the path is still surfaced.
+      const changelogWrites = mockWriteFileSync.mock.calls.filter(
+        (call: unknown[]) => call[0] === 'packages/arrays/CHANGELOG.md',
+      );
+      expect(changelogWrites).toHaveLength(0);
+      expect(mockUpsertChangelogJson).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke git-cliff for any empty-range unit in a multi-workspace --force run', () => {
+      // Pins the SHOULD-have acceptance criterion: a `prepare --force` run against multiple
+      // zero-commit workspaces does not invoke `runGitCliff` for those workspaces — the
+      // root cause of the `2 × N` `WARN  git_cliff > There is already a tag` amplification
+      // (issue #369). For each empty-range workspace, today's behavior would emit two
+      // git-cliff invocations (one for `generateChangelog`, one for `buildChangelogEntries
+      // --context`); the synthetic path bypasses both.
+      const config = makeConfig({
+        changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true },
+        workspaces: [
+          {
+            dir: 'arrays',
+            name: '@test/arrays',
+            tagPrefix: 'arrays-v',
+            workspacePath: 'packages/arrays',
+            isPublishable: true,
+            packageFiles: ['packages/arrays/package.json'],
+            changelogPaths: ['packages/arrays'],
+            paths: ['packages/arrays/**'],
+          },
+          {
+            dir: 'strings',
+            name: '@test/strings',
+            tagPrefix: 'strings-v',
+            workspacePath: 'packages/strings',
+            isPublishable: true,
+            packageFiles: ['packages/strings/package.json'],
+            changelogPaths: ['packages/strings'],
+            paths: ['packages/strings/**'],
+          },
+          {
+            dir: 'numbers',
+            name: '@test/numbers',
+            tagPrefix: 'numbers-v',
+            workspacePath: 'packages/numbers',
+            isPublishable: true,
+            packageFiles: ['packages/numbers/package.json'],
+            changelogPaths: ['packages/numbers'],
+            paths: ['packages/numbers/**'],
+          },
+        ],
+      });
+
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') {
+          const matchArg = args.find((a: string) => a.startsWith('--match='));
+          if (matchArg?.includes('arrays-v')) return 'arrays-v1.0.0\n';
+          if (matchArg?.includes('strings-v')) return 'strings-v1.0.0\n';
+          if (matchArg?.includes('numbers-v')) return 'numbers-v1.0.0\n';
+        }
+        // No commits for any workspace.
+        return '';
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+      mockExistsSync.mockReturnValue(false);
+
+      releasePrepareMono(config, { dryRun: false, force: true });
+
+      // Three workspaces, all empty-range, all forced — git-cliff must be invoked zero times.
+      expect(countCliffCalls()).toBe(0);
     });
   });
 

--- a/packages/release-kit/src/__tests__/releasePrepareProject.int.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareProject.int.test.ts
@@ -332,6 +332,56 @@ describe('releasePrepareProject (integration)', () => {
     });
   }, 60_000);
 
+  it('preserves prior changelog.json entries when an empty-range project release runs', () => {
+    // Regression: the empty-range project branch must use upsert semantics. A plain
+    // overwrite would erase prior structured history because the synthetic branch
+    // produces only the new entry — git-cliff is not consulted to replay the full log.
+    // Move the project baseline tag to HEAD so the project stage finds zero commits since,
+    // forcing the empty-range branch.
+    execFileSync('git', ['tag', '--delete', 'v0.9.0'], { cwd: fixture.repoDir, stdio: ['ignore', 'pipe', 'pipe'] });
+    execFileSync('git', ['tag', 'v0.9.0', 'HEAD'], { cwd: fixture.repoDir, stdio: ['ignore', 'pipe', 'pipe'] });
+
+    // Pre-seed the structured changelog with a prior entry that no current run could
+    // reproduce. This entry must survive the empty-range release.
+    const changelogJsonPath = join(fixture.repoDir, '.meta', 'changelog.json');
+    mkdirSync(join(fixture.repoDir, '.meta'), { recursive: true });
+    const priorEntry = {
+      version: '0.8.0',
+      date: '2026-01-15',
+      sections: [
+        {
+          title: 'Features',
+          audience: 'consumer',
+          items: [{ description: 'Historical entry that must not be lost.' }],
+        },
+      ],
+    };
+    writeFileSync(changelogJsonPath, JSON.stringify([priorEntry], null, 2) + '\n', 'utf8');
+
+    withinFixture(fixture.repoDir, () => {
+      const config = mergeMonorepoConfig(
+        ['packages/pkg-a', 'packages/pkg-b', 'packages/pkg-c'],
+        { project: {} },
+        { exists: true, version: '0.9.0' },
+      );
+
+      releasePrepareMono(config, { dryRun: false, force: true });
+
+      const written: Array<{ version: string; sections: Array<{ items: Array<{ description: string }> }> }> =
+        JSON.parse(readFileSync(changelogJsonPath, 'utf8'));
+
+      // The prior entry survives.
+      const survivedPrior = written.find((e) => e.version === '0.8.0');
+      expect(survivedPrior).toBeDefined();
+      expect(survivedPrior?.sections[0]?.items[0]?.description).toBe('Historical entry that must not be lost.');
+
+      // The new synthetic entry is also present.
+      const newEntry = written.find((e) => e.version === '0.9.1');
+      expect(newEntry).toBeDefined();
+      expect(newEntry?.sections[0]?.items[0]?.description).toBe('Forced version bump.');
+    });
+  }, 60_000);
+
   it('rejects --only via prepareCommand before any project work runs', async () => {
     // The CLI guard lives in prepareCommand. We exercise it directly so the integration test
     // reflects the user-observable behavior end-to-end. Failure must occur before any file is

--- a/packages/release-kit/src/__tests__/releasePrepareProject.int.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareProject.int.test.ts
@@ -283,6 +283,55 @@ describe('releasePrepareProject (integration)', () => {
     });
   }, 60_000);
 
+  it('writes a synthetic Notes / Forced version bump entry for empty-range project releases', () => {
+    // Move the project baseline tag to HEAD so the project stage finds zero commits since.
+    // Per-workspace baselines stay at the initial commit, so workspaces still release naturally
+    // (we are testing the project stage's empty-range branch, not the workspace path).
+    execFileSync('git', ['tag', '--delete', 'v0.9.0'], { cwd: fixture.repoDir, stdio: ['ignore', 'pipe', 'pipe'] });
+    execFileSync('git', ['tag', 'v0.9.0', 'HEAD'], { cwd: fixture.repoDir, stdio: ['ignore', 'pipe', 'pipe'] });
+
+    withinFixture(fixture.repoDir, () => {
+      const config = mergeMonorepoConfig(
+        ['packages/pkg-a', 'packages/pkg-b', 'packages/pkg-c'],
+        { project: {} },
+        { exists: true, version: '0.9.0' },
+      );
+
+      const result = releasePrepareMono(config, { dryRun: false, force: true });
+
+      // Project release proceeded under --force, choosing patch level (issue #369 fix).
+      const project = result.project;
+      if (project?.status !== 'released') throw new Error('expected released project');
+      expect(project.previousTag).toBe('v0.9.0');
+      expect(project.commits).toHaveLength(0);
+      expect(project.releaseType).toBe('patch');
+      expect(project.newVersion).toBe('0.9.1');
+
+      // Root CHANGELOG.md contains the synthetic header at the top.
+      const rootChangelogPath = join(fixture.repoDir, 'CHANGELOG.md');
+      expect(existsSync(rootChangelogPath)).toBe(true);
+      const rootChangelog = readFileSync(rootChangelogPath, 'utf8');
+      expect(rootChangelog).toMatch(/^## 0\.9\.1 — \d{4}-\d{2}-\d{2}/);
+      expect(rootChangelog).toContain('### Notes');
+      expect(rootChangelog).toContain('- Forced version bump.');
+
+      // Root .meta/changelog.json contains a corresponding canonical entry.
+      const changelogJsonPath = join(fixture.repoDir, '.meta', 'changelog.json');
+      expect(existsSync(changelogJsonPath)).toBe(true);
+      const parsed: Array<{
+        version: string;
+        sections: Array<{ title: string; audience: string; items: Array<{ description: string }> }>;
+      }> = JSON.parse(readFileSync(changelogJsonPath, 'utf8'));
+      const entry = parsed.find((e) => e.version === '0.9.1');
+      expect(entry).toBeDefined();
+      expect(entry?.sections[0]).toMatchObject({
+        title: 'Notes',
+        audience: 'dev',
+        items: [{ description: 'Forced version bump.' }],
+      });
+    });
+  }, 60_000);
+
   it('rejects --only via prepareCommand before any project work runs', async () => {
     // The CLI guard lives in prepareCommand. We exercise it directly so the integration test
     // reflects the user-observable behavior end-to-end. Failure must occur before any file is

--- a/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
@@ -542,6 +542,156 @@ describe(releasePrepareProject, () => {
     ).toThrow(/without a configured project block/);
   });
 
+  describe('empty-range project release', () => {
+    // Project-stage counterpart to the per-workspace empty-range branch: when `--force` /
+    // `--bump=X` triggers a project release with zero qualifying commits since the last
+    // project tag, git-cliff is bypassed in favor of a synthetic "Notes / Forced version
+    // bump." entry. Without this, git-cliff emits the same `WARN  git_cliff > There is
+    // already a tag` lines that surface for empty-range workspaces (issue #369).
+
+    /** Stub git so the project has a tag but no qualifying commits since it. */
+    function stubEmptyRange(): void {
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'describe') return 'v0.9.0\n';
+        if (cmd === 'git' && args[0] === 'log') return '';
+        return '';
+      });
+    }
+
+    /** Count git-cliff *work* invocations (those that pass `--config`). */
+    function countCliffWorkCalls(): number {
+      return mockExecFileSync.mock.calls.filter(
+        (call: unknown[]) =>
+          call[0] === 'npx' && Array.isArray(call[1]) && call[1].includes('git-cliff') && call[1].includes('--config'),
+      ).length;
+    }
+
+    it('writes a synthetic Notes / Forced version bump entry for the root CHANGELOG when --force is used with no commits', () => {
+      stubEmptyRange();
+      const tags: string[] = [];
+      const modifiedFiles: string[] = [];
+
+      const result = releasePrepareProject({
+        config: makeConfig(),
+        options: { dryRun: false, force: true },
+        modifiedFiles,
+        tags,
+      });
+
+      if (result.status !== 'released') throw new Error('expected released');
+      expect(result.tag).toBe('v0.9.1');
+      expect(result.changelogFiles).toContain('./CHANGELOG.md');
+      expect(tags).toStrictEqual(['v0.9.1']);
+
+      // Root CHANGELOG.md was written with the synthetic header.
+      const changelogWrite = mockWriteFileSync.mock.calls.find((call: unknown[]) => call[0] === './CHANGELOG.md');
+      expect(changelogWrite).toBeDefined();
+      expect(changelogWrite?.[1]).toContain('## 0.9.1');
+      expect(changelogWrite?.[1]).toContain('### Notes');
+      expect(changelogWrite?.[1]).toContain('- Forced version bump.');
+    });
+
+    it('does not invoke git-cliff for the project stage on the empty-range path', () => {
+      stubEmptyRange();
+
+      releasePrepareProject({
+        config: makeConfig(),
+        options: { dryRun: false, force: true },
+        modifiedFiles: [],
+        tags: [],
+      });
+
+      expect(countCliffWorkCalls()).toBe(0);
+    });
+
+    it('writes a synthetic empty-range entry into the root changelog.json when enabled', () => {
+      stubEmptyRange();
+      const config = makeConfig({ changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true } });
+
+      releasePrepareProject({
+        config,
+        options: { dryRun: false, force: true },
+        modifiedFiles: [],
+        tags: [],
+      });
+
+      // Project stage uses `writeChangelogJson` (fresh write) rather than upsert.
+      expect(mockWriteChangelogJson).toHaveBeenCalledTimes(1);
+      const writeEntries = mockWriteChangelogJson.mock.calls[0]?.[1];
+      expect(writeEntries).toMatchObject([
+        {
+          version: '0.9.1',
+          sections: [
+            {
+              title: 'Notes',
+              audience: 'dev',
+              items: [{ description: 'Forced version bump.' }],
+            },
+          ],
+        },
+      ]);
+      // Build-via-cliff path must not be exercised on the empty-range branch.
+      expect(mockBuildChangelogEntries).not.toHaveBeenCalled();
+    });
+
+    it('skips synthetic file writes in dry-run mode but still appends tag and modified files', () => {
+      stubEmptyRange();
+      const tags: string[] = [];
+      const modifiedFiles: string[] = [];
+
+      const result = releasePrepareProject({
+        config: makeConfig({ changelogJson: { ...DEFAULT_CHANGELOG_JSON_CONFIG, enabled: true } }),
+        options: { dryRun: true, force: true },
+        modifiedFiles,
+        tags,
+      });
+
+      if (result.status !== 'released') throw new Error('expected released');
+      expect(tags).toStrictEqual(['v0.9.1']);
+      expect(modifiedFiles).toContain('./CHANGELOG.md');
+      expect(modifiedFiles).toContain('./.meta/changelog.json');
+
+      // No synthetic CHANGELOG.md write under dry-run.
+      const changelogWrites = mockWriteFileSync.mock.calls.filter((call: unknown[]) => call[0] === './CHANGELOG.md');
+      expect(changelogWrites).toHaveLength(0);
+      expect(mockWriteChangelogJson).not.toHaveBeenCalled();
+    });
+
+    it('keeps non-empty-range project releases on the cliff path (no regression)', () => {
+      setupDefaultGit();
+
+      releasePrepareProject({
+        config: makeConfig(),
+        options: { dryRun: false },
+        modifiedFiles: [],
+        tags: [],
+      });
+
+      // Real commits → cliff path runs.
+      expect(countCliffWorkCalls()).toBe(1);
+    });
+
+    it('leaves a skipped-project result unchanged (no synthetic entries for skipped projects)', () => {
+      stubEmptyRange();
+      const tags: string[] = [];
+      const modifiedFiles: string[] = [];
+
+      const result = releasePrepareProject({
+        config: makeConfig(),
+        options: { dryRun: false }, // No --force, no --bump → skip path.
+        modifiedFiles,
+        tags,
+      });
+
+      expect(result.status).toBe('skipped');
+      expect(tags).toStrictEqual([]);
+      expect(modifiedFiles).toStrictEqual([]);
+      // No CHANGELOG.md write for the skipped project.
+      const changelogWrites = mockWriteFileSync.mock.calls.filter((call: unknown[]) => call[0] === './CHANGELOG.md');
+      expect(changelogWrites).toHaveLength(0);
+    });
+  });
+
   describe('policy violations', () => {
     /** ASCII unit separator (U+001F) used by `git log --pretty=format` to delimit subject from hash. */
     const SEP = String.fromCodePoint(0x1f);

--- a/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareProject.unit.test.ts
@@ -10,6 +10,7 @@ const mockRmSync = vi.hoisted(() => vi.fn());
 const mockCopyFileSync = vi.hoisted(() => vi.fn());
 const mockBuildChangelogEntries = vi.hoisted(() => vi.fn());
 const mockWriteChangelogJson = vi.hoisted(() => vi.fn());
+const mockUpsertChangelogJson = vi.hoisted(() => vi.fn());
 const mockWriteReleaseNotesPreviews = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
@@ -38,7 +39,7 @@ vi.mock('../changelogJsonFile.ts', () => ({
   resolveChangelogJsonPath: (config: { changelogJson: { outputPath: string } }, changelogPath: string): string =>
     `${changelogPath}/${config.changelogJson.outputPath}`,
   writeChangelogJson: mockWriteChangelogJson,
-  upsertChangelogJson: vi.fn(),
+  upsertChangelogJson: mockUpsertChangelogJson,
 }));
 
 vi.mock('../writeReleaseNotesPreviews.ts', () => ({
@@ -98,6 +99,7 @@ describe(releasePrepareProject, () => {
   beforeEach(() => {
     mockBuildChangelogEntries.mockReturnValue([]);
     mockWriteChangelogJson.mockImplementation((filePath: string) => filePath);
+    mockUpsertChangelogJson.mockImplementation((filePath: string) => filePath);
     mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'root', version: '0.9.0' }));
     mockExistsSync.mockReturnValue(false);
   });
@@ -113,6 +115,7 @@ describe(releasePrepareProject, () => {
     mockCopyFileSync.mockReset();
     mockBuildChangelogEntries.mockReset();
     mockWriteChangelogJson.mockReset();
+    mockUpsertChangelogJson.mockReset();
     mockWriteReleaseNotesPreviews.mockReset();
   });
 
@@ -406,6 +409,7 @@ describe(releasePrepareProject, () => {
     expect(mockBuildChangelogEntries).toHaveBeenCalledTimes(1);
     expect(mockWriteChangelogJson).toHaveBeenCalledTimes(1);
     expect(mockWriteChangelogJson).toHaveBeenCalledWith('./.meta/changelog.json', expect.any(Array));
+    expect(mockUpsertChangelogJson).not.toHaveBeenCalled();
     expect(modifiedFiles).toContain('./.meta/changelog.json');
   });
 
@@ -615,10 +619,13 @@ describe(releasePrepareProject, () => {
         tags: [],
       });
 
-      // Project stage uses `writeChangelogJson` (fresh write) rather than upsert.
-      expect(mockWriteChangelogJson).toHaveBeenCalledTimes(1);
-      const writeEntries = mockWriteChangelogJson.mock.calls[0]?.[1];
-      expect(writeEntries).toMatchObject([
+      // Empty-range branch uses `upsertChangelogJson` so prior entries are preserved
+      // when only the new synthetic entry is being written. Overwriting via
+      // `writeChangelogJson` here would obliterate every previously-recorded entry.
+      expect(mockUpsertChangelogJson).toHaveBeenCalledTimes(1);
+      expect(mockWriteChangelogJson).not.toHaveBeenCalled();
+      const upsertEntries = mockUpsertChangelogJson.mock.calls[0]?.[1];
+      expect(upsertEntries).toMatchObject([
         {
           version: '0.9.1',
           sections: [
@@ -655,6 +662,7 @@ describe(releasePrepareProject, () => {
       const changelogWrites = mockWriteFileSync.mock.calls.filter((call: unknown[]) => call[0] === './CHANGELOG.md');
       expect(changelogWrites).toHaveLength(0);
       expect(mockWriteChangelogJson).not.toHaveBeenCalled();
+      expect(mockUpsertChangelogJson).not.toHaveBeenCalled();
     });
 
     it('keeps non-empty-range project releases on the cliff path (no regression)', () => {

--- a/packages/release-kit/src/__tests__/writeEmptyReleaseChangelog.unit.test.ts
+++ b/packages/release-kit/src/__tests__/writeEmptyReleaseChangelog.unit.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+import { writeEmptyReleaseChangelog } from '../writeEmptyReleaseChangelog.ts';
+
+describe(writeEmptyReleaseChangelog, () => {
+  afterEach(() => {
+    mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
+    mockWriteFileSync.mockReset();
+  });
+
+  it('writes the canonical header and Forced version bump bullet for a fresh file', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const result = writeEmptyReleaseChangelog({
+      changelogPath: 'packages/app',
+      newVersion: '1.0.1',
+      date: '2026-05-06',
+    });
+
+    expect(result).toBe('packages/app/CHANGELOG.md');
+    const writtenContent = mockWriteFileSync.mock.calls[0]?.[1];
+    expect(writtenContent).toContain('## 1.0.1 — 2026-05-06');
+    expect(writtenContent).toContain('### Notes');
+    expect(writtenContent).toContain('- Forced version bump.');
+  });
+
+  it('prepends to existing changelog content', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('## 1.0.0 — 2026-03-01\n\nInitial release.\n');
+
+    writeEmptyReleaseChangelog({
+      changelogPath: 'packages/app',
+      newVersion: '1.0.1',
+      date: '2026-05-06',
+    });
+
+    const writtenContent = mockWriteFileSync.mock.calls[0]?.[1];
+    expect(writtenContent).toMatch(/^## 1\.0\.1/);
+    expect(writtenContent).toContain('## 1.0.0 — 2026-03-01');
+    expect(writtenContent).toContain('Initial release.');
+  });
+
+  it('creates the file when it does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    writeEmptyReleaseChangelog({
+      changelogPath: 'packages/new-pkg',
+      newVersion: '0.0.1',
+      date: '2026-05-06',
+    });
+
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the write in dry-run mode but returns the file path', () => {
+    const result = writeEmptyReleaseChangelog({
+      changelogPath: 'packages/app',
+      newVersion: '1.0.1',
+      date: '2026-05-06',
+      dryRun: true,
+    });
+
+    expect(result).toBe('packages/app/CHANGELOG.md');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/release-kit/src/buildEmptyReleaseEntry.ts
+++ b/packages/release-kit/src/buildEmptyReleaseEntry.ts
@@ -1,0 +1,23 @@
+import type { ChangelogEntry } from './types.ts';
+
+/**
+ * Build a synthetic changelog entry for a forced empty-range release.
+ *
+ * Produces a single `ChangelogEntry` with one `'Notes'` section (audience `'dev'`)
+ * containing a single `'Forced version bump.'` item. Used when `release-kit prepare`
+ * proceeds via `--force`, `--bump=X`, or `--set-version` against a unit with zero
+ * qualifying commits since its last tag. Pure function: no I/O.
+ */
+export function buildEmptyReleaseEntry(version: string, date: string): ChangelogEntry {
+  return {
+    version,
+    date,
+    sections: [
+      {
+        title: 'Notes',
+        audience: 'dev',
+        items: [{ description: 'Forced version bump.' }],
+      },
+    ],
+  };
+}

--- a/packages/release-kit/src/prependChangelogSection.ts
+++ b/packages/release-kit/src/prependChangelogSection.ts
@@ -1,0 +1,24 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+/**
+ * Prepend a pre-formatted section to a `CHANGELOG.md` file, creating the file if it does not exist.
+ *
+ * Reads any existing content, concatenates the new section ahead of it (separated by a blank line),
+ * and writes the result back. In dry-run mode, performs no I/O. Shared by `writeEmptyReleaseChangelog`
+ * and `writeSyntheticChangelog` so the file-level semantics stay consistent across synthetic-entry
+ * paths.
+ */
+export function prependChangelogSection(filePath: string, section: string, dryRun: boolean): void {
+  if (dryRun) {
+    return;
+  }
+
+  let existingContent = '';
+  if (existsSync(filePath)) {
+    existingContent = readFileSync(filePath, 'utf8');
+  }
+
+  const newContent = `${section}\n${existingContent}`;
+
+  writeFileSync(filePath, newContent, 'utf8');
+}

--- a/packages/release-kit/src/releasePrepare.ts
+++ b/packages/release-kit/src/releasePrepare.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 
 import { buildChangelogEntries } from './buildChangelogEntries.ts';
+import { buildEmptyReleaseEntry } from './buildEmptyReleaseEntry.ts';
 import { bumpAllVersions, setAllVersions } from './bumpAllVersions.ts';
 import { resolveChangelogJsonPath, upsertChangelogJson } from './changelogJsonFile.ts';
 import { createPolicyViolationCollector } from './collectPolicyViolations.ts';
@@ -24,6 +25,7 @@ import type {
   ReleaseType,
   SkippedWorkspaceResult,
 } from './types.ts';
+import { writeEmptyReleaseChangelog } from './writeEmptyReleaseChangelog.ts';
 import { writeReleaseNotesPreviews } from './writeReleaseNotesPreviews.ts';
 
 /** Options for the release preparation workflow. */
@@ -136,11 +138,17 @@ export function releasePrepare(config: ReleaseConfig, options: ReleasePrepareOpt
 
   const newTag = `${config.tagPrefix}${bump.newVersion}`;
 
-  // 4. Generate changelogs
-  const changelogFiles = generateChangelogs(config, newTag, dryRun);
-
-  // 4b. Generate changelog JSON if enabled.
-  const changelogJsonFiles = config.changelogJson.enabled ? buildAndPersistChangelogJson(config, newTag, dryRun) : [];
+  // 4/4b. Generate the CHANGELOG.md files and (optionally) changelog.json. When the release
+  // proceeds with zero qualifying commits since the last tag (`--force`, `--bump=X`, or
+  // `--set-version` with no new commits), the routing helper bypasses git-cliff in favor
+  // of the synthetic "Forced version bump." entry — issue #369.
+  const { changelogFiles, changelogJsonFiles } = writeSinglePackageChangelogs({
+    config,
+    commits,
+    newTag,
+    newVersion: bump.newVersion,
+    dryRun,
+  });
 
   // 4c. Write release-notes previews (optional, opt-in via --with-release-notes)
   maybeWriteSinglePackagePreviews(withReleaseNotes === true, config, newTag, changelogJsonFiles[0], dryRun);
@@ -291,6 +299,42 @@ function buildReleasedSinglePackage(args: BuildReleasedSinglePackageArgs): Relea
   return released;
 }
 
+/** Inputs to {@link writeSinglePackageChangelogs}. */
+interface WriteSinglePackageChangelogsArgs {
+  config: ReleaseConfig;
+  commits: Commit[];
+  newTag: string;
+  newVersion: string;
+  dryRun: boolean;
+}
+
+/**
+ * Route between the empty-range synthetic path and the cliff path for both `CHANGELOG.md`
+ * and the optional `changelog.json`. Pulls the routing logic out of the `releasePrepare`
+ * host so the host stays under the project's cyclomatic-complexity ceiling.
+ */
+function writeSinglePackageChangelogs(args: WriteSinglePackageChangelogsArgs): {
+  changelogFiles: string[];
+  changelogJsonFiles: string[];
+} {
+  const { config, commits, newTag, newVersion, dryRun } = args;
+  const isEmptyRange = commits.length === 0;
+  const today = new Date().toISOString().slice(0, 10);
+
+  const changelogFiles = isEmptyRange
+    ? writeEmptyRangeChangelogs(config, newVersion, today, dryRun)
+    : generateChangelogs(config, newTag, dryRun);
+
+  let changelogJsonFiles: string[] = [];
+  if (config.changelogJson.enabled) {
+    changelogJsonFiles = isEmptyRange
+      ? upsertEmptyRangeChangelogJson(config, newVersion, today, dryRun)
+      : buildAndPersistChangelogJson(config, newTag, dryRun);
+  }
+
+  return { changelogFiles, changelogJsonFiles };
+}
+
 /**
  * Build entries via git-cliff and write them through `upsertChangelogJson` for each configured
  * changelog path. git-cliff is invoked unconditionally; only the file write is skipped under
@@ -303,6 +347,49 @@ function buildAndPersistChangelogJson(config: ReleaseConfig, newTag: string, dry
     const jsonPath = resolveChangelogJsonPath(config, changelogPath);
     if (!dryRun) {
       upsertChangelogJson(jsonPath, entries);
+    }
+    changelogJsonFiles.push(jsonPath);
+  }
+  return changelogJsonFiles;
+}
+
+/**
+ * Empty-range counterpart to `generateChangelogs`. Writes a synthetic "Forced version bump."
+ * section for each configured changelog path via `writeEmptyReleaseChangelog`. Returns the
+ * list of changelog file paths (always populated, even on dry-run).
+ */
+function writeEmptyRangeChangelogs(config: ReleaseConfig, newVersion: string, date: string, dryRun: boolean): string[] {
+  const changelogFiles: string[] = [];
+  for (const changelogPath of config.changelogPaths) {
+    changelogFiles.push(
+      writeEmptyReleaseChangelog({
+        changelogPath,
+        newVersion,
+        date,
+        dryRun,
+      }),
+    );
+  }
+  return changelogFiles;
+}
+
+/**
+ * Empty-range counterpart to `buildAndPersistChangelogJson`. Builds a synthetic
+ * "Forced version bump." entry and upserts it for each configured changelog path. Returns
+ * the list of `changelog.json` file paths (always populated, even on dry-run).
+ */
+function upsertEmptyRangeChangelogJson(
+  config: ReleaseConfig,
+  newVersion: string,
+  date: string,
+  dryRun: boolean,
+): string[] {
+  const changelogJsonFiles: string[] = [];
+  const syntheticEntry = buildEmptyReleaseEntry(newVersion, date);
+  for (const changelogPath of config.changelogPaths) {
+    const jsonPath = resolveChangelogJsonPath(config, changelogPath);
+    if (!dryRun) {
+      upsertChangelogJson(jsonPath, [syntheticEntry]);
     }
     changelogJsonFiles.push(jsonPath);
   }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process';
 import { buildChangelogEntries } from './buildChangelogEntries.ts';
 import type { DependencyGraph } from './buildDependencyGraph.ts';
 import { buildDependencyGraph } from './buildDependencyGraph.ts';
+import { buildEmptyReleaseEntry } from './buildEmptyReleaseEntry.ts';
 import { buildSyntheticChangelogEntry } from './buildSyntheticChangelogEntry.ts';
 import { bumpAllVersions, setAllVersions } from './bumpAllVersions.ts';
 import { resolveChangelogJsonPath, upsertChangelogJson } from './changelogJsonFile.ts';
@@ -34,6 +35,7 @@ import type {
   WorkspaceConfig,
   WorkspacePrepareResult,
 } from './types.ts';
+import { writeEmptyReleaseChangelog } from './writeEmptyReleaseChangelog.ts';
 import { writeReleaseNotesPreviews } from './writeReleaseNotesPreviews.ts';
 import { writeSyntheticChangelog } from './writeSyntheticChangelog.ts';
 
@@ -439,12 +441,16 @@ function executeWorkspaceRelease(args: ExecuteWorkspaceReleaseArgs): void {
   modifiedFiles.push(...workspace.packageFiles, ...workspace.changelogPaths.map((p) => `${p}/CHANGELOG.md`));
 
   const isPropagationOnly = directResult === undefined;
+  // A workspace is empty-range when it has a direct release (i.e., not propagation-only) but
+  // its commit window is empty — the `--force` / `--bump=X` / `--set-version` paths land here.
+  const isEmptyRange = directResult !== undefined && directResult.commits.length === 0;
   const changelogFiles = generateWorkspaceChangelogs({
     workspace,
     releaseEntry,
     newTag,
     newVersion: bump.newVersion,
     isPropagationOnly,
+    isEmptyRange,
     config,
     dryRun,
     today,
@@ -529,6 +535,13 @@ interface GenerateWorkspaceChangelogsArgs {
   newTag: string;
   newVersion: string;
   isPropagationOnly: boolean;
+  /**
+   * True when this workspace has a direct release with zero qualifying commits since the
+   * last tag (e.g., `--force`-bumped, `--bump=X`, or `--set-version` with no new commits).
+   * Routes to the synthetic empty-range path instead of git-cliff so consumers do not see
+   * `WARN  git_cliff > There is already a tag` lines (issue #369).
+   */
+  isEmptyRange: boolean;
   config: MonorepoReleaseConfig;
   dryRun: boolean;
   today: string;
@@ -537,9 +550,17 @@ interface GenerateWorkspaceChangelogsArgs {
 }
 
 /**
- * Generate changelogs for a workspace: synthetic entries for propagation-only bumps, git-cliff
- * output for direct bumps (including `--set-version`). Returns the list of changelog files written.
- * Additional changelog JSON files are appended to `modifiedFiles` when the feature is enabled.
+ * Generate changelogs for a workspace by routing to one of three branches:
+ *
+ * 1. Propagation-only bump (no direct commits, but a transitive bump): synthetic
+ *    "Dependency updates" entry via `writeSyntheticChangelog` / `buildSyntheticChangelogEntry`.
+ * 2. Empty-range direct bump (`--force` / `--bump=X` / `--set-version` against zero commits):
+ *    synthetic "Notes / Forced version bump." entry via the new sibling pair. Bypasses
+ *    git-cliff to avoid the `WARN  git_cliff > There is already a tag` noise (issue #369).
+ * 3. Direct bump with commits: git-cliff output.
+ *
+ * Returns the list of changelog files written. Additional `changelog.json` files are
+ * appended to `modifiedFiles` when the feature is enabled.
  */
 function generateWorkspaceChangelogs(args: GenerateWorkspaceChangelogsArgs): string[] {
   const {
@@ -548,48 +569,173 @@ function generateWorkspaceChangelogs(args: GenerateWorkspaceChangelogsArgs): str
     newTag,
     newVersion,
     isPropagationOnly,
+    isEmptyRange,
     config,
     dryRun,
     today,
     modifiedFiles,
     previewOptions,
   } = args;
-  const changelogFiles: string[] = [];
-  // Track the first changelog.json path written for this workspace so the preview writer can
-  // read the same data that `publish` and `create-github-release` will consume later.
-  let firstChangelogJsonPath: string | undefined;
 
   if (isPropagationOnly && releaseEntry.propagatedFrom !== undefined) {
-    for (const changelogPath of workspace.changelogPaths) {
-      changelogFiles.push(
-        writeSyntheticChangelog({
-          changelogPath,
-          newVersion,
-          date: today,
-          propagatedFrom: releaseEntry.propagatedFrom,
-          dryRun,
-        }),
-      );
-    }
-
-    if (config.changelogJson.enabled) {
-      // Synthetic entries are pure constructs (no subprocess), so the dry-run guard applies
-      // only to the upsert write. The path is still resolved and surfaced in `modifiedFiles`.
-      const syntheticEntry = buildSyntheticChangelogEntry(releaseEntry.propagatedFrom, newVersion, today);
-      for (const changelogPath of workspace.changelogPaths) {
-        const jsonPath = resolveChangelogJsonPath(config, changelogPath);
-        if (!dryRun) {
-          upsertChangelogJson(jsonPath, [syntheticEntry]);
-        }
-        modifiedFiles.push(jsonPath);
-        firstChangelogJsonPath ??= jsonPath;
-      }
-    }
-    maybeWritePreviews(workspace, newTag, firstChangelogJsonPath, previewOptions, dryRun);
-    return changelogFiles;
+    return writePropagationOnlyWorkspaceChangelogs({
+      workspace,
+      newTag,
+      newVersion,
+      propagatedFrom: releaseEntry.propagatedFrom,
+      config,
+      dryRun,
+      today,
+      modifiedFiles,
+      previewOptions,
+    });
   }
 
+  if (isEmptyRange) {
+    return writeEmptyRangeWorkspaceChangelogs({
+      workspace,
+      newTag,
+      newVersion,
+      config,
+      dryRun,
+      today,
+      modifiedFiles,
+      previewOptions,
+    });
+  }
+
+  return writeCliffWorkspaceChangelogs({
+    workspace,
+    newTag,
+    config,
+    dryRun,
+    modifiedFiles,
+    previewOptions,
+  });
+}
+
+/** Arguments for `writePropagationOnlyWorkspaceChangelogs`. */
+interface WritePropagationOnlyArgs {
+  workspace: WorkspaceConfig;
+  newTag: string;
+  newVersion: string;
+  propagatedFrom: NonNullable<ReleaseEntry['propagatedFrom']>;
+  config: MonorepoReleaseConfig;
+  dryRun: boolean;
+  today: string;
+  modifiedFiles: string[];
+  previewOptions: PreviewOptions;
+}
+
+/**
+ * Write synthetic propagation-only changelog entries (CHANGELOG.md and optional
+ * `changelog.json`) for a workspace bumped solely via dependency propagation.
+ */
+function writePropagationOnlyWorkspaceChangelogs(args: WritePropagationOnlyArgs): string[] {
+  const { workspace, newTag, newVersion, propagatedFrom, config, dryRun, today, modifiedFiles, previewOptions } = args;
+  const changelogFiles: string[] = [];
+  let firstChangelogJsonPath: string | undefined;
+
+  for (const changelogPath of workspace.changelogPaths) {
+    changelogFiles.push(
+      writeSyntheticChangelog({
+        changelogPath,
+        newVersion,
+        date: today,
+        propagatedFrom,
+        dryRun,
+      }),
+    );
+  }
+
+  if (config.changelogJson.enabled) {
+    // Synthetic entries are pure constructs (no subprocess), so the dry-run guard applies
+    // only to the upsert write. The path is still resolved and surfaced in `modifiedFiles`.
+    const syntheticEntry = buildSyntheticChangelogEntry(propagatedFrom, newVersion, today);
+    for (const changelogPath of workspace.changelogPaths) {
+      const jsonPath = resolveChangelogJsonPath(config, changelogPath);
+      if (!dryRun) {
+        upsertChangelogJson(jsonPath, [syntheticEntry]);
+      }
+      modifiedFiles.push(jsonPath);
+      firstChangelogJsonPath ??= jsonPath;
+    }
+  }
+  maybeWritePreviews(workspace, newTag, firstChangelogJsonPath, previewOptions, dryRun);
+  return changelogFiles;
+}
+
+/** Arguments for `writeEmptyRangeWorkspaceChangelogs`. */
+interface WriteEmptyRangeArgs {
+  workspace: WorkspaceConfig;
+  newTag: string;
+  newVersion: string;
+  config: MonorepoReleaseConfig;
+  dryRun: boolean;
+  today: string;
+  modifiedFiles: string[];
+  previewOptions: PreviewOptions;
+}
+
+/**
+ * Write synthetic empty-range changelog entries (CHANGELOG.md and optional
+ * `changelog.json`) for a workspace forced to release with zero qualifying commits.
+ *
+ * Mirrors `writePropagationOnlyWorkspaceChangelogs` but emits a "Notes / Forced version bump."
+ * section. Bypasses git-cliff entirely so consumers do not see `WARN  git_cliff > There is
+ * already a tag` lines (issue #369).
+ */
+function writeEmptyRangeWorkspaceChangelogs(args: WriteEmptyRangeArgs): string[] {
+  const { workspace, newTag, newVersion, config, dryRun, today, modifiedFiles, previewOptions } = args;
+  const changelogFiles: string[] = [];
+  let firstChangelogJsonPath: string | undefined;
+
+  for (const changelogPath of workspace.changelogPaths) {
+    changelogFiles.push(
+      writeEmptyReleaseChangelog({
+        changelogPath,
+        newVersion,
+        date: today,
+        dryRun,
+      }),
+    );
+  }
+
+  if (config.changelogJson.enabled) {
+    const syntheticEntry = buildEmptyReleaseEntry(newVersion, today);
+    for (const changelogPath of workspace.changelogPaths) {
+      const jsonPath = resolveChangelogJsonPath(config, changelogPath);
+      if (!dryRun) {
+        upsertChangelogJson(jsonPath, [syntheticEntry]);
+      }
+      modifiedFiles.push(jsonPath);
+      firstChangelogJsonPath ??= jsonPath;
+    }
+  }
+  maybeWritePreviews(workspace, newTag, firstChangelogJsonPath, previewOptions, dryRun);
+  return changelogFiles;
+}
+
+/** Arguments for `writeCliffWorkspaceChangelogs`. */
+interface WriteCliffArgs {
+  workspace: WorkspaceConfig;
+  newTag: string;
+  config: MonorepoReleaseConfig;
+  dryRun: boolean;
+  modifiedFiles: string[];
+  previewOptions: PreviewOptions;
+}
+
+/**
+ * Write changelogs for a workspace that has real qualifying commits, using git-cliff. The
+ * `changelog.json` upsert preserves any synthetic entries written by prior propagation runs.
+ */
+function writeCliffWorkspaceChangelogs(args: WriteCliffArgs): string[] {
+  const { workspace, newTag, config, dryRun, modifiedFiles, previewOptions } = args;
+  const changelogFiles: string[] = [];
+  let firstChangelogJsonPath: string | undefined;
   const tagPattern = buildTagPattern(getAllTagPrefixes(workspace));
+
   for (const changelogPath of workspace.changelogPaths) {
     changelogFiles.push(
       ...generateChangelog(config, changelogPath, newTag, dryRun, {

--- a/packages/release-kit/src/releasePrepareProject.ts
+++ b/packages/release-kit/src/releasePrepareProject.ts
@@ -1,7 +1,7 @@
 import { buildChangelogEntries } from './buildChangelogEntries.ts';
 import { buildEmptyReleaseEntry } from './buildEmptyReleaseEntry.ts';
 import { bumpAllVersions } from './bumpAllVersions.ts';
-import { resolveChangelogJsonPath, writeChangelogJson } from './changelogJsonFile.ts';
+import { resolveChangelogJsonPath, upsertChangelogJson, writeChangelogJson } from './changelogJsonFile.ts';
 import { createPolicyViolationCollector } from './collectPolicyViolations.ts';
 import { decideRelease } from './decideRelease.ts';
 import { DEFAULT_BREAKING_POLICIES, DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
@@ -184,10 +184,12 @@ interface WriteProjectChangelogsArgs {
 
 /**
  * Route between the empty-range synthetic path and the cliff path for the project stage's
- * root `CHANGELOG.md` and (optional) root `changelog.json`. Project stage uses
- * `writeChangelogJson` (fresh write, no merge) on both branches — symmetric with the
- * existing non-empty-range behavior. Pulls the routing logic out of `releasePrepareProject`
- * so the host stays under the project's cyclomatic-complexity ceiling.
+ * root `CHANGELOG.md` and (optional) root `changelog.json`. The cliff path uses
+ * `writeChangelogJson` (fresh overwrite) because git-cliff returns the FULL release history
+ * in `--context` mode. The empty-range path uses `upsertChangelogJson` because it produces
+ * only the new synthetic entry — overwriting would obliterate prior entries. Pulls the
+ * routing logic out of `releasePrepareProject` so the host stays under the project's
+ * cyclomatic-complexity ceiling.
  */
 function writeProjectChangelogs(args: WriteProjectChangelogsArgs): {
   changelogFiles: string[];
@@ -208,14 +210,18 @@ function writeProjectChangelogs(args: WriteProjectChangelogsArgs): {
   const changelogJsonFiles: string[] = [];
   if (config.changelogJson.enabled) {
     const changelogJsonPath = resolveChangelogJsonPath(config, ROOT_CHANGELOG_PATH);
-    const entries = isEmptyRange
-      ? [buildEmptyReleaseEntry(newVersion, today)]
-      : buildChangelogEntries(config, newTag, {
-          tagPattern,
-          includePaths: contributingPaths,
-        });
-    if (!dryRun) {
-      writeChangelogJson(changelogJsonPath, entries);
+    if (isEmptyRange) {
+      if (!dryRun) {
+        upsertChangelogJson(changelogJsonPath, [buildEmptyReleaseEntry(newVersion, today)]);
+      }
+    } else {
+      const entries = buildChangelogEntries(config, newTag, {
+        tagPattern,
+        includePaths: contributingPaths,
+      });
+      if (!dryRun) {
+        writeChangelogJson(changelogJsonPath, entries);
+      }
     }
     changelogJsonFiles.push(changelogJsonPath);
   }

--- a/packages/release-kit/src/releasePrepareProject.ts
+++ b/packages/release-kit/src/releasePrepareProject.ts
@@ -1,4 +1,5 @@
 import { buildChangelogEntries } from './buildChangelogEntries.ts';
+import { buildEmptyReleaseEntry } from './buildEmptyReleaseEntry.ts';
 import { bumpAllVersions } from './bumpAllVersions.ts';
 import { resolveChangelogJsonPath, writeChangelogJson } from './changelogJsonFile.ts';
 import { createPolicyViolationCollector } from './collectPolicyViolations.ts';
@@ -9,6 +10,7 @@ import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import type { ReleasePrepareOptions } from './releasePrepare.ts';
 import { deriveSectionOrder } from './resolveReleaseNotesConfig.ts';
 import type { MonorepoReleaseConfig, ProjectPrepareResult, SkippedProjectResult } from './types.ts';
+import { writeEmptyReleaseChangelog } from './writeEmptyReleaseChangelog.ts';
 import { writeReleaseNotesPreviews } from './writeReleaseNotesPreviews.ts';
 
 /** File path for the root `package.json` bumped during the project release stage. */
@@ -110,29 +112,18 @@ export function releasePrepareProject(args: ReleasePrepareProjectArgs): ProjectP
   // 6. Compose the project tag.
   const newTag = `${project.tagPrefix}${bump.newVersion}`;
 
-  // 7. Generate the root CHANGELOG via git-cliff, filtered to project tags only.
-  const tagPattern = buildTagPattern([project.tagPrefix]);
-  const changelogFiles = generateChangelog(config, ROOT_CHANGELOG_PATH, newTag, dryRun, {
-    tagPattern,
-    includePaths: contributingPaths,
+  // 7/8. Generate the root CHANGELOG and (optionally) changelog.json via the routing helper.
+  //      When `commits.length === 0` (forced empty-range project release) the helper bypasses
+  //      git-cliff in favor of the synthetic "Forced version bump." entry — issue #369.
+  const { changelogFiles, changelogJsonFiles } = writeProjectChangelogs({
+    config,
+    project,
+    commits,
+    contributingPaths,
+    newTag,
+    newVersion: bump.newVersion,
+    dryRun,
   });
-
-  // 8. Emit the root changelog.json when enabled. Project stage uses a fresh write (no merge):
-  //    every entry is derivable from git history + cliff config, and there are no synthetic
-  //    propagation entries to preserve. git-cliff is invoked even in dry-run; only the file
-  //    write is guarded by `dryRun`.
-  const changelogJsonFiles: string[] = [];
-  if (config.changelogJson.enabled) {
-    const changelogJsonPath = resolveChangelogJsonPath(config, ROOT_CHANGELOG_PATH);
-    const entries = buildChangelogEntries(config, newTag, {
-      tagPattern,
-      includePaths: contributingPaths,
-    });
-    if (!dryRun) {
-      writeChangelogJson(changelogJsonPath, entries);
-    }
-    changelogJsonFiles.push(changelogJsonPath);
-  }
 
   // 9. Optional release-notes previews under root docs/.
   const firstChangelogJsonPath = changelogJsonFiles[0];
@@ -178,4 +169,56 @@ export function releasePrepareProject(args: ReleasePrepareProjectArgs): ProjectP
     result.bumpOverride = bumpOverride;
   }
   return result;
+}
+
+/** Inputs to {@link writeProjectChangelogs}. */
+interface WriteProjectChangelogsArgs {
+  config: MonorepoReleaseConfig;
+  project: NonNullable<MonorepoReleaseConfig['project']>;
+  commits: ReadonlyArray<unknown>;
+  contributingPaths: string[];
+  newTag: string;
+  newVersion: string;
+  dryRun: boolean;
+}
+
+/**
+ * Route between the empty-range synthetic path and the cliff path for the project stage's
+ * root `CHANGELOG.md` and (optional) root `changelog.json`. Project stage uses
+ * `writeChangelogJson` (fresh write, no merge) on both branches — symmetric with the
+ * existing non-empty-range behavior. Pulls the routing logic out of `releasePrepareProject`
+ * so the host stays under the project's cyclomatic-complexity ceiling.
+ */
+function writeProjectChangelogs(args: WriteProjectChangelogsArgs): {
+  changelogFiles: string[];
+  changelogJsonFiles: string[];
+} {
+  const { config, project, commits, contributingPaths, newTag, newVersion, dryRun } = args;
+  const isEmptyRange = commits.length === 0;
+  const today = new Date().toISOString().slice(0, 10);
+  const tagPattern = buildTagPattern([project.tagPrefix]);
+
+  const changelogFiles = isEmptyRange
+    ? [writeEmptyReleaseChangelog({ changelogPath: ROOT_CHANGELOG_PATH, newVersion, date: today, dryRun })]
+    : generateChangelog(config, ROOT_CHANGELOG_PATH, newTag, dryRun, {
+        tagPattern,
+        includePaths: contributingPaths,
+      });
+
+  const changelogJsonFiles: string[] = [];
+  if (config.changelogJson.enabled) {
+    const changelogJsonPath = resolveChangelogJsonPath(config, ROOT_CHANGELOG_PATH);
+    const entries = isEmptyRange
+      ? [buildEmptyReleaseEntry(newVersion, today)]
+      : buildChangelogEntries(config, newTag, {
+          tagPattern,
+          includePaths: contributingPaths,
+        });
+    if (!dryRun) {
+      writeChangelogJson(changelogJsonPath, entries);
+    }
+    changelogJsonFiles.push(changelogJsonPath);
+  }
+
+  return { changelogFiles, changelogJsonFiles };
 }

--- a/packages/release-kit/src/writeEmptyReleaseChangelog.ts
+++ b/packages/release-kit/src/writeEmptyReleaseChangelog.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { prependChangelogSection } from './prependChangelogSection.ts';
 
 /** Parameters for writing a synthetic changelog entry for a forced empty-range release. */
 export interface WriteEmptyReleaseChangelogParams {
@@ -17,23 +17,12 @@ export interface WriteEmptyReleaseChangelogParams {
  * propagation-only paths behave identically at the file level.
  */
 export function writeEmptyReleaseChangelog(params: WriteEmptyReleaseChangelogParams): string {
-  const { changelogPath, newVersion, date, dryRun } = params;
+  const { changelogPath, newVersion, date, dryRun = false } = params;
   const filePath = `${changelogPath}/CHANGELOG.md`;
 
   const section = `## ${newVersion} — ${date}\n\n### Notes\n\n- Forced version bump.\n`;
 
-  if (dryRun) {
-    return filePath;
-  }
-
-  let existingContent = '';
-  if (existsSync(filePath)) {
-    existingContent = readFileSync(filePath, 'utf8');
-  }
-
-  const newContent = existingContent.length > 0 ? `${section}\n${existingContent}` : `${section}\n`;
-
-  writeFileSync(filePath, newContent, 'utf8');
+  prependChangelogSection(filePath, section, dryRun);
 
   return filePath;
 }

--- a/packages/release-kit/src/writeEmptyReleaseChangelog.ts
+++ b/packages/release-kit/src/writeEmptyReleaseChangelog.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+/** Parameters for writing a synthetic changelog entry for a forced empty-range release. */
+export interface WriteEmptyReleaseChangelogParams {
+  changelogPath: string;
+  newVersion: string;
+  date: string;
+  dryRun?: boolean;
+}
+
+/**
+ * Prepend a synthetic changelog section for a forced empty-range release.
+ *
+ * Creates the changelog file if it doesn't exist. The section contains a single
+ * `- Forced version bump.` bullet under a "Notes" heading. Returns the changelog
+ * file path. Mirrors `writeSyntheticChangelog`'s I/O semantics so empty-range and
+ * propagation-only paths behave identically at the file level.
+ */
+export function writeEmptyReleaseChangelog(params: WriteEmptyReleaseChangelogParams): string {
+  const { changelogPath, newVersion, date, dryRun } = params;
+  const filePath = `${changelogPath}/CHANGELOG.md`;
+
+  const section = `## ${newVersion} — ${date}\n\n### Notes\n\n- Forced version bump.\n`;
+
+  if (dryRun) {
+    return filePath;
+  }
+
+  let existingContent = '';
+  if (existsSync(filePath)) {
+    existingContent = readFileSync(filePath, 'utf8');
+  }
+
+  const newContent = existingContent.length > 0 ? `${section}\n${existingContent}` : `${section}\n`;
+
+  writeFileSync(filePath, newContent, 'utf8');
+
+  return filePath;
+}

--- a/packages/release-kit/src/writeSyntheticChangelog.ts
+++ b/packages/release-kit/src/writeSyntheticChangelog.ts
@@ -1,5 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-
+import { prependChangelogSection } from './prependChangelogSection.ts';
 import type { PropagationSource } from './types.ts';
 
 /** Parameters for writing a synthetic changelog entry for propagated bumps. */
@@ -18,25 +17,14 @@ export interface WriteSyntheticChangelogParams {
  * a bullet under a "Dependency updates" heading. Returns the changelog file path.
  */
 export function writeSyntheticChangelog(params: WriteSyntheticChangelogParams): string {
-  const { changelogPath, newVersion, date, propagatedFrom, dryRun } = params;
+  const { changelogPath, newVersion, date, propagatedFrom, dryRun = false } = params;
   const filePath = `${changelogPath}/CHANGELOG.md`;
 
   const bullets = propagatedFrom.map((dep) => `- Bumped \`${dep.packageName}\` to ${dep.newVersion}`).join('\n');
 
   const section = `## ${newVersion} — ${date}\n\n### Dependency updates\n\n${bullets}\n`;
 
-  if (dryRun) {
-    return filePath;
-  }
-
-  let existingContent = '';
-  if (existsSync(filePath)) {
-    existingContent = readFileSync(filePath, 'utf8');
-  }
-
-  const newContent = existingContent.length > 0 ? `${section}\n${existingContent}` : `${section}\n`;
-
-  writeFileSync(filePath, newContent, 'utf8');
+  prependChangelogSection(filePath, section, dryRun);
 
   return filePath;
 }


### PR DESCRIPTION
## What

Fixes an issue where `release-kit prepare` with `--force`, `--bump=X`, or `--set-version` would invoke git-cliff against units that had no commits since their last tag, surfacing confusing `WARN  git_cliff > There is already a tag (...)` lines (twice per affected unit) and silently leaving `CHANGELOG.md` and `.meta/changelog.json` stale. Empty-range bumps now write a synthetic `Notes / Forced version bump.` entry to both files instead of invoking git-cliff. Applies to all three release stages: single-package, per-workspace, and project. Prior changelog history is preserved on every path.

## Why

A forced or overridden bump against a unit with no qualifying commits exercised the cliff path even though there was nothing for cliff to summarize. The output was both noisy (8+ stale-tag warnings on a typical 3-workspace monorepo run) and incomplete (`CHANGELOG.md` and `.meta/changelog.json` advanced their headers but no entry was written for the new version). Reading the warning correctly required knowledge of git-cliff internals — it fires when the new tag is being applied at or before an existing tag, so it sounds like the tool is trying to create a tag that already exists. Both symptoms had the same root cause: the cliff invocation in the empty-commit path was unhelpful, and the propagation-only path already had a synthetic-entry sibling that solved the same problem in a different shape.

## Details

### Fixes

- Add `buildEmptyReleaseEntry(version, date)` — a pure helper returning a `ChangelogEntry` with one `Notes` section containing a single `Forced version bump.` item.
- Add `writeEmptyReleaseChangelog({ changelogPath, newVersion, date, dryRun })` — prepends the canonical empty-release header to `CHANGELOG.md`, with the same I/O semantics as the existing `writeSyntheticChangelog` (creates if missing, no-op file write under `dryRun`, returns absolute file path).
- Branch on `commits.length === 0` at all three call sites:
  - Single-package mode (`releasePrepare`): empty-range path writes the synthetic CHANGELOG entry per `config.changelogPaths` and upserts the synthetic JSON entry; non-empty path is unchanged.
  - Monorepo per-workspace (`releasePrepareMono.generateWorkspaceChangelogs`): adds a third branch ordering — propagation → empty-range → cliff — gated by an explicit `isEmptyRange` flag computed at the host. Workspaces correctly skipped today (no commits, no `--force`) remain skipped.
  - Project release (`releasePrepareProject.writeProjectChangelogs`): empty-range path writes the synthetic root `CHANGELOG.md` and upserts the synthetic `.meta/changelog.json`. Critically, this path uses `upsertChangelogJson` (not `writeChangelogJson`) so prior history is preserved — the cliff path retains `writeChangelogJson` because git-cliff in `--context` mode returns the full release history.

### Refactoring

- Extract a shared `prependChangelogSection(filePath, section, dryRun)` helper used by both the new `writeEmptyReleaseChangelog` and the pre-existing `writeSyntheticChangelog`. The two functions had character-identical I/O bodies; only the section text differed.

### Tests

- Unit tests for `buildEmptyReleaseEntry`, `writeEmptyReleaseChangelog`, and the extracted `prependChangelogSection`.
- Behavioral unit tests at all three call sites covering empty-range and non-empty paths.
- Real-filesystem integration test verifying the synthetic root entry lands at the expected path.
- Regression test asserting `runGitCliff` is invoked zero times for empty-range workspaces in a multi-workspace `--force` run.
- History-preservation regression test: pre-seeds a prior `.meta/changelog.json` entry, runs an empty-range project release, and asserts both the prior entry and the new synthetic entry survive.

Closes #369
