### PR TITLE
#386 Accept `breakingPolicies` field in config files

### DIFF
--- a/packages/release-kit/package.json
+++ b/packages/release-kit/package.json
@@ -48,7 +48,8 @@
     "jiti": "2.7.0",
     "js-yaml": "4.1.1",
     "json-stringify-pretty-compact": "4.0.0",
-    "semver": "7.8.0"
+    "semver": "7.8.0",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@types/js-yaml": "4.0.9",

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -2,6 +2,32 @@ import { describe, expect, it } from 'vitest';
 
 import { validateConfig } from '../validateConfig.ts';
 
+/**
+ * Assert that at least one error in `errors` is attributed to the given field path. Used
+ * for cases where the validator's responsibility is to catch the input at the right path
+ * — the message text itself is Zod's default and should not be pinned to a specific
+ * wording (Zod minor versions can shift wording without our code changing).
+ *
+ * For errors with messages we own (deprecation messages, duplicate-detection messages,
+ * collision messages, cross-field warnings, our targeted "must be a non-empty string"
+ * customization), use `expect(errors).toContain('exact message')` instead.
+ */
+function expectErrorAtPath(errors: readonly string[], path: string): void {
+  const matched = errors.some((e) => e.startsWith(`${path}:`));
+  expect(matched, `expected an error at path '${path}'\nactual errors:\n  ${errors.join('\n  ')}`).toBe(true);
+}
+
+/**
+ * Assert that at least one error in `errors` mentions the given substring. Used for
+ * top-level errors that have no path prefix (e.g., a top-level `Unrecognized key: "X"`
+ * from Zod's `.strict()` check) where we want to confirm the validator surfaced the
+ * offending key without pinning the wording.
+ */
+function expectErrorMentioning(errors: readonly string[], substring: string): void {
+  const matched = errors.some((e) => e.includes(substring));
+  expect(matched, `expected an error mentioning '${substring}'\nactual errors:\n  ${errors.join('\n  ')}`).toBe(true);
+}
+
 describe(validateConfig, () => {
   it('returns no errors for an empty config object', () => {
     const { errors } = validateConfig({});
@@ -13,9 +39,9 @@ describe(validateConfig, () => {
     expect(errors).toContain('Config must be an object');
   });
 
-  it('returns an error for unknown fields', () => {
+  it('returns an error for unknown top-level fields', () => {
     const { errors } = validateConfig({ unknownField: true });
-    expect(errors).toContain('Unrecognized key: "unknownField"');
+    expectErrorMentioning(errors, 'unknownField');
   });
 
   describe('workspaces', () => {
@@ -29,19 +55,19 @@ describe(validateConfig, () => {
 
     it('returns an error when workspaces is not an array', () => {
       const { errors } = validateConfig({ workspaces: 'invalid' });
-      expect(errors).toContain('workspaces: Invalid input: expected array, received string');
+      expectErrorAtPath(errors, 'workspaces');
     });
 
     it('returns an error when dir is missing', () => {
       const { errors } = validateConfig({ workspaces: [{ shouldExclude: true }] });
-      expect(errors).toContain('workspaces[0].dir: Invalid input: expected string, received undefined');
+      expectErrorAtPath(errors, 'workspaces[0].dir');
     });
 
     it('returns an error when shouldExclude is not a boolean', () => {
       const { errors } = validateConfig({
         workspaces: [{ dir: 'arrays', shouldExclude: 'yes' }],
       });
-      expect(errors).toContain('workspaces[0].shouldExclude: Invalid input: expected boolean, received string');
+      expectErrorAtPath(errors, 'workspaces[0].shouldExclude');
     });
 
     it('returns a deprecation error when tagPrefix is present', () => {
@@ -57,7 +83,7 @@ describe(validateConfig, () => {
       const { errors } = validateConfig({
         workspaces: [{ dir: 'arrays', bogusField: true }],
       });
-      expect(errors).toContain('workspaces[0]: Unrecognized key: "bogusField"');
+      expectErrorMentioning(errors, 'bogusField');
     });
 
     describe('legacyIdentities', () => {
@@ -100,57 +126,49 @@ describe(validateConfig, () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: 'core-v' }],
         });
-        expect(errors).toContain('workspaces[0].legacyIdentities: Invalid input: expected array, received string');
+        expectErrorAtPath(errors, 'workspaces[0].legacyIdentities');
       });
 
       it('returns a per-index error when an entry is not an object', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: ['core-v'] }],
         });
-        expect(errors).toContain('workspaces[0].legacyIdentities[0]: Invalid input: expected object, received string');
+        expectErrorAtPath(errors, 'workspaces[0].legacyIdentities[0]');
       });
 
       it('returns a per-index error when name is missing', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: [{ tagPrefix: 'core-v' }] }],
         });
-        expect(errors).toContain(
-          'workspaces[0].legacyIdentities[0].name: Invalid input: expected string, received undefined',
-        );
+        expectErrorAtPath(errors, 'workspaces[0].legacyIdentities[0].name');
       });
 
       it('returns a per-index error when name is an empty string', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: [{ name: '', tagPrefix: 'core-v' }] }],
         });
-        expect(errors).toContain(
-          'workspaces[0].legacyIdentities[0].name: Too small: expected string to have >=1 characters',
-        );
+        expect(errors).toContain('workspaces[0].legacyIdentities[0].name: must be a non-empty string');
       });
 
       it('returns a per-index error when tagPrefix is missing', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@scope/core' }] }],
         });
-        expect(errors).toContain(
-          'workspaces[0].legacyIdentities[0].tagPrefix: Invalid input: expected string, received undefined',
-        );
+        expectErrorAtPath(errors, 'workspaces[0].legacyIdentities[0].tagPrefix');
       });
 
       it('returns a per-index error when tagPrefix is an empty string', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@scope/core', tagPrefix: '' }] }],
         });
-        expect(errors).toContain(
-          'workspaces[0].legacyIdentities[0].tagPrefix: Too small: expected string to have >=1 characters',
-        );
+        expect(errors).toContain('workspaces[0].legacyIdentities[0].tagPrefix: must be a non-empty string');
       });
 
       it('returns an error on unknown identity fields', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@scope/core', tagPrefix: 'core-v', bogus: true }] }],
         });
-        expect(errors).toContain('workspaces[0].legacyIdentities[0]: Unrecognized key: "bogus"');
+        expectErrorMentioning(errors, 'bogus');
       });
 
       it('rejects full-tuple duplicates', () => {
@@ -226,7 +244,7 @@ describe(validateConfig, () => {
             },
           ],
         });
-        expect(errors).toContain('workspaces[0].legacyIdentities[1]: Invalid input: expected object, received string');
+        expectErrorAtPath(errors, 'workspaces[0].legacyIdentities[1]');
         // Schema validation is all-or-nothing per field: when any entry is invalid, the
         // whole `workspaces` field fails parse and downstream consumers see no config at all.
         expect(config.workspaces).toBeUndefined();
