### PR TITLE
#399 Respect package.json#private in npm-auto-publish kit

### DIFF
--- a/.readyup/kits/__tests__/npm-auto-publish-checks.test.ts
+++ b/.readyup/kits/__tests__/npm-auto-publish-checks.test.ts
@@ -1,0 +1,78 @@
+import type { Workspace } from 'readyup/check-utils';
+import { describe, expect, it } from 'vitest';
+
+import { buildWorkspaceCheck, skipIfNotPublishable } from '../npm-auto-publish.ts';
+
+function makeWorkspace(overrides: Partial<Workspace> & Pick<Workspace, 'isPackage'>): Workspace {
+  return {
+    dir: 'packages/example',
+    absolutePath: '/repo/packages/example',
+    name: '@scope/example',
+    packageJson: { name: '@scope/example' },
+    ...overrides,
+  };
+}
+
+describe(skipIfNotPublishable, () => {
+  it('returns false for a publishable workspace (isPackage true)', () => {
+    const workspace = makeWorkspace({ isPackage: true });
+
+    expect(skipIfNotPublishable(workspace)).toBe(false);
+  });
+
+  it('returns the skip reason for a non-publishable workspace (isPackage false)', () => {
+    const workspace = makeWorkspace({ isPackage: false, packageJson: { name: '@scope/example', private: true } });
+
+    expect(skipIfNotPublishable(workspace)).toBe('package.json#private is true');
+  });
+});
+
+describe(buildWorkspaceCheck, () => {
+  it('marks the parent check as skipped for a non-publishable workspace', async () => {
+    const workspace = makeWorkspace({ isPackage: false, packageJson: { name: '@scope/example', private: true } });
+
+    const check = buildWorkspaceCheck(workspace);
+
+    expect(check.name).toBe('@scope/example');
+    expect(check.skip).toBeDefined();
+    await expect(Promise.resolve(check.skip?.())).resolves.toBe('package.json#private is true');
+  });
+
+  it('does not include a "not marked private" child check', () => {
+    const workspace = makeWorkspace({ isPackage: true });
+
+    const check = buildWorkspaceCheck(workspace);
+
+    const childNames = check.checks?.map((c) => c.name) ?? [];
+    expect(childNames).not.toContain('not marked private');
+  });
+
+  it('lets the parent check run when the workspace is publishable', async () => {
+    const workspace = makeWorkspace({ isPackage: true });
+
+    const check = buildWorkspaceCheck(workspace);
+
+    await expect(Promise.resolve(check.skip?.())).resolves.toBe(false);
+  });
+
+  it('includes the scoped-name child only when the package name starts with @', () => {
+    const scoped = buildWorkspaceCheck(makeWorkspace({ isPackage: true, name: '@scope/example' }));
+    const unscoped = buildWorkspaceCheck(
+      makeWorkspace({ isPackage: true, name: 'example', packageJson: { name: 'example' } }),
+    );
+
+    const scopedChildren = scoped.checks?.map((c) => c.name) ?? [];
+    const unscopedChildren = unscoped.checks?.map((c) => c.name) ?? [];
+
+    expect(scopedChildren).toContain('publishConfig.access is "public"');
+    expect(unscopedChildren).not.toContain('publishConfig.access is "public"');
+  });
+
+  it('falls back to "(unnamed)" when the workspace has no name', () => {
+    const workspace = makeWorkspace({ isPackage: true, name: undefined, packageJson: {} });
+
+    const check = buildWorkspaceCheck(workspace);
+
+    expect(check.name).toBe('(unnamed)');
+  });
+});

--- a/.readyup/kits/npm-auto-publish.js
+++ b/.readyup/kits/npm-auto-publish.js
@@ -5,24 +5,29 @@ export const __readyupVersion = "0.21.0";
 
 // .readyup/kits/npm-auto-publish.ts
 import { execSync } from "node:child_process";
