### PR TITLE
#398 Validate overrides against the full release history

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -459,7 +459,7 @@ The override file is validated when `release-kit prepare` loads it. Each error n
 
 #### Standalone validation: `release-kit overrides validate`
 
-For a fast overrides-only health check (locally or as a CI gate), run:
+For a focused overrides-only health check (locally or as a CI gate), run:
 
 ```sh
 pnpm exec release-kit overrides validate

--- a/packages/release-kit/src/__tests__/validateOverridesCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateOverridesCommand.unit.test.ts
@@ -337,4 +337,71 @@ describe(validateOverridesCommand, () => {
       expect(mockedRunGitCliff).toHaveBeenCalled();
     });
   });
+
+  // Monorepo wiring: pin the per-workspace and project-tier `buildEntries` arguments so a
+  // future refactor that drops legacy identities, narrows the project path-union, or otherwise
+  // diverges from `releasePrepareMono.ts:722-723` / `releasePrepareProject.ts:262-266` fails
+  // here rather than silently producing wrong stale-key reports.
+  describe('buildMonorepoInputs (monorepo wiring)', () => {
+    let tempDir: string;
+    let originalCwd: string;
+
+    beforeEach(() => {
+      originalCwd = process.cwd();
+      tempDir = mkdtempSync(path.join(tmpdir(), 'validate-overrides-mono-'));
+      // Root package.json — required when the user config declares a `project` block.
+      writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'mono-root', version: '1.0.0' }));
+      // Workspace `foo` with a legacy npm name `old-foo`.
+      mkdirSync(path.join(tempDir, 'packages/foo'), { recursive: true });
+      writeFileSync(path.join(tempDir, 'packages/foo/package.json'), JSON.stringify({ name: 'foo' }));
+      // Workspace `bar` with a scoped npm name (strips to `bar` for tag-prefix derivation).
+      mkdirSync(path.join(tempDir, 'packages/bar'), { recursive: true });
+      writeFileSync(path.join(tempDir, 'packages/bar/package.json'), JSON.stringify({ name: '@scope/bar' }));
+      process.chdir(tempDir);
+    });
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('passes per-workspace tagPattern (with legacy identities) and project-tier tagPattern with the union of workspace paths', async () => {
+      const calls: { tagPattern: string | undefined; includePaths: readonly string[] | undefined }[] = [];
+
+      await validateOverridesCommand({
+        discoverWorkspaces: () => Promise.resolve(['packages/foo', 'packages/bar']),
+        loadConfig: () =>
+          Promise.resolve({
+            workspaces: [{ dir: 'foo', legacyIdentities: [{ name: 'old-foo', tagPrefix: 'old-foo-v' }] }],
+            project: { tagPrefix: 'mono-v' },
+          }),
+        buildEntries: (_config, tagPattern, includePaths) => {
+          calls.push({ tagPattern, includePaths });
+          return [];
+        },
+        validate: () => ({ errors: [], warnings: [] }),
+      });
+
+      // Three invocations: foo workspace, bar workspace, project-tier.
+      expect(calls).toHaveLength(3);
+
+      // foo: workspace tagPattern is the union of derived + legacy prefixes; includePaths is the workspace glob.
+      expect(calls[0]).toEqual({
+        tagPattern: '(foo-v|old-foo-v)[0-9].*',
+        includePaths: ['packages/foo/**'],
+      });
+
+      // bar: single derived prefix (no legacy identities); includePaths is its workspace glob.
+      expect(calls[1]).toEqual({
+        tagPattern: 'bar-v[0-9].*',
+        includePaths: ['packages/bar/**'],
+      });
+
+      // Project tier: project tagPattern; includePaths is the union of workspace globs.
+      expect(calls[2]).toEqual({
+        tagPattern: 'mono-v[0-9].*',
+        includePaths: ['packages/foo/**', 'packages/bar/**'],
+      });
+    });
+  });
 });

--- a/packages/release-kit/src/__tests__/validateOverridesCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateOverridesCommand.unit.test.ts
@@ -1,6 +1,46 @@
-import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runGitCliff } from '../runGitCliff.ts';
+import type { ChangelogEntry } from '../types.ts';
 import { formatValidateOverridesResult, validateOverridesCommand } from '../validateOverridesCommand.ts';
+
+// Stub `runGitCliff` so the near-integration block can exercise the real
+// `validateOverridesCommand → buildChangelogEntries → validateAllChangelogOverrides` pipeline
+// without requiring git-cliff on PATH. Other tests in this file inject `buildEntries` directly,
+// so they never reach the stubbed call site.
+vi.mock('../runGitCliff.ts', () => ({
+  runGitCliff: vi.fn(() => '[]'),
+}));
+
+const mockedRunGitCliff = vi.mocked(runGitCliff);
+
+/**
+ * Wrap a flat list of hashes into the minimal `ChangelogEntry[]` shape that the production
+ * code's `flattenEntriesToHashes` walks. Use {@link entriesFromReleases} when a test needs to
+ * differentiate per-release groupings (e.g., past vs. unreleased).
+ */
+function entriesFromHashes(hashes: string[]): ChangelogEntry[] {
+  return entriesFromReleases([{ version: '0.0.0-test', hashes }]);
+}
+
+/** Build a multi-release entry tree. Each spec becomes one `ChangelogEntry`. */
+function entriesFromReleases(specs: { version: string; hashes: string[] }[]): ChangelogEntry[] {
+  return specs.map((spec) => ({
+    version: spec.version,
+    date: '0000-00-00',
+    sections: [
+      {
+        title: 'Test',
+        audience: 'all',
+        items: spec.hashes.map((hash) => ({ description: '', hash })),
+      },
+    ],
+  }));
+}
 
 describe(formatValidateOverridesResult, () => {
   it('returns exit 0 with a success message when there are no findings', () => {
@@ -55,7 +95,7 @@ describe(validateOverridesCommand, () => {
     const result = await validateOverridesCommand({
       discoverWorkspaces: () => Promise.resolve(undefined),
       loadConfig: () => Promise.resolve(undefined),
-      collectHashes: () => [],
+      buildEntries: () => entriesFromHashes([]),
       validate: () => ({ errors: [], warnings: [] }),
     });
     expect(result.exitCode).toBe(0);
@@ -65,7 +105,7 @@ describe(validateOverridesCommand, () => {
     const result = await validateOverridesCommand({
       discoverWorkspaces: () => Promise.resolve(undefined),
       loadConfig: () => Promise.resolve(undefined),
-      collectHashes: () => [],
+      buildEntries: () => entriesFromHashes([]),
       validate: () => ({ errors: [], warnings: ['file.json: stale key'] }),
     });
     expect(result.exitCode).toBe(1);
@@ -75,7 +115,7 @@ describe(validateOverridesCommand, () => {
     const result = await validateOverridesCommand({
       discoverWorkspaces: () => Promise.resolve(undefined),
       loadConfig: () => Promise.resolve(undefined),
-      collectHashes: () => [],
+      buildEntries: () => entriesFromHashes([]),
       validate: () => ({ errors: ['file.json: ambiguous'], warnings: [] }),
     });
     expect(result.exitCode).toBe(2);
@@ -108,7 +148,7 @@ describe(validateOverridesCommand, () => {
     await validateOverridesCommand({
       discoverWorkspaces: () => Promise.resolve(undefined),
       loadConfig: () => Promise.resolve(undefined),
-      collectHashes: () => ['hash1', 'hash2'],
+      buildEntries: () => entriesFromHashes(['hash1', 'hash2']),
       validate: (inputs) => {
         received = {
           workspaces: inputs.workspaces?.length ?? 0,
@@ -118,5 +158,183 @@ describe(validateOverridesCommand, () => {
       },
     });
     expect(received).toStrictEqual({ workspaces: 0, projectHashes: 2 });
+  });
+
+  // Bug-fix coverage: the validator's hash universe must be byte-equal to what `prepare`
+  // walks. Tests below verify that the full multi-release tree (not just the latestTag..HEAD
+  // window the prior implementation used) is delivered to the validator, and that the
+  // downstream classification still surfaces unreachable keys and ambiguous prefixes correctly.
+
+  it('delivers the full multi-release hash universe to the validator (past releases included)', async () => {
+    // Regression for issue #398: prior to the fix, only the current unreleased window was
+    // available to the validator. An override targeting a hash in a past release (here:
+    // 'aabbcc1234') was reported stale because the validator never saw that hash.
+    let capturedHashes: readonly string[] = [];
+    await validateOverridesCommand({
+      discoverWorkspaces: () => Promise.resolve(undefined),
+      loadConfig: () => Promise.resolve(undefined),
+      buildEntries: () =>
+        entriesFromReleases([
+          { version: '1.0.0', hashes: ['aabbcc1234567890aabbcc1234567890aabbcc12'] },
+          { version: '2.0.0', hashes: ['ddeeff5678901234ddeeff5678901234ddeeff56'] },
+          { version: 'validate-only', hashes: ['9988aabbccddeeff9988aabbccddeeff9988aabb'] },
+        ]),
+      validate: (inputs) => {
+        capturedHashes = inputs.project?.hashes ?? [];
+        return { errors: [], warnings: [] };
+      },
+    });
+    expect(capturedHashes).toEqual([
+      'aabbcc1234567890aabbcc1234567890aabbcc12',
+      'ddeeff5678901234ddeeff5678901234ddeeff56',
+      '9988aabbccddeeff9988aabbccddeeff9988aabb',
+    ]);
+  });
+
+  describe('against the real validator (writes a temp override file)', () => {
+    let tempDir: string;
+    let originalCwd: string;
+
+    beforeEach(() => {
+      originalCwd = process.cwd();
+      tempDir = mkdtempSync(path.join(tmpdir(), 'validate-overrides-'));
+      mkdirSync(path.join(tempDir, '.meta'), { recursive: true });
+      process.chdir(tempDir);
+    });
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    function writeOverrides(overrides: Record<string, unknown>): void {
+      writeFileSync(path.join(tempDir, '.meta', 'changelog-overrides.json'), JSON.stringify(overrides, null, 2));
+    }
+
+    it('does NOT flag an override targeting a past-release commit as stale', async () => {
+      const pastHash = 'aabbcc1234567890aabbcc1234567890aabbcc12';
+      const unreleasedHash = '9988aabbccddeeff9988aabbccddeeff9988aabb';
+      writeOverrides({ aabbcc12: { audience: 'skip' } });
+
+      const result = await validateOverridesCommand({
+        discoverWorkspaces: () => Promise.resolve(undefined),
+        loadConfig: () => Promise.resolve(undefined),
+        buildEntries: () =>
+          entriesFromReleases([
+            { version: '1.0.0', hashes: [pastHash] },
+            { version: 'validate-only', hashes: [unreleasedHash] },
+          ]),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.message).not.toContain('aabbcc12');
+      expect(result.message).not.toContain('did not match');
+    });
+
+    it('flags an override targeting an unreachable hash as stale', async () => {
+      writeOverrides({ deadbeef: { audience: 'skip' } });
+
+      const result = await validateOverridesCommand({
+        discoverWorkspaces: () => Promise.resolve(undefined),
+        loadConfig: () => Promise.resolve(undefined),
+        buildEntries: () =>
+          entriesFromReleases([
+            { version: '1.0.0', hashes: ['aabbcc1234567890aabbcc1234567890aabbcc12'] },
+            { version: 'validate-only', hashes: ['9988aabbccddeeff9988aabbccddeeff9988aabb'] },
+          ]),
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.message).toContain('deadbeef');
+      expect(result.message).toContain('stale');
+    });
+
+    it('surfaces an ambiguous-prefix error with file-path attribution', async () => {
+      writeOverrides({ aa: { audience: 'skip' } });
+
+      const result = await validateOverridesCommand({
+        discoverWorkspaces: () => Promise.resolve(undefined),
+        loadConfig: () => Promise.resolve(undefined),
+        buildEntries: () =>
+          entriesFromReleases([
+            {
+              version: '1.0.0',
+              hashes: ['aabbcc1234567890aabbcc1234567890aabbcc12', 'aabbdd5678901234aabbdd5678901234aabbdd56'],
+            },
+          ]),
+      });
+
+      expect(result.exitCode).toBe(2);
+      expect(result.message).toContain('.meta/changelog-overrides.json:');
+      expect(result.message).toContain('ambiguous');
+      expect(result.message).toContain('aa');
+    });
+  });
+
+  describe('near-integration: full pipeline with mocked runGitCliff', () => {
+    let tempDir: string;
+    let originalCwd: string;
+
+    beforeEach(() => {
+      originalCwd = process.cwd();
+      tempDir = mkdtempSync(path.join(tmpdir(), 'validate-overrides-int-'));
+      mkdirSync(path.join(tempDir, '.meta'), { recursive: true });
+      process.chdir(tempDir);
+      mockedRunGitCliff.mockReset();
+      mockedRunGitCliff.mockReturnValue('[]');
+    });
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('exercises real validateOverridesCommand → buildChangelogEntries → validator with a multi-release cliff context (#398)', async () => {
+      // Canned `git-cliff --context` output simulating two releases plus the unreleased range.
+      // The past-release commit `aabbcc12…` is what regressed prior to the fix: the narrow
+      // `git log <latestTag>..HEAD` universe excluded it, causing a false-positive stale warning.
+      const pastHash = 'aabbcc1234567890aabbcc1234567890aabbcc12';
+      const currentHash = 'ddeeff5678901234ddeeff5678901234ddeeff56';
+      const unreleasedHash = '9988aabbccddeeff9988aabbccddeeff9988aabb';
+      mockedRunGitCliff.mockReturnValue(
+        JSON.stringify([
+          {
+            version: 'v1.0.0',
+            timestamp: 1_700_000_000,
+            commits: [{ id: pastHash, message: 'feat: past feature', group: 'Features' }],
+          },
+          {
+            version: 'v2.0.0',
+            timestamp: 1_710_000_000,
+            commits: [{ id: currentHash, message: 'feat: current feature', group: 'Features' }],
+          },
+          {
+            version: 'validate-only',
+            commits: [{ id: unreleasedHash, message: 'feat: unreleased feature', group: 'Features' }],
+          },
+        ]),
+      );
+
+      writeFileSync(
+        path.join(tempDir, '.meta', 'changelog-overrides.json'),
+        JSON.stringify({
+          aabbcc12: { audience: 'skip' }, // past-release commit — must NOT be stale
+          deadbeef: { audience: 'skip' }, // unreachable — must be flagged stale
+        }),
+      );
+
+      const result = await validateOverridesCommand({
+        discoverWorkspaces: () => Promise.resolve(undefined),
+        loadConfig: () => Promise.resolve(undefined),
+      });
+
+      // Bug regression gate: aabbcc12 must not appear in any warning.
+      expect(result.message).not.toContain('aabbcc12');
+      // The genuinely-orphaned key must still be flagged.
+      expect(result.message).toContain('deadbeef');
+      expect(result.exitCode).toBe(1);
+      // Confirm the production code path actually invoked cliff (proves the pipeline ran).
+      expect(mockedRunGitCliff).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/release-kit/src/changelogOverrides.ts
+++ b/packages/release-kit/src/changelogOverrides.ts
@@ -499,10 +499,13 @@ export interface ValidateAllChangelogOverridesResult {
  * hash universes and returns aggregated findings. The CLI command and any other consumer
  * (programmatic library callers, future composite checks) wrap this with discovery and I/O.
  *
- * The match-set is byte-equal to what `release-kit prepare` would compute, including the
- * tier asymmetry: workspace-tier keys are stale if they don't match in their own workspace;
+ * When invoked via the standard `validateOverridesCommand` entry point, each scope's
+ * `hashes` is built by `buildChangelogEntries` — the same path `release-kit prepare` walks —
+ * so the match-set is byte-equal to what `prepare` would compute. The tier asymmetry is part
+ * of that contract: workspace-tier keys are stale if they don't match in their own workspace;
  * root-tier keys are stale only if they don't match in any scope (no workspace AND not the
- * project release window).
+ * project release window). Library callers that construct `inputs` directly are responsible
+ * for supplying the same hash universes if they want this guarantee.
  *
  * Every returned string is prefixed with the relative override-file path it pertains to so
  * consumers can locate the offending file without further structuring.

--- a/packages/release-kit/src/generateChangelogs.ts
+++ b/packages/release-kit/src/generateChangelogs.ts
@@ -1,3 +1,5 @@
+import type { WorkspaceConfig } from './types.ts';
+
 /**
  * Build a git-cliff tag pattern from one or more tag prefixes.
  *
@@ -21,13 +23,12 @@ export function buildTagPattern(tagPrefixes: readonly string[]): string {
 }
 
 /**
- * Escape regex metacharacters so a literal prefix is matched as-is.
- *
- * Derived prefixes from npm package names are restricted to `[a-z0-9-]`, but legacy entries
- * from user config may contain anything; defensive escaping prevents silent pattern drift.
+ * Return the workspace's derived tag prefix followed by each declared legacy-identity tag
+ * prefix. Shared by `releasePrepareMono` (the production prepare path) and
+ * `validateOverridesCommand` so the two compute byte-equal per-workspace tag-prefix unions.
  */
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+export function getAllTagPrefixes(workspace: WorkspaceConfig): string[] {
+  return [workspace.tagPrefix, ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? [])];
 }
 
 /**
@@ -43,4 +44,14 @@ export interface GenerateChangelogOptions {
   tagPattern?: string;
   /** Paths to include in the changelog (passed as --include-path to git-cliff). */
   includePaths?: string[];
+}
+
+/**
+ * Escape regex metacharacters so a literal prefix is matched as-is.
+ *
+ * Derived prefixes from npm package names are restricted to `[a-z0-9-]`, but legacy entries
+ * from user config may contain anything; defensive escaping prevents silent pattern drift.
+ */
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -22,7 +22,7 @@ import { isForwardVersion } from './compareVersions.ts';
 import { decideRelease } from './decideRelease.ts';
 import { DEFAULT_BREAKING_POLICIES, DEFAULT_VERSION_PATTERNS, DEFAULT_WORK_TYPES } from './defaults.ts';
 import { detectUndeclaredTagPrefixes } from './detectUndeclaredTagPrefixes.ts';
-import { buildTagPattern } from './generateChangelogs.ts';
+import { buildTagPattern, getAllTagPrefixes } from './generateChangelogs.ts';
 import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
 import { hasPrettierConfig } from './hasPrettierConfig.ts';
 import { resolveWorkTypes } from './loadConfig.ts';
@@ -918,9 +918,4 @@ function topologicalSort(
   }
 
   return { sorted, cyclicDirs };
-}
-
-/** Return the workspace's derived tag prefix followed by each declared legacy-identity tag prefix. */
-function getAllTagPrefixes(workspace: WorkspaceConfig): string[] {
-  return [workspace.tagPrefix, ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? [])];
 }

--- a/packages/release-kit/src/validateOverridesCommand.ts
+++ b/packages/release-kit/src/validateOverridesCommand.ts
@@ -1,3 +1,4 @@
+import { buildChangelogEntries } from './buildChangelogEntries.ts';
 import {
   resolveOverridePath,
   validateAllChangelogOverrides,
@@ -5,10 +6,19 @@ import {
   type ValidateAllChangelogOverridesResult,
 } from './changelogOverrides.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
-import { getCommitsSinceTarget } from './getCommitsSinceTarget.ts';
+import { buildTagPattern, type GenerateChangelogOptions } from './generateChangelogs.ts';
 import { loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig, readRootPackageVersion } from './loadConfig.ts';
-import type { MonorepoReleaseConfig, ReleaseConfig, ReleaseKitConfig } from './types.ts';
+import type { ChangelogEntry, MonorepoReleaseConfig, ReleaseConfig, ReleaseKitConfig } from './types.ts';
 import { validateConfig } from './validateConfig.ts';
+
+/**
+ * Synthetic `--tag` value passed to `buildChangelogEntries` during validation. Cliff uses the
+ * tag only as a label for the unreleased range; the matching universe is determined by cliff's
+ * history walk (filtered by `tagPattern`), not by this label. `validate` persists nothing, so
+ * any non-empty string is acceptable — a clearly synthetic literal aids debugging if the value
+ * ever surfaces.
+ */
+const SYNTHETIC_VALIDATE_TAG = 'validate-only';
 
 /**
  * Result of {@link validateOverridesCommand}: tiered exit code paired with a human-readable
@@ -29,8 +39,16 @@ export interface ValidateOverridesCommandResult {
 export interface ValidateOverridesCommandDependencies {
   discoverWorkspaces?: () => Promise<string[] | undefined>;
   loadConfig?: () => Promise<unknown>;
-  /** Collect commit hashes for a given tag-prefix union and optional path filter. Defaults to a real `git log` invocation. */
-  collectHashes?: (tagPrefixes: readonly string[], paths?: string[]) => readonly string[];
+  /**
+   * Build changelog entries for a scope. Defaults to `buildChangelogEntries`, the same path
+   * `release-kit prepare` uses — anchoring `validate`'s hash universe to `prepare`'s by
+   * construction. `tagPattern` and `includePaths` are passed straight through to git-cliff.
+   */
+  buildEntries?: (
+    config: Pick<ReleaseConfig, 'cliffConfigPath' | 'changelogJson'>,
+    tagPattern?: string,
+    includePaths?: string[],
+  ) => ChangelogEntry[];
   /** Pluggable validator (default: the production library function). Tests use this to drive specific result shapes through the formatter. */
   validate?: (inputs: ValidateAllChangelogOverridesInputs) => ValidateAllChangelogOverridesResult;
 }
@@ -49,7 +67,7 @@ export async function validateOverridesCommand(
 ): Promise<ValidateOverridesCommandResult> {
   const discover = dependencies.discoverWorkspaces ?? discoverWorkspaces;
   const load = dependencies.loadConfig ?? loadConfig;
-  const collect = dependencies.collectHashes ?? defaultCollectHashes;
+  const buildEntries = dependencies.buildEntries ?? defaultBuildEntries;
   const validate = dependencies.validate ?? validateAllChangelogOverrides;
 
   let userConfig: ReleaseKitConfig | undefined;
@@ -70,8 +88,8 @@ export async function validateOverridesCommand(
   try {
     inputs =
       discoveredPaths === undefined
-        ? buildSinglePackageInputs(userConfig, collect)
-        : buildMonorepoInputs(discoveredPaths, userConfig, collect);
+        ? buildSinglePackageInputs(userConfig, buildEntries)
+        : buildMonorepoInputs(discoveredPaths, userConfig, buildEntries);
   } catch (error: unknown) {
     return { exitCode: 2, message: `Error resolving overrides scope: ${errorMessage(error)}` };
   }
@@ -120,12 +138,44 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/** Default hash collector — wraps `getCommitsSinceTarget` and projects to the hash list. */
-function defaultCollectHashes(tagPrefixes: readonly string[], paths?: string[]): readonly string[] {
-  if (tagPrefixes.length === 0) {
-    return [];
+/**
+ * Default entry builder — delegates to `buildChangelogEntries`, the same function `prepare`
+ * uses. The synthetic tag label is throwaway; cliff's history walk is what produces the
+ * matching universe.
+ */
+function defaultBuildEntries(
+  config: Pick<ReleaseConfig, 'cliffConfigPath' | 'changelogJson'>,
+  tagPattern?: string,
+  includePaths?: string[],
+): ChangelogEntry[] {
+  // Build options conditionally — `exactOptionalPropertyTypes` distinguishes "omitted" from
+  // "present-but-undefined", and `GenerateChangelogOptions` requires omission for the absent case.
+  const options: GenerateChangelogOptions = {};
+  if (tagPattern !== undefined) {
+    options.tagPattern = tagPattern;
   }
-  return getCommitsSinceTarget(tagPrefixes, paths).commits.map((commit) => commit.hash);
+  if (includePaths !== undefined) {
+    options.includePaths = includePaths;
+  }
+  return buildChangelogEntries(config, SYNTHETIC_VALIDATE_TAG, options);
+}
+
+/**
+ * Project every release's items down to a flat list of commit hashes. Synthetic propagation
+ * entries (no `hash`) contribute nothing — they cannot match an override key.
+ */
+function flattenEntriesToHashes(entries: readonly ChangelogEntry[]): string[] {
+  const hashes: string[] = [];
+  for (const entry of entries) {
+    for (const section of entry.sections) {
+      for (const item of section.items) {
+        if (item.hash !== undefined) {
+          hashes.push(item.hash);
+        }
+      }
+    }
+  }
+  return hashes;
 }
 
 /** Load and validate the user's config file, throwing a descriptive error on any problem. */
@@ -148,23 +198,35 @@ async function loadAndValidateConfig(load: () => Promise<unknown>): Promise<Rele
   return config;
 }
 
-/** Build validation inputs for a single-package repo (no `pnpm-workspace.yaml`). */
+/**
+ * Build validation inputs for a single-package repo (no `pnpm-workspace.yaml`).
+ *
+ * Mirrors `releasePrepare.ts`'s `buildChangelogEntries(config, newTag)` call: no
+ * `tagPattern`/`includePaths`, letting cliff emit every release across all paths.
+ */
 function buildSinglePackageInputs(
   userConfig: ReleaseKitConfig | undefined,
-  collect: (tagPrefixes: readonly string[], paths?: string[]) => readonly string[],
+  buildEntries: NonNullable<ValidateOverridesCommandDependencies['buildEntries']>,
 ): ValidateAllChangelogOverridesInputs {
   const config: ReleaseConfig = mergeSinglePackageConfig(userConfig);
-  const hashes = [...collect([config.tagPrefix])];
+  const hashes = flattenEntriesToHashes(buildEntries(config));
   return {
     project: { filePath: resolveOverridePath('.'), hashes },
   };
 }
 
-/** Build validation inputs for a monorepo, mirroring the per-scope hash universes `prepare` would compute. */
+/**
+ * Build validation inputs for a monorepo, mirroring the per-scope hash universes `prepare` would compute.
+ *
+ * Workspace scopes mirror `releasePrepareMono.ts:722-723`: `buildTagPattern` over the workspace's
+ * derived prefix plus any legacy-identity prefixes, with the workspace's `includePaths`. The
+ * project scope mirrors `releasePrepareProject.ts:262-266`: `buildTagPattern([project.tagPrefix])`
+ * with the union of all workspace paths.
+ */
 function buildMonorepoInputs(
   discoveredPaths: string[],
   userConfig: ReleaseKitConfig | undefined,
-  collect: (tagPrefixes: readonly string[], paths?: string[]) => readonly string[],
+  buildEntries: NonNullable<ValidateOverridesCommandDependencies['buildEntries']>,
 ): ValidateAllChangelogOverridesInputs {
   const rootPackage = readRootPackageVersion();
   const config: MonorepoReleaseConfig = mergeMonorepoConfig(discoveredPaths, userConfig, rootPackage);
@@ -174,9 +236,10 @@ function buildMonorepoInputs(
       workspace.tagPrefix,
       ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? []),
     ];
+    const tagPattern = buildTagPattern(tagPrefixes);
     return {
       filePath: resolveOverridePath(workspace.workspacePath),
-      hashes: [...collect(tagPrefixes, workspace.paths)],
+      hashes: flattenEntriesToHashes(buildEntries(config, tagPattern, workspace.paths)),
     };
   });
 
@@ -186,7 +249,8 @@ function buildMonorepoInputs(
   };
   if (project !== undefined) {
     const contributingPaths = config.workspaces.flatMap((workspace) => workspace.paths);
-    projectScope.hashes = [...collect([project.tagPrefix], contributingPaths)];
+    const projectTagPattern = buildTagPattern([project.tagPrefix]);
+    projectScope.hashes = flattenEntriesToHashes(buildEntries(config, projectTagPattern, contributingPaths));
   }
 
   return { project: projectScope, workspaces };

--- a/packages/release-kit/src/validateOverridesCommand.ts
+++ b/packages/release-kit/src/validateOverridesCommand.ts
@@ -6,7 +6,7 @@ import {
   type ValidateAllChangelogOverridesResult,
 } from './changelogOverrides.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
-import { buildTagPattern, type GenerateChangelogOptions } from './generateChangelogs.ts';
+import { buildTagPattern, type GenerateChangelogOptions, getAllTagPrefixes } from './generateChangelogs.ts';
 import { loadConfig, mergeMonorepoConfig, mergeSinglePackageConfig, readRootPackageVersion } from './loadConfig.ts';
 import type { ChangelogEntry, MonorepoReleaseConfig, ReleaseConfig, ReleaseKitConfig } from './types.ts';
 import { validateConfig } from './validateConfig.ts';
@@ -232,11 +232,7 @@ function buildMonorepoInputs(
   const config: MonorepoReleaseConfig = mergeMonorepoConfig(discoveredPaths, userConfig, rootPackage);
 
   const workspaces = config.workspaces.map((workspace) => {
-    const tagPrefixes = [
-      workspace.tagPrefix,
-      ...(workspace.legacyIdentities?.map((identity) => identity.tagPrefix) ?? []),
-    ];
-    const tagPattern = buildTagPattern(tagPrefixes);
+    const tagPattern = buildTagPattern(getAllTagPrefixes(workspace));
     return {
       filePath: resolveOverridePath(workspace.workspacePath),
       hashes: flattenEntriesToHashes(buildEntries(config, tagPattern, workspace.paths)),


### PR DESCRIPTION
## What

Fixes an issue where `release-kit overrides validate` reported overrides as stale when they targeted commits in past releases, even though `release-kit prepare` correctly matched them. The two commands now agree on which overrides are stale.

## Why

The standalone `validate` subcommand was functionally unusable for projects with a steady set of editorial overrides: it produced a flood of false-positive stale warnings for any override targeting commits in a previously-released version. A consumer on `release-kit@5.3.0` had nine overrides, of which `prepare` correctly identified four as stale and applied the remaining five — but `validate` flagged all nine. The bug originated in #388 (the introduction of the standalone validator), where the input-construction layer fed `validateAllChangelogOverrides` a narrower hash window than `prepare` walks. The bug was in input construction, not in the validator algorithm.

## Details

### 🐛 Bug fixes

`validate` now invokes `buildChangelogEntries` for every scope (single-package, monorepo workspace, monorepo project) with the same `tagPattern` and `includePaths` that `prepare` constructs at the corresponding site. The matching universe is byte-equal to `prepare`'s by construction rather than by hope. A near-integration test stubs `runGitCliff` and drives the real `validateOverridesCommand → buildChangelogEntries → validateAllChangelogOverrides` pipeline against a multi-release context to gate the regression.

### ♻️ Refactoring

`getAllTagPrefixes(workspace)` moves from `releasePrepareMono` (where it was private) to `generateChangelogs` alongside the paired `buildTagPattern` helper. `releasePrepareMono` and `validateOverridesCommand` both call the shared definition rather than each maintaining an inline copy that could silently diverge.

### 🧪 Tests

A new monorepo wiring test captures every per-scope `buildEntries` invocation and asserts each receives the expected `(tagPattern, includePaths)` tuple: the workspace's full tag-prefix union (derived prefix plus any `legacyIdentities`) and include-paths for workspace scopes; the project tag pattern plus the union of workspace paths for the project-tier scope. Single-package coverage is added for past-release matches, unreachable hashes, and ambiguous-prefix file-path attribution. Statement coverage on `validateOverridesCommand.ts` rises from 73% to 95%.

### 📚 Documentation

The validator docstring in `changelogOverrides.ts` clarifies that the byte-equality guarantee is owned by the production caller (`validateOverridesCommand`); library callers constructing `inputs` directly are responsible for supplying the same hash universes. The README description of `release-kit overrides validate` softens from "fast" to "focused" — the command now invokes git-cliff once per scope rather than `git log`, so the performance framing was no longer accurate.

Closes #398
