### PR TITLE
#392 Add section markers and authenticated upstream fetch

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -276,33 +276,33 @@ The canonical taxonomy lives in `packages/release-kit/src/work-types.json` and i
 
 | Tier     | Key         | Header                    | Aliases       | `!` policy   |
 | -------- | ----------- | ------------------------- | ------------- | ------------ |
-| Public   | `feat`      | 🎉 Features               | `feature`     | optional     |
-| Public   | `drop`      | 🪦 Removed                |               | **required** |
-| Public   | `deprecate` | 🗑️ Deprecated             |               | forbidden    |
-| Public   | `fix`       | 🐛 Bug fixes              | `bugfix`      | forbidden    |
-| Public   | `sec`       | 🔒 Security               | `security`    | optional     |
-| Public   | `perf`      | ⚡ Performance            | `performance` | forbidden    |
-| Internal | `internal`  | 🏗️ Internal features      | `utility`     | forbidden    |
-| Internal | `refactor`  | ♻️ Refactoring            |               | forbidden    |
-| Internal | `tests`     | 🧪 Tests                  | `test`        | forbidden    |
-| Process  | `tooling`   | ⚙️ Tooling                |               | forbidden    |
-| Process  | `ci`        | 👷 CI                     |               | forbidden    |
-| Process  | `deps`      | 📦 Dependencies           | `dep`         | forbidden    |
-| Process  | `ai`        | 🤖 Agentic support        |               | forbidden    |
-| Process  | `docs`      | 📚 Documentation          | `doc`         | forbidden    |
-| Process  | `fmt`       | (excluded from changelog) |               | forbidden    |
+| public   | `feat`      | 🎉 Features               | `feature`     | optional     |
+| public   | `drop`      | 🪦 Removed                |               | **required** |
+| public   | `deprecate` | 🗑️ Deprecated             |               | forbidden    |
+| public   | `fix`       | 🐛 Bug fixes              | `bugfix`      | forbidden    |
+| public   | `sec`       | 🔒 Security               | `security`    | optional     |
+| public   | `perf`      | ⚡ Performance            | `performance` | forbidden    |
+| internal | `internal`  | 🏗️ Internal features      | `utility`     | forbidden    |
+| internal | `refactor`  | ♻️ Refactoring            |               | forbidden    |
+| internal | `tests`     | 🧪 Tests                  | `test`        | forbidden    |
+| process  | `tooling`   | ⚙️ Tooling                |               | forbidden    |
+| process  | `ci`        | 👷 CI                     |               | forbidden    |
+| process  | `deps`      | 📦 Dependencies           | `dep`         | forbidden    |
+| process  | `ai`        | 🤖 Agentic support        |               | forbidden    |
+| process  | `docs`      | 📚 Documentation          | `doc`         | forbidden    |
+| process  | `fmt`       | (excluded from changelog) |               | forbidden    |
 
 #### Tier semantics
 
-- **Public** — visible to all audiences. Public-tier sections appear in both public release notes and dev changelogs.
-- **Internal** — dev-only. Internal-tier sections appear in dev changelogs but not in public-facing release notes.
-- **Process** — dev-only. Same audience treatment as Internal.
+- **`public`** — visible to all audiences. `public`-tier sections appear in both public release notes and dev changelogs.
+- **`internal`** — dev-only. `internal`-tier sections appear in dev changelogs but not in public-facing release notes.
+- **`process`** — dev-only. Same audience treatment as `internal`.
 
-Section render order is **tier order (Public → Internal → Process), then row order within tier**. The bundled `cliff.toml.template` encodes this order via hidden `<!-- NN -->` HTML-comment prefixes on each parser's `group` value; tera's `group_by` filter sorts groups lexicographically (now monotonic by row number), and the body template's `striptags` filter erases the prefix from rendered headings.
+Section render order is **tier order (`public` → `internal` → `process`), then row order within tier**. The bundled `cliff.toml.template` encodes this order via hidden `<!-- NN -->` HTML-comment prefixes on each parser's `group` value; tera's `group_by` filter sorts groups lexicographically (now monotonic by row number), and the body template's `striptags` filter erases the prefix from rendered headings.
 
 #### `docs` reclassification
 
-`docs`/Documentation has moved from the all-audience tier (where it lived before this taxonomy was formalised) to the dev-only Process tier. **Documentation commits no longer appear in public-facing release notes.** They still appear in `CHANGELOG.md` and `changelog.json` under the `audience: 'dev'` classification.
+`docs`/Documentation has moved from the all-audience tier (where it lived before this taxonomy was formalised) to the dev-only `process` tier. **Documentation commits no longer appear in public-facing release notes.** They still appear in `CHANGELOG.md` and `changelog.json` under the `audience: 'dev'` classification.
 
 #### `utility` alias
 