-import { existsSync, globSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { defineRdyChecklist, defineRdyKit, defineRdyStagedChecklist } from "readyup";
-import { fileContains, fileExists, getJsonValue, isRecord, readFile, readJsonFile } from "readyup/check-utils";
+import {
+  defineRdyChecklist,
+  defineRdyKit,
+  defineRdyStagedChecklist
+} from "readyup";
+import {
+  discoverWorkspaces,
+  fileContains,
+  fileExists,
+  getJsonValue,
+  isRecord,
+  readFile,
+  readJsonFile
+} from "readyup/check-utils";
 var PUBLISH_WORKFLOW_FILE = "publish.yaml";
 var cachedOwnerRepo;
-var cachedPackages;
 function getCachedOwnerRepo() {
   if (cachedOwnerRepo === void 0) {
     cachedOwnerRepo = getOwnerRepo();
   }
   return cachedOwnerRepo;
-}
-function getPackages() {
-  if (cachedPackages === void 0) {
-    cachedPackages = discoverPackages();
-  }
-  return cachedPackages;
 }
 var repoChecklist = defineRdyStagedChecklist({
   name: "repo",
@@ -56,11 +61,6 @@ var packagesChecklist = defineRdyChecklist({
   name: "packages",
   preconditions: [
     {
-      name: "Node.js >= 22",
-      check: () => getNodeMajorVersion() >= 22,
-      fix: "Upgrade to Node.js 22 or later"
-    },
-    {
       name: 'packageManager field starts with "pnpm"',
       check: () => {
         const rootPkg = readJsonFile("package.json");
@@ -70,38 +70,37 @@ var packagesChecklist = defineRdyChecklist({
       fix: 'Set "packageManager": "pnpm@..." in root package.json'
     },
     {
-      name: "At least one package discovered",
-      check: () => getPackages().length > 0,
+      name: "At least one workspace discovered",
+      check: () => discoverWorkspaces().length > 0,
       fix: "Ensure pnpm-workspace.yaml lists package globs, or that a root package.json exists"
     }
   ],
   get checks() {
-    return getPackages().map((pkg) => buildPackageCheck(pkg));
+    return discoverWorkspaces().map((workspace) => buildWorkspaceCheck(workspace));
   }
 });
 var npm_auto_publish_default = defineRdyKit({
   fixLocation: "inline",
   checklists: [repoChecklist, packagesChecklist]
 });
-function buildPackageCheck(pkg) {
-  const pkgJsonPath = path.join(pkg.relativePath, "package.json");
+function skipIfNotPublishable(workspace) {
+  return workspace.isPackage ? false : "package.json#private is true";
+}
+function buildWorkspaceCheck(workspace) {
+  const displayName = workspace.name ?? "(unnamed)";
+  const pkgJsonPath = path.join(workspace.dir, "package.json");
   const children = [
     {
       name: "repository field exists",
-      check: () => pkg.packageJson.repository !== void 0 && pkg.packageJson.repository !== null,
+      check: () => workspace.packageJson.repository !== void 0 && workspace.packageJson.repository !== null,
       fix: `Add a "repository" field to ${pkgJsonPath} pointing to the GitHub repo`
-    },
-    {
-      name: "not marked private",
-      check: () => pkg.packageJson.private !== true,
-      fix: `Remove "private": true from ${pkgJsonPath}, or exclude this package from the publish workflow`
     }
   ];
-  if (pkg.name.startsWith("@")) {
+  if (workspace.name?.startsWith("@")) {
     children.push({
       name: 'publishConfig.access is "public"',
       check: () => {
-        const access = getJsonValue(pkg.packageJson, "publishConfig", "access");
+        const access = getJsonValue(workspace.packageJson, "publishConfig", "access");
         return typeof access === "string" && access === "public";
       },
       fix: `Add "publishConfig": { "access": "public" } to ${pkgJsonPath}`
@@ -110,14 +109,14 @@ function buildPackageCheck(pkg) {
   children.push(
     {
       name: "published to npm",
-      check: () => isPublishedToNpm(pkg.name),
-      fix: `Run "npm publish --access public" from ${pkg.relativePath} to bootstrap the package on npm`,
+      check: () => isPublishedToNpm(displayName),
+      fix: `Run "npm publish --access public" from ${workspace.dir} to bootstrap the package on npm`,
       checks: [
         {
           name: "trusted publisher configured",
-          check: () => hasTrustedPublisher(pkg.name, getCachedOwnerRepo(), PUBLISH_WORKFLOW_FILE),
+          check: () => hasTrustedPublisher(displayName, getCachedOwnerRepo(), PUBLISH_WORKFLOW_FILE),
           get fix() {
-            return `Run: npm trust github ${pkg.name} --repo ${getCachedOwnerRepo()} --file ${PUBLISH_WORKFLOW_FILE}`;
+            return `Run: npm trust github ${displayName} --repo ${getCachedOwnerRepo()} --file ${PUBLISH_WORKFLOW_FILE}`;
           }
         }
       ]
@@ -125,12 +124,13 @@ function buildPackageCheck(pkg) {
     {
       name: "files field exists",
       severity: "warn",
-      check: () => pkg.packageJson.files !== void 0,
+      check: () => workspace.packageJson.files !== void 0,
       fix: `Add a "files" field to ${pkgJsonPath} to control which files are included in the published tarball`
     }
   );
   return {
-    name: pkg.name,
+    name: displayName,
+    skip: () => skipIfNotPublishable(workspace),
     check: () => true,
     checks: children
   };
@@ -162,48 +162,6 @@ function checkProvenanceMatchesVisibility() {
   }
   return { ok: true };
 }
-function discoverPackages() {
-  if (fileExists("pnpm-workspace.yaml")) {
-    return discoverWorkspacePackages(path.resolve(process.cwd(), "pnpm-workspace.yaml"));
-  }
-  const rootPkg = readJsonFile("package.json");
-  if (rootPkg === void 0) {
-    return [];
-  }
-  return [
-    {
-      name: getPackageName(rootPkg),
-      dir: process.cwd(),
-      relativePath: ".",
-      packageJson: rootPkg
-    }
-  ];
-}
-function discoverWorkspacePackages(workspaceConfigPath) {
-  const content = readFileSync(workspaceConfigPath, "utf8");
-  const globs = parseWorkspaceGlobs(content);
-  const results = [];
-  for (const pattern of globs) {
-    const dirs = globSync(pattern, { cwd: process.cwd() });
-    for (const dir of dirs) {
-      const pkgJsonPath = path.join(dir, "package.json");
-      const pkgJson = readJsonFile(pkgJsonPath);
-      if (pkgJson === void 0) {
-        continue;
-      }
-      results.push({
-        name: getPackageName(pkgJson),
-        dir: path.resolve(process.cwd(), dir),
-        relativePath: dir,
-        packageJson: pkgJson
-      });
-    }
-  }
-  return results;
-}
-function getNodeMajorVersion() {
-  return Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
-}
 function getOwnerRepo() {
   const url = execSync("git remote get-url origin", {
     encoding: "utf8"
@@ -217,9 +175,6 @@ function getOwnerRepo() {
     return httpsMatch[1];
   }
   throw new Error(`Cannot parse GitHub owner/repo from remote URL: ${url}`);
-}
-function getPackageName(packageJson) {
-  return typeof packageJson.name === "string" ? packageJson.name : "(unnamed)";
 }
 function hasTokenReferences() {
   const workflowDir = path.resolve(process.cwd(), ".github/workflows");
@@ -277,27 +232,8 @@ function isRepoPrivate() {
 function parseProvenanceSetting(workflowContent) {
   return /^[^#]*provenance:\s*['"]?true['"]?/im.test(workflowContent);
 }
-function parseWorkspaceGlobs(content) {
-  const globs = [];
-  let inPackages = false;
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed === "packages:") {
-      inPackages = true;
-      continue;
-    }
-    if (inPackages && trimmed !== "" && !trimmed.startsWith("-") && !trimmed.startsWith("#")) {
-      break;
-    }
-    if (inPackages && trimmed.startsWith("-")) {
-      const glob = trimmed.replace(/^-\s*/, "").replace(/^['"]|['"]$/g, "");
-      if (glob) {
-        globs.push(glob);
-      }
-    }
-  }
-  return globs;
-}
 export {
-  npm_auto_publish_default as default
+  buildWorkspaceCheck,
+  npm_auto_publish_default as default,
+  skipIfNotPublishable
 };

--- a/.readyup/kits/npm-auto-publish.js
+++ b/.readyup/kits/npm-auto-publish.js
@@ -7,11 +7,7 @@ export const __readyupVersion = "0.21.0";
 import { execSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
-import {
-  defineRdyChecklist,
-  defineRdyKit,
-  defineRdyStagedChecklist
-} from "readyup";
+import { defineRdyChecklist, defineRdyKit, defineRdyStagedChecklist } from "readyup";
 import {
   discoverWorkspaces,
   fileContains,

--- a/.readyup/kits/npm-auto-publish.ts
+++ b/.readyup/kits/npm-auto-publish.ts
@@ -16,11 +16,8 @@ import {
 
 const PUBLISH_WORKFLOW_FILE = 'publish.yaml';
 
-// -- Primary logic --
-
-// Deferred so that `getOwnerRepo` (which shells out to git) is not called at
-// module load time — preserves the ability to load the kit in environments
-// without a git remote configured.
+// Cached so that `getOwnerRepo` (which shells out to git) runs at most once per kit invocation;
+// this also keeps module load tolerant of environments without a git remote configured.
 let cachedOwnerRepo: string | undefined;
 
 function getCachedOwnerRepo(): string {
@@ -87,22 +84,21 @@ export default defineRdyKit({
   checklists: [repoChecklist, packagesChecklist],
 });
 
-// -- Helper functions --
+// region | Helpers
 
 /**
- * Skip predicate: returns the skip reason when a workspace is not for publication
+ * Skip predicate: Returns the skip reason when a workspace is not for publication
  * (i.e. `package.json#private` is `true`), else `false` (the check should run).
  *
- * Wired into the parent (per-workspace) check via `skip`. Readyup's reporter
- * suppresses descendants of a check whose `skip` returns a string, so a
- * non-publishable workspace appears as a single skipped entry rather than as
- * a tree of false-positive errors.
+ * Wired into the parent (per-workspace) check via `skip`.
+ * Readyup's reporter suppresses descendants of a check whose `skip` returns a string, so a non-publishable workspace
+ * appears as a single skipped entry rather than as a tree of false-positive errors.
  */
 export function skipIfNotPublishable(workspace: Workspace): SkipResult {
   return workspace.isPackage ? false : 'package.json#private is true';
 }
 
-/** Build a parent check for a workspace with nested publish-readiness children. */
+/** Builds a parent check for a workspace with nested publish-readiness children. */
 export function buildWorkspaceCheck(workspace: Workspace): RdyCheck {
   const displayName = workspace.name ?? '(unnamed)';
   const pkgJsonPath = path.join(workspace.dir, 'package.json');
@@ -157,7 +153,7 @@ export function buildWorkspaceCheck(workspace: Workspace): RdyCheck {
   };
 }
 
-/** Check whether the provenance setting in publish.yaml matches the repo's visibility. */
+/** Checks whether the provenance setting in publish.yaml matches the repo's visibility. */
 function checkProvenanceMatchesVisibility(): { ok: boolean; detail?: string } {
   const workflowPath = '.github/workflows/publish.yaml';
 
@@ -214,7 +210,7 @@ function getOwnerRepo(): string {
   throw new Error(`Cannot parse GitHub owner/repo from remote URL: ${url}`);
 }
 
-/** Scan all workflow files for legacy NPM token references. */
+/** Scans all workflow files for legacy NPM token references. */
 function hasTokenReferences(): boolean {
   const workflowDir = path.resolve(process.cwd(), '.github/workflows');
   if (!existsSync(workflowDir)) {
@@ -233,7 +229,7 @@ function hasTokenReferences(): boolean {
   return false;
 }
 
-/** Verify that a package has a matching GitHub trusted publisher on npm. */
+/** Verifies that a package has a matching GitHub trusted publisher on npm. */
 function hasTrustedPublisher(packageName: string, expectedRepo: string, expectedFile: string): boolean {
   let output: string;
   try {
@@ -259,7 +255,7 @@ function hasTrustedPublisher(packageName: string, expectedRepo: string, expected
   return parsed.type === 'github' && parsed.repository === expectedRepo && parsed.file === expectedFile;
 }
 
-/** Check whether a package exists on the npm registry. */
+/** Checks whether a package exists on the npm registry. */
 function isPublishedToNpm(packageName: string): boolean {
   try {
     execSync(`npm view ${packageName} version`, {
@@ -272,7 +268,7 @@ function isPublishedToNpm(packageName: string): boolean {
   }
 }
 
-/** Query the GitHub API to determine whether the current repo is private. */
+/** Queries the GitHub API to determine whether the current repo is private. */
 function isRepoPrivate(): boolean {
   const ownerRepo = getOwnerRepo();
   const result = execSync(`gh api repos/${ownerRepo} --jq .private`, {
@@ -281,7 +277,9 @@ function isRepoPrivate(): boolean {
   return result === 'true';
 }
 
-/** Check whether the publish.yaml workflow has provenance enabled. */
+/** Checks whether the publish.yaml workflow has provenance enabled. */
 function parseProvenanceSetting(workflowContent: string): boolean {
   return /^[^#]*provenance:\s*['"]?true['"]?/im.test(workflowContent);
 }
+
+// endregion | Helpers

--- a/.readyup/kits/npm-auto-publish.ts
+++ b/.readyup/kits/npm-auto-publish.ts
@@ -1,34 +1,33 @@
 import { execSync } from 'node:child_process';
-import { existsSync, globSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { defineRdyChecklist, defineRdyKit, defineRdyStagedChecklist, type RdyCheck } from 'readyup';
-import { fileContains, fileExists, getJsonValue, isRecord, readFile, readJsonFile } from 'readyup/check-utils';
+import { defineRdyChecklist, defineRdyKit, defineRdyStagedChecklist, type RdyCheck, type SkipResult } from 'readyup';
+import {
+  discoverWorkspaces,
+  fileContains,
+  fileExists,
+  getJsonValue,
+  isRecord,
+  readFile,
+  readJsonFile,
+  type Workspace,
+} from 'readyup/check-utils';
 
 const PUBLISH_WORKFLOW_FILE = 'publish.yaml';
 
 // -- Primary logic --
 
-// Deferred so that `globSync` (Node 22+) is not called at module load time.
-// The packages checklist has a Node >= 22 precondition that surfaces a helpful
-// fix hint; eager discovery would crash before that precondition runs.
+// Deferred so that `getOwnerRepo` (which shells out to git) is not called at
+// module load time — preserves the ability to load the kit in environments
+// without a git remote configured.
 let cachedOwnerRepo: string | undefined;
-let cachedPackages: PackageInfo[] | undefined;
 
-/** Return the GitHub owner/repo, computing on first access. */
 function getCachedOwnerRepo(): string {
   if (cachedOwnerRepo === undefined) {
     cachedOwnerRepo = getOwnerRepo();
   }
   return cachedOwnerRepo;
-}
-
-/** Return discovered packages, computing on first access. */
-function getPackages(): PackageInfo[] {
-  if (cachedPackages === undefined) {
-    cachedPackages = discoverPackages();
-  }
-  return cachedPackages;
 }
 
 const repoChecklist = defineRdyStagedChecklist({
@@ -64,11 +63,6 @@ const packagesChecklist = defineRdyChecklist({
   name: 'packages',
   preconditions: [
     {
-      name: 'Node.js >= 22',
-      check: () => getNodeMajorVersion() >= 22,
-      fix: 'Upgrade to Node.js 22 or later',
-    },
-    {
       name: 'packageManager field starts with "pnpm"',
       check: () => {
         const rootPkg = readJsonFile('package.json');
@@ -78,13 +72,13 @@ const packagesChecklist = defineRdyChecklist({
       fix: 'Set "packageManager": "pnpm@..." in root package.json',
     },
     {
-      name: 'At least one package discovered',
-      check: () => getPackages().length > 0,
+      name: 'At least one workspace discovered',
+      check: () => discoverWorkspaces().length > 0,
       fix: 'Ensure pnpm-workspace.yaml lists package globs, or that a root package.json exists',
     },
   ],
   get checks(): RdyCheck[] {
-    return getPackages().map((pkg) => buildPackageCheck(pkg));
+    return discoverWorkspaces().map((workspace) => buildWorkspaceCheck(workspace));
   },
 });
 
@@ -93,39 +87,39 @@ export default defineRdyKit({
   checklists: [repoChecklist, packagesChecklist],
 });
 
-// -- Helper types --
-
-interface PackageInfo {
-  name: string;
-  dir: string;
-  relativePath: string;
-  packageJson: Record<string, unknown>;
-}
-
 // -- Helper functions --
 
-/** Build a parent check for a package with nested child checks. */
-function buildPackageCheck(pkg: PackageInfo): RdyCheck {
-  const pkgJsonPath = path.join(pkg.relativePath, 'package.json');
+/**
+ * Skip predicate: returns the skip reason when a workspace is not for publication
+ * (i.e. `package.json#private` is `true`), else `false` (the check should run).
+ *
+ * Wired into the parent (per-workspace) check via `skip`. Readyup's reporter
+ * suppresses descendants of a check whose `skip` returns a string, so a
+ * non-publishable workspace appears as a single skipped entry rather than as
+ * a tree of false-positive errors.
+ */
+export function skipIfNotPublishable(workspace: Workspace): SkipResult {
+  return workspace.isPackage ? false : 'package.json#private is true';
+}
+
+/** Build a parent check for a workspace with nested publish-readiness children. */
+export function buildWorkspaceCheck(workspace: Workspace): RdyCheck {
+  const displayName = workspace.name ?? '(unnamed)';
+  const pkgJsonPath = path.join(workspace.dir, 'package.json');
 
   const children: RdyCheck[] = [
     {
       name: 'repository field exists',
-      check: () => pkg.packageJson.repository !== undefined && pkg.packageJson.repository !== null,
+      check: () => workspace.packageJson.repository !== undefined && workspace.packageJson.repository !== null,
       fix: `Add a "repository" field to ${pkgJsonPath} pointing to the GitHub repo`,
-    },
-    {
-      name: 'not marked private',
-      check: () => pkg.packageJson.private !== true,
-      fix: `Remove "private": true from ${pkgJsonPath}, or exclude this package from the publish workflow`,
     },
   ];
 
-  if (pkg.name.startsWith('@')) {
+  if (workspace.name?.startsWith('@')) {
     children.push({
       name: 'publishConfig.access is "public"',
       check: () => {
-        const access = getJsonValue(pkg.packageJson, 'publishConfig', 'access');
+        const access = getJsonValue(workspace.packageJson, 'publishConfig', 'access');
         return typeof access === 'string' && access === 'public';
       },
       fix: `Add "publishConfig": { "access": "public" } to ${pkgJsonPath}`,
@@ -135,14 +129,14 @@ function buildPackageCheck(pkg: PackageInfo): RdyCheck {
   children.push(
     {
       name: 'published to npm',
-      check: () => isPublishedToNpm(pkg.name),
-      fix: `Run "npm publish --access public" from ${pkg.relativePath} to bootstrap the package on npm`,
+      check: () => isPublishedToNpm(displayName),
+      fix: `Run "npm publish --access public" from ${workspace.dir} to bootstrap the package on npm`,
       checks: [
         {
           name: 'trusted publisher configured',
-          check: () => hasTrustedPublisher(pkg.name, getCachedOwnerRepo(), PUBLISH_WORKFLOW_FILE),
+          check: () => hasTrustedPublisher(displayName, getCachedOwnerRepo(), PUBLISH_WORKFLOW_FILE),
           get fix() {
-            return `Run: npm trust github ${pkg.name} --repo ${getCachedOwnerRepo()} --file ${PUBLISH_WORKFLOW_FILE}`;
+            return `Run: npm trust github ${displayName} --repo ${getCachedOwnerRepo()} --file ${PUBLISH_WORKFLOW_FILE}`;
           },
         },
       ],
@@ -150,13 +144,14 @@ function buildPackageCheck(pkg: PackageInfo): RdyCheck {
     {
       name: 'files field exists',
       severity: 'warn',
-      check: () => pkg.packageJson.files !== undefined,
+      check: () => workspace.packageJson.files !== undefined,
       fix: `Add a "files" field to ${pkgJsonPath} to control which files are included in the published tarball`,
     },
   );
 
   return {
-    name: pkg.name,
+    name: displayName,
+    skip: () => skipIfNotPublishable(workspace),
     check: () => true,
     checks: children,
   };
@@ -198,59 +193,6 @@ function checkProvenanceMatchesVisibility(): { ok: boolean; detail?: string } {
   return { ok: true };
 }
 
-/** Discover all publishable packages in the workspace. */
-function discoverPackages(): PackageInfo[] {
-  if (fileExists('pnpm-workspace.yaml')) {
-    return discoverWorkspacePackages(path.resolve(process.cwd(), 'pnpm-workspace.yaml'));
-  }
-
-  // Single-package repo: use root package.json
-  const rootPkg = readJsonFile('package.json');
-  if (rootPkg === undefined) {
-    return [];
-  }
-
-  return [
-    {
-      name: getPackageName(rootPkg),
-      dir: process.cwd(),
-      relativePath: '.',
-      packageJson: rootPkg,
-    },
-  ];
-}
-
-/** Parse pnpm-workspace.yaml and expand globs to find workspace packages. */
-function discoverWorkspacePackages(workspaceConfigPath: string): PackageInfo[] {
-  const content = readFileSync(workspaceConfigPath, 'utf8');
-  const globs = parseWorkspaceGlobs(content);
-  const results: PackageInfo[] = [];
-
-  for (const pattern of globs) {
-    const dirs = globSync(pattern, { cwd: process.cwd() });
-    for (const dir of dirs) {
-      const pkgJsonPath = path.join(dir, 'package.json');
-      const pkgJson = readJsonFile(pkgJsonPath);
-      if (pkgJson === undefined) {
-        continue;
-      }
-      results.push({
-        name: getPackageName(pkgJson),
-        dir: path.resolve(process.cwd(), dir),
-        relativePath: dir,
-        packageJson: pkgJson,
-      });
-    }
-  }
-
-  return results;
-}
-
-/** Extract the node major version from process.versions. */
-function getNodeMajorVersion(): number {
-  return Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
-}
-
 /** Derive {owner}/{repo} from the git remote origin URL. */
 function getOwnerRepo(): string {
   const url = execSync('git remote get-url origin', {
@@ -270,11 +212,6 @@ function getOwnerRepo(): string {
   }
 
   throw new Error(`Cannot parse GitHub owner/repo from remote URL: ${url}`);
-}
-
-/** Extract the package name from a parsed package.json, falling back to "(unnamed)". */
-function getPackageName(packageJson: Record<string, unknown>): string {
-  return typeof packageJson.name === 'string' ? packageJson.name : '(unnamed)';
 }
 
 /** Scan all workflow files for legacy NPM token references. */
@@ -347,33 +284,4 @@ function isRepoPrivate(): boolean {
 /** Check whether the publish.yaml workflow has provenance enabled. */
 function parseProvenanceSetting(workflowContent: string): boolean {
   return /^[^#]*provenance:\s*['"]?true['"]?/im.test(workflowContent);
-}
-
-/** Extract workspace glob patterns from pnpm-workspace.yaml content. */
-function parseWorkspaceGlobs(content: string): string[] {
-  const globs: string[] = [];
-  let inPackages = false;
-
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim();
-
-    if (trimmed === 'packages:') {
-      inPackages = true;
-      continue;
-    }
-
-    // A new top-level key ends the packages section.
-    if (inPackages && trimmed !== '' && !trimmed.startsWith('-') && !trimmed.startsWith('#')) {
-      break;
-    }
-
-    if (inPackages && trimmed.startsWith('-')) {
-      const glob = trimmed.replace(/^-\s*/, '').replace(/^['"]|['"]$/g, '');
-      if (glob) {
-        globs.push(glob);
-      }
-    }
-  }
-
-  return globs;
 }

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -20,7 +20,7 @@
       "path": "kits/npm-auto-publish.js",
       "readyupVersion": "0.21.0",
       "source": "kits/npm-auto-publish.ts",
-      "targetHash": "46a0c4c2"
+      "targetHash": "833f37da"
     },
     {
       "name": "release-kit",

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -20,7 +20,7 @@
       "path": "kits/npm-auto-publish.js",
       "readyupVersion": "0.21.0",
       "source": "kits/npm-auto-publish.ts",
-      "targetHash": "8aad25e4"
+      "targetHash": "46a0c4c2"
     },
     {
       "name": "release-kit",


### PR DESCRIPTION
## What

Fixes the issue that checks in `npm-auto-publish` readyup kit were failing when applied to a private workspace. That kit now honors `package.json#private: true` as an explicit opt-out, reporting each private workspace as a single skipped entry instead of a cascade of errors directing the package to be made public.

## Why

The kit treated `private: true` as a misconfiguration rather than an opt-out, contradicting the project-wide convention that release-kit's publish flow already honors. The only available workaround was over-strong — excluding the workspace from changelog and release-notes generation as well — which forced contributors to choose between two wrong behaviors.

## Details

### 🐛 Bug fixes

- Workspaces with `package.json#private: true` now surface in the kit's report as a single skipped entry, reason `package.json#private is true`. The `not marked private` check, which inverted the project's `private`-means-opt-out convention, has been removed.

### ♻️ Refactoring

- Workspace discovery flows through readyup's `discoverWorkspaces` helper from `readyup/check-utils`, matching how the sibling `release-kit` kit does discovery.

### 🧪 Tests

- Added unit tests covering the publishable / non-publishable skip behavior and the per-workspace check shape (scoped vs unscoped names, unnamed fallback).

Closes #399