@@ -282,53 +300,53 @@ describe(validateConfig, () => {
 
     it('returns an error when retiredPackages is not an array', () => {
       const { errors } = validateConfig({ retiredPackages: 'preflight-v' });
-      expect(errors).toContain('retiredPackages: Invalid input: expected array, received string');
+      expectErrorAtPath(errors, 'retiredPackages');
     });
 
     it('returns a per-index error when an entry is not an object', () => {
       const { errors } = validateConfig({ retiredPackages: ['preflight-v'] });
-      expect(errors).toContain('retiredPackages[0]: Invalid input: expected object, received string');
+      expectErrorAtPath(errors, 'retiredPackages[0]');
     });
 
     it('returns a per-index error when name is missing', () => {
       const { errors } = validateConfig({ retiredPackages: [{ tagPrefix: 'preflight-v' }] });
-      expect(errors).toContain('retiredPackages[0].name: Invalid input: expected string, received undefined');
+      expectErrorAtPath(errors, 'retiredPackages[0].name');
     });
 
     it('returns a per-index error when name is an empty string', () => {
       const { errors } = validateConfig({ retiredPackages: [{ name: '', tagPrefix: 'preflight-v' }] });
-      expect(errors).toContain('retiredPackages[0].name: Too small: expected string to have >=1 characters');
+      expect(errors).toContain('retiredPackages[0].name: must be a non-empty string');
     });
 
     it('returns a per-index error when tagPrefix is missing', () => {
       const { errors } = validateConfig({ retiredPackages: [{ name: '@scope/preflight' }] });
-      expect(errors).toContain('retiredPackages[0].tagPrefix: Invalid input: expected string, received undefined');
+      expectErrorAtPath(errors, 'retiredPackages[0].tagPrefix');
     });
 
     it('returns a per-index error when tagPrefix is an empty string', () => {
       const { errors } = validateConfig({ retiredPackages: [{ name: '@scope/preflight', tagPrefix: '' }] });
-      expect(errors).toContain('retiredPackages[0].tagPrefix: Too small: expected string to have >=1 characters');
+      expect(errors).toContain('retiredPackages[0].tagPrefix: must be a non-empty string');
     });
 
     it('returns a per-index error when successor is not a string', () => {
       const { errors } = validateConfig({
         retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', successor: 42 }],
       });
-      expect(errors).toContain('retiredPackages[0].successor: Invalid input: expected string, received number');
+      expectErrorAtPath(errors, 'retiredPackages[0].successor');
     });
 
     it('returns a per-index error when successor is an empty string', () => {
       const { errors } = validateConfig({
         retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', successor: '' }],
       });
-      expect(errors).toContain('retiredPackages[0].successor: Too small: expected string to have >=1 characters');
+      expect(errors).toContain('retiredPackages[0].successor: must be a non-empty string');
     });
 
     it('returns an error on unknown retired-package fields', () => {
       const { errors } = validateConfig({
         retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', bogus: true }],
       });
-      expect(errors).toContain('retiredPackages[0]: Unrecognized key: "bogus"');
+      expectErrorMentioning(errors, 'bogus');
     });
 
     it('rejects full-tuple duplicates', () => {
@@ -402,7 +420,7 @@ describe(validateConfig, () => {
           { name: '@scope/dead', tagPrefix: 'dead-v', successor: 'alive' },
         ],
       });
-      expect(errors).toContain('retiredPackages[1]: Invalid input: expected object, received string');
+      expectErrorAtPath(errors, 'retiredPackages[1]');
       // Schema validation is all-or-nothing per field: when any entry is invalid, the
       // whole `retiredPackages` field fails parse and downstream consumers see no config at all.
       expect(config.retiredPackages).toBeUndefined();
@@ -422,21 +440,21 @@ describe(validateConfig, () => {
       const { errors } = validateConfig({
         versionPatterns: { major: 'invalid', minor: ['feat'] },
       });
-      expect(errors).toContain('versionPatterns.major: Invalid input: expected array, received string');
+      expectErrorAtPath(errors, 'versionPatterns.major');
     });
 
     it('returns an error when minor is not a string array', () => {
       const { errors } = validateConfig({
         versionPatterns: { major: ['!'], minor: 123 },
       });
-      expect(errors).toContain('versionPatterns.minor: Invalid input: expected array, received number');
+      expectErrorAtPath(errors, 'versionPatterns.minor');
     });
 
     it('returns an error and does not set config.versionPatterns when only major is valid', () => {
       const { config, errors } = validateConfig({
         versionPatterns: { major: ['!'], minor: 'invalid' },
       });
-      expect(errors).toContain('versionPatterns.minor: Invalid input: expected array, received string');
+      expectErrorAtPath(errors, 'versionPatterns.minor');
       expect(config.versionPatterns).toBeUndefined();
     });
 
@@ -444,7 +462,7 @@ describe(validateConfig, () => {
       const { config, errors } = validateConfig({
         versionPatterns: { major: 123, minor: ['feat'] },
       });
-      expect(errors).toContain('versionPatterns.major: Invalid input: expected array, received number');
+      expectErrorAtPath(errors, 'versionPatterns.major');
       expect(config.versionPatterns).toBeUndefined();
     });
   });
@@ -468,14 +486,14 @@ describe(validateConfig, () => {
 
     it('returns an error when workTypes is an array', () => {
       const { errors } = validateConfig({ workTypes: [] });
-      expect(errors).toContain('workTypes: Invalid input: expected record, received array');
+      expectErrorAtPath(errors, 'workTypes');
     });
 
     it('returns an error when header is missing', () => {
       const { errors } = validateConfig({
         workTypes: { perf: { aliases: ['performance'] } },
       });
-      expect(errors).toContain('workTypes.perf.header: Invalid input: expected string, received undefined');
+      expectErrorAtPath(errors, 'workTypes.perf.header');
     });
   });
 
@@ -488,7 +506,7 @@ describe(validateConfig, () => {
 
     it('returns an error when formatCommand is not a string', () => {
       const { errors } = validateConfig({ formatCommand: 123 });
-      expect(errors).toContain('formatCommand: Invalid input: expected string, received number');
+      expectErrorAtPath(errors, 'formatCommand');
     });
 
     it('validates cliffConfigPath as a string', () => {
@@ -505,7 +523,7 @@ describe(validateConfig, () => {
 
     it('returns an error when scopeAliases values are not strings', () => {
       const { errors } = validateConfig({ scopeAliases: { api: 123 } });
-      expect(errors).toContain('scopeAliases.api: Invalid input: expected string, received number');
+      expectErrorAtPath(errors, 'scopeAliases.api');
     });
   });
 
@@ -526,29 +544,25 @@ describe(validateConfig, () => {
 
     it('returns an error when breakingPolicies is not an object', () => {
       const { config, errors } = validateConfig({ breakingPolicies: 'invalid' });
-      expect(errors).toContain('breakingPolicies: Invalid input: expected record, received string');
+      expectErrorAtPath(errors, 'breakingPolicies');
       expect(config.breakingPolicies).toBeUndefined();
     });
 
     it('returns an error when breakingPolicies is an array', () => {
       const { config, errors } = validateConfig({ breakingPolicies: [] });
-      expect(errors).toContain('breakingPolicies: Invalid input: expected record, received array');
+      expectErrorAtPath(errors, 'breakingPolicies');
       expect(config.breakingPolicies).toBeUndefined();
     });
 
-    it('returns an error naming the valid values when a value is not a known policy literal', () => {
+    it('returns an error naming the offending field when a value is not a known policy literal', () => {
       const { config, errors } = validateConfig({ breakingPolicies: { feat: 'sometimes' } });
-      expect(errors).toContain(
-        'breakingPolicies.feat: Invalid option: expected one of "forbidden"|"optional"|"required"',
-      );
+      expectErrorAtPath(errors, 'breakingPolicies.feat');
       expect(config.breakingPolicies).toBeUndefined();
     });
 
     it('returns an error when a value is not a string', () => {
       const { config, errors } = validateConfig({ breakingPolicies: { feat: 123 } });
-      expect(errors).toContain(
-        'breakingPolicies.feat: Invalid option: expected one of "forbidden"|"optional"|"required"',
-      );
+      expectErrorAtPath(errors, 'breakingPolicies.feat');
       expect(config.breakingPolicies).toBeUndefined();
     });
 
@@ -556,9 +570,7 @@ describe(validateConfig, () => {
       const { config, errors } = validateConfig({
         breakingPolicies: { feat: 'forbidden', drop: 'maybe' },
       });
-      expect(errors).toContain(
-        'breakingPolicies.drop: Invalid option: expected one of "forbidden"|"optional"|"required"',
-      );
+      expectErrorAtPath(errors, 'breakingPolicies.drop');
       expect(config.breakingPolicies).toBeUndefined();
     });
   });
@@ -584,27 +596,27 @@ describe(validateConfig, () => {
 
     it('returns an error when changelogJson is not an object', () => {
       const { errors } = validateConfig({ changelogJson: 'invalid' });
-      expect(errors).toContain('changelogJson: Invalid input: expected object, received string');
+      expectErrorAtPath(errors, 'changelogJson');
     });
 
     it('returns an error when enabled is not a boolean', () => {
       const { errors } = validateConfig({ changelogJson: { enabled: 'yes' } });
-      expect(errors).toContain('changelogJson.enabled: Invalid input: expected boolean, received string');
+      expectErrorAtPath(errors, 'changelogJson.enabled');
     });
 
     it('returns an error when outputPath is not a string', () => {
       const { errors } = validateConfig({ changelogJson: { outputPath: 123 } });
-      expect(errors).toContain('changelogJson.outputPath: Invalid input: expected string, received number');
+      expectErrorAtPath(errors, 'changelogJson.outputPath');
     });
 
     it('returns an error when devOnlySections is not a string array', () => {
       const { errors } = validateConfig({ changelogJson: { devOnlySections: [1, 2] } });
-      expect(errors).toContain('changelogJson.devOnlySections[0]: Invalid input: expected string, received number');
+      expectErrorAtPath(errors, 'changelogJson.devOnlySections[0]');
     });
 
     it('returns an error for unknown changelogJson fields', () => {
       const { errors } = validateConfig({ changelogJson: { bogus: true } });
-      expect(errors).toContain('changelogJson: Unrecognized key: "bogus"');
+      expectErrorMentioning(errors, 'bogus');
     });
   });
 
@@ -621,12 +633,12 @@ describe(validateConfig, () => {
 
     it('returns an error when releaseNotes is not an object', () => {
       const { errors } = validateConfig({ releaseNotes: 'invalid' });
-      expect(errors).toContain('releaseNotes: Invalid input: expected object, received string');
+      expectErrorAtPath(errors, 'releaseNotes');
     });
 
     it('returns an error when shouldInjectIntoReadme is not a boolean', () => {
       const { errors } = validateConfig({ releaseNotes: { shouldInjectIntoReadme: 'yes' } });
-      expect(errors).toContain('releaseNotes.shouldInjectIntoReadme: Invalid input: expected boolean, received string');
+      expectErrorAtPath(errors, 'releaseNotes.shouldInjectIntoReadme');
     });
 
     it('returns a targeted migration error when shouldCreateGithubRelease is set', () => {
@@ -638,7 +650,7 @@ describe(validateConfig, () => {
 
     it('returns an error for unknown releaseNotes fields', () => {
       const { errors } = validateConfig({ releaseNotes: { unknownField: true } });
-      expect(errors).toContain('releaseNotes: Unrecognized key: "unknownField"');
+      expectErrorMentioning(errors, 'unknownField');
     });
   });
 
@@ -657,22 +669,22 @@ describe(validateConfig, () => {
 
     it('returns an error when project is not an object', () => {
       const { errors } = validateConfig({ project: 'v' });
-      expect(errors).toContain('project: Invalid input: expected object, received string');
+      expectErrorAtPath(errors, 'project');
     });
 
     it('returns an error when tagPrefix is not a string', () => {
       const { errors } = validateConfig({ project: { tagPrefix: 42 } });
-      expect(errors).toContain('project.tagPrefix: Invalid input: expected string, received number');
+      expectErrorAtPath(errors, 'project.tagPrefix');
     });
 
     it('returns an error when tagPrefix is an empty string', () => {
       const { errors } = validateConfig({ project: { tagPrefix: '' } });
-      expect(errors).toContain('project.tagPrefix: Too small: expected string to have >=1 characters');
+      expect(errors).toContain('project.tagPrefix: must be a non-empty string');
     });
 
     it('returns an error for unknown subfields', () => {
       const { errors } = validateConfig({ project: { tagPrefix: 'v', bogus: true } });
-      expect(errors).toContain('project: Unrecognized key: "bogus"');
+      expectErrorMentioning(errors, 'bogus');
     });
 
     it('omits project from the result when the field is not provided', () => {

--- a/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateConfig.unit.test.ts
@@ -15,7 +15,7 @@ describe(validateConfig, () => {
 
   it('returns an error for unknown fields', () => {
     const { errors } = validateConfig({ unknownField: true });
-    expect(errors).toContain("Unknown field: 'unknownField'");
+    expect(errors).toContain('Unrecognized key: "unknownField"');
   });
 
   describe('workspaces', () => {
@@ -29,19 +29,19 @@ describe(validateConfig, () => {
 
     it('returns an error when workspaces is not an array', () => {
       const { errors } = validateConfig({ workspaces: 'invalid' });
-      expect(errors).toContain("'workspaces' must be an array");
+      expect(errors).toContain('workspaces: Invalid input: expected array, received string');
     });
 
     it('returns an error when dir is missing', () => {
       const { errors } = validateConfig({ workspaces: [{ shouldExclude: true }] });
-      expect(errors).toContain("workspaces[0]: 'dir' is required");
+      expect(errors).toContain('workspaces[0].dir: Invalid input: expected string, received undefined');
     });
 
     it('returns an error when shouldExclude is not a boolean', () => {
       const { errors } = validateConfig({
         workspaces: [{ dir: 'arrays', shouldExclude: 'yes' }],
       });
-      expect(errors).toContain("workspaces[0]: 'shouldExclude' must be a boolean");
+      expect(errors).toContain('workspaces[0].shouldExclude: Invalid input: expected boolean, received string');
     });
 
     it('returns a deprecation error when tagPrefix is present', () => {
@@ -57,7 +57,7 @@ describe(validateConfig, () => {
       const { errors } = validateConfig({
         workspaces: [{ dir: 'arrays', bogusField: true }],
       });
-      expect(errors).toContain("workspaces[0]: unknown field 'bogusField'");
+      expect(errors).toContain('workspaces[0]: Unrecognized key: "bogusField"');
     });
 
     describe('legacyIdentities', () => {
@@ -100,49 +100,57 @@ describe(validateConfig, () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: 'core-v' }],
         });
-        expect(errors).toContain("workspaces[0]: 'legacyIdentities' must be an array");
+        expect(errors).toContain('workspaces[0].legacyIdentities: Invalid input: expected array, received string');
       });
 
       it('returns a per-index error when an entry is not an object', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: ['core-v'] }],
         });
-        expect(errors).toContain('workspaces[0].legacyIdentities[0]: must be an object');
+        expect(errors).toContain('workspaces[0].legacyIdentities[0]: Invalid input: expected object, received string');
       });
 
       it('returns a per-index error when name is missing', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: [{ tagPrefix: 'core-v' }] }],
         });
-        expect(errors).toContain('workspaces[0].legacyIdentities[0].name: must be a string');
+        expect(errors).toContain(
+          'workspaces[0].legacyIdentities[0].name: Invalid input: expected string, received undefined',
+        );
       });
 
       it('returns a per-index error when name is an empty string', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: [{ name: '', tagPrefix: 'core-v' }] }],
         });
-        expect(errors).toContain('workspaces[0].legacyIdentities[0].name: must be a non-empty string');
+        expect(errors).toContain(
+          'workspaces[0].legacyIdentities[0].name: Too small: expected string to have >=1 characters',
+        );
       });
 
       it('returns a per-index error when tagPrefix is missing', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@scope/core' }] }],
         });
-        expect(errors).toContain('workspaces[0].legacyIdentities[0].tagPrefix: must be a string');
+        expect(errors).toContain(
+          'workspaces[0].legacyIdentities[0].tagPrefix: Invalid input: expected string, received undefined',
+        );
       });
 
       it('returns a per-index error when tagPrefix is an empty string', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@scope/core', tagPrefix: '' }] }],
         });
-        expect(errors).toContain('workspaces[0].legacyIdentities[0].tagPrefix: must be a non-empty string');
+        expect(errors).toContain(
+          'workspaces[0].legacyIdentities[0].tagPrefix: Too small: expected string to have >=1 characters',
+        );
       });
 
       it('returns an error on unknown identity fields', () => {
         const { errors } = validateConfig({
           workspaces: [{ dir: 'core', legacyIdentities: [{ name: '@scope/core', tagPrefix: 'core-v', bogus: true }] }],
         });
-        expect(errors).toContain("workspaces[0].legacyIdentities[0]: unknown field 'bogus'");
+        expect(errors).toContain('workspaces[0].legacyIdentities[0]: Unrecognized key: "bogus"');
       });
 
       it('rejects full-tuple duplicates', () => {
@@ -205,7 +213,7 @@ describe(validateConfig, () => {
         ]);
       });
 