@@ -348,6 +348,22 @@ Items whose commit subject carries the `!` prefix (e.g. `feat!`, `drop!`, `feat(
 
 Only the prefix `!` triggers this marker. A `BREAKING CHANGE:` body footer on its own does **not** retroactively mark a changelog item as breaking — the changelog signal is tied to the commit-prefix policy. This avoids surprise breaking-marker appearances for older commits written under earlier conventions.
 
+The emoji and label of this marker are sourced from the `markers.breaking` entry in `work-types.json` (see [Section markers](#section-markers)) so consumers that render their own breaking-changes section draw from the same SSOT.
+
+### Section markers
+
+Alongside `tiers` and `types`, `work-types.json` exposes a top-level `markers` object for cross-cutting section markers — visual indicators that aren't tied to a specific work type. Today the canonical entry is `breaking`; additional keys (e.g., security advisories, migration notices) can be added without a schema change.
+
+```jsonc
+{
+  "markers": {
+    "breaking": { "emoji": "🚨", "label": "Breaking" },
+  },
+}
+```
+
+Entries store plain text only — the SSOT is format-agnostic, so consumers apply their own emphasis (Markdown bold, ANSI escape, HTML `<strong>`) when constructing the rendered form. release-kit's own renderer constructs the per-bullet prefix as `${emoji} **${label}:** ` from this entry.
+
 #### `fmt`
 
 `fmt:` commits are recognized by `parseCommitMessage` (they contribute to a patch bump) but `fmt` carries `excludedFromChangelog: true`. The bundled `cliff.toml.template` skips `fmt:` commits at the parser level, so they never appear in `CHANGELOG.md`, `changelog.json`, or release notes. The label and emoji are present in `work-types.json` for schema parity with the codeassembly upstream but never render.
@@ -356,7 +372,7 @@ Only the prefix `!` triggers this marker. A `BREAKING CHANGE:` body footer on it
 
 Work types from your config are merged with these defaults by key — your entries override or extend, they don't replace the full set. Release-notes sections are rendered in the declaration order of the merged work-types record, with any unknown titles trailing the known ones.
 
-The default `devOnlySections` (excluded from public release notes but still written to `CHANGELOG.md`) are derived from the Internal and Process tiers (excluding `fmt`). Override via `changelogJson.devOnlySections` in your config; matching is decorator-tolerant, so a bare-name override like `['Internal features']` keeps working against the emoji-prefixed and prefix-decorated default titles.
+The default `devOnlySections` (excluded from public release notes but still written to `CHANGELOG.md`) are derived from the `internal` and `process` tiers (excluding `fmt`). Override via `changelogJson.devOnlySections` in your config; matching is decorator-tolerant, so a bare-name override like `['Internal features']` keeps working against the emoji-prefixed and prefix-decorated default titles.
 
 ## Editorial overrides
 
@@ -651,6 +667,18 @@ Manage the canonical work-types taxonomy used by changelog and release-notes gen
 The check is non-blocking initially: until codeassembly publishes its `work-types.json`, the upstream URL returns 404 and `check` exits 0 with a warning. CI flip to a blocking check is tracked as a follow-up once the upstream ships.
 
 These commands are also exposed as `nmr work-types:check` / `nmr work-types:sync` from any package directory.
+
+#### Authenticated fetches
+
+When the upstream codeassembly repo is private, both `check` and `sync` need a GitHub token to fetch the canonical `work-types.json`. Set `GITHUB_TOKEN` in the environment and the commands send `Authorization: Bearer <token>` automatically; without it, requests are unauthenticated and a private upstream will return 404.
+
+```sh
+# Source from `gh auth` for local runs:
+export GITHUB_TOKEN=$(gh auth token)
+pnpm exec release-kit work-types check
+```
+
+The token needs `contents: read` on the codeassembly repo (fine-grained PAT scope) or the equivalent classic-PAT scope. A token without sufficient scope still produces a 404 — same response as a missing upstream — so a misconfigured token degrades to the transitional-warning path rather than failing loudly. CI wiring against private upstream is deferred until either codeassembly is publicly readable or a cross-repo PAT is provisioned as a workflow secret.
 
 ### `release-kit sync-labels`
 

--- a/packages/release-kit/src/__tests__/checkWorkTypesDrift.unit.test.ts
+++ b/packages/release-kit/src/__tests__/checkWorkTypesDrift.unit.test.ts
@@ -9,10 +9,10 @@ import { checkWorkTypesDrift } from '../checkWorkTypesDrift.ts';
 const FIXTURE_URL = 'https://test.example/work-types.json';
 
 const SAMPLE_DATA = {
-  tiers: ['Public', 'Internal', 'Process'],
+  tiers: ['public', 'internal', 'process'],
   types: [
     {
-      tier: 'Public',
+      tier: 'public',
       key: 'feat',
       aliases: ['feature'],
       emoji: '🎉',
@@ -39,11 +39,15 @@ describe(checkWorkTypesDrift, () => {
     tempDir = mkdtempSync(join(tmpdir(), 'work-types-drift-'));
     localPath = join(tempDir, 'work-types.json');
     writeFileSync(localPath, `${JSON.stringify(SAMPLE_DATA, null, 2)}\n`, 'utf8');
+    // Default to no token so tests are deterministic regardless of the host shell's environment.
+    // Individual tests opt into a stubbed token by calling `vi.stubEnv('GITHUB_TOKEN', '<value>')`.
+    vi.stubEnv('GITHUB_TOKEN', '');
   });
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('exits 0 with a match message when local equals upstream', async () => {
@@ -149,5 +153,24 @@ describe(checkWorkTypesDrift, () => {
     });
     expect(result.exitCode).toBe(3);
     expect(result.message).toMatch(/not valid JSON/);
+  });
+
+  describe('GITHUB_TOKEN auth header', () => {
+    it('sends `Authorization: Bearer <token>` when GITHUB_TOKEN is set', async () => {
+      vi.stubEnv('GITHUB_TOKEN', 'ghp_test_token_value');
+      const fakeFetch = vi.fn().mockResolvedValue(makeResponse({ status: 200, body: JSON.stringify(SAMPLE_DATA) }));
+      await checkWorkTypesDrift({ localPath, upstreamUrl: FIXTURE_URL, fetch: fakeFetch });
+      expect(fakeFetch).toHaveBeenCalledWith(FIXTURE_URL, {
+        headers: { Authorization: 'Bearer ghp_test_token_value' },
+      });
+    });
+
+    it('sends no `init` argument when GITHUB_TOKEN is unset', async () => {
+      vi.stubEnv('GITHUB_TOKEN', '');
+      const fakeFetch = vi.fn().mockResolvedValue(makeResponse({ status: 200, body: JSON.stringify(SAMPLE_DATA) }));
+      await checkWorkTypesDrift({ localPath, upstreamUrl: FIXTURE_URL, fetch: fakeFetch });
+      expect(fakeFetch).toHaveBeenCalledWith(FIXTURE_URL);
+      expect(fakeFetch.mock.calls[0]).toHaveLength(1);
+    });
   });
 });

--- a/packages/release-kit/src/__tests__/defaults.unit.test.ts
+++ b/packages/release-kit/src/__tests__/defaults.unit.test.ts
@@ -50,25 +50,25 @@ describe('DEFAULT_WORK_TYPES derivation from work-types.json', () => {
 });
 
 describe('DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections derivation', () => {
-  it('contains exactly Internal and Process entries (excluding excludedFromChangelog), in canonical order', () => {
+  it('contains exactly internal and process entries (excluding excludedFromChangelog), in canonical order', () => {
     const expected = workTypesData.types
       .filter(
-        (entry) => (entry.tier === 'Internal' || entry.tier === 'Process') && entry.excludedFromChangelog !== true,
+        (entry) => (entry.tier === 'internal' || entry.tier === 'process') && entry.excludedFromChangelog !== true,
       )
       .map((entry) => composeHeader(entry));
     expect(DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections).toStrictEqual(expected);
   });
 
-  it('excludes `fmt` (Process, excludedFromChangelog) from devOnlySections', () => {
+  it('excludes `fmt` (process, excludedFromChangelog) from devOnlySections', () => {
     const fmtHeader = composeHeader({ emoji: '🎨', label: 'Formatting' });
     expect(DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections).not.toContain(fmtHeader);
   });
 
-  it('includes `📚 Documentation` (docs reclassified to dev-only Process tier)', () => {
+  it('includes `📚 Documentation` (docs reclassified to dev-only `process` tier)', () => {
     expect(DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections).toContain('📚 Documentation');
   });
 
-  it('does NOT contain Public-tier entries (Features, Bug fixes, Removed, etc.)', () => {
+  it('does NOT contain `public` tier entries (Features, Bug fixes, Removed, etc.)', () => {
     expect(DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections).not.toContain('🎉 Features');
     expect(DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections).not.toContain('🐛 Bug fixes');
     expect(DEFAULT_CHANGELOG_JSON_CONFIG.devOnlySections).not.toContain('🪦 Removed');

--- a/packages/release-kit/src/__tests__/renderReleaseNotes.unit.test.ts
+++ b/packages/release-kit/src/__tests__/renderReleaseNotes.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { matchesAudience, renderReleaseNotesMulti, renderReleaseNotesSingle } from '../renderReleaseNotes.ts';
 import type { ChangelogEntry } from '../types.ts';
+import { WORK_TYPES_DATA } from '../workTypesData.ts';
 
 const sampleEntry: ChangelogEntry = {
   version: '2.0.0',
@@ -173,6 +174,29 @@ describe(renderReleaseNotesSingle, () => {
       };
       const result = renderReleaseNotesSingle(entry, { includeHeading: false });
       expect(result).not.toContain('🚨');
+    });
+
+    it('sources the breaking-marker emoji and label from `WORK_TYPES_DATA.markers.breaking`', () => {
+      // Anchors the constructed prefix to the SSOT so a future intentional change to the
+      // emoji or label in `work-types.json` triggers a visible test update rather than a
+      // silent CHANGELOG.md diff. The literal expectations in the other tests in this block
+      // (and in `renderChangelogMarkdown.unit.test.ts`) remain end-to-end string checks.
+      expect(WORK_TYPES_DATA.markers.breaking.emoji).toBe('🚨');
+      expect(WORK_TYPES_DATA.markers.breaking.label).toBe('Breaking');
+      const entry: ChangelogEntry = {
+        version: '1.0.0',
+        date: '2024-01-01',
+        sections: [
+          {
+            title: 'Features',
+            audience: 'all',
+            items: [{ description: 'Redesign API', breaking: true }],
+          },
+        ],
+      };
+      const result = renderReleaseNotesSingle(entry, { includeHeading: false });
+      const expectedPrefix = `${WORK_TYPES_DATA.markers.breaking.emoji} **${WORK_TYPES_DATA.markers.breaking.label}:** `;
+      expect(result).toContain(`- ${expectedPrefix}Redesign API`);
     });
 
     it('renders breaking marker before the description when the item also has body text', () => {

--- a/packages/release-kit/src/__tests__/syncWorkTypes.unit.test.ts
+++ b/packages/release-kit/src/__tests__/syncWorkTypes.unit.test.ts
@@ -9,10 +9,10 @@ import { syncWorkTypes } from '../syncWorkTypes.ts';
 const FIXTURE_URL = 'https://test.example/work-types.json';
 
 const SAMPLE_DATA = {
-  tiers: ['Public', 'Internal', 'Process'],
+  tiers: ['public', 'internal', 'process'],
   types: [
     {
-      tier: 'Public',
+      tier: 'public',
       key: 'feat',
       aliases: ['feature'],
       emoji: '🎉',
@@ -38,6 +38,9 @@ describe(syncWorkTypes, () => {
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'work-types-sync-'));
     localPath = join(tempDir, 'work-types.json');
+    // Default to no token so tests are deterministic regardless of the host shell's environment.
+    // Individual tests opt into a stubbed token by calling `vi.stubEnv('GITHUB_TOKEN', '<value>')`.
+    vi.stubEnv('GITHUB_TOKEN', '');
   });
 
   afterEach(() => {
@@ -50,6 +53,7 @@ describe(syncWorkTypes, () => {
     }
     rmSync(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('exits 0 when sync writes new content to local', async () => {
@@ -135,7 +139,7 @@ describe(syncWorkTypes, () => {
       ...SAMPLE_DATA,
       types: [
         ...SAMPLE_DATA.types,
-        { tier: 'Public', key: 'sec', aliases: [], emoji: '🔒', label: 'Security', breakingPolicy: 'optional' },
+        { tier: 'public', key: 'sec', aliases: [], emoji: '🔒', label: 'Security', breakingPolicy: 'optional' },
       ],
     };
     const fakeFetch = vi.fn().mockResolvedValue(makeResponse({ status: 200, body: JSON.stringify(upstreamData) }));
@@ -157,7 +161,7 @@ describe(syncWorkTypes, () => {
     // If the prior local content lacks `$schema` (e.g., upstream-canonical write), the sync must not
     // hallucinate one — the absence is itself the local truth.
     writeFileSync(localPath, `${JSON.stringify(SAMPLE_DATA, null, 2)}\n`, 'utf8');
-    const upstreamData = { ...SAMPLE_DATA, tiers: ['Public', 'Internal', 'Process', 'Future'] };
+    const upstreamData = { ...SAMPLE_DATA, tiers: ['public', 'internal', 'process', 'future'] };
     const fakeFetch = vi.fn().mockResolvedValue(makeResponse({ status: 200, body: JSON.stringify(upstreamData) }));
 
     const result = await syncWorkTypes({
@@ -182,5 +186,24 @@ describe(syncWorkTypes, () => {
     });
     expect(result.exitCode).toBe(3);
     expect(result.message).toMatch(/expected schema shape/);
+  });
+
+  describe('GITHUB_TOKEN auth header', () => {
+    it('sends `Authorization: Bearer <token>` when GITHUB_TOKEN is set', async () => {
+      vi.stubEnv('GITHUB_TOKEN', 'ghp_test_token_value');
+      const fakeFetch = vi.fn().mockResolvedValue(makeResponse({ status: 200, body: JSON.stringify(SAMPLE_DATA) }));
+      await syncWorkTypes({ localPath, upstreamUrl: FIXTURE_URL, fetch: fakeFetch });
+      expect(fakeFetch).toHaveBeenCalledWith(FIXTURE_URL, {
+        headers: { Authorization: 'Bearer ghp_test_token_value' },
+      });
+    });
+
+    it('sends no `init` argument when GITHUB_TOKEN is unset', async () => {
+      vi.stubEnv('GITHUB_TOKEN', '');
+      const fakeFetch = vi.fn().mockResolvedValue(makeResponse({ status: 200, body: JSON.stringify(SAMPLE_DATA) }));
+      await syncWorkTypes({ localPath, upstreamUrl: FIXTURE_URL, fetch: fakeFetch });
+      expect(fakeFetch).toHaveBeenCalledWith(FIXTURE_URL);
+      expect(fakeFetch.mock.calls[0]).toHaveLength(1);
+    });
   });
 });

--- a/packages/release-kit/src/__tests__/workTypesData.unit.test.ts
+++ b/packages/release-kit/src/__tests__/workTypesData.unit.test.ts
@@ -23,6 +23,10 @@ interface WorkTypesJsonData {
     breakingPolicy: string;
     excludedFromChangelog?: boolean;
   }>;
+  markers: {
+    breaking: { emoji: string; label: string };
+    [key: string]: { emoji: string; label: string };
+  };
 }
 
 function readJsonFile(): WorkTypesJsonData {
@@ -46,7 +50,19 @@ function isWorkTypesJsonData(value: unknown): value is WorkTypesJsonData {
   if (!isRecord(value)) return false;
   if (!isStringArray(value.tiers)) return false;
   if (!Array.isArray(value.types) || !value.types.every(isWorkTypesEntry)) return false;
+  if (!isMarkersRecord(value.markers)) return false;
   return true;
+}
+
+function isMarkerEntry(value: unknown): value is { emoji: string; label: string } {
+  if (!isRecord(value)) return false;
+  return typeof value.emoji === 'string' && typeof value.label === 'string';
+}
+
+function isMarkersRecord(value: unknown): value is WorkTypesJsonData['markers'] {
+  if (!isRecord(value)) return false;
+  if (!isMarkerEntry(value.breaking)) return false;
+  return Object.values(value).every(isMarkerEntry);
 }
 
 function isWorkTypesEntry(value: unknown): value is WorkTypesJsonData['types'][number] {
@@ -93,6 +109,21 @@ describe('work-types.json mirrors workTypesData.ts (drift detection)', () => {
       expect(tsEntry?.excludedFromChangelog).toBe(jsonEntry.excludedFromChangelog);
     }
   });
+
+  it('the TS mirror exposes the same `markers` keys as the JSON canonical', () => {
+    const json = readJsonFile();
+    expect(new Set(Object.keys(WORK_TYPES_DATA.markers))).toStrictEqual(new Set(Object.keys(json.markers)));
+  });
+
+  it('every JSON marker deep-equals its TS counterpart', () => {
+    const json = readJsonFile();
+    for (const [key, jsonMarker] of Object.entries(json.markers)) {
+      const tsMarker = WORK_TYPES_DATA.markers[key];
+      expect(tsMarker, `marker "${key}" missing in TS mirror`).toBeDefined();
+      expect(tsMarker?.emoji).toBe(jsonMarker.emoji);
+      expect(tsMarker?.label).toBe(jsonMarker.label);
+    }
+  });
 });
 
 describe('work-types.json structural invariants', () => {
@@ -106,17 +137,17 @@ describe('work-types.json structural invariants', () => {
     expect(WORK_TYPES_DATA.types.length).toBeGreaterThan(0);
   });
 
-  it('contains exactly the canonical 15 entries (6 Public, 3 Internal, 6 Process including fmt)', () => {
+  it('contains exactly the canonical 15 entries (6 public, 3 internal, 6 process including fmt)', () => {
     expect(WORK_TYPES_DATA.types).toHaveLength(15);
     const tierCounts = new Map<string, number>();
     for (const entry of WORK_TYPES_DATA.types) {
       tierCounts.set(entry.tier, (tierCounts.get(entry.tier) ?? 0) + 1);
     }
-    expect(tierCounts.get('Public')).toBe(6);
-    expect(tierCounts.get('Internal')).toBe(3);
-    // `fmt` is in the Process tier (canonical count is 6); the implementation plan listed it
-    // separately as "5 Process plus fmt" to emphasize its `excludedFromChangelog` flag.
-    expect(tierCounts.get('Process')).toBe(6);
+    expect(tierCounts.get('public')).toBe(6);
+    expect(tierCounts.get('internal')).toBe(3);
+    // `fmt` is in the `process` tier (canonical count is 6); the implementation plan listed it
+    // separately as "5 process plus fmt" to emphasize its `excludedFromChangelog` flag.
+    expect(tierCounts.get('process')).toBe(6);
   });
 
   it('every entry has a non-empty `label` and `emoji`', () => {
@@ -166,7 +197,7 @@ describe('work-types.json structural invariants', () => {
     }
   });
 
-  it('orders entries by tier (Public → Internal → Process), then by row within tier', () => {
+  it('orders entries by tier (public → internal → process), then by row within tier', () => {
     const tierOrder = new Map(WORK_TYPES_DATA.tiers.map((tier, index) => [tier, index]));
     let previousTierIndex = -1;
     for (const entry of WORK_TYPES_DATA.types) {

--- a/packages/release-kit/src/__tests__/workTypesSchema.unit.test.ts
+++ b/packages/release-kit/src/__tests__/workTypesSchema.unit.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const schemaPath = resolve(thisDir, '..', 'work-types.schema.json');
+
+describe('work-types.schema.json', () => {
+  const raw = readFileSync(schemaPath, 'utf8');
+  const schema: unknown = JSON.parse(raw);
+
+  it('parses as a JSON object', () => {
+    expect(schema).toBeTypeOf('object');
+    expect(schema).not.toBeNull();
+    expect(Array.isArray(schema)).toBe(false);
+  });
+
+  it('declares draft-07 as its meta-schema', () => {
+    expect(schema).toMatchObject({ $schema: 'http://json-schema.org/draft-07/schema#' });
+  });
+
+  it('requires `tiers`, `types`, and `markers` at the top level', () => {
+    expect(schema).toMatchObject({
+      type: 'object',
+      additionalProperties: false,
+      required: expect.arrayContaining(['tiers', 'types', 'markers']),
+    });
+  });
+
+  it('defines the `markers` property as an object that requires `breaking`', () => {
+    expect(schema).toMatchObject({
+      properties: {
+        markers: {
+          type: 'object',
+          required: expect.arrayContaining(['breaking']),
+          properties: {
+            breaking: { $ref: '#/definitions/marker' },
+          },
+        },
+      },
+    });
+  });
+
+  it('keeps `markers` extensible — `additionalProperties` references the same marker shape', () => {
+    expect(schema).toMatchObject({
+      properties: {
+        markers: {
+          additionalProperties: { $ref: '#/definitions/marker' },
+        },
+      },
+    });
+  });
+
+  it('defines a reusable `marker` shape requiring `emoji` and `label`', () => {
+    expect(schema).toMatchObject({
+      definitions: {
+        marker: {
+          type: 'object',
+          required: expect.arrayContaining(['emoji', 'label']),
+          additionalProperties: false,
+          properties: {
+            emoji: { type: 'string', minLength: 1 },
+            label: { type: 'string', minLength: 1 },
+          },
+        },
+      },
+    });
+  });
+
+  it('preserves the existing `workType` shape so types-only consumers continue to validate', () => {
+    expect(schema).toMatchObject({
+      definitions: {
+        workType: {
+          type: 'object',
+          required: expect.arrayContaining(['tier', 'key', 'aliases', 'emoji', 'label', 'breakingPolicy']),
+        },
+      },
+    });
+  });
+});

--- a/packages/release-kit/src/checkWorkTypesDrift.ts
+++ b/packages/release-kit/src/checkWorkTypesDrift.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { errorMessage, hasExpectedTopLevelShape } from './workTypesUtils.ts';
+import { buildFetchInit, errorMessage, hasExpectedTopLevelShape } from './workTypesUtils.ts';
 
 /** URL of the upstream canonical `work-types.json` published by codeassembly. */
 export const UPSTREAM_WORK_TYPES_URL =
@@ -67,9 +67,10 @@ export async function checkWorkTypesDrift(
     };
   }
 
+  const fetchInit = buildFetchInit();
   let response: Response;
   try {
-    response = await fetcher(url);
+    response = fetchInit === undefined ? await fetcher(url) : await fetcher(url, fetchInit);
   } catch (error) {
     return {
       exitCode: 2,

--- a/packages/release-kit/src/defaults.ts
+++ b/packages/release-kit/src/defaults.ts
@@ -16,7 +16,7 @@ export function composeHeader(entry: { emoji: string; label: string }): string {
 }
 
 /** Tier names treated as dev-only (not surfaced in public release notes). */
-const DEV_ONLY_TIERS = new Set(['Internal', 'Process']);
+const DEV_ONLY_TIERS = new Set(['internal', 'process']);
 
 /** Derive `DEFAULT_WORK_TYPES` from the loaded work-types data in canonical order. */
 function deriveDefaultWorkTypes(): Record<string, WorkTypeConfig> {

--- a/packages/release-kit/src/renderReleaseNotes.ts
+++ b/packages/release-kit/src/renderReleaseNotes.ts
@@ -1,4 +1,18 @@
 import type { ChangelogAudience, ChangelogEntry, ChangelogSection } from './types.ts';
+import { WORK_TYPES_DATA } from './workTypesData.ts';
+
+/**
+ * Build the per-bullet breaking-marker prefix from the canonical `markers.breaking` SSOT.
+ *
+ * Construction template: `${emoji} **${label}:** ` — the colon stays inside the bold to
+ * preserve byte-identical rendered output across the `markers`-block adoption. If a future
+ * change to the SSOT (emoji or label) is intentional, regenerate snapshots and update the
+ * literal expectations in `renderReleaseNotes.unit.test.ts` / `renderChangelogMarkdown.unit.test.ts`.
+ */
+function getBreakingPrefix(): string {
+  const { emoji, label } = WORK_TYPES_DATA.markers.breaking;
+  return `${emoji} **${label}:** `;
+}
 
 /** Options for rendering a single changelog entry to markdown. */
 export interface RenderOptions {
@@ -62,7 +76,7 @@ export function renderReleaseNotesSingle(entry: ChangelogEntry, options?: Render
     }
     lines.push(`### ${section.title}`, '');
     for (const [index, item] of section.items.entries()) {
-      const prefix = item.breaking === true ? '🚨 **Breaking:** ' : '';
+      const prefix = item.breaking === true ? getBreakingPrefix() : '';
       lines.push(`- ${prefix}${item.description}`);
       if (item.body !== undefined && item.body.length > 0) {
         lines.push('', ...indentBodyLines(item.body));

--- a/packages/release-kit/src/syncWorkTypes.ts
+++ b/packages/release-kit/src/syncWorkTypes.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { UPSTREAM_WORK_TYPES_URL } from './checkWorkTypesDrift.ts';
 import { isRecord } from './typeGuards.ts';
-import { errorMessage, hasExpectedTopLevelShape } from './workTypesUtils.ts';
+import { buildFetchInit, errorMessage, hasExpectedTopLevelShape } from './workTypesUtils.ts';
 
 /** Outcome of a sync operation. */
 export interface SyncResult {
@@ -61,9 +61,10 @@ export async function syncWorkTypes(dependencies: SyncWorkTypesDependencies = {}
   const fetcher = dependencies.fetch ?? globalThis.fetch;
   const url = dependencies.upstreamUrl ?? UPSTREAM_WORK_TYPES_URL;
 
+  const fetchInit = buildFetchInit();
   let response: Response;
   try {
-    response = await fetcher(url);
+    response = fetchInit === undefined ? await fetcher(url) : await fetcher(url, fetchInit);
   } catch (error) {
     return {
       exitCode: 2,

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -14,8 +14,9 @@ export interface ChangelogItem {
    *
    * `true` when the commit subject carries the `!` prefix (e.g. `feat!:` or `drop(scope)!:`).
    * The `BREAKING CHANGE:` body footer is intentionally NOT considered here — only the prefix
-   * `!` marks a changelog item as breaking. Renderers prefix breaking-item bullets with
-   * `🚨 **Breaking:** ` to surface them prominently in release notes.
+   * `!` marks a changelog item as breaking. Renderers prefix breaking-item bullets with the
+   * marker constructed from `WORK_TYPES_DATA.markers.breaking` (rendered as `🚨 **Breaking:** `
+   * with the canonical SSOT values) to surface them prominently in release notes.
    */
   breaking?: boolean;
   /**

--- a/packages/release-kit/src/work-types.json
+++ b/packages/release-kit/src/work-types.json
@@ -1,9 +1,9 @@
 {
   "$schema": "./work-types.schema.json",
-  "tiers": ["Public", "Internal", "Process"],
+  "tiers": ["public", "internal", "process"],
   "types": [
     {
-      "tier": "Public",
+      "tier": "public",
       "key": "feat",
       "aliases": ["feature"],
       "emoji": "🎉",
@@ -11,7 +11,7 @@
       "breakingPolicy": "optional"
     },
     {
-      "tier": "Public",
+      "tier": "public",
       "key": "drop",
       "aliases": [],
       "emoji": "🪦",
@@ -19,7 +19,7 @@
       "breakingPolicy": "required"
     },
     {
-      "tier": "Public",
+      "tier": "public",
       "key": "deprecate",
       "aliases": [],
       "emoji": "🗑️",
@@ -27,7 +27,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Public",
+      "tier": "public",
       "key": "fix",
       "aliases": ["bugfix"],
       "emoji": "🐛",
@@ -35,7 +35,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Public",
+      "tier": "public",
       "key": "sec",
       "aliases": ["security"],
       "emoji": "🔒",
@@ -43,7 +43,7 @@
       "breakingPolicy": "optional"
     },
     {
-      "tier": "Public",
+      "tier": "public",
       "key": "perf",
       "aliases": ["performance"],
       "emoji": "⚡",
@@ -51,7 +51,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Internal",
+      "tier": "internal",
       "key": "internal",
       "aliases": ["utility"],
       "emoji": "🏗️",
@@ -59,7 +59,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Internal",
+      "tier": "internal",
       "key": "refactor",
       "aliases": [],
       "emoji": "♻️",
@@ -67,7 +67,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Internal",
+      "tier": "internal",
       "key": "tests",
       "aliases": ["test"],
       "emoji": "🧪",
@@ -75,7 +75,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Process",
+      "tier": "process",
       "key": "tooling",
       "aliases": [],
       "emoji": "⚙️",
@@ -83,7 +83,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Process",
+      "tier": "process",
       "key": "ci",
       "aliases": [],
       "emoji": "👷",
@@ -91,7 +91,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Process",
+      "tier": "process",
       "key": "deps",
       "aliases": ["dep"],
       "emoji": "📦",
@@ -99,7 +99,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Process",
+      "tier": "process",
       "key": "ai",
       "aliases": [],
       "emoji": "🤖",
@@ -107,7 +107,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Process",
+      "tier": "process",
       "key": "docs",
       "aliases": ["doc"],
       "emoji": "📚",
@@ -115,7 +115,7 @@
       "breakingPolicy": "forbidden"
     },
     {
-      "tier": "Process",
+      "tier": "process",
       "key": "fmt",
       "aliases": [],
       "emoji": "🎨",
@@ -123,5 +123,11 @@
       "breakingPolicy": "forbidden",
       "excludedFromChangelog": true
     }
-  ]
+  ],
+  "markers": {
+    "breaking": {
+      "emoji": "🚨",
+      "label": "Breaking"
+    }
+  }
 }

--- a/packages/release-kit/src/work-types.schema.json
+++ b/packages/release-kit/src/work-types.schema.json
@@ -4,7 +4,7 @@
   "title": "Work types",
   "description": "Canonical taxonomy of commit work types used by release-kit. Drives section ordering, audience classification, and the `!` (breaking) policy. The structured single-source-of-truth for everything that previously lived in `DEFAULT_WORK_TYPES` and `cliff.toml.template` group definitions.",
   "type": "object",
-  "required": ["tiers", "types"],
+  "required": ["tiers", "types", "markers"],
   "additionalProperties": false,
   "properties": {
     "$schema": {
@@ -23,9 +23,36 @@
       "description": "Work-type entries in canonical render order (tier order, then row order within tier).",
       "items": { "$ref": "#/definitions/workType" },
       "minItems": 1
+    },
+    "markers": {
+      "type": "object",
+      "description": "Orthogonal section markers used by downstream renderers (PR descriptions, changelogs, release notes). Keyed by marker name; values describe the rendering inputs (emoji + label). Markers are cross-cutting — they are not tied to a specific work type.",
+      "required": ["breaking"],
+      "properties": {
+        "breaking": { "$ref": "#/definitions/marker" }
+      },
+      "additionalProperties": { "$ref": "#/definitions/marker" }
     }
   },
   "definitions": {
+    "marker": {
+      "type": "object",
+      "description": "Rendering inputs for a single marker. Stored as plain text; consumers apply their own formatting (e.g., bolding, prefix punctuation) at construction time.",
+      "required": ["emoji", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "emoji": {
+          "type": "string",
+          "description": "Decorative emoji rendered as the prefix of the marker.",
+          "minLength": 1
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable marker label. Plain text; consumers add their own emphasis (e.g., bold) when constructing the rendered form.",
+          "minLength": 1
+        }
+      }
+    },
     "workType": {
       "type": "object",
       "required": ["tier", "key", "aliases", "emoji", "label", "breakingPolicy"],

--- a/packages/release-kit/src/workTypesData.ts
+++ b/packages/release-kit/src/workTypesData.ts
@@ -23,23 +23,43 @@ export interface WorkTypeEntry {
   excludedFromChangelog?: boolean;
 }
 
+/**
+ * Schema for an orthogonal section marker (e.g., breaking-changes indicator).
+ *
+ * Stored as plain text — consumers add formatting (bold, prefix punctuation) when
+ * constructing the rendered form. Keeps the SSOT format-agnostic across Markdown,
+ * HTML, terminal, and plain-text consumers.
+ */
+export interface MarkerEntry {
+  emoji: string;
+  label: string;
+}
+
 /** Schema for the full data. */
 export interface WorkTypesData {
   tiers: string[];
   types: WorkTypeEntry[];
+  /**
+   * Cross-cutting section markers keyed by marker name. The `breaking` marker is
+   * canonical and required; additional keys are permitted for forward-compatibility.
+   */
+  markers: {
+    breaking: MarkerEntry;
+    [key: string]: MarkerEntry;
+  };
 }
 
 /** Canonical work-types data, kept in lockstep with `work-types.json`. */
 export const WORK_TYPES_DATA: WorkTypesData = {
-  tiers: ['Public', 'Internal', 'Process'],
+  tiers: ['public', 'internal', 'process'],
   types: [
-    { tier: 'Public', key: 'feat', aliases: ['feature'], emoji: '🎉', label: 'Features', breakingPolicy: 'optional' },
-    { tier: 'Public', key: 'drop', aliases: [], emoji: '🪦', label: 'Removed', breakingPolicy: 'required' },
-    { tier: 'Public', key: 'deprecate', aliases: [], emoji: '🗑️', label: 'Deprecated', breakingPolicy: 'forbidden' },
-    { tier: 'Public', key: 'fix', aliases: ['bugfix'], emoji: '🐛', label: 'Bug fixes', breakingPolicy: 'forbidden' },
-    { tier: 'Public', key: 'sec', aliases: ['security'], emoji: '🔒', label: 'Security', breakingPolicy: 'optional' },
+    { tier: 'public', key: 'feat', aliases: ['feature'], emoji: '🎉', label: 'Features', breakingPolicy: 'optional' },
+    { tier: 'public', key: 'drop', aliases: [], emoji: '🪦', label: 'Removed', breakingPolicy: 'required' },
+    { tier: 'public', key: 'deprecate', aliases: [], emoji: '🗑️', label: 'Deprecated', breakingPolicy: 'forbidden' },
+    { tier: 'public', key: 'fix', aliases: ['bugfix'], emoji: '🐛', label: 'Bug fixes', breakingPolicy: 'forbidden' },
+    { tier: 'public', key: 'sec', aliases: ['security'], emoji: '🔒', label: 'Security', breakingPolicy: 'optional' },
     {
-      tier: 'Public',
+      tier: 'public',
       key: 'perf',
       aliases: ['performance'],
       emoji: '⚡',
@@ -47,7 +67,7 @@ export const WORK_TYPES_DATA: WorkTypesData = {
       breakingPolicy: 'forbidden',
     },
     {
-      tier: 'Internal',
+      tier: 'internal',
       key: 'internal',
       aliases: ['utility'],
       emoji: '🏗️',
@@ -55,20 +75,20 @@ export const WORK_TYPES_DATA: WorkTypesData = {
       breakingPolicy: 'forbidden',
     },
     {
-      tier: 'Internal',
+      tier: 'internal',
       key: 'refactor',
       aliases: [],
       emoji: '♻️',
       label: 'Refactoring',
       breakingPolicy: 'forbidden',
     },
-    { tier: 'Internal', key: 'tests', aliases: ['test'], emoji: '🧪', label: 'Tests', breakingPolicy: 'forbidden' },
-    { tier: 'Process', key: 'tooling', aliases: [], emoji: '⚙️', label: 'Tooling', breakingPolicy: 'forbidden' },
-    { tier: 'Process', key: 'ci', aliases: [], emoji: '👷', label: 'CI', breakingPolicy: 'forbidden' },
-    { tier: 'Process', key: 'deps', aliases: ['dep'], emoji: '📦', label: 'Dependencies', breakingPolicy: 'forbidden' },
-    { tier: 'Process', key: 'ai', aliases: [], emoji: '🤖', label: 'Agentic support', breakingPolicy: 'forbidden' },
+    { tier: 'internal', key: 'tests', aliases: ['test'], emoji: '🧪', label: 'Tests', breakingPolicy: 'forbidden' },
+    { tier: 'process', key: 'tooling', aliases: [], emoji: '⚙️', label: 'Tooling', breakingPolicy: 'forbidden' },
+    { tier: 'process', key: 'ci', aliases: [], emoji: '👷', label: 'CI', breakingPolicy: 'forbidden' },
+    { tier: 'process', key: 'deps', aliases: ['dep'], emoji: '📦', label: 'Dependencies', breakingPolicy: 'forbidden' },
+    { tier: 'process', key: 'ai', aliases: [], emoji: '🤖', label: 'Agentic support', breakingPolicy: 'forbidden' },
     {
-      tier: 'Process',
+      tier: 'process',
       key: 'docs',
       aliases: ['doc'],
       emoji: '📚',
@@ -76,7 +96,7 @@ export const WORK_TYPES_DATA: WorkTypesData = {
       breakingPolicy: 'forbidden',
     },
     {
-      tier: 'Process',
+      tier: 'process',
       key: 'fmt',
       aliases: [],
       emoji: '🎨',
@@ -85,4 +105,7 @@ export const WORK_TYPES_DATA: WorkTypesData = {
       excludedFromChangelog: true,
     },
   ],
+  markers: {
+    breaking: { emoji: '🚨', label: 'Breaking' },
+  },
 };

--- a/packages/release-kit/src/workTypesUtils.ts
+++ b/packages/release-kit/src/workTypesUtils.ts
@@ -21,3 +21,20 @@ export function hasExpectedTopLevelShape(value: unknown): value is { tiers: unkn
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+/**
+ * Build the `init` argument for `fetch` to reach codeassembly's canonical work-types files.
+ *
+ * Returns `{ headers: { Authorization: 'Bearer <token>' } }` when `GITHUB_TOKEN` is set in the
+ * environment; returns `undefined` otherwise so the call site stays byte-identical to an
+ * unauthenticated request. Centralised here so `checkWorkTypesDrift` and `syncWorkTypes`
+ * cannot diverge on auth handling. Tests stub the env via `vi.stubEnv` rather than parameter
+ * injection, so this reads `process.env` directly.
+ */
+export function buildFetchInit(): RequestInit | undefined {
+  const token = process.env.GITHUB_TOKEN;
+  if (token === undefined || token === '') {
+    return undefined;
+  }
+  return { headers: { Authorization: `Bearer ${token}` } };
+}


### PR DESCRIPTION
## What

A new `markers` block in `work-types.json` describes the breaking-changes emoji and label, making them available for use by consumers.

`work-types check` and `work-types sync` now authenticate when `GITHUB_TOKEN` is set, so they can reach private upstream repositories.

## Why

Three coordinated improvements stabilize the work-types JSON as a published contract for downstream consumers. Authenticated fetches let private codeassembly upstreams be reached, unblocking both maintainer use and future CI wiring. The `markers` block gives consumers a stable entry for the breaking-changes indicator instead of each consumer hardcoding the emoji and label, and lowercasing tier values aligns the only Title Case exception in the taxonomy's identifier fields.

## Details

### Features

- `work-types.json` adds a top-level `markers` object, with `breaking: { emoji: "🚨", label: "Breaking" }` as the canonical entry. Additional marker keys are permitted by the schema for forward compatibility (security advisories, migration notices, etc., are natural future fits).
- `work-types.schema.json` defines the `markers` block via a reusable `marker` `$ref` definition; `additionalProperties` references the same shape so adding a new marker key requires no schema change. `additionalProperties: false` per marker entry guards against typos.
- `WorkTypesData` in `workTypesData.ts` mirrors the JSON shape via a new `MarkerEntry` interface, keeping the runtime TS mirror in lockstep with the JSON canonical. The existing JSON↔TS drift test is extended to compare `markers` field-by-field alongside `tiers` and `types`.
- `buildFetchInit()` in `workTypesUtils.ts` reads `process.env.GITHUB_TOKEN` and returns `{ headers: { Authorization: 'Bearer <token>' } }` when set, `undefined` otherwise. Both `syncWorkTypes` and `checkWorkTypesDrift` route their fetches through it. The no-token path stays byte-identical to the prior single-arg fetch call so existing fetch mocks are unaffected.

### Refactoring

- `renderReleaseNotes.ts` replaces the hardcoded `'🚨 **Breaking:** '` literal with a `getBreakingPrefix()` helper that constructs the prefix from `WORK_TYPES_DATA.markers.breaking`. Construction template is `${emoji} **${label}:** ` (colon inside the bold) so the rendered output is byte-identical to the prior literal — existing `CHANGELOG.md` files do not churn on the next release.
- Tier values are now lowercase across the data files, the one behavioral comparison (`DEV_ONLY_TIERS` in `defaults.ts`), and the affected test fixtures. The schema does not enum-pin tier values, so no schema-level constraint changes.
- `types.ts` docstring on `ChangelogItem.breaking` updated to point at the SSOT path rather than the bare emoji+label literal.
- README adds a `Section markers` subsection explaining the orthogonal-marker concept with a worked JSON example, plus an `Authenticated fetches` subsection documenting the `GITHUB_TOKEN` pattern, scope requirements, and the deferred CI-wiring follow-up. Tier-identifier code-spans throughout the `Tier semantics` and related subsections use lowercase identifiers.

### Tests

- New `workTypesSchema.unit.test.ts` asserts structural invariants of the schema document via `toMatchObject` (no Ajv): `markers` is required at top level, `markers.breaking` is required, the reusable `marker` shape requires `emoji` and `label`, `additionalProperties` is keyed off the marker shape for extensibility, and the existing `workType` definition is preserved so types-only consumers continue to validate.
- `renderReleaseNotes.unit.test.ts` adds a SSOT-anchored test that pins the constructed prefix to the canonical `WORK_TYPES_DATA.markers.breaking` values, so a future intentional change to the emoji or label triggers a deliberate, visible test update rather than a silent CHANGELOG.md diff. Existing literal-output assertions remain end-to-end, so the byte-identical rendered-output guarantee is enforced as a regression check.
- `syncWorkTypes.unit.test.ts` and `checkWorkTypesDrift.unit.test.ts` add a `GITHUB_TOKEN auth header` describe block in each, with one test asserting the `Authorization: Bearer <token>` header is sent when set and another asserting no `init` argument is passed when unset. Tests use `vi.stubEnv` for deterministic env mutation regardless of the host shell's `GITHUB_TOKEN`.

Closes #392