### PR TITLE
#382 Prevent unbound-variable error after publish-bare.sh runs

### DIFF
--- a/scripts/publish-bare.sh
+++ b/scripts/publish-bare.sh
@@ -22,6 +22,9 @@ readonly PROG
 readonly NAME_REGEX='^(@[a-z0-9][a-z0-9_.-]*/)?[a-z0-9][a-z0-9_.-]*$'
 readonly MAX_NAME_LEN=214
 
+# Cleanup state — accessed by EXIT trap after main() returns.
+tmp=""
+
 # Main flow
 main() {
   local name=""
@@ -59,9 +62,8 @@ main() {
   require_name_available "$name"
 
   # Build placeholder in a temp directory; trap before any further work
-  local tmp
   tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' EXIT
+  trap cleanup EXIT
 
   build_placeholder "$tmp" "$name"
   print_summary "$tmp" "$name" "$dry_run"
@@ -205,6 +207,14 @@ confirm_publish() {
     echo "$PROG: publish cancelled" >&2
     exit 0
   fi
+}
+
+# Remove the placeholder files we created, then the temp dir if empty.
+# Targets files by name to avoid `rm -rf` on a path the script constructs.
+cleanup() {
+  [[ -n "${tmp:-}" && -d "$tmp" ]] || return 0
+  rm -f -- "$tmp/package.json" "$tmp/README.md"
+  rmdir -- "$tmp" 2>/dev/null || true
 }
 
 # endregion | Helper functions


### PR DESCRIPTION
## What

Fixes an issue where `scripts/publish-bare.sh` printed a `tmp: unbound variable` error and exited with status 1 after a successful publish, even though npm itself reported success. The placeholder temp directory was also left behind because the cleanup never ran. The script now exits cleanly on success and removes its temp directory.

## Why

The trailing error masked successful publishes from any caller checking the exit code, and made the run look like a failure even when the package had landed on the registry. Removing the noise restores trust in the script as a one-shot bootstrap step.

## Details

### Fixes

- Hoists `tmp` to script scope so the `EXIT` trap can read it after `main()` returns; the previous `local tmp` was out of scope by the time the trap fired, and `set -u` aborted the trap on the unbound name.
- Replaces the inline `rm -rf "$tmp"` trap body with a `cleanup` helper that removes only the two known placeholder files (`package.json`, `README.md`) by name and `rmdir`s the directory. The script no longer uses `rm -rf` anywhere.
- Adds an empty/missing-directory guard in `cleanup` so an `EXIT` before the temp directory is created (e.g., a preflight failure) is a silent no-op.

Closes #382
