### PR TITLE
#418 Write the build cache only after a successful compile

### DIFF
--- a/packages/nmr/src/commands/__tests__/build.test.ts
+++ b/packages/nmr/src/commands/__tests__/build.test.ts
@@ -2,9 +2,17 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import { build } from 'esbuild';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildPackage, computeBuildHash, resolveAliasImports, rewriteTsImportExtensions } from '../build.ts';
+
+// Default esbuild's build to the real implementation so the success-path tests compile for real;
+// the cache-integrity tests override it per-call to simulate a failing or transient compile.
+vi.mock('esbuild', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('esbuild')>();
+  return { ...actual, build: vi.fn(actual.build) };
+});
 
 describe(computeBuildHash, () => {
   let dir: string;
@@ -108,7 +116,9 @@ describe(buildPackage, () => {
 
   afterEach(() => {
     fs.rmSync(dir, { recursive: true, force: true });
-    vi.restoreAllMocks();
+    vi.mocked(console.info).mockRestore();
+    // Clear call history but keep the real default implementation for the next test.
+    vi.mocked(build).mockClear();
   });
 
   function scaffoldPackage(): void {
@@ -149,5 +159,48 @@ describe(buildPackage, () => {
 
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining('📦'));
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining(path.basename(dir)));
+  });
+
+  it('does not write the build cache when the compile fails', async () => {
+    scaffoldPackage();
+    vi.mocked(build).mockRejectedValueOnce(new Error('compile failed'));
+
+    await expect(buildPackage(dir)).rejects.toThrow('compile failed');
+
+    expect(fs.existsSync(path.join(dir, 'dist', 'esm', '.cache'))).toBe(false);
+  });
+
+  it('re-attempts and rebuilds after a transient compile failure instead of skipping', async () => {
+    scaffoldPackage();
+    vi.mocked(build).mockRejectedValueOnce(new Error('transient failure'));
+    await expect(buildPackage(dir)).rejects.toThrow();
+
+    // Sources are unchanged: a cache poisoned by the failed run would make this skip the compile.
+    // Instead it must re-attempt, and with the transient failure gone, produce output and cache it.
+    await buildPackage(dir);
+
+    expect(build).toHaveBeenCalledTimes(2);
+    expect(fs.existsSync(path.join(dir, 'dist', 'esm', 'index.js'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'dist', 'esm', '.cache'))).toBe(true);
+  });
+
+  it('preserves an existing cache when a changed-source rebuild fails', async () => {
+    scaffoldPackage();
+    await buildPackage(dir);
+    const cachePath = path.join(dir, 'dist', 'esm', '.cache');
+    const lastGoodDigest = fs.readFileSync(cachePath, 'utf8');
+
+    // A changed source forces the rebuild to be attempted rather than skipped; make that rebuild fail.
+    fs.writeFileSync(path.join(dir, 'src', 'util.ts'), 'export const util = 2;\n');
+    vi.mocked(build).mockRejectedValueOnce(new Error('rebuild failed'));
+    await expect(buildPackage(dir)).rejects.toThrow();
+
+    // The failed rebuild must leave the last successful build's digest intact, not overwrite it.
+    expect(fs.readFileSync(cachePath, 'utf8')).toBe(lastGoodDigest);
+
+    // With the failure gone, the next run rebuilds the changed source and refreshes the cache.
+    await buildPackage(dir);
+    expect(fs.readFileSync(path.join(dir, 'dist', 'esm', 'util.js'), 'utf8')).toContain('util = 2');
+    expect(fs.readFileSync(cachePath, 'utf8')).not.toBe(lastGoodDigest);
   });
 });

--- a/packages/nmr/src/commands/build.ts
+++ b/packages/nmr/src/commands/build.ts
@@ -54,7 +54,12 @@ export async function buildPackage(packageDir: string, options: BuildOptions = {
   });
   const dependencies = ['package.json'];
 
-  const changed = await hashChanged(packageDir, [...entryPoints, ...dependencies], outputConfig, cacheFile);
+  const { changed, currentHash } = await detectBuildChanges(
+    packageDir,
+    [...entryPoints, ...dependencies],
+    outputConfig,
+    cacheFile,
+  );
   if (!changed) {
     return;
   }
@@ -68,6 +73,10 @@ export async function buildPackage(packageDir: string, options: BuildOptions = {
     plugins: [rewriteTsExtensions(packageDir, aliases)],
     ...outputConfig,
   });
+
+  // Persist the digest only after a successful build, so a failed compile cannot poison the cache
+  // and cause the next run to skip a never-completed build.
+  await writeBuildCache(packageDir, cacheFile, currentHash);
 }
 
 /**
@@ -118,13 +127,17 @@ export function rewriteTsImportExtensions(code: string): string {
   return code.replaceAll(/(?<=from\s+['"])(\.{1,2}\/[^'"]+)\.ts(?=['"])/g, '$1.js');
 }
 
-/** Compares the current input digest against the cached one, writing the new digest on a miss. */
-async function hashChanged(
+/**
+ * Compares the current input digest against the cached one, reporting whether the inputs changed
+ * and returning the freshly computed digest. Emits the 📦/⏭️ status but performs no write, so the
+ * caller can persist the digest only after a successful build.
+ */
+async function detectBuildChanges(
   packageDir: string,
   files: string[],
   outputConfig: OutputConfig,
   cacheFile: string,
-): Promise<boolean> {
+): Promise<{ changed: boolean; currentHash: string }> {
   const packageName = path.basename(packageDir);
   const cachePath = path.join(packageDir, cacheFile);
   const previousHash = existsSync(cachePath) ? readFileSync(cachePath, 'utf8') : undefined;
@@ -132,13 +145,18 @@ async function hashChanged(
 
   if (previousHash === currentHash) {
     console.info(`${SKIPPED_ICON} ${packageName}: No changes detected. Skipping build.`);
-    return false;
+    return { changed: false, currentHash };
   }
 
   console.info(`${PACKAGE_ICON} ${packageName}: Changes detected.`);
+  return { changed: true, currentHash };
+}
+
+/** Writes the build digest to the cache file, creating the cache directory if it does not exist. */
+async function writeBuildCache(packageDir: string, cacheFile: string, hash: string): Promise<void> {
+  const cachePath = path.join(packageDir, cacheFile);
   await mkdir(path.dirname(cachePath), { recursive: true });
-  await writeFile(cachePath, currentHash);
-  return true;
+  await writeFile(cachePath, hash);
 }
 
 /** esbuild plugin that strips/reattaches a shebang and rewrites alias + `.ts` import specifiers. */


### PR DESCRIPTION
## What

Fixes an issue where a package compile that failed partway — from a crash, disk error, or transient build failure — could leave stale or incomplete output that the next build skipped over as unchanged. The next build now retries the failed compile, so recovering no longer requires a manual `nmr clean` or a source-file edit.

## Why

The change-detection cache that lets unchanged packages skip rebuilding was recorded before the compile ran. A compile that failed afterward left the cache claiming the never-produced output was current, so the next run reported "no changes" and skipped the build — silently keeping stale or incomplete output until someone ran `nmr clean` or edited a source file. Because this build step is now the published `nmr-compile` bin running across every consuming repo, the failure mode has broad blast radius.

## Details

### 🐛 Bug fixes

- The build digest is now written only after `build()` resolves successfully. The pre-existing compare-and-write helper was split into a pure compare (`detectBuildChanges`, which computes the digest, compares it to the cached value, emits the `📦`/`⏭️` status, and returns the digest with no write) and a separate writer (`writeBuildCache`) invoked from `buildPackage` only after a successful compile. A failed compile therefore leaves `dist/esm/.cache` untouched — including its directory, since the `mkdir` moved to the writer — and the next run rebuilds rather than skipping. Successful, unchanged rebuilds still skip, preserving the existing deterministic behavior.
- No `try`/`catch` was added: the compile rejection propagates to the `nmr-compile` entry point, which already exits non-zero, so the failure stays loud while the cache stays clean.

### 🧪 Tests

- Three regression tests cover the failure path: a failed compile writes no cache; a transient failure is retried and rebuilt on the next run; and an existing valid cache is preserved (not overwritten) when a changed-source rebuild fails. Failure is injected by mocking esbuild's `build` to reject, which models the "crash, disk error" framing deterministically and keeps test output free of compiler noise; the mock defaults to the real implementation so the success-path tests still compile for real.

Closes #418
