### PR TITLE
#388 Validate changelog overrides from the command line

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -457,6 +457,32 @@ The override file is validated when `release-kit prepare` loads it. Each error n
 - An entry with no fields set → error (a copy-paste mistake more often than not).
 - `audience: 'all'` or `audience: 'dev'` → error in the current release: only `'skip'` is supported (see below).
 
+#### Standalone validation: `release-kit overrides validate`
+
+For a fast overrides-only health check (locally or as a CI gate), run:
+
+```sh
+pnpm exec release-kit overrides validate
+```
+
+This walks every `.meta/changelog-overrides.json` file across the project tier and per-workspace tier, reporting three classes of finding:
+
+| Class               | Examples                                                                                    | Exit code |
+| ------------------- | ------------------------------------------------------------------------------------------- | --------- |
+| Schema/parse errors | malformed JSON, unknown fields, wrong field types, no-field entries, unsupported `audience` | `2`       |
+| Ambiguous-prefix    | an override key resolves to 2+ commit hashes                                                | `2`       |
+| Stale-key warnings  | an override key resolves to no commit in its applicable scope                               | `1`       |
+
+Exit code semantics:
+
+- `0` — clean (no errors, no stale keys).
+- `1` — only stale-key warnings.
+- `2` — schema/parse or ambiguous-prefix errors (errors dominate when both classes are present).
+
+Tier-aware stale-key semantics match `release-kit prepare`'s match-set exactly: a workspace-tier key is stale if it does not match in its own workspace's history; a root-tier key is stale only if it matches in **no** scope (no workspace AND not the project release window).
+
+The same logic is also exposed programmatically via the `validateAllChangelogOverrides` function exported from `@williamthorsen/release-kit`, for callers that want to integrate the check into their own tooling.
+
 ### Audience semantics: v1 supports `'skip'` only
 
 The on-disk format declares the full `'all' | 'dev' | 'skip'` audience vocabulary so the file format will not need to change when the v2 reclassification feature ships. In the current release, only `'skip'` is supported at runtime; `'all'` and `'dev'` are rejected with an explicit "not yet supported" error.

--- a/packages/release-kit/src/__tests__/changelogOverrides.unit.test.ts
+++ b/packages/release-kit/src/__tests__/changelogOverrides.unit.test.ts
@@ -14,6 +14,7 @@ import {
   loadOverridesForScopes,
   type OverrideContext,
   resolveOverridePath,
+  validateAllChangelogOverrides,
   validateChangelogOverrides,
 } from '../changelogOverrides.ts';
 import type { ChangelogEntry, ChangelogOverride, WorkspaceConfig } from '../types.ts';