-      it('preserves valid entries when only some entries in a multi-entry array are invalid', () => {
+      it('rejects the entire workspaces array when any legacyIdentities entry is invalid', () => {
         const { config, errors } = validateConfig({
           workspaces: [
             {
@@ -218,11 +226,10 @@ describe(validateConfig, () => {
             },
           ],
         });
-        expect(errors).toContain('workspaces[0].legacyIdentities[1]: must be an object');
-        expect(config.workspaces?.[0]?.legacyIdentities).toStrictEqual([
-          { name: '@scope/core', tagPrefix: 'core-v' },
-          { name: '@other-scope/core', tagPrefix: 'other-core-v' },
-        ]);
+        expect(errors).toContain('workspaces[0].legacyIdentities[1]: Invalid input: expected object, received string');
+        // Schema validation is all-or-nothing per field: when any entry is invalid, the
+        // whole `workspaces` field fails parse and downstream consumers see no config at all.
+        expect(config.workspaces).toBeUndefined();
       });
 
       it('accepts tuples that would have collided under a space-separator dedup key', () => {
@@ -275,53 +282,53 @@ describe(validateConfig, () => {
 
     it('returns an error when retiredPackages is not an array', () => {
       const { errors } = validateConfig({ retiredPackages: 'preflight-v' });
-      expect(errors).toContain("'retiredPackages' must be an array");
+      expect(errors).toContain('retiredPackages: Invalid input: expected array, received string');
     });
 
     it('returns a per-index error when an entry is not an object', () => {
       const { errors } = validateConfig({ retiredPackages: ['preflight-v'] });
-      expect(errors).toContain('retiredPackages[0]: must be an object');
+      expect(errors).toContain('retiredPackages[0]: Invalid input: expected object, received string');
     });
 
     it('returns a per-index error when name is missing', () => {
       const { errors } = validateConfig({ retiredPackages: [{ tagPrefix: 'preflight-v' }] });
-      expect(errors).toContain('retiredPackages[0].name: must be a string');
+      expect(errors).toContain('retiredPackages[0].name: Invalid input: expected string, received undefined');
     });
 
     it('returns a per-index error when name is an empty string', () => {
       const { errors } = validateConfig({ retiredPackages: [{ name: '', tagPrefix: 'preflight-v' }] });
-      expect(errors).toContain('retiredPackages[0].name: must be a non-empty string');
+      expect(errors).toContain('retiredPackages[0].name: Too small: expected string to have >=1 characters');
     });
 
     it('returns a per-index error when tagPrefix is missing', () => {
       const { errors } = validateConfig({ retiredPackages: [{ name: '@scope/preflight' }] });
-      expect(errors).toContain('retiredPackages[0].tagPrefix: must be a string');
+      expect(errors).toContain('retiredPackages[0].tagPrefix: Invalid input: expected string, received undefined');
     });
 
     it('returns a per-index error when tagPrefix is an empty string', () => {
       const { errors } = validateConfig({ retiredPackages: [{ name: '@scope/preflight', tagPrefix: '' }] });
-      expect(errors).toContain('retiredPackages[0].tagPrefix: must be a non-empty string');
+      expect(errors).toContain('retiredPackages[0].tagPrefix: Too small: expected string to have >=1 characters');
     });
 
     it('returns a per-index error when successor is not a string', () => {
       const { errors } = validateConfig({
         retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', successor: 42 }],
       });
-      expect(errors).toContain('retiredPackages[0].successor: must be a string');
+      expect(errors).toContain('retiredPackages[0].successor: Invalid input: expected string, received number');
     });
 
     it('returns a per-index error when successor is an empty string', () => {
       const { errors } = validateConfig({
         retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', successor: '' }],
       });
-      expect(errors).toContain('retiredPackages[0].successor: must be a non-empty string');
+      expect(errors).toContain('retiredPackages[0].successor: Too small: expected string to have >=1 characters');
     });
 
     it('returns an error on unknown retired-package fields', () => {
       const { errors } = validateConfig({
         retiredPackages: [{ name: '@scope/preflight', tagPrefix: 'preflight-v', bogus: true }],
       });
-      expect(errors).toContain("retiredPackages[0]: unknown field 'bogus'");
+      expect(errors).toContain('retiredPackages[0]: Unrecognized key: "bogus"');
     });
 
     it('rejects full-tuple duplicates', () => {
@@ -360,9 +367,9 @@ describe(validateConfig, () => {
       expect(errors).toContain(
         "retiredPackages[0]: tagPrefix 'old-core-v' collides with a declared legacyIdentities[].tagPrefix on workspace 'core'",
       );
-      // The colliding entry is still written to `config.retiredPackages` — the returned config
-      // is not guaranteed to be internally consistent when `errors` is non-empty. Callers must
-      // check `errors` before trusting `config`.
+      // The colliding entry is still written to `config.retiredPackages` — the schema-level
+      // parse succeeds (the entry is structurally valid); the collision is a post-parse
+      // cross-field check that surfaces an error without rejecting the parsed config.
       expect(config.retiredPackages).toStrictEqual([{ name: '@scope/retired', tagPrefix: 'old-core-v' }]);
     });
 
@@ -384,12 +391,10 @@ describe(validateConfig, () => {
       expect(errors).toContain(
         "retiredPackages[0]: tagPrefix 'shared-v' collides with a declared legacyIdentities[].tagPrefix on workspace 'arrays'",
       );
-      // The colliding entry is still present in `config.retiredPackages` under the current
-      // contract (mirrors `validateWorkspaces` behavior).
       expect(config.retiredPackages).toStrictEqual([{ name: '@scope/retired', tagPrefix: 'shared-v' }]);
     });
 
-    it('preserves valid entries when only some entries in a multi-entry array are invalid', () => {
+    it('rejects the entire retiredPackages array when any entry is invalid', () => {
       const { config, errors } = validateConfig({
         retiredPackages: [
           { name: '@scope/preflight', tagPrefix: 'preflight-v' },
@@ -397,31 +402,10 @@ describe(validateConfig, () => {
           { name: '@scope/dead', tagPrefix: 'dead-v', successor: 'alive' },
         ],
       });
-      expect(errors).toContain('retiredPackages[1]: must be an object');
-      expect(config.retiredPackages).toStrictEqual([
-        { name: '@scope/preflight', tagPrefix: 'preflight-v' },
-        { name: '@scope/dead', tagPrefix: 'dead-v', successor: 'alive' },
-      ]);
-    });
-
-    it('reports the user-supplied index in the collision error when an earlier entry was rejected', () => {
-      const { errors } = validateConfig({
-        workspaces: [
-          {
-            dir: 'core',
-            legacyIdentities: [{ name: '@old-scope/core', tagPrefix: 'old-core-v' }],
-          },
-        ],
-        retiredPackages: [
-          // Structurally invalid: bare string, rejected during per-entry validation.
-          'not-an-object',
-          // Valid entry whose tagPrefix collides with the legacy identity above.
-          { name: '@scope/retired', tagPrefix: 'old-core-v' },
-        ],
-      });
-      expect(errors).toContain(
-        "retiredPackages[1]: tagPrefix 'old-core-v' collides with a declared legacyIdentities[].tagPrefix on workspace 'core'",
-      );
+      expect(errors).toContain('retiredPackages[1]: Invalid input: expected object, received string');
+      // Schema validation is all-or-nothing per field: when any entry is invalid, the
+      // whole `retiredPackages` field fails parse and downstream consumers see no config at all.
+      expect(config.retiredPackages).toBeUndefined();
     });
   });
 
@@ -438,21 +422,21 @@ describe(validateConfig, () => {
       const { errors } = validateConfig({
         versionPatterns: { major: 'invalid', minor: ['feat'] },
       });
-      expect(errors).toContain('versionPatterns.major: expected string array');
+      expect(errors).toContain('versionPatterns.major: Invalid input: expected array, received string');
     });
 
     it('returns an error when minor is not a string array', () => {
       const { errors } = validateConfig({
         versionPatterns: { major: ['!'], minor: 123 },
       });
-      expect(errors).toContain('versionPatterns.minor: expected string array');
+      expect(errors).toContain('versionPatterns.minor: Invalid input: expected array, received number');
     });
 
     it('returns an error and does not set config.versionPatterns when only major is valid', () => {
       const { config, errors } = validateConfig({
         versionPatterns: { major: ['!'], minor: 'invalid' },
       });
-      expect(errors).toContain('versionPatterns.minor: expected string array');
+      expect(errors).toContain('versionPatterns.minor: Invalid input: expected array, received string');
       expect(config.versionPatterns).toBeUndefined();
     });
 
@@ -460,7 +444,7 @@ describe(validateConfig, () => {
       const { config, errors } = validateConfig({
         versionPatterns: { major: 123, minor: ['feat'] },
       });
-      expect(errors).toContain('versionPatterns.major: expected string array');
+      expect(errors).toContain('versionPatterns.major: Invalid input: expected array, received number');
       expect(config.versionPatterns).toBeUndefined();
     });
   });
@@ -484,14 +468,14 @@ describe(validateConfig, () => {
 
     it('returns an error when workTypes is an array', () => {
       const { errors } = validateConfig({ workTypes: [] });
-      expect(errors).toContain("'workTypes' must be a record (object)");
+      expect(errors).toContain('workTypes: Invalid input: expected record, received array');
     });
 
     it('returns an error when header is missing', () => {
       const { errors } = validateConfig({
         workTypes: { perf: { aliases: ['performance'] } },
       });
-      expect(errors).toContain("workTypes.perf: 'header' is required and must be a string");
+      expect(errors).toContain('workTypes.perf.header: Invalid input: expected string, received undefined');
     });
   });
 
@@ -504,7 +488,7 @@ describe(validateConfig, () => {
 
     it('returns an error when formatCommand is not a string', () => {
       const { errors } = validateConfig({ formatCommand: 123 });
-      expect(errors).toContain("'formatCommand' must be a string");
+      expect(errors).toContain('formatCommand: Invalid input: expected string, received number');
     });
 
     it('validates cliffConfigPath as a string', () => {
@@ -521,7 +505,61 @@ describe(validateConfig, () => {
 
     it('returns an error when scopeAliases values are not strings', () => {
       const { errors } = validateConfig({ scopeAliases: { api: 123 } });
-      expect(errors).toContain('scopeAliases.api: value must be a string');
+      expect(errors).toContain('scopeAliases.api: Invalid input: expected string, received number');
+    });
+  });
+
+  describe('breakingPolicies', () => {
+    it('accepts a record covering all three policy literals', () => {
+      const { config, errors } = validateConfig({
+        breakingPolicies: { feat: 'forbidden', drop: 'required', fix: 'optional' },
+      });
+      expect(errors).toStrictEqual([]);
+      expect(config.breakingPolicies).toStrictEqual({ feat: 'forbidden', drop: 'required', fix: 'optional' });
+    });
+
+    it('accepts an empty object as the documented opt-out', () => {
+      const { config, errors } = validateConfig({ breakingPolicies: {} });
+      expect(errors).toStrictEqual([]);
+      expect(config.breakingPolicies).toStrictEqual({});
+    });
+
+    it('returns an error when breakingPolicies is not an object', () => {
+      const { config, errors } = validateConfig({ breakingPolicies: 'invalid' });
+      expect(errors).toContain('breakingPolicies: Invalid input: expected record, received string');
+      expect(config.breakingPolicies).toBeUndefined();
+    });
+
+    it('returns an error when breakingPolicies is an array', () => {
+      const { config, errors } = validateConfig({ breakingPolicies: [] });
+      expect(errors).toContain('breakingPolicies: Invalid input: expected record, received array');
+      expect(config.breakingPolicies).toBeUndefined();
+    });
+
+    it('returns an error naming the valid values when a value is not a known policy literal', () => {
+      const { config, errors } = validateConfig({ breakingPolicies: { feat: 'sometimes' } });
+      expect(errors).toContain(
+        'breakingPolicies.feat: Invalid option: expected one of "forbidden"|"optional"|"required"',
+      );
+      expect(config.breakingPolicies).toBeUndefined();
+    });
+
+    it('returns an error when a value is not a string', () => {
+      const { config, errors } = validateConfig({ breakingPolicies: { feat: 123 } });
+      expect(errors).toContain(
+        'breakingPolicies.feat: Invalid option: expected one of "forbidden"|"optional"|"required"',
+      );
+      expect(config.breakingPolicies).toBeUndefined();
+    });
+
+    it('rejects the entire map when any entry is invalid', () => {
+      const { config, errors } = validateConfig({
+        breakingPolicies: { feat: 'forbidden', drop: 'maybe' },
+      });
+      expect(errors).toContain(
+        'breakingPolicies.drop: Invalid option: expected one of "forbidden"|"optional"|"required"',
+      );
+      expect(config.breakingPolicies).toBeUndefined();
     });
   });
 
@@ -546,27 +584,27 @@ describe(validateConfig, () => {
 
     it('returns an error when changelogJson is not an object', () => {
       const { errors } = validateConfig({ changelogJson: 'invalid' });
-      expect(errors).toContain("'changelogJson' must be an object");
+      expect(errors).toContain('changelogJson: Invalid input: expected object, received string');
     });
 
     it('returns an error when enabled is not a boolean', () => {
       const { errors } = validateConfig({ changelogJson: { enabled: 'yes' } });
-      expect(errors).toContain('changelogJson.enabled: must be a boolean');
+      expect(errors).toContain('changelogJson.enabled: Invalid input: expected boolean, received string');
     });
 
     it('returns an error when outputPath is not a string', () => {
       const { errors } = validateConfig({ changelogJson: { outputPath: 123 } });
-      expect(errors).toContain('changelogJson.outputPath: must be a string');
+      expect(errors).toContain('changelogJson.outputPath: Invalid input: expected string, received number');
     });
 
     it('returns an error when devOnlySections is not a string array', () => {
       const { errors } = validateConfig({ changelogJson: { devOnlySections: [1, 2] } });
-      expect(errors).toContain('changelogJson.devOnlySections: must be a string array');
+      expect(errors).toContain('changelogJson.devOnlySections[0]: Invalid input: expected string, received number');
     });
 
     it('returns an error for unknown changelogJson fields', () => {
       const { errors } = validateConfig({ changelogJson: { bogus: true } });
-      expect(errors).toContain("changelogJson: unknown field 'bogus'");
+      expect(errors).toContain('changelogJson: Unrecognized key: "bogus"');
     });
   });
 
@@ -583,12 +621,12 @@ describe(validateConfig, () => {
 
     it('returns an error when releaseNotes is not an object', () => {
       const { errors } = validateConfig({ releaseNotes: 'invalid' });
-      expect(errors).toContain("'releaseNotes' must be an object");
+      expect(errors).toContain('releaseNotes: Invalid input: expected object, received string');
     });
 
     it('returns an error when shouldInjectIntoReadme is not a boolean', () => {
       const { errors } = validateConfig({ releaseNotes: { shouldInjectIntoReadme: 'yes' } });
-      expect(errors).toContain('releaseNotes.shouldInjectIntoReadme: must be a boolean');
+      expect(errors).toContain('releaseNotes.shouldInjectIntoReadme: Invalid input: expected boolean, received string');
     });
 
     it('returns a targeted migration error when shouldCreateGithubRelease is set', () => {
@@ -600,7 +638,7 @@ describe(validateConfig, () => {
 
     it('returns an error for unknown releaseNotes fields', () => {
       const { errors } = validateConfig({ releaseNotes: { unknownField: true } });
-      expect(errors).toContain("releaseNotes: unknown field 'unknownField'");
+      expect(errors).toContain('releaseNotes: Unrecognized key: "unknownField"');
     });
   });
 
@@ -619,22 +657,22 @@ describe(validateConfig, () => {
 
     it('returns an error when project is not an object', () => {
       const { errors } = validateConfig({ project: 'v' });
-      expect(errors).toContain("'project' must be an object");
+      expect(errors).toContain('project: Invalid input: expected object, received string');
     });
 
     it('returns an error when tagPrefix is not a string', () => {
       const { errors } = validateConfig({ project: { tagPrefix: 42 } });
-      expect(errors).toContain('project.tagPrefix: must be a string');
+      expect(errors).toContain('project.tagPrefix: Invalid input: expected string, received number');
     });
 
     it('returns an error when tagPrefix is an empty string', () => {
       const { errors } = validateConfig({ project: { tagPrefix: '' } });
-      expect(errors).toContain('project.tagPrefix: must be a non-empty string');
+      expect(errors).toContain('project.tagPrefix: Too small: expected string to have >=1 characters');
     });
 
     it('returns an error for unknown subfields', () => {
       const { errors } = validateConfig({ project: { tagPrefix: 'v', bogus: true } });
-      expect(errors).toContain("project: unknown field 'bogus'");
+      expect(errors).toContain('project: Unrecognized key: "bogus"');
     });
 
     it('omits project from the result when the field is not provided', () => {

--- a/packages/release-kit/src/loadConfig.ts
+++ b/packages/release-kit/src/loadConfig.ts
@@ -265,12 +265,12 @@ export function mergeSinglePackageConfig(userConfig: ReleaseKitConfig | undefine
  *
  * Preserves the declaration order of defaults; net-new consumer keys append at the end.
  */
-export function resolveWorkTypes(userWorkTypes?: Record<string, WorkTypeConfig>): Record<string, WorkTypeConfig> {
+export function resolveWorkTypes(userWorkTypes?: ReleaseKitConfig['workTypes']): Record<string, WorkTypeConfig> {
   return userWorkTypes === undefined ? { ...DEFAULT_WORK_TYPES } : { ...DEFAULT_WORK_TYPES, ...userWorkTypes };
 }
 
 /** Merge user-provided changelog JSON config with defaults. */
-function mergeChangelogJsonConfig(partial: Partial<ChangelogJsonConfig> | undefined): ChangelogJsonConfig {
+function mergeChangelogJsonConfig(partial: ReleaseKitConfig['changelogJson']): ChangelogJsonConfig {
   if (partial === undefined) {
     return { ...DEFAULT_CHANGELOG_JSON_CONFIG };
   }
@@ -346,7 +346,7 @@ function assertRetiredPackagesDoNotCollideWithActive(
  * function is a pure transformation and never touches the filesystem.
  */
 function resolveProjectConfig(
-  userProject: { tagPrefix?: string } | undefined,
+  userProject: ReleaseKitConfig['project'],
   rootPackage: RootPackageInfo | undefined,
 ): ResolvedProjectConfig | undefined {
   if (userProject === undefined) {
@@ -471,7 +471,7 @@ function assertUniqueTagPrefixes(workspaces: readonly WorkspaceConfig[]): void {
 }
 
 /** Merge user-provided release notes config with defaults. */
-function mergeReleaseNotesConfig(partial: Partial<ReleaseNotesConfig> | undefined): ReleaseNotesConfig {
+function mergeReleaseNotesConfig(partial: ReleaseKitConfig['releaseNotes']): ReleaseNotesConfig {
   if (partial === undefined) {
     return { ...DEFAULT_RELEASE_NOTES_CONFIG };
   }

--- a/packages/release-kit/src/resolveReleaseNotesConfig.ts
+++ b/packages/release-kit/src/resolveReleaseNotesConfig.ts
@@ -66,7 +66,10 @@ export async function resolveReleaseNotesConfig(
   }
 
   return {
-    releaseNotes: { ...DEFAULT_RELEASE_NOTES_CONFIG, ...config.releaseNotes },
+    releaseNotes: {
+      shouldInjectIntoReadme:
+        config.releaseNotes?.shouldInjectIntoReadme ?? DEFAULT_RELEASE_NOTES_CONFIG.shouldInjectIntoReadme,
+    },
     changelogJsonOutputPath: config.changelogJson?.outputPath ?? DEFAULT_CHANGELOG_JSON_CONFIG.outputPath,
     sectionOrder: deriveSectionOrder(resolveWorkTypes(config.workTypes)),
   };

--- a/packages/release-kit/src/types.ts
+++ b/packages/release-kit/src/types.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 /** Semver release type for version bumping. */
 export type ReleaseType = 'major' | 'minor' | 'patch';
 
@@ -77,18 +79,6 @@ export type ChangelogOverridesFile = Record<string, ChangelogOverride>;
 /** Configuration for release notes consumption (README injection). */
 export interface ReleaseNotesConfig {
   shouldInjectIntoReadme: boolean;
-}
-
-/**
- * Consumer-facing project-release config (`project` block in `release-kit.config.ts`).
- *
- * Declaring an empty `project: {}` opts the repo into project-level releases. All fields
- * are optional; defaults are applied during config merging. The set of contributing
- * workspaces is implicit — every non-excluded discovered workspace contributes.
- */
-export interface ProjectConfig {
-  /** Tag prefix for project-level tags (e.g., `'v'` produces `'v1.2.0'`). Defaults to `'v'`. */
-  tagPrefix?: string;
 }
 
 /**
@@ -307,7 +297,7 @@ export interface WorkTypeConfig {
   /** Human-readable label for the section heading in changelogs. */
   header: string;
   /** Optional aliases that map to this work type (e.g., 'feature' -> 'feat'). */
-  aliases?: string[];
+  aliases?: string[] | undefined;
 }
 
 /**
@@ -322,116 +312,134 @@ export interface VersionPatterns {
   minor: string[];
 }
 
+// region | Schemas for consumer-facing config file
+//
+// Defined in zod so the runtime validator and the static type stay in lockstep — adding a
+// field to the schema flows through `z.infer` automatically; nothing can drift. Schemas
+// describe the *input* shape (fields optional, no defaults). Resolved/post-merge shapes
+// (`ChangelogJsonConfig`, `ReleaseNotesConfig`, `WorkspaceConfig`, etc.) stay as
+// hand-written interfaces because they are produced by `mergeMonorepoConfig` after defaults
+// are applied — they have nothing to validate.
+
+/**
+ * Schema for a single historical identity snapshot for a workspace.
+ *
+ * Captures what the package looked like at some earlier point: the full npm `name`
+ * (e.g., `'@williamthorsen/nmr-core'`) and the `tagPrefix` under which tags were
+ * published (e.g., `'core-v'`).
+ */
+export const legacyIdentitySchema = z
+  .object({
+    name: z.string().min(1),
+    tagPrefix: z.string().min(1),
+  })
+  .strict();
+
+/**
+ * A single historical identity snapshot for a workspace. Both fields are required — a full
+ * tuple stays unambiguous across any number of future renames.
+ */
+export type LegacyIdentity = z.infer<typeof legacyIdentitySchema>;
+
+/**
+ * Schema for a package that once lived in this repo but has since been extracted or removed.
+ *
+ * Unlike `legacyIdentitySchema`, retired packages are never consulted for baseline lookup
+ * or changelog attribution — they acknowledge historical tag prefixes and suppress
+ * undeclared-candidate warnings.
+ */
+export const retiredPackageSchema = z
+  .object({
+    name: z.string().min(1),
+    tagPrefix: z.string().min(1),
+    successor: z.string().min(1).optional(),
+  })
+  .strict();
+
+/** A package that once lived in this repo but has since been extracted or removed. */
+export type RetiredPackage = z.infer<typeof retiredPackageSchema>;
+
+/** Schema for a single workspace override entry in the config file. */
+export const workspaceOverrideSchema = z
+  .object({
+    dir: z.string().min(1),
+    shouldExclude: z.boolean().optional(),
+    legacyIdentities: z.array(legacyIdentitySchema).optional(),
+  })
+  .strict();
+
+/** Override for a single workspace in the config file. Matches a discovered workspace by `dir`. */
+export type WorkspaceOverride = z.infer<typeof workspaceOverrideSchema>;
+
+/** Schema for the optional `project` block. */
+export const projectConfigSchema = z
+  .object({
+    tagPrefix: z.string().min(1).optional(),
+  })
+  .strict();
+
+/** Consumer-facing project-release config (`project` block). Empty object opts in to project releases. */
+export type ProjectConfig = z.infer<typeof projectConfigSchema>;
+
+/** Schema for the optional `changelogJson` block (input shape, all fields optional). */
+export const changelogJsonInputSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    outputPath: z.string().optional(),
+    devOnlySections: z.array(z.string()).optional(),
+  })
+  .strict();
+
+/** Schema for the optional `releaseNotes` block (input shape, all fields optional). */
+export const releaseNotesInputSchema = z
+  .object({
+    shouldInjectIntoReadme: z.boolean().optional(),
+  })
+  .strict();
+
+/** Schema for a single `workTypes` entry. */
+export const workTypeConfigSchema = z
+  .object({
+    header: z.string(),
+    aliases: z.array(z.string()).optional(),
+  })
+  .strict();
+
+/** Schema for the `versionPatterns` block. Both arrays are required when the field is provided. */
+export const versionPatternsSchema = z
+  .object({
+    major: z.array(z.string()),
+    minor: z.array(z.string()),
+  })
+  .strict();
+
+/** Schema for a single `breakingPolicies` value. */
+export const breakingPolicyValueSchema = z.enum(['forbidden', 'optional', 'required']);
+
+/** Schema for the consumer-facing config file shape (`.config/release-kit.config.ts`). */
+export const releaseKitConfigSchema = z
+  .object({
+    breakingPolicies: z.record(z.string(), breakingPolicyValueSchema).optional(),
+    changelogJson: changelogJsonInputSchema.optional(),
+    cliffConfigPath: z.string().min(1).optional(),
+    formatCommand: z.string().min(1).optional(),
+    project: projectConfigSchema.optional(),
+    releaseNotes: releaseNotesInputSchema.optional(),
+    retiredPackages: z.array(retiredPackageSchema).optional(),
+    scopeAliases: z.record(z.string(), z.string()).optional(),
+    versionPatterns: versionPatternsSchema.optional(),
+    workspaces: z.array(workspaceOverrideSchema).optional(),
+    workTypes: z.record(z.string(), workTypeConfigSchema).optional(),
+  })
+  .strict();
+
 /**
  * Consumer-facing config file shape (`.config/release-kit.config.ts`).
  * All fields are optional; defaults are applied during config merging.
  */
-export interface ReleaseKitConfig {
-  /**
-   * Workspace overrides. Each entry matches a discovered workspace by `dir`.
-   * Use `shouldExclude: true` to remove a workspace from release processing.
-   */
-  workspaces?: WorkspaceOverride[];
-  /** Version bump patterns. Replaces defaults entirely when provided. */
-  versionPatterns?: VersionPatterns;
-  /** Work type overrides. Merged with defaults by key. */
-  workTypes?: Record<string, WorkTypeConfig>;
-  /**
-   * Per-canonical-type breaking-policy lookup driving release-time `!`-policy enforcement.
-   *
-   * When omitted, release-prepare flows apply `DEFAULT_BREAKING_POLICIES`. When provided, the
-   * map replaces the default entirely (no merge). To disable enforcement, pass `{}` — the
-   * parser falls back to `'optional'` for any type missing from the map. Individual entries
-   * can be overridden (e.g., make `feat` `'forbidden'` for a stricter dialect).
-   */
-  breakingPolicies?: Record<string, 'forbidden' | 'optional' | 'required'>;
-  /**
-   * Shell command to run after all changelogs are generated (e.g., 'pnpm run fmt').
-   * Modified file paths (package.json files and CHANGELOGs) are appended as space-separated
-   * arguments. Paths are repo-relative; file paths containing spaces are not supported.
-   */
-  formatCommand?: string;
-  /** Path to the cliff.toml file; defaults to 'cliff.toml' when absent. */
-  cliffConfigPath?: string;
-  /**
-   * Maps scope shorthand names to their canonical names.
-   * When a commit uses `shorthand|type: description` or `type(shorthand): description`,
-   * the shorthand is resolved to the canonical scope name before the parsed commit is returned.
-   */
-  scopeAliases?: Record<string, string>;
-  /** Controls structured changelog JSON generation. */
-  changelogJson?: Partial<ChangelogJsonConfig>;
-  /** Controls release notes consumption (README injection). */
-  releaseNotes?: Partial<ReleaseNotesConfig>;
-  /**
-   * Packages that once lived in this repo but have since been extracted or removed.
-   *
-   * Complements the per-workspace `workspaces[].legacyIdentities` field. Use
-   * `legacyIdentities` when the workspace still exists under a new identity; use
-   * `retiredPackages` when no workspace for this package exists in this repo anymore.
-   * Retired packages are never consulted for baseline lookup or changelog attribution —
-   * their declared `tagPrefix` values are treated as known so `show-tag-prefixes` does
-   * not flag them as undeclared candidates.
-   */
-  retiredPackages?: RetiredPackage[];
-  /**
-   * Project-level release block. Declaring `project: {}` (even empty) opts the repo into
-   * project-level releases: each `prepare` run additionally bumps the root `package.json`,
-   * regenerates the root `CHANGELOG.md`, and emits a project tag. Contributing workspaces
-   * are implicitly all non-excluded discovered workspaces. Single-package mode does not
-   * support this block.
-   */
-  project?: ProjectConfig;
-}
+export type ReleaseKitConfig = z.infer<typeof releaseKitConfigSchema>;
 
-/**
- * A single historical identity snapshot for a workspace.
- *
- * Captures what the package looked like at some earlier point: the full npm `name`
- * (e.g., `'@williamthorsen/nmr-core'`) and the `tagPrefix` under which tags
- * were published (e.g., `'core-v'`). Both fields are required — a full tuple stays
- * unambiguous across any number of future renames.
- */
-export interface LegacyIdentity {
-  /** Full scoped npm name as it appeared at the time (e.g., `'@scope/pkg'`). */
-  name: string;
-  /** Tag prefix under which the workspace's historical tags were published (e.g., `'core-v'`). */
-  tagPrefix: string;
-}
-
-/**
- * A package that once lived in this repo but has since been extracted or removed.
- *
- * Unlike `LegacyIdentity`, retired packages are never consulted for baseline lookup or
- * changelog attribution — they exist purely to acknowledge historical tag prefixes and
- * suppress undeclared-candidate warnings. Use `legacyIdentities` when the workspace
- * still exists under a new identity; use `retiredPackages` when no workspace for this
- * package exists anymore.
- */
-export interface RetiredPackage {
-  /** The package's final npm name while it lived in this repo. */
-  name: string;
-  /** The tag prefix under which the package's tags were published (e.g., `'preflight-v'`). */
-  tagPrefix: string;
-  /** Optional successor package name, for packages that were renamed/extracted rather than deleted. */
-  successor?: string;
-}
-
-/** Override for a single workspace in the config file. */
-export interface WorkspaceOverride {
-  /** The package directory name (e.g., 'arrays'). */
-  dir: string;
-  /** If true, exclude this workspace from release processing. */
-  shouldExclude?: boolean;
-  /**
-   * Prior identities of this workspace, used to recognize historical tags across renames.
-   * Each entry is a complete `(name, tagPrefix)` snapshot. The union of the current `tagPrefix`
-   * and each identity's `tagPrefix` is consulted when release-kit searches for the most recent
-   * baseline tag and when generating changelogs. Declaring identities allows release-kit to
-   * recognize legacy tags without any tag mutation.
-   */
-  legacyIdentities?: LegacyIdentity[];
-}
+// endregion | Schemas for consumer-facing config file
 
 /** A raw commit from the git log. */
 export interface Commit {

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -7,12 +7,15 @@ import { releaseKitConfigSchema } from './types.ts';
 /**
  * Validate a raw config object loaded from `.config/release-kit.config.ts`.
  *
- * The schema (`releaseKitConfigSchema` in `types.ts`) is the single source of truth for
- * both the `ReleaseKitConfig` type (via `z.infer`) and the runtime shape check, so the
- * type and the validator cannot drift. Schema-driven shape validation runs after a
- * preprocessing pass that surfaces actionable migration messages for known-removed keys
- * and after schema parse runs cross-field checks (full-tuple duplicates, retired-vs-legacy
- * collisions) that benefit from the schema's already-typed result.
+ * Single source of truth: `releaseKitConfigSchema` in `types.ts`, with
+ * `ReleaseKitConfig = z.infer<typeof releaseKitConfigSchema>`. Adding a field to the type
+ * without updating the schema is impossible because the type *is* derived from the
+ * schema.
+ *
+ * Pipeline: (1) preprocess strips deprecated keys and emits migration-guidance errors;
+ * (2) `releaseKitConfigSchema.safeParse` does shape validation; (3) post-parse cross-field
+ * checks (full-tuple duplicates, retired-vs-legacy collisions) operate on the typed
+ * result.
  */
 export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors: string[]; warnings: string[] } {
   if (!isRecord(raw)) {
@@ -54,6 +57,9 @@ export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors
  * generic "Unrecognized key" message — losing the per-key migration instructions that
  * existing consumers rely on. This pass owns those messages and removes the keys from
  * the input so the schema parse only sees fields it recognizes.
+ *
+ * Contract: every removed/renamed config key must be handled here, not via Zod's
+ * generic Unrecognized-key path. Future deprecations should add a branch below.
  */
 function preprocessDeprecatedKeys(raw: unknown): { cleaned: unknown; deprecationErrors: string[] } {
   if (!isRecord(raw)) return { cleaned: raw, deprecationErrors: [] };
@@ -94,14 +100,24 @@ function preprocessDeprecatedKeys(raw: unknown): { cleaned: unknown; deprecation
 
 /**
  * Format a Zod issue as a single-line error string using the project's existing path
- * convention (`object.key`, `array[index]`). Top-level issues without a path render with
- * the leading bare key (e.g. `'foo' must be an object`) for issues whose `path` resolves
- * to a single top-level key, matching the prior hand-rolled message shape.
+ * convention (`object.key`, `array[index]`). Top-level issues without a path render bare.
+ *
+ * The message body is Zod's default with one targeted exception: `too_small` on strings
+ * is rephrased as "must be a non-empty string" because Zod's "Too small: expected string
+ * to have >=N characters" reads as a numeric-bound error in CLI output.
  */
 function formatZodIssue(issue: z.core.$ZodIssue): string {
   const path = renderPath(issue.path);
-  if (path === '') return issue.message;
-  return `${path}: ${issue.message}`;
+  const message = customizeMessage(issue);
+  return path === '' ? message : `${path}: ${message}`;
+}
+
+/** Apply targeted message customizations to Zod's defaults. */
+function customizeMessage(issue: z.core.$ZodIssue): string {
+  if (issue.code === 'too_small' && issue.origin === 'string') {
+    return 'must be a non-empty string';
+  }
+  return issue.message;
 }
 
 /** Render a Zod path as `top.nested[2].leaf`. */

--- a/packages/release-kit/src/validateConfig.ts
+++ b/packages/release-kit/src/validateConfig.ts
@@ -1,51 +1,40 @@
+import type { z } from 'zod';
+
 import { isRecord } from './typeGuards.ts';
-import type { LegacyIdentity, ProjectConfig, ReleaseKitConfig, RetiredPackage } from './types.ts';
+import type { ReleaseKitConfig } from './types.ts';
+import { releaseKitConfigSchema } from './types.ts';
 
 /**
- * Validates a raw config object loaded from `.config/release-kit.config.ts`.
+ * Validate a raw config object loaded from `.config/release-kit.config.ts`.
  *
- * Returns an array of validation error messages. An empty array means the config is valid.
- * Uses hand-coded type guards rather than a schema library.
+ * The schema (`releaseKitConfigSchema` in `types.ts`) is the single source of truth for
+ * both the `ReleaseKitConfig` type (via `z.infer`) and the runtime shape check, so the
+ * type and the validator cannot drift. Schema-driven shape validation runs after a
+ * preprocessing pass that surfaces actionable migration messages for known-removed keys
+ * and after schema parse runs cross-field checks (full-tuple duplicates, retired-vs-legacy
+ * collisions) that benefit from the schema's already-typed result.
  */
 export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors: string[]; warnings: string[] } {
-  const errors: string[] = [];
-
   if (!isRecord(raw)) {
     return { config: {}, errors: ['Config must be an object'], warnings: [] };
   }
 
-  const config: ReleaseKitConfig = {};
+  const { cleaned, deprecationErrors } = preprocessDeprecatedKeys(raw);
 
-  // Detect unknown fields
-  const knownFields = new Set([
-    'changelogJson',
-    'cliffConfigPath',
-    'formatCommand',
-    'project',
-    'releaseNotes',
-    'retiredPackages',
-    'scopeAliases',
-    'versionPatterns',
-    'workspaces',
-    'workTypes',
-  ]);
-
-  for (const key of Object.keys(raw)) {
-    if (!knownFields.has(key)) {
-      errors.push(`Unknown field: '${key}'`);
-    }
+  const parseResult = releaseKitConfigSchema.safeParse(cleaned);
+  if (!parseResult.success) {
+    return {
+      config: {},
+      errors: [...deprecationErrors, ...parseResult.error.issues.map(formatZodIssue)],
+      warnings: [],
+    };
   }
 
-  validateChangelogJson(raw.changelogJson, config, errors);
-  validateWorkspaces(raw.workspaces, config, errors);
-  validateReleaseNotes(raw.releaseNotes, config, errors);
-  validateVersionPatterns(raw.versionPatterns, config, errors);
-  validateWorkTypes(raw.workTypes, config, errors);
-  validateStringField('formatCommand', raw.formatCommand, config, errors);
-  validateStringField('cliffConfigPath', raw.cliffConfigPath, config, errors);
-  validateScopeAliases(raw.scopeAliases, config, errors);
-  validateRetiredPackages(raw.retiredPackages, config, errors);
-  validateProjectConfig(raw.project, config, errors);
+  const config = parseResult.data;
+  const errors = [...deprecationErrors];
+  detectLegacyIdentityDuplicates(config, errors);
+  detectRetiredPackageDuplicates(config, errors);
+  detectRetiredVsLegacyCollisions(config, errors);
 
   // Cross-field warnings: releaseNotes features require changelogJson to be enabled.
   const warnings: string[] = [];
@@ -59,358 +48,130 @@ export function validateConfig(raw: unknown): { config: ReleaseKitConfig; errors
   return { config, errors, warnings };
 }
 
-function validateChangelogJson(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
-  if (value === undefined) return;
-
-  if (!isRecord(value)) {
-    errors.push("'changelogJson' must be an object");
-    return;
-  }
-
-  const knownChangelogJsonFields = new Set(['enabled', 'outputPath', 'devOnlySections']);
-  for (const key of Object.keys(value)) {
-    if (!knownChangelogJsonFields.has(key)) {
-      errors.push(`changelogJson: unknown field '${key}'`);
-    }
-  }
-
-  const result: NonNullable<ReleaseKitConfig['changelogJson']> = {};
-
-  if (value.enabled !== undefined) {
-    if (typeof value.enabled === 'boolean') {
-      result.enabled = value.enabled;
-    } else {
-      errors.push('changelogJson.enabled: must be a boolean');
-    }
-  }
-
-  if (value.outputPath !== undefined) {
-    if (typeof value.outputPath === 'string') {
-      result.outputPath = value.outputPath;
-    } else {
-      errors.push('changelogJson.outputPath: must be a string');
-    }
-  }
-
-  if (value.devOnlySections !== undefined) {
-    if (isStringArray(value.devOnlySections)) {
-      result.devOnlySections = value.devOnlySections;
-    } else {
-      errors.push('changelogJson.devOnlySections: must be a string array');
-    }
-  }
-
-  config.changelogJson = result;
-}
-
 /**
- * Validate the optional `project` config block.
- *
- * Accepts an empty object (`{}`) as a valid opt-in marker. Rejects unknown subfields and
- * non-string `tagPrefix`. Tag-prefix collision validation lives in `loadConfig` since it
- * requires the discovered workspace list.
+ * Strip removed/deprecated config keys and emit migration-guidance errors. The schema
+ * uses `.strict()` everywhere, so unknown keys would otherwise be reported with Zod's
+ * generic "Unrecognized key" message — losing the per-key migration instructions that
+ * existing consumers rely on. This pass owns those messages and removes the keys from
+ * the input so the schema parse only sees fields it recognizes.
  */
-function validateProjectConfig(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
-  if (value === undefined) return;
+function preprocessDeprecatedKeys(raw: unknown): { cleaned: unknown; deprecationErrors: string[] } {
+  if (!isRecord(raw)) return { cleaned: raw, deprecationErrors: [] };
 
-  if (!isRecord(value)) {
-    errors.push("'project' must be an object");
-    return;
+  const errors: string[] = [];
+  const cleaned: Record<string, unknown> = { ...raw };
+
+  if (isRecord(cleaned.releaseNotes) && 'shouldCreateGithubRelease' in cleaned.releaseNotes) {
+    errors.push(
+      'releaseNotes.shouldCreateGithubRelease is no longer supported. Adoption is now signaled by installing the create-github-release workflow. Remove this field from your config; see README for the updated workflow.',
+    );
+    const releaseNotesCopy = { ...cleaned.releaseNotes };
+    delete releaseNotesCopy.shouldCreateGithubRelease;
+    cleaned.releaseNotes = releaseNotesCopy;
   }
 
-  const knownProjectFields = new Set(['tagPrefix']);
-  for (const key of Object.keys(value)) {
-    if (!knownProjectFields.has(key)) {
-      errors.push(`project: unknown field '${key}'`);
-    }
-  }
-
-  const result: ProjectConfig = {};
-
-  if (value.tagPrefix !== undefined) {
-    if (typeof value.tagPrefix !== 'string') {
-      errors.push('project.tagPrefix: must be a string');
-    } else if (value.tagPrefix === '') {
-      errors.push('project.tagPrefix: must be a non-empty string');
-    } else {
-      result.tagPrefix = value.tagPrefix;
-    }
-  }
-
-  config.project = result;
-}
-
-function validateReleaseNotes(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
-  if (value === undefined) return;
-
-  if (!isRecord(value)) {
-    errors.push("'releaseNotes' must be an object");
-    return;
-  }
-
-  const knownReleaseNotesFields = new Set(['shouldInjectIntoReadme']);
-  for (const key of Object.keys(value)) {
-    if (!knownReleaseNotesFields.has(key)) {
-      if (key === 'shouldCreateGithubRelease') {
+  if (Array.isArray(cleaned.workspaces)) {
+    cleaned.workspaces = cleaned.workspaces.map((ws: unknown, i: number): unknown => {
+      if (!isRecord(ws)) return ws;
+      const wsCopy = { ...ws };
+      if ('tagPrefix' in wsCopy) {
+        const dir = typeof wsCopy.dir === 'string' && wsCopy.dir !== '' ? wsCopy.dir : '<dir>';
+        errors.push(`workspaces[${i}]: 'tagPrefix' is no longer supported; remove it to use the default '${dir}-v'`);
+        delete wsCopy.tagPrefix;
+      }
+      if ('legacyTagPrefixes' in wsCopy) {
         errors.push(
-          'releaseNotes.shouldCreateGithubRelease is no longer supported. Adoption is now signaled by installing the create-github-release workflow. Remove this field from your config; see README for the updated workflow.',
+          `workspaces[${i}]: 'legacyTagPrefixes' is no longer supported; use 'legacyIdentities: [{ name, tagPrefix }, ...]' instead`,
         );
-      } else {
-        errors.push(`releaseNotes: unknown field '${key}'`);
+        delete wsCopy.legacyTagPrefixes;
       }
-    }
+      return wsCopy;
+    });
   }
 
-  const result: NonNullable<ReleaseKitConfig['releaseNotes']> = {};
-
-  if (value.shouldInjectIntoReadme !== undefined) {
-    if (typeof value.shouldInjectIntoReadme === 'boolean') {
-      result.shouldInjectIntoReadme = value.shouldInjectIntoReadme;
-    } else {
-      errors.push('releaseNotes.shouldInjectIntoReadme: must be a boolean');
-    }
-  }
-
-  config.releaseNotes = result;
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === 'string');
-}
-
-function validateWorkspaces(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
-  if (value === undefined) return;
-
-  if (!Array.isArray(value)) {
-    errors.push("'workspaces' must be an array");
-    return;
-  }
-
-  const workspaces: NonNullable<ReleaseKitConfig['workspaces']> = [];
-  const knownWorkspaceFields = new Set(['dir', 'shouldExclude', 'legacyIdentities']);
-  for (const [i, entry] of value.entries()) {
-    if (!isRecord(entry)) {
-      errors.push(`workspaces[${i}]: must be an object`);
-      continue;
-    }
-    if (typeof entry.dir !== 'string' || entry.dir === '') {
-      errors.push(`workspaces[${i}]: 'dir' is required`);
-      continue;
-    }
-
-    // Detect unknown or removed fields
-    for (const key of Object.keys(entry)) {
-      if (!knownWorkspaceFields.has(key)) {
-        if (key === 'tagPrefix') {
-          errors.push(
-            `workspaces[${i}]: 'tagPrefix' is no longer supported; remove it to use the default '${entry.dir}-v'`,
-          );
-        } else if (key === 'legacyTagPrefixes') {
-          errors.push(
-            `workspaces[${i}]: 'legacyTagPrefixes' is no longer supported; use 'legacyIdentities: [{ name, tagPrefix }, ...]' instead`,
-          );
-        } else {
-          errors.push(`workspaces[${i}]: unknown field '${key}'`);
-        }
-      }
-    }
-
-    const workspace: NonNullable<ReleaseKitConfig['workspaces']>[number] = { dir: entry.dir };
-
-    if (entry.shouldExclude !== undefined) {
-      if (typeof entry.shouldExclude === 'boolean') {
-        workspace.shouldExclude = entry.shouldExclude;
-      } else {
-        errors.push(`workspaces[${i}]: 'shouldExclude' must be a boolean`);
-      }
-    }
-
-    if (entry.legacyIdentities !== undefined) {
-      const identities = validateLegacyIdentities(entry.legacyIdentities, i, errors);
-      if (identities !== undefined) {
-        workspace.legacyIdentities = identities;
-      }
-    }
-    workspaces.push(workspace);
-  }
-  config.workspaces = workspaces;
+  return { cleaned, deprecationErrors: errors };
 }
 
 /**
- * Validate a `legacyIdentities` field on a workspace override.
- *
- * Accepts an array of records, each with non-empty string `name` and `tagPrefix` fields and
- * no unknown fields. Rejects full-tuple duplicates (two entries whose `name` and `tagPrefix`
- * both match). Appends a per-entry error for each invalid entry and returns the array of
- * valid entries (including partial results when some entries fail). Returns `undefined`
- * only when the top-level value is not an array.
+ * Format a Zod issue as a single-line error string using the project's existing path
+ * convention (`object.key`, `array[index]`). Top-level issues without a path render with
+ * the leading bare key (e.g. `'foo' must be an object`) for issues whose `path` resolves
+ * to a single top-level key, matching the prior hand-rolled message shape.
  */
-function validateLegacyIdentities(
-  value: unknown,
-  workspaceIndex: number,
-  errors: string[],
-): LegacyIdentity[] | undefined {
-  if (!Array.isArray(value)) {
-    errors.push(`workspaces[${workspaceIndex}]: 'legacyIdentities' must be an array`);
-    return undefined;
+function formatZodIssue(issue: z.core.$ZodIssue): string {
+  const path = renderPath(issue.path);
+  if (path === '') return issue.message;
+  return `${path}: ${issue.message}`;
+}
+
+/** Render a Zod path as `top.nested[2].leaf`. */
+function renderPath(path: ReadonlyArray<PropertyKey>): string {
+  let rendered = '';
+  for (const segment of path) {
+    if (typeof segment === 'number') {
+      rendered += `[${segment}]`;
+    } else if (rendered === '') {
+      rendered += String(segment);
+    } else {
+      rendered += `.${String(segment)}`;
+    }
   }
-
-  const knownIdentityFields = new Set(['name', 'tagPrefix']);
-  const identities: LegacyIdentity[] = [];
-  const seenTuples = new Set<string>();
-
-  for (const [entryIndex, entry] of value.entries()) {
-    if (!isRecord(entry)) {
-      errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}]: must be an object`);
-      continue;
-    }
-
-    let entryValid = true;
-    for (const key of Object.keys(entry)) {
-      if (!knownIdentityFields.has(key)) {
-        errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}]: unknown field '${key}'`);
-        entryValid = false;
-      }
-    }
-
-    const { name, tagPrefix } = entry;
-    if (typeof name !== 'string') {
-      errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}].name: must be a string`);
-      entryValid = false;
-    } else if (name === '') {
-      errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}].name: must be a non-empty string`);
-      entryValid = false;
-    }
-
-    if (typeof tagPrefix !== 'string') {
-      errors.push(`workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}].tagPrefix: must be a string`);
-      entryValid = false;
-    } else if (tagPrefix === '') {
-      errors.push(
-        `workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}].tagPrefix: must be a non-empty string`,
-      );
-      entryValid = false;
-    }
-
-    if (!entryValid || typeof name !== 'string' || typeof tagPrefix !== 'string') {
-      continue;
-    }
-
-    // Use a null-byte separator: neither npm names nor tag prefixes can contain `\0`,
-    // so distinct `(name, tagPrefix)` tuples always produce distinct keys.
-    const key = `${name}\0${tagPrefix}`;
-    if (seenTuples.has(key)) {
-      errors.push(
-        `workspaces[${workspaceIndex}].legacyIdentities[${entryIndex}]: duplicate identity (name='${name}', tagPrefix='${tagPrefix}')`,
-      );
-      continue;
-    }
-    seenTuples.add(key);
-    identities.push({ name, tagPrefix });
-  }
-
-  return identities;
+  return rendered;
 }
 
 /**
- * Validate a top-level `retiredPackages` field.
- *
- * Accepts an array of records, each with non-empty string `name` and `tagPrefix` and an
- * optional non-empty string `successor`. Rejects full-tuple `(name, tagPrefix)` duplicates
- * within the array (two entries sharing the same `tagPrefix` but different `name`s are
- * allowed — this documents a package renamed before retirement). After per-entry validation,
- * rejects any `tagPrefix` that collides with a declared `workspaces[].legacyIdentities[].tagPrefix`.
+ * Append per-entry errors when two entries in the same workspace's `legacyIdentities`
+ * share a full `(name, tagPrefix)` tuple. Two entries with the same `tagPrefix` but
+ * different `name` are valid — they document a prior rename that reused the tag shape.
+ */
+function detectLegacyIdentityDuplicates(config: ReleaseKitConfig, errors: string[]): void {
+  if (config.workspaces === undefined) return;
+  for (const [wsIndex, workspace] of config.workspaces.entries()) {
+    if (workspace.legacyIdentities === undefined) continue;
+    const seen = new Set<string>();
+    for (const [entryIndex, identity] of workspace.legacyIdentities.entries()) {
+      // Null-byte separator: neither npm names nor tag prefixes can contain `\0`,
+      // so distinct `(name, tagPrefix)` tuples always produce distinct keys.
+      const key = `${identity.name}\0${identity.tagPrefix}`;
+      if (seen.has(key)) {
+        errors.push(
+          `workspaces[${wsIndex}].legacyIdentities[${entryIndex}]: duplicate identity (name='${identity.name}', tagPrefix='${identity.tagPrefix}')`,
+        );
+      }
+      seen.add(key);
+    }
+  }
+}
+
+/**
+ * Append per-entry errors for full `(name, tagPrefix)` duplicates within `retiredPackages`.
+ * Two entries with the same `tagPrefix` but different `name` are valid — they document a
+ * package renamed before retirement.
+ */
+function detectRetiredPackageDuplicates(config: ReleaseKitConfig, errors: string[]): void {
+  if (config.retiredPackages === undefined) return;
+  const seen = new Set<string>();
+  for (const [index, retired] of config.retiredPackages.entries()) {
+    const key = `${retired.name}\0${retired.tagPrefix}`;
+    if (seen.has(key)) {
+      errors.push(
+        `retiredPackages[${index}]: duplicate package (name='${retired.name}', tagPrefix='${retired.tagPrefix}')`,
+      );
+    }
+    seen.add(key);
+  }
+}
+
+/**
+ * Append errors when a `retiredPackages[]` entry's `tagPrefix` matches any workspace's
+ * declared `legacyIdentities[].tagPrefix`. The first declaring workspace is named in the
+ * error.
  *
  * Collisions with an active workspace's *derived* `tagPrefix` are not checked here — that
- * check requires reading each workspace's `package.json` and belongs in `loadConfig`.
+ * check requires reading each workspace's `package.json` and lives in `loadConfig`.
  */
-function validateRetiredPackages(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
-  if (value === undefined) return;
-
-  if (!Array.isArray(value)) {
-    errors.push("'retiredPackages' must be an array");
-    return;
-  }
-
-  const validEntries: Array<{ entry: RetiredPackage; rawIndex: number }> = [];
-  const seenTuples = new Set<string>();
-
-  for (const [i, entry] of value.entries()) {
-    const retired = validateRetiredPackageEntry(entry, i, errors);
-    if (retired === undefined) continue;
-
-    // Null-byte separator: neither npm names nor tag prefixes can contain `\0`.
-    const key = `${retired.name}\0${retired.tagPrefix}`;
-    if (seenTuples.has(key)) {
-      errors.push(
-        `retiredPackages[${i}]: duplicate package (name='${retired.name}', tagPrefix='${retired.tagPrefix}')`,
-      );
-      continue;
-    }
-    seenTuples.add(key);
-    validEntries.push({ entry: retired, rawIndex: i });
-  }
-
-  detectRetiredVsLegacyCollisions(validEntries, config, errors);
-
-  config.retiredPackages = validEntries.map(({ entry }) => entry);
-}
-
-/**
- * Validate a single `retiredPackages[i]` entry. Returns the parsed entry when every required
- * field is a valid non-empty string (and `successor`, if present, is too). Appends any errors
- * encountered and returns `undefined` for otherwise-invalid entries.
- */
-function validateRetiredPackageEntry(entry: unknown, i: number, errors: string[]): RetiredPackage | undefined {
-  if (!isRecord(entry)) {
-    errors.push(`retiredPackages[${i}]: must be an object`);
-    return undefined;
-  }
-
-  const knownRetiredFields = new Set(['name', 'tagPrefix', 'successor']);
-  let entryValid = true;
-  for (const key of Object.keys(entry)) {
-    if (!knownRetiredFields.has(key)) {
-      errors.push(`retiredPackages[${i}]: unknown field '${key}'`);
-      entryValid = false;
-    }
-  }
-
-  const { name, tagPrefix, successor } = entry;
-  if (!validateNonEmptyString(name, `retiredPackages[${i}].name`, errors)) {
-    entryValid = false;
-  }
-  if (!validateNonEmptyString(tagPrefix, `retiredPackages[${i}].tagPrefix`, errors)) {
-    entryValid = false;
-  }
-  if (successor !== undefined && !validateNonEmptyString(successor, `retiredPackages[${i}].successor`, errors)) {
-    entryValid = false;
-  }
-
-  if (!entryValid || typeof name !== 'string' || typeof tagPrefix !== 'string') {
-    return undefined;
-  }
-
-  const retired: RetiredPackage = { name, tagPrefix };
-  if (typeof successor === 'string' && successor !== '') {
-    retired.successor = successor;
-  }
-  return retired;
-}
-
-/**
- * Append errors when a `retiredPackages` entry's `tagPrefix` matches any workspace's declared
- * `legacyIdentities[].tagPrefix`. The first declaring workspace is named in the error. Each
- * entry carries its `rawIndex` (the position in the user-supplied `retiredPackages` array) so
- * error messages point at the entry the user actually wrote, not the position in the filtered
- * valid-entries array.
- */
-function detectRetiredVsLegacyCollisions(
-  retiredPackages: readonly { entry: RetiredPackage; rawIndex: number }[],
-  config: ReleaseKitConfig,
-  errors: string[],
-): void {
-  if (config.workspaces === undefined) return;
+function detectRetiredVsLegacyCollisions(config: ReleaseKitConfig, errors: string[]): void {
+  if (config.retiredPackages === undefined || config.workspaces === undefined) return;
 
   const legacyPrefixToWorkspace = new Map<string, string>();
   for (const workspace of config.workspaces) {
@@ -422,123 +183,12 @@ function detectRetiredVsLegacyCollisions(
     }
   }
 
-  for (const { entry: retired, rawIndex } of retiredPackages) {
+  for (const [index, retired] of config.retiredPackages.entries()) {
     const collidingDir = legacyPrefixToWorkspace.get(retired.tagPrefix);
     if (collidingDir !== undefined) {
       errors.push(
-        `retiredPackages[${rawIndex}]: tagPrefix '${retired.tagPrefix}' collides with a declared legacyIdentities[].tagPrefix on workspace '${collidingDir}'`,
+        `retiredPackages[${index}]: tagPrefix '${retired.tagPrefix}' collides with a declared legacyIdentities[].tagPrefix on workspace '${collidingDir}'`,
       );
     }
-  }
-}
-
-/**
- * Append a typed error when `value` is not a non-empty string under `fieldPath`. Returns `true`
- * when the value passes, `false` when any error was appended.
- */
-function validateNonEmptyString(value: unknown, fieldPath: string, errors: string[]): boolean {
-  if (typeof value !== 'string') {
-    errors.push(`${fieldPath}: must be a string`);
-    return false;
-  }
-  if (value === '') {
-    errors.push(`${fieldPath}: must be a non-empty string`);
-    return false;
-  }
-  return true;
-}
-
-function validateVersionPatterns(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
-  if (value === undefined) return;
-
-  if (!isRecord(value)) {
-    errors.push("'versionPatterns' must be an object");
-    return;
-  }
-
-  if (!isStringArray(value.major)) {
-    errors.push('versionPatterns.major: expected string array');
-  }
-  if (!isStringArray(value.minor)) {
-    errors.push('versionPatterns.minor: expected string array');
-  }
-  if (isStringArray(value.major) && isStringArray(value.minor)) {
-    config.versionPatterns = { major: value.major, minor: value.minor };
-  }
-}
-
-function validateWorkTypes(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
-  if (value === undefined) return;
-
-  if (!isRecord(value) || Array.isArray(value)) {
-    errors.push("'workTypes' must be a record (object)");
-    return;
-  }
-
-  const workTypes: Record<string, { header: string; aliases?: string[] }> = {};
-  for (const [key, entry] of Object.entries(value)) {
-    if (!isRecord(entry)) {
-      errors.push(`workTypes.${key}: must be an object`);
-      continue;
-    }
-    if (typeof entry.header !== 'string') {
-      errors.push(`workTypes.${key}: 'header' is required and must be a string`);
-      continue;
-    }
-    const wtEntry: { header: string; aliases?: string[] } = { header: entry.header };
-    if (entry.aliases !== undefined) {
-      if (isStringArray(entry.aliases)) {
-        wtEntry.aliases = entry.aliases;
-      } else {
-        errors.push(`workTypes.${key}: 'aliases' must be a string array`);
-      }
-    }
-    workTypes[key] = wtEntry;
-  }
-  config.workTypes = workTypes;
-}
-
-function validateStringField(
-  fieldName: 'formatCommand' | 'cliffConfigPath',
-  value: unknown,
-  config: ReleaseKitConfig,
-  errors: string[],
-): void {
-  if (value === undefined) return;
-
-  if (typeof value !== 'string') {
-    errors.push(`'${fieldName}' must be a string`);
-    return;
-  }
-  if (value === '') {
-    errors.push(`'${fieldName}' must be a non-empty string`);
-    return;
-  }
-  config[fieldName] = value;
-}
-
-function validateScopeAliases(value: unknown, config: ReleaseKitConfig, errors: string[]): void {
-  if (value === undefined) return;
-
-  if (!isRecord(value)) {
-    errors.push("'scopeAliases' must be a record (object)");
-    return;
-  }
-
-  const aliases: Record<string, string> = {};
-  let valid = true;
-  for (const [key, v] of Object.entries(value)) {
-    if (typeof v === 'string') {
-      aliases[key] = v;
-    } else {
-      errors.push(`scopeAliases.${key}: value must be a string`);
-      valid = false;
-    }
-  }
-  // All-or-nothing: only assign aliases when every entry is valid.
-  // Unlike `validateWorkspaces`, partial results are not useful for aliases
-  // because the mapping is consumed as a complete lookup table.
-  if (valid) {
-    config.scopeAliases = aliases;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       semver:
         specifier: 7.8.0
         version: 7.8.0
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/js-yaml':
         specifier: 4.0.9


### PR DESCRIPTION
## What

Fixes an issue where setting `breakingPolicies` in `release-kit.config.ts` was rejected as an unknown field, leaving per-work-type breaking-policy configuration unreachable from the config file. Each entry accepts `'forbidden'`, `'optional'`, or `'required'`; an empty object opts out of enforcement.

## Why

The `breakingPolicies` field was wired through the type system, the merge layer, and runtime consumers, but `validateConfig` rejected it as unknown — leaving a documented feature unreachable for any user editing `release-kit.config.ts`. The bug also exposed a structural drift class: config fields had three independent allowlists (the `ReleaseKitConfig` type, `validateConfig`'s known-field set, and `applyOptionalPassthroughFields`'s parameter shape), with nothing enforcing they stay in sync. Closing the bug without addressing the drift class would leave the same trap set for the next field added to the type.

## Details

### 🐛 Bug fixes

- `breakingPolicies` configured in `release-kit.config.ts` is accepted, validated against the `'forbidden' | 'optional' | 'required'` literal set, and reaches `releasePrepare*` and `parseCommitMessage` unchanged.
- Empty-string validation errors render as `must be a non-empty string` rather than `Too small: expected string to have >=1 characters` — the Zod default reads as a numeric-bound error in CLI output.

### ♻️ Refactoring

- `validateConfig` rebuilt around a Zod schema as the single source of truth for both the `ReleaseKitConfig` type (via `z.infer`) and the runtime shape check. Adding a field to `ReleaseKitConfig` cannot silently miss validation — the type *is* the schema. Cross-field validations (full-tuple duplicate detection, retired-vs-legacy collisions) run as post-parse checks against the typed result. Deprecation guidance for removed fields (`workspaces[].tagPrefix`, `workspaces[].legacyTagPrefixes`, `releaseNotes.shouldCreateGithubRelease`) is preserved as a preprocessing pass with a documented contract for handling future deprecations.
- Schema validation is now uniformly all-or-nothing per field — when any entry in `workspaces[].legacyIdentities` or `retiredPackages` is invalid, the whole field is omitted from the resolved config rather than partially populated. Practical impact is bounded because every CLI caller (`prepareCommand`, `previewTagPrefixes`, `resolveReleaseNotesConfig`) treats any error as a stop condition. Documenting the change for transparency.

### 🧪 Tests

- Eight new test cases cover `breakingPolicies` shape, opt-out, all-or-nothing, and known-field registration.
- Test assertions for shape errors decoupled from Zod's exact wording via two helpers (`expectErrorAtPath`, `expectErrorMentioning`) that verify path attribution and field surfacing — the test contract pins what this codebase owns (paths, behavior, custom messages) without coupling to library wording that can shift across Zod minor versions.

### 📦 Dependencies

- `release-kit` adds `zod@4.4.3` as a runtime dependency. Zod is already used by `nmr` and `v11y-check` in this monorepo, so this is portfolio standardization rather than introducing a new dependency family.

Closes #386