@@ -582,6 +583,233 @@ describe(applyWorkspaceOverrides, () => {
     // aaa1111 is dropped via the root override; bbb2222 remains because the workspace file
     // does not apply at the project tier.
     expect(remainingHashes).toStrictEqual(['bbb2222']);
+  });
+});
+
+describe(validateAllChangelogOverrides, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `test-validate-overrides-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeOverrides(scopeDir: string, contents: string): string {
+    const filePath = join(scopeDir, 'overrides.json');
+    writeFileSync(filePath, contents, 'utf8');
+    return filePath;
+  }
+
+  it('returns no findings when no scopes are provided', () => {
+    const result = validateAllChangelogOverrides({});
+    expect(result.errors).toStrictEqual([]);
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it('returns no findings when override files are absent (missing files are no-ops)', () => {
+    const result = validateAllChangelogOverrides({
+      project: { filePath: join(tempDir, 'missing-project.json'), hashes: ['aaa1111'] },
+      workspaces: [{ filePath: join(tempDir, 'missing-workspace.json'), hashes: ['bbb2222'] }],
+    });
+    expect(result.errors).toStrictEqual([]);
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it('returns no findings on a clean run with all matched keys', () => {
+    const projectFile = writeOverrides(tempDir, JSON.stringify({ aaa1111: { audience: 'skip' } }));
+    const workspaceDir = join(tempDir, 'workspace-a');
+    mkdirSync(workspaceDir);
+    const workspaceFile = writeOverrides(workspaceDir, JSON.stringify({ bbb2222: { description: 'Cleaned' } }));
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile },
+      workspaces: [{ filePath: workspaceFile, hashes: ['aaa1111aaa', 'bbb2222bbb'] }],
+    });
+
+    expect(result.errors).toStrictEqual([]);
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it('reports schema/parse errors with the file path prefix', () => {
+    const projectFile = writeOverrides(tempDir, '{not-valid');
+    const workspaceDir = join(tempDir, 'workspace-a');
+    mkdirSync(workspaceDir);
+    const workspaceFile = writeOverrides(workspaceDir, '[]');
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile, hashes: [] },
+      workspaces: [{ filePath: workspaceFile, hashes: [] }],
+    });
+
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toContain(projectFile);
+    expect(result.errors[0]).toMatch(/Failed to parse override file/);
+    expect(result.errors[1]).toContain(workspaceFile);
+    expect(result.errors[1]).toMatch(/top-level value must be an object/);
+  });
+
+  it('reports per-key validation errors with the file path prefix', () => {
+    const projectFile = writeOverrides(tempDir, JSON.stringify({ abc: { unknown: true } }));
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile, hashes: [] },
+    });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain(projectFile);
+    expect(result.errors[0]).toMatch(/unknown field 'unknown'/);
+  });
+
+  it('reports ambiguous-prefix errors at workspace tier with the workspace file path', () => {
+    const workspaceDir = join(tempDir, 'workspace-a');
+    mkdirSync(workspaceDir);
+    const workspaceFile = writeOverrides(workspaceDir, JSON.stringify({ abc: { audience: 'skip' } }));
+
+    const result = validateAllChangelogOverrides({
+      workspaces: [{ filePath: workspaceFile, hashes: ['abc111', 'abc222'] }],
+    });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain(workspaceFile);
+    expect(result.errors[0]).toMatch(/ambiguous/);
+  });
+
+  it('reports ambiguous-prefix errors at project tier with the project file path', () => {
+    const projectFile = writeOverrides(tempDir, JSON.stringify({ abc: { audience: 'skip' } }));
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile, hashes: ['abc111', 'abc222'] },
+    });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain(projectFile);
+    expect(result.errors[0]).toMatch(/ambiguous/);
+  });
+
+  it('warns on a workspace-tier stale key with the workspace file path', () => {
+    const workspaceDir = join(tempDir, 'workspace-a');
+    mkdirSync(workspaceDir);
+    const workspaceFile = writeOverrides(workspaceDir, JSON.stringify({ stale12: { audience: 'skip' } }));
+
+    const result = validateAllChangelogOverrides({
+      workspaces: [{ filePath: workspaceFile, hashes: ['real0001', 'real0002'] }],
+    });
+
+    expect(result.errors).toStrictEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain(workspaceFile);
+    expect(result.warnings[0]).toContain("'stale12'");
+    expect(result.warnings[0]).toMatch(/this workspace's history/);
+  });
+
+  it('warns on a root-tier key matched in no scope', () => {
+    const projectFile = writeOverrides(tempDir, JSON.stringify({ stale99: { audience: 'skip' } }));
+    const workspaceDir = join(tempDir, 'workspace-a');
+    mkdirSync(workspaceDir);
+    const workspaceFile = writeOverrides(workspaceDir, '{}');
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile },
+      workspaces: [{ filePath: workspaceFile, hashes: ['real1234'] }],
+    });
+
+    expect(result.errors).toStrictEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain(projectFile);
+    expect(result.warnings[0]).toContain("'stale99'");
+    expect(result.warnings[0]).toMatch(/any scope/);
+  });
+
+  it('does NOT warn on a root key matched in some workspace', () => {
+    const projectFile = writeOverrides(tempDir, JSON.stringify({ aaa1111: { audience: 'skip' } }));
+    const workspaceA = join(tempDir, 'a');
+    const workspaceB = join(tempDir, 'b');
+    mkdirSync(workspaceA);
+    mkdirSync(workspaceB);
+    const fileA = writeOverrides(workspaceA, '{}');
+    const fileB = writeOverrides(workspaceB, '{}');
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile },
+      workspaces: [
+        { filePath: fileA, hashes: ['aaa1111ext'] },
+        { filePath: fileB, hashes: ['unrelated'] },
+      ],
+    });
+
+    expect(result.errors).toStrictEqual([]);
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it('does NOT warn on a root key matched only in the project release window', () => {
+    const projectFile = writeOverrides(tempDir, JSON.stringify({ aaa1111: { audience: 'skip' } }));
+    const workspaceDir = join(tempDir, 'workspace-a');
+    mkdirSync(workspaceDir);
+    const workspaceFile = writeOverrides(workspaceDir, '{}');
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile, hashes: ['aaa1111ext'] },
+      workspaces: [{ filePath: workspaceFile, hashes: ['unrelated'] }],
+    });
+
+    expect(result.errors).toStrictEqual([]);
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it('treats a root key as stale when it is shadowed everywhere and never matches at the root tier', () => {
+    // Root key 'aaa1111' is shadowed by an identical workspace key in the only workspace.
+    // The workspace match counts toward the workspace tier, not the root, and there is no
+    // project release window — so the root key matches nowhere and should be flagged stale.
+    const projectFile = writeOverrides(tempDir, JSON.stringify({ aaa1111: { audience: 'skip' } }));
+    const workspaceDir = join(tempDir, 'workspace-a');
+    mkdirSync(workspaceDir);
+    const workspaceFile = writeOverrides(workspaceDir, JSON.stringify({ aaa1111: { description: 'Workspace wins' } }));
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile },
+      workspaces: [{ filePath: workspaceFile, hashes: ['aaa1111ext'] }],
+    });
+
+    expect(result.errors).toStrictEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain(projectFile);
+    expect(result.warnings[0]).toContain("'aaa1111'");
+  });
+
+  it('reports both errors and warnings simultaneously when both classes occur', () => {
+    const projectFile = writeOverrides(tempDir, JSON.stringify({ stale99: { audience: 'skip' } }));
+    const workspaceDir = join(tempDir, 'workspace-a');
+    mkdirSync(workspaceDir);
+    const workspaceFile = writeOverrides(workspaceDir, JSON.stringify({ abc: { audience: 'skip' } }));
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile },
+      workspaces: [{ filePath: workspaceFile, hashes: ['abc111', 'abc222'] }],
+    });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/ambiguous/);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("'stale99'");
+  });
+
+  it('handles single-package mode (project scope only, no workspaces)', () => {
+    const projectFile = writeOverrides(
+      tempDir,
+      JSON.stringify({ aaa1111: { audience: 'skip' }, stale99: { audience: 'skip' } }),
+    );
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile, hashes: ['aaa1111ext'] },
+    });
+
+    expect(result.errors).toStrictEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("'stale99'");
   });
 });
 

--- a/packages/release-kit/src/__tests__/changelogOverrides.unit.test.ts
+++ b/packages/release-kit/src/__tests__/changelogOverrides.unit.test.ts
@@ -690,6 +690,25 @@ describe(validateAllChangelogOverrides, () => {
     expect(result.errors[0]).toMatch(/ambiguous/);
   });
 
+  it('attributes a project-tier ambiguous-prefix error to the project file when detected via a workspace hash window', () => {
+    // The project key 'abc' resolves ambiguously against workspace A's hashes. The error must
+    // attribute to the project file (where 'abc' lives), not the workspace file (which is empty).
+    const projectFile = writeOverrides(tempDir, JSON.stringify({ abc: { audience: 'skip' } }));
+    const workspaceDir = join(tempDir, 'workspace-a');
+    mkdirSync(workspaceDir);
+    const workspaceFile = writeOverrides(workspaceDir, '{}');
+
+    const result = validateAllChangelogOverrides({
+      project: { filePath: projectFile },
+      workspaces: [{ filePath: workspaceFile, hashes: ['abc111aaa', 'abc222bbb'] }],
+    });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain(projectFile);
+    expect(result.errors[0]).not.toContain(workspaceFile);
+    expect(result.errors[0]).toMatch(/ambiguous/);
+  });
+
   it('warns on a workspace-tier stale key with the workspace file path', () => {
     const workspaceDir = join(tempDir, 'workspace-a');
     mkdirSync(workspaceDir);

--- a/packages/release-kit/src/__tests__/validateOverridesCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateOverridesCommand.unit.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatValidateOverridesResult, validateOverridesCommand } from '../validateOverridesCommand.ts';
+
+describe(formatValidateOverridesResult, () => {
+  it('returns exit 0 with a success message when there are no findings', () => {
+    const result = formatValidateOverridesResult({ errors: [], warnings: [] });
+    expect(result.exitCode).toBe(0);
+    expect(result.message).toMatch(/valid/);
+  });
+
+  it('returns exit 1 with only warnings rendered', () => {
+    const result = formatValidateOverridesResult({
+      errors: [],
+      warnings: ["packages/foo/.meta/changelog-overrides.json: Override key 'stale99' did not match"],
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain('0 errors');
+    expect(result.message).toContain('1 warning');
+    expect(result.message).toContain('stale99');
+    expect(result.message).not.toContain('❌');
+    expect(result.message).toContain('⚠️');
+  });
+
+  it('returns exit 2 when any error is present, regardless of warnings', () => {
+    const result = formatValidateOverridesResult({
+      errors: [".meta/changelog-overrides.json: Override key 'abc' is ambiguous: matches multiple commits"],
+      warnings: ["packages/foo/.meta/changelog-overrides.json: Override key 'stale' did not match"],
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.message).toContain('ambiguous');
+    expect(result.message).toContain('stale');
+  });
+
+  it('pluralizes the summary line', () => {
+    const result = formatValidateOverridesResult({
+      errors: ['file.json: error a', 'file.json: error b'],
+      warnings: ['file.json: warn a'],
+    });
+    expect(result.message).toContain('Found 2 errors and 1 warning');
+  });
+});
+
+describe(validateOverridesCommand, () => {
+  it('returns exit 0 in a single-package layout with no overrides', async () => {
+    const result = await validateOverridesCommand({
+      discoverWorkspaces: () => Promise.resolve(undefined),
+      loadConfig: () => Promise.resolve(undefined),
+      collectHashes: () => [],
+      validate: () => ({ errors: [], warnings: [] }),
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('returns exit 1 when validation surfaces only warnings', async () => {
+    const result = await validateOverridesCommand({
+      discoverWorkspaces: () => Promise.resolve(undefined),
+      loadConfig: () => Promise.resolve(undefined),
+      collectHashes: () => [],
+      validate: () => ({ errors: [], warnings: ['file.json: stale key'] }),
+    });
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('returns exit 2 when validation surfaces errors', async () => {
+    const result = await validateOverridesCommand({
+      discoverWorkspaces: () => Promise.resolve(undefined),
+      loadConfig: () => Promise.resolve(undefined),
+      collectHashes: () => [],
+      validate: () => ({ errors: ['file.json: ambiguous'], warnings: [] }),
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('returns exit 2 with a config-load failure message', async () => {
+    const result = await validateOverridesCommand({
+      discoverWorkspaces: () => Promise.resolve(undefined),
+      loadConfig: () => Promise.reject(new Error('boom')),
+      validate: () => ({ errors: [], warnings: [] }),
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.message).toContain('Error loading config');
+    expect(result.message).toContain('boom');
+  });
+
+  it('passes a project-only scope to validate in single-package mode', async () => {
+    let received: { workspaces: number; projectHashes: number } | undefined;
+    await validateOverridesCommand({
+      discoverWorkspaces: () => Promise.resolve(undefined),
+      loadConfig: () => Promise.resolve(undefined),
+      collectHashes: () => ['hash1', 'hash2'],
+      validate: (inputs) => {
+        received = {
+          workspaces: inputs.workspaces?.length ?? 0,
+          projectHashes: inputs.project?.hashes?.length ?? 0,
+        };
+        return { errors: [], warnings: [] };
+      },
+    });
+    expect(received).toStrictEqual({ workspaces: 0, projectHashes: 2 });
+  });
+});

--- a/packages/release-kit/src/__tests__/validateOverridesCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateOverridesCommand.unit.test.ts
@@ -9,17 +9,26 @@ describe(formatValidateOverridesResult, () => {
     expect(result.message).toMatch(/valid/);
   });
 
-  it('returns exit 1 with only warnings rendered', () => {
+  it('returns exit 1 with only warnings rendered (zero-count error category is omitted)', () => {
     const result = formatValidateOverridesResult({
       errors: [],
       warnings: ["packages/foo/.meta/changelog-overrides.json: Override key 'stale99' did not match"],
     });
     expect(result.exitCode).toBe(1);
-    expect(result.message).toContain('0 errors');
-    expect(result.message).toContain('1 warning');
+    expect(result.message).toContain('Found 1 warning:');
+    expect(result.message).not.toContain('error');
     expect(result.message).toContain('stale99');
     expect(result.message).not.toContain('❌');
     expect(result.message).toContain('⚠️');
+  });
+
+  it('omits the warning category from the summary when only errors are present', () => {
+    const result = formatValidateOverridesResult({
+      errors: ["file.json: Override key 'abc' is ambiguous: matches multiple commits"],
+      warnings: [],
+    });
+    expect(result.message).toContain('Found 1 error:');
+    expect(result.message).not.toContain('warning');
   });
 
   it('returns exit 2 when any error is present, regardless of warnings', () => {
@@ -81,6 +90,17 @@ describe(validateOverridesCommand, () => {
     expect(result.exitCode).toBe(2);
     expect(result.message).toContain('Error loading config');
     expect(result.message).toContain('boom');
+  });
+
+  it('returns exit 2 with an Invalid config message when the loaded config fails validation', async () => {
+    // `validateConfig` rejects non-record top-level values with "Config must be an object".
+    const result = await validateOverridesCommand({
+      discoverWorkspaces: () => Promise.resolve(undefined),
+      loadConfig: () => Promise.resolve(42),
+      validate: () => ({ errors: [], warnings: [] }),
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.message).toContain('Invalid config');
   });
 
   it('passes a project-only scope to validate in single-package mode', async () => {

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -17,6 +17,7 @@ import { syncLabelsInitCommand } from '../sync-labels/initCommand.ts';
 import { syncLabelsCommand } from '../sync-labels/syncCommand.ts';
 import { syncWorkTypes } from '../syncWorkTypes.ts';
 import { tagCommand } from '../tagCommand.ts';
+import { validateOverridesCommand } from '../validateOverridesCommand.ts';
 
 const VERSION = readPackageVersion(import.meta.url);
 
@@ -33,6 +34,7 @@ Commands:
   create-github-release  Create GitHub Releases from changelog.json for tags on HEAD
   show-tag-prefixes  Show derived and declared legacy tag prefixes per workspace
   init             Initialize release-kit in the current repository
+  overrides        Manage editorial changelog overrides
   sync-labels      Manage GitHub label synchronization
   work-types       Check for or sync work-type taxonomy drift against the upstream canonical
 
@@ -190,6 +192,37 @@ Print a per-workspace table of derived tag prefixes, tag counts, and declared
 legacy tag prefixes. Surfaces any release-shaped tags whose prefix is neither a
 derived prefix nor declared in \`legacyIdentities\`, with a copy-pasteable
 config snippet.
+
+Options:
+  --help, -h    Show this help message
+`);
+}
+
+function showOverridesHelp(): void {
+  console.info(`
+Usage: release-kit overrides <subcommand> [options]
+
+Manage editorial changelog overrides.
+
+Subcommands:
+  validate      Validate every \`.meta/changelog-overrides.json\` file across all scopes
+
+Options:
+  --help, -h    Show this help message
+`);
+}
+
+function showOverridesValidateHelp(): void {
+  console.info(`
+Usage: release-kit overrides validate
+
+Validate every \`.meta/changelog-overrides.json\` file across the project and per-workspace
+scopes. Reports schema/parse errors, ambiguous-prefix errors, and stale-key warnings.
+
+Exit codes:
+  0    Clean — no errors, no stale keys
+  1    Stale-key warnings only (no errors)
+  2    Schema/parse or ambiguous-prefix errors (errors dominate)
 
 Options:
   --help, -h    Show this help message
@@ -442,6 +475,38 @@ if (command === 'sync-labels') {
 
   console.error(`Error: Unknown subcommand: ${subcommand}`);
   showSyncLabelsHelp();
+  process.exit(1);
+}
+
+if (command === 'overrides') {
+  const subcommand = flags[0];
+  const subflags = flags.slice(1);
+
+  if (subcommand === '--help' || subcommand === '-h' || subcommand === undefined) {
+    showOverridesHelp();
+    process.exit(0);
+  }
+
+  if (subcommand === 'validate') {
+    if (subflags.some((f) => f === '--help' || f === '-h')) {
+      showOverridesValidateHelp();
+      process.exit(0);
+    }
+    if (subflags.length > 0) {
+      console.error(`Error: Unknown option: ${subflags[0]}`);
+      process.exit(1);
+    }
+    const result = await validateOverridesCommand();
+    if (result.exitCode === 0) {
+      console.info(result.message);
+    } else {
+      console.error(result.message);
+    }
+    process.exit(result.exitCode);
+  }
+
+  console.error(`Error: Unknown subcommand: ${subcommand}`);
+  showOverridesHelp();
   process.exit(1);
 }
 

--- a/packages/release-kit/src/changelogOverrides.ts
+++ b/packages/release-kit/src/changelogOverrides.ts
@@ -463,6 +463,167 @@ export function createOverrideContext(workspaces: WorkspaceConfig[]): OverrideCo
   };
 }
 
+/** Per-scope input to {@link validateAllChangelogOverrides}. */
+export interface ChangelogOverrideScope {
+  /** Path to the override file (relative to the repo root). Used to load the file and to attribute findings. */
+  filePath: string;
+  /** Commit hashes in this scope's history window. Each override key is matched against these. */
+  hashes: readonly string[];
+}
+
+/** Inputs to {@link validateAllChangelogOverrides}. */
+export interface ValidateAllChangelogOverridesInputs {
+  /**
+   * Project-tier scope (the override file at the repo root).
+   *
+   * The file at `filePath` is loaded once and used in two ways:
+   * - Its overrides are composed into every workspace's apply (root-tier overrides apply globally).
+   * - When `hashes` is provided, the project map is also applied directly to that hash universe
+   *   (project release in monorepo mode, or the package's history in single-package mode).
+   *
+   * Omit when no project file exists (rare — most repos have a root file even if empty).
+   */
+  project?: { filePath: string; hashes?: readonly string[] };
+  /** Per-workspace scopes. Each workspace's file applies only to its own hash universe. */
+  workspaces?: readonly ChangelogOverrideScope[];
+}
+
+/** Result of {@link validateAllChangelogOverrides}: aggregated errors and warnings, each prefixed with the file path it pertains to. */
+export interface ValidateAllChangelogOverridesResult {
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * End-to-end health check across every override file and scope. Pure: takes already-collected
+ * hash universes and returns aggregated findings. The CLI command and any other consumer
+ * (programmatic library callers, future composite checks) wrap this with discovery and I/O.
+ *
+ * The match-set is byte-equal to what `release-kit prepare` would compute, including the
+ * tier asymmetry: workspace-tier keys are stale if they don't match in their own workspace;
+ * root-tier keys are stale only if they don't match in any scope (no workspace AND not the
+ * project release window).
+ *
+ * Every returned string is prefixed with the relative override-file path it pertains to so
+ * consumers can locate the offending file without further structuring.
+ */
+export function validateAllChangelogOverrides(
+  inputs: ValidateAllChangelogOverridesInputs,
+): ValidateAllChangelogOverridesResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const projectFilePath = inputs.project?.filePath;
+  const projectMap = loadScopeMap(projectFilePath, errors);
+
+  const workspaceMaps = (inputs.workspaces ?? []).map((scope) => ({
+    filePath: scope.filePath,
+    hashes: scope.hashes,
+    map: loadScopeMap(scope.filePath, errors),
+  }));
+
+  // Track root keys matched anywhere — in any non-shadowing workspace OR in the project
+  // release. Shadowed matches do NOT count, mirroring `applyWorkspaceOverrides`'s semantics:
+  // a root key that's overridden everywhere is functionally dead and reported as stale.
+  const globalMatchedRootKeys = new Set<string>();
+
+  // Workspace tier — apply composed (root + workspace) map against the workspace's hashes to
+  // surface ambiguous-prefix errors. Stale-key detection runs independently from prefix-match
+  // counts so ambiguous keys (2+ hits) aren't doubly flagged as stale.
+  for (const { filePath, hashes, map } of workspaceMaps) {
+    const composed = composeOverrides(projectMap, map);
+    const applied = applyChangelogOverrides(makeValidationEntries(hashes), composed);
+    for (const message of applied.errors) {
+      errors.push(prefixWithFilePath(filePath, message));
+    }
+    for (const key of map.keys()) {
+      if (!hasAnyMatch(key, hashes)) {
+        warnings.push(formatWorkspaceStaleWarning(filePath, key));
+      }
+    }
+    for (const key of projectMap.keys()) {
+      // Workspace-shadowed root keys do not count as root matches.
+      if (map.has(key)) continue;
+      if (hasAnyMatch(key, hashes)) {
+        globalMatchedRootKeys.add(key);
+      }
+    }
+  }
+
+  // Project tier — apply project map against project hashes (when a release window is provided)
+  // to surface ambiguous-prefix errors and account for root-tier matches.
+  if (projectFilePath !== undefined && inputs.project?.hashes !== undefined) {
+    const applied = applyChangelogOverrides(makeValidationEntries(inputs.project.hashes), projectMap);
+    for (const message of applied.errors) {
+      errors.push(prefixWithFilePath(projectFilePath, message));
+    }
+    for (const key of projectMap.keys()) {
+      if (hasAnyMatch(key, inputs.project.hashes)) {
+        globalMatchedRootKeys.add(key);
+      }
+    }
+  }
+
+  // Root-tier stale keys: project keys matched nowhere (after honoring shadowing).
+  if (projectFilePath !== undefined) {
+    for (const key of projectMap.keys()) {
+      if (!globalMatchedRootKeys.has(key)) {
+        warnings.push(formatRootStaleWarning(projectFilePath, key));
+      }
+    }
+  }
+
+  return { errors, warnings };
+}
+
+function hasAnyMatch(key: string, hashes: readonly string[]): boolean {
+  return hashes.some((hash) => hash.startsWith(key));
+}
+
+/** Load a scope's override map, pushing any load/schema errors (each prefixed with the file path) onto `errors`. */
+function loadScopeMap(filePath: string | undefined, errors: string[]): Map<string, ChangelogOverride> {
+  if (filePath === undefined) {
+    return new Map();
+  }
+  const result = loadChangelogOverrides(filePath);
+  if ('errors' in result) {
+    for (const message of result.errors) {
+      errors.push(prefixWithFilePath(filePath, message));
+    }
+    return new Map();
+  }
+  return result.overrides;
+}
+
+/** Build a single synthetic `ChangelogEntry[]` whose items carry the given hashes — sufficient for `applyChangelogOverrides`'s matching logic. */
+function makeValidationEntries(hashes: readonly string[]): ChangelogEntry[] {
+  return [
+    {
+      version: '0.0.0',
+      date: '0000-00-00',
+      sections: [
+        {
+          title: 'Validation',
+          audience: 'all',
+          items: hashes.map((hash) => ({ description: '', hash })),
+        },
+      ],
+    },
+  ];
+}
+
+function prefixWithFilePath(filePath: string, message: string): string {
+  return `${filePath}: ${message}`;
+}
+
+function formatWorkspaceStaleWarning(filePath: string, key: string): string {
+  return `${filePath}: Override key '${key}' did not match any commit in this workspace's history (likely a stale reference)`;
+}
+
+function formatRootStaleWarning(filePath: string, key: string): string {
+  return `${filePath}: Override key '${key}' did not match any commit in any scope (likely a stale reference)`;
+}
+
 /**
  * Apply the composed (root + workspace) override map to a workspace's changelog entries and
  * report stale-key warnings tier-by-tier.

--- a/packages/release-kit/src/changelogOverrides.ts
+++ b/packages/release-kit/src/changelogOverrides.ts
@@ -527,63 +527,119 @@ export function validateAllChangelogOverrides(
   // a root key that's overridden everywhere is functionally dead and reported as stale.
   const globalMatchedRootKeys = new Set<string>();
 
-  // Workspace tier — apply each map separately against the workspace's hashes so ambiguous-
-  // prefix errors attribute to the file that contains the offending key, not to the composed
-  // view. The shadowing semantic still applies to the root-tier accounting below: byte-equal
-  // keys in the workspace map exclude their root counterparts from the project apply for this
-  // workspace (workspace's value would win at runtime, so the root entry is dead at this scope).
-  // Stale-key detection runs independently from prefix-match counts so ambiguous keys
-  // (2+ hits) aren't doubly flagged as stale.
-  for (const { filePath, hashes, map } of workspaceMaps) {
-    const workspaceApplied = applyChangelogOverrides(makeValidationEntries(hashes), map);
-    for (const message of workspaceApplied.errors) {
-      errors.push(prefixWithFilePath(filePath, message));
-    }
-    if (projectFilePath !== undefined && projectMap.size > 0) {
-      const projectMinusShadowed = filterShadowedKeys(projectMap, map);
-      const projectApplied = applyChangelogOverrides(makeValidationEntries(hashes), projectMinusShadowed);
-      for (const message of projectApplied.errors) {
-        errors.push(prefixWithFilePath(projectFilePath, message));
-      }
-    }
-    for (const key of map.keys()) {
-      if (!hasAnyMatch(key, hashes)) {
-        warnings.push(formatWorkspaceStaleWarning(filePath, key));
-      }
-    }
-    for (const key of projectMap.keys()) {
-      // Workspace-shadowed root keys do not count as root matches.
-      if (map.has(key)) continue;
-      if (hasAnyMatch(key, hashes)) {
-        globalMatchedRootKeys.add(key);
-      }
-    }
+  for (const workspace of workspaceMaps) {
+    processWorkspaceScope({
+      workspace,
+      projectFilePath,
+      projectMap,
+      errors,
+      warnings,
+      globalMatchedRootKeys,
+    });
   }
 
-  // Project tier — apply project map against project hashes (when a release window is provided)
-  // to surface ambiguous-prefix errors and account for root-tier matches.
-  if (projectFilePath !== undefined && inputs.project?.hashes !== undefined) {
-    const applied = applyChangelogOverrides(makeValidationEntries(inputs.project.hashes), projectMap);
-    for (const message of applied.errors) {
-      errors.push(prefixWithFilePath(projectFilePath, message));
-    }
-    for (const key of projectMap.keys()) {
-      if (hasAnyMatch(key, inputs.project.hashes)) {
-        globalMatchedRootKeys.add(key);
-      }
-    }
+  const projectHashes = inputs.project?.hashes;
+  if (projectFilePath !== undefined && projectHashes !== undefined) {
+    processProjectScope({ projectFilePath, projectMap, projectHashes, errors, globalMatchedRootKeys });
   }
 
   // Root-tier stale keys: project keys matched nowhere (after honoring shadowing).
   if (projectFilePath !== undefined) {
-    for (const key of projectMap.keys()) {
-      if (!globalMatchedRootKeys.has(key)) {
-        warnings.push(formatRootStaleWarning(projectFilePath, key));
-      }
-    }
+    collectRootStaleWarnings(projectFilePath, projectMap, globalMatchedRootKeys, warnings);
   }
 
   return { errors, warnings };
+}
+
+interface WorkspaceScopeArgs {
+  workspace: { filePath: string; hashes: readonly string[]; map: Map<string, ChangelogOverride> };
+  projectFilePath: string | undefined;
+  projectMap: Map<string, ChangelogOverride>;
+  errors: string[];
+  warnings: string[];
+  globalMatchedRootKeys: Set<string>;
+}
+
+/**
+ * Process one workspace scope: surface ambiguous-prefix errors (attributing each to its source
+ * file), record workspace-tier stale warnings, and contribute non-shadowed root-key matches
+ * to `globalMatchedRootKeys`.
+ *
+ * Apply is split into two calls (workspace map alone; project map minus shadowed keys) so
+ * errors attribute to the file that contains the offending key, not to the composed view.
+ * Stale detection runs independently from prefix-match counts so ambiguous keys (2+ hits)
+ * aren't doubly flagged as stale.
+ */
+function processWorkspaceScope(args: WorkspaceScopeArgs): void {
+  const { workspace, projectFilePath, projectMap, errors, warnings, globalMatchedRootKeys } = args;
+  const { filePath, hashes, map } = workspace;
+
+  const workspaceApplied = applyChangelogOverrides(makeValidationEntries(hashes), map);
+  for (const message of workspaceApplied.errors) {
+    errors.push(prefixWithFilePath(filePath, message));
+  }
+
+  if (projectFilePath !== undefined && projectMap.size > 0) {
+    const projectMinusShadowed = filterShadowedKeys(projectMap, map);
+    const projectApplied = applyChangelogOverrides(makeValidationEntries(hashes), projectMinusShadowed);
+    for (const message of projectApplied.errors) {
+      errors.push(prefixWithFilePath(projectFilePath, message));
+    }
+  }
+
+  for (const key of map.keys()) {
+    if (!hasAnyMatch(key, hashes)) {
+      warnings.push(formatWorkspaceStaleWarning(filePath, key));
+    }
+  }
+
+  for (const key of projectMap.keys()) {
+    // Workspace-shadowed root keys do not count as root matches.
+    if (map.has(key)) continue;
+    if (hasAnyMatch(key, hashes)) {
+      globalMatchedRootKeys.add(key);
+    }
+  }
+}
+
+interface ProjectScopeArgs {
+  projectFilePath: string;
+  projectMap: Map<string, ChangelogOverride>;
+  projectHashes: readonly string[];
+  errors: string[];
+  globalMatchedRootKeys: Set<string>;
+}
+
+/**
+ * Process the project release scope: surface ambiguous-prefix errors and contribute every
+ * matched root key to `globalMatchedRootKeys`. Only invoked when the caller supplied a
+ * project release window (monorepo with a `project` block, or single-package mode).
+ */
+function processProjectScope(args: ProjectScopeArgs): void {
+  const { projectFilePath, projectMap, projectHashes, errors, globalMatchedRootKeys } = args;
+  const applied = applyChangelogOverrides(makeValidationEntries(projectHashes), projectMap);
+  for (const message of applied.errors) {
+    errors.push(prefixWithFilePath(projectFilePath, message));
+  }
+  for (const key of projectMap.keys()) {
+    if (hasAnyMatch(key, projectHashes)) {
+      globalMatchedRootKeys.add(key);
+    }
+  }
+}
+
+/** Push a root-stale warning for every project key not already marked as matched. */
+function collectRootStaleWarnings(
+  projectFilePath: string,
+  projectMap: Map<string, ChangelogOverride>,
+  globalMatchedRootKeys: Set<string>,
+  warnings: string[],
+): void {
+  for (const key of projectMap.keys()) {
+    if (!globalMatchedRootKeys.has(key)) {
+      warnings.push(formatRootStaleWarning(projectFilePath, key));
+    }
+  }
 }
 
 function hasAnyMatch(key: string, hashes: readonly string[]): boolean {

--- a/packages/release-kit/src/changelogOverrides.ts
+++ b/packages/release-kit/src/changelogOverrides.ts
@@ -527,14 +527,24 @@ export function validateAllChangelogOverrides(
   // a root key that's overridden everywhere is functionally dead and reported as stale.
   const globalMatchedRootKeys = new Set<string>();
 
-  // Workspace tier — apply composed (root + workspace) map against the workspace's hashes to
-  // surface ambiguous-prefix errors. Stale-key detection runs independently from prefix-match
-  // counts so ambiguous keys (2+ hits) aren't doubly flagged as stale.
+  // Workspace tier — apply each map separately against the workspace's hashes so ambiguous-
+  // prefix errors attribute to the file that contains the offending key, not to the composed
+  // view. The shadowing semantic still applies to the root-tier accounting below: byte-equal
+  // keys in the workspace map exclude their root counterparts from the project apply for this
+  // workspace (workspace's value would win at runtime, so the root entry is dead at this scope).
+  // Stale-key detection runs independently from prefix-match counts so ambiguous keys
+  // (2+ hits) aren't doubly flagged as stale.
   for (const { filePath, hashes, map } of workspaceMaps) {
-    const composed = composeOverrides(projectMap, map);
-    const applied = applyChangelogOverrides(makeValidationEntries(hashes), composed);
-    for (const message of applied.errors) {
+    const workspaceApplied = applyChangelogOverrides(makeValidationEntries(hashes), map);
+    for (const message of workspaceApplied.errors) {
       errors.push(prefixWithFilePath(filePath, message));
+    }
+    if (projectFilePath !== undefined && projectMap.size > 0) {
+      const projectMinusShadowed = filterShadowedKeys(projectMap, map);
+      const projectApplied = applyChangelogOverrides(makeValidationEntries(hashes), projectMinusShadowed);
+      for (const message of projectApplied.errors) {
+        errors.push(prefixWithFilePath(projectFilePath, message));
+      }
     }
     for (const key of map.keys()) {
       if (!hasAnyMatch(key, hashes)) {
@@ -578,6 +588,19 @@ export function validateAllChangelogOverrides(
 
 function hasAnyMatch(key: string, hashes: readonly string[]): boolean {
   return hashes.some((hash) => hash.startsWith(key));
+}
+
+/** Return a fresh map containing every entry of `projectMap` whose key does not appear in `workspaceMap`. */
+function filterShadowedKeys(
+  projectMap: Map<string, ChangelogOverride>,
+  workspaceMap: Map<string, ChangelogOverride>,
+): Map<string, ChangelogOverride> {
+  const result = new Map<string, ChangelogOverride>();
+  for (const [key, value] of projectMap) {
+    if (workspaceMap.has(key)) continue;
+    result.set(key, value);
+  }
+  return result;
 }
 
 /** Load a scope's override map, pushing any load/schema errors (each prefixed with the file path) onto `errors`. */

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -1,2 +1,8 @@
+export {
+  type ChangelogOverrideScope,
+  validateAllChangelogOverrides,
+  type ValidateAllChangelogOverridesInputs,
+  type ValidateAllChangelogOverridesResult,
+} from './changelogOverrides.ts';
 export type { SyncLabelsConfig } from './sync-labels/types.ts';
 export type { ReleaseKitConfig } from './types.ts';

--- a/packages/release-kit/src/index.ts
+++ b/packages/release-kit/src/index.ts
@@ -6,3 +6,4 @@ export {
 } from './changelogOverrides.ts';
 export type { SyncLabelsConfig } from './sync-labels/types.ts';
 export type { ReleaseKitConfig } from './types.ts';
+export { formatValidateOverridesResult, type ValidateOverridesCommandResult } from './validateOverridesCommand.ts';

--- a/packages/release-kit/src/validateOverridesCommand.ts
+++ b/packages/release-kit/src/validateOverridesCommand.ts
@@ -93,11 +93,23 @@ export function formatValidateOverridesResult(
   }
 
   const exitCode = errors.length > 0 ? 2 : 1;
-  const summary = `Found ${pluralize(errors.length, 'error')} and ${pluralize(warnings.length, 'warning')}:`;
+  const summary = formatSummaryLine(errors.length, warnings.length);
   const errorLines = errors.map((message) => `  ❌ ${message}`);
   const warningLines = warnings.map((message) => `  ⚠️  ${message}`);
   const message = [summary, '', ...errorLines, ...warningLines].join('\n');
   return { exitCode, message };
+}
+
+/** Render the leading summary, omitting zero-count categories (e.g., `Found 1 warning:` rather than `Found 0 errors and 1 warning:`). */
+function formatSummaryLine(errorCount: number, warningCount: number): string {
+  const parts: string[] = [];
+  if (errorCount > 0) {
+    parts.push(pluralize(errorCount, 'error'));
+  }
+  if (warningCount > 0) {
+    parts.push(pluralize(warningCount, 'warning'));
+  }
+  return `Found ${parts.join(' and ')}:`;
 }
 
 function pluralize(count: number, noun: string): string {

--- a/packages/release-kit/src/validateOverridesCommand.ts
+++ b/packages/release-kit/src/validateOverridesCommand.ts
@@ -1,0 +1,181 @@
+import {
+  resolveOverridePath,
+  validateAllChangelogOverrides,
+  type ValidateAllChangelogOverridesInputs,
+  type ValidateAllChangelogOverridesResult,
+} from './changelogOverrides.ts';
+import { discoverWorkspaces } from './discoverWorkspaces.ts';
+import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
+import { loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig, readRootPackageVersion } from './loadConfig.ts';
+import type { MonorepoReleaseConfig, ReleaseConfig, ReleaseKitConfig } from './types.ts';
+import { validateConfig } from './validateConfig.ts';
+
+/**
+ * Result of {@link validateOverridesCommand}: tiered exit code paired with a human-readable
+ * message. Mirrors the shape of `checkWorkTypesDrift` so the CLI dispatch layer can stay
+ * uniformly thin.
+ *
+ * Exit codes:
+ * - `0` — clean: no errors, no warnings.
+ * - `1` — only stale-key warnings.
+ * - `2` — schema/parse or ambiguous-prefix errors (errors dominate when both classes exist).
+ */
+export interface ValidateOverridesCommandResult {
+  exitCode: 0 | 1 | 2;
+  message: string;
+}
+
+/** Injection seams for unit testing. Production callers leave defaults; tests substitute deterministic fakes. */
+export interface ValidateOverridesCommandDependencies {
+  discoverWorkspaces?: () => Promise<string[] | undefined>;
+  loadConfig?: () => Promise<unknown>;
+  /** Collect commit hashes for a given tag-prefix union and optional path filter. Defaults to a real `git log` invocation. */
+  collectHashes?: (tagPrefixes: readonly string[], paths?: string[]) => readonly string[];
+  /** Pluggable validator (default: the production library function). Tests use this to drive specific result shapes through the formatter. */
+  validate?: (inputs: ValidateAllChangelogOverridesInputs) => ValidateAllChangelogOverridesResult;
+}
+
+/**
+ * Validate every changelog override file across the project and per-workspace scopes, and
+ * return a tiered exit-code-plus-message result. Performs workspace discovery, config load,
+ * and per-scope hash collection, then delegates the actual validation to
+ * {@link validateAllChangelogOverrides}.
+ *
+ * Single-package and monorepo modes are handled uniformly: single-package collapses to one
+ * project scope; monorepo expands to a project scope plus one scope per workspace.
+ */
+export async function validateOverridesCommand(
+  dependencies: ValidateOverridesCommandDependencies = {},
+): Promise<ValidateOverridesCommandResult> {
+  const discover = dependencies.discoverWorkspaces ?? discoverWorkspaces;
+  const load = dependencies.loadConfig ?? loadConfig;
+  const collect = dependencies.collectHashes ?? defaultCollectHashes;
+  const validate = dependencies.validate ?? validateAllChangelogOverrides;
+
+  let userConfig: ReleaseKitConfig | undefined;
+  try {
+    userConfig = await loadAndValidateConfig(load);
+  } catch (error: unknown) {
+    return { exitCode: 2, message: errorMessage(error) };
+  }
+
+  let discoveredPaths: string[] | undefined;
+  try {
+    discoveredPaths = await discover();
+  } catch (error: unknown) {
+    return { exitCode: 2, message: `Error discovering workspaces: ${errorMessage(error)}` };
+  }
+
+  let inputs: ValidateAllChangelogOverridesInputs;
+  try {
+    inputs =
+      discoveredPaths === undefined
+        ? buildSinglePackageInputs(userConfig, collect)
+        : buildMonorepoInputs(discoveredPaths, userConfig, collect);
+  } catch (error: unknown) {
+    return { exitCode: 2, message: `Error resolving overrides scope: ${errorMessage(error)}` };
+  }
+
+  const result = validate(inputs);
+  return formatValidateOverridesResult(result);
+}
+
+/**
+ * Pure formatter — take an aggregated validation result, return the tiered exit code and a
+ * rendered message. Exported for unit testing without going through the full discovery path.
+ */
+export function formatValidateOverridesResult(
+  result: ValidateAllChangelogOverridesResult,
+): ValidateOverridesCommandResult {
+  const { errors, warnings } = result;
+  if (errors.length === 0 && warnings.length === 0) {
+    return { exitCode: 0, message: 'All override files are valid (no errors, no stale keys).' };
+  }
+
+  const exitCode = errors.length > 0 ? 2 : 1;
+  const summary = `Found ${pluralize(errors.length, 'error')} and ${pluralize(warnings.length, 'warning')}:`;
+  const errorLines = errors.map((message) => `  ❌ ${message}`);
+  const warningLines = warnings.map((message) => `  ⚠️  ${message}`);
+  const message = [summary, '', ...errorLines, ...warningLines].join('\n');
+  return { exitCode, message };
+}
+
+function pluralize(count: number, noun: string): string {
+  return count === 1 ? `${count} ${noun}` : `${count} ${noun}s`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Default hash collector — wraps `getCommitsSinceTarget` and projects to the hash list. */
+function defaultCollectHashes(tagPrefixes: readonly string[], paths?: string[]): readonly string[] {
+  if (tagPrefixes.length === 0) {
+    return [];
+  }
+  return getCommitsSinceTarget(tagPrefixes, paths).commits.map((commit) => commit.hash);
+}
+
+/** Load and validate the user's config file, throwing a descriptive error on any problem. */
+async function loadAndValidateConfig(load: () => Promise<unknown>): Promise<ReleaseKitConfig | undefined> {
+  let rawConfig: unknown;
+  try {
+    rawConfig = await load();
+  } catch (error: unknown) {
+    throw new Error(`Error loading config: ${errorMessage(error)}`);
+  }
+
+  if (rawConfig === undefined) {
+    return undefined;
+  }
+
+  const { config, errors } = validateConfig(rawConfig);
+  if (errors.length > 0) {
+    throw new Error(`Invalid config:\n  - ${errors.join('\n  - ')}`);
+  }
+  return config;
+}
+
+/** Build validation inputs for a single-package repo (no `pnpm-workspace.yaml`). */
+function buildSinglePackageInputs(
+  userConfig: ReleaseKitConfig | undefined,
+  collect: (tagPrefixes: readonly string[], paths?: string[]) => readonly string[],
+): ValidateAllChangelogOverridesInputs {
+  const config: ReleaseConfig = mergeSinglePackageConfig(userConfig);
+  const hashes = [...collect([config.tagPrefix])];
+  return {
+    project: { filePath: resolveOverridePath('.'), hashes },
+  };
+}
+
+/** Build validation inputs for a monorepo, mirroring the per-scope hash universes `prepare` would compute. */
+function buildMonorepoInputs(
+  discoveredPaths: string[],
+  userConfig: ReleaseKitConfig | undefined,
+  collect: (tagPrefixes: readonly string[], paths?: string[]) => readonly string[],
+): ValidateAllChangelogOverridesInputs {
+  const rootPackage = readRootPackageVersion();
+  const config: MonorepoReleaseConfig = mergeMonorepoConfig(discoveredPaths, userConfig, rootPackage);
+
+  const workspaces = config.workspaces.map((workspace) => {
+    const tagPrefixes = [
+      workspace.tagPrefix,
+      ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? []),
+    ];
+    return {
+      filePath: resolveOverridePath(workspace.workspacePath),
+      hashes: [...collect(tagPrefixes, workspace.paths)],
+    };
+  });
+
+  const project = config.project;
+  const projectScope: { filePath: string; hashes?: readonly string[] } = {
+    filePath: resolveOverridePath('.'),
+  };
+  if (project !== undefined) {
+    const contributingPaths = config.workspaces.flatMap((workspace) => workspace.paths);
+    projectScope.hashes = [...collect([project.tagPrefix], contributingPaths)];
+  }
+
+  return { project: projectScope, workspaces };
+}


### PR DESCRIPTION
## What

Adds a `release-kit overrides validate` subcommand that audits every `.meta/changelog-overrides.json` file across the project root and per-workspace scopes in one pass. The command reports schema errors, ambiguous-prefix collisions, and stale-key warnings with tiered exit codes so CI can choose its own failure threshold. The same validation is also available via a library function exported by the package.

## Why

Editorial overrides accumulate over time, and stale references — keys that no longer match any commit after a rebase or branch deletion — silently linger until the next `release-kit prepare` run, where they surface mixed in with release output. There was no way to run an overrides-only health check from the command line or from CI.

## Details

### 🎉 Features

- New `release-kit overrides validate` subcommand walks every `.meta/changelog-overrides.json` across the project root and per-workspace scopes, surfacing schema errors, ambiguous-prefix collisions, and stale-key warnings with tiered exit codes (`0`/`1`/`2`). `release-kit overrides --help` and `release-kit overrides validate --help` document the behavior.
- Validation logic is also exposed on the package's public API (`validateAllChangelogOverrides` plus a companion result formatter) for programmatic consumers and future composite checks.
- Tier-aware stale-key semantics match `release-kit prepare`'s match-set exactly: workspace-tier keys are stale only when they don't match in their own workspace's history; root-tier keys are stale only when they don't match in any scope, including the case where the key is shadowed by an identical workspace-tier key everywhere it would otherwise apply.

### 🐛 Bug fixes

- Ambiguous-prefix errors now attribute to the file containing the offending key. The initial implementation ran a composed (root + workspace) apply per workspace and tagged every error with the workspace's file path, so a project-tier key resolving ambiguously against a workspace's hash window pointed users at the wrong file. The fix splits the per-workspace apply into two — workspace map alone, project map minus shadowed keys — so each error names its source file. Caught during code review before any release.

### ♻️ Refactoring

- The validator is split into per-scope helpers — one each for the workspace tier, the project release window, and the final root-stale sweep — so each helper reads as one slice of the algorithm.

### 🧪 Tests

- New unit tests cover every documented finding class, both tiers, the cross-tier attribution path (locked in to prevent regression of the bug above), and every exit-code path through dependency-injected stubs.

Closes #388
