### PR TITLE
#415 Stop sync-agent-files --check failing on version-only bumps

### DIFF
--- a/.agents/nmr/AGENTS.md
+++ b/.agents/nmr/AGENTS.md
@@ -4,7 +4,7 @@ source: '@williamthorsen/nmr@0.14.2'
 
 # nmr: agent guidance
 
-This file is managed by `@williamthorsen/nmr`. Do not edit; re-run `nmr sync-agent-files` after an nmr upgrade to refresh it.
+This file is managed by `@williamthorsen/nmr`. Do not edit; run `nmr sync-agent-files` to refresh it after an nmr upgrade that changes this guidance.
 
 ## Discover scripts by running nmr
 

--- a/packages/nmr/AGENTS.md
+++ b/packages/nmr/AGENTS.md
@@ -4,7 +4,7 @@ source: '@williamthorsen/nmr@0.0.0-source'
 
 # nmr: agent guidance
 
-This file is managed by `@williamthorsen/nmr`. Do not edit; re-run `nmr sync-agent-files` after an nmr upgrade to refresh it.
+This file is managed by `@williamthorsen/nmr`. Do not edit; run `nmr sync-agent-files` to refresh it after an nmr upgrade that changes this guidance.
 
 ## Discover scripts by running nmr
 

--- a/packages/nmr/src/cli-sync-agent-files.ts
+++ b/packages/nmr/src/cli-sync-agent-files.ts
@@ -1,39 +1,55 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
+import { parseArgs, type ParsedArgs, translateParseError } from '@williamthorsen/nmr-core';
+
 import { check, sync } from './commands/sync-agent-files.ts';
 import { findMonorepoRoot } from './context.ts';
 
-function parseArgs(argv: string[]): { mode: 'sync' | 'check' } | { error: string } {
-  const args = argv.slice(2);
-  if (args.length === 0) return { mode: 'sync' };
-  if (args.length === 1 && args[0] === '--check') return { mode: 'check' };
-  return { error: `Usage: nmr sync-agent-files [--check]` };
-}
+const flagSchema = {
+  check: { long: '--check', type: 'boolean' as const },
+};
+
+const { flags } = parseArgsOrExit(process.argv.slice(2));
 
 try {
-  const parsed = parseArgs(process.argv);
-  if ('error' in parsed) {
-    console.error(parsed.error);
+  runCommand(flags.check);
+} catch (error: unknown) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+// region | Helpers
+
+/** Parses argv against the flag schema, printing a usage error and exiting on failure. */
+function parseArgsOrExit(argv: string[]): ParsedArgs<typeof flagSchema> {
+  try {
+    return parseArgs(argv, flagSchema);
+  } catch (error: unknown) {
+    console.error(`Error: ${translateParseError(error)}`);
     process.exit(1);
   }
+}
 
+/** Runs sync (default) or check (`--check`), printing the outcome and exiting with the right code. */
+function runCommand(checkOnly: boolean): void {
   const monorepoRoot = findMonorepoRoot();
 
-  if (parsed.mode === 'sync') {
-    const { written, stamp } = sync(monorepoRoot);
-    console.info(`✓ Wrote ${written} (${stamp})`);
+  if (!checkOnly) {
+    const { path: destinationPath, packageSpecifier, changed } = sync(monorepoRoot);
+    console.info(
+      changed ? `✓ Wrote ${destinationPath} (${packageSpecifier})` : `✓ ${destinationPath} already up to date`,
+    );
     process.exit(0);
   }
 
   const result = check(monorepoRoot);
   if (result.ok) {
-    console.info(`✓ .agents/nmr/AGENTS.md is in sync (${result.stamp})`);
+    console.info('✓ .agents/nmr/AGENTS.md is in sync');
     process.exit(0);
   }
   console.error(result.reason);
   process.exit(1);
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
 }
+
+// endregion | Helpers

--- a/packages/nmr/src/commands/__tests__/sync-agent-files.test.ts
+++ b/packages/nmr/src/commands/__tests__/sync-agent-files.test.ts
@@ -5,33 +5,60 @@ import path from 'node:path';
 import { readPackageVersion } from '@williamthorsen/nmr-core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { check, parseSourceStamp, sync } from '../sync-agent-files.ts';
+import { check, sync } from '../sync-agent-files.ts';
 
 const DESTINATION_RELATIVE_PATH = '.agents/nmr/AGENTS.md';
-const currentStamp = `@williamthorsen/nmr@${readPackageVersion(import.meta.url)}`;
+const currentPackageSpecifier = `@williamthorsen/nmr@${readPackageVersion(import.meta.url)}`;
+const STALE_PACKAGE_SPECIFIER = '@williamthorsen/nmr@0.0.1-stale';
 
-describe('parseSourceStamp', () => {
-  it('extracts source value from well-formed frontmatter', () => {
-    const content = `---\nsource: '@williamthorsen/nmr@1.2.3'\n---\nbody\n`;
-    expect(parseSourceStamp(content)).toBe('@williamthorsen/nmr@1.2.3');
+describe(check, () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nmr-agent-files-check-'));
   });
 
-  it('returns null when frontmatter is missing', () => {
-    expect(parseSourceStamp('# just a heading\n')).toBeNull();
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('returns null when frontmatter has no source field', () => {
-    const content = `---\nother: value\n---\nbody\n`;
-    expect(parseSourceStamp(content)).toBeNull();
+  it('returns ok when the body matches the installed version', () => {
+    sync(tmpDir);
+    expect(check(tmpDir).ok).toBe(true);
   });
 
-  it('accepts a double-quoted source value', () => {
-    const content = `---\nsource: "@williamthorsen/nmr@1.2.3"\n---\nbody\n`;
-    expect(parseSourceStamp(content)).toBe('@williamthorsen/nmr@1.2.3');
+  it('returns ok when the body matches but the package specifier is older than installed', () => {
+    const destination = path.join(tmpDir, DESTINATION_RELATIVE_PATH);
+    sync(tmpDir);
+    rewritePackageSpecifier(destination, STALE_PACKAGE_SPECIFIER);
+
+    expect(check(tmpDir).ok).toBe(true);
+  });
+
+  it('fails when the body differs even though the package specifier matches installed', () => {
+    const destination = path.join(tmpDir, DESTINATION_RELATIVE_PATH);
+    sync(tmpDir);
+    fs.appendFileSync(destination, '\nlocal edit\n');
+
+    const result = check(tmpDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('content is out of date');
+      expect(result.reason).toContain('nmr sync-agent-files');
+    }
+  });
+
+  it('returns a missing-file reason when the destination does not exist', () => {
+    const result = check(tmpDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('.agents/nmr/AGENTS.md is missing');
+      expect(result.reason).toContain('nmr sync-agent-files');
+    }
   });
 });
 
-describe('sync', () => {
+describe(sync, () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -46,11 +73,12 @@ describe('sync', () => {
     const result = sync(tmpDir);
 
     const destination = path.join(tmpDir, DESTINATION_RELATIVE_PATH);
-    expect(result.written).toBe(destination);
-    expect(result.stamp).toBe(currentStamp);
+    expect(result.path).toBe(destination);
+    expect(result.packageSpecifier).toBe(currentPackageSpecifier);
+    expect(result.changed).toBe(true);
 
     const written = fs.readFileSync(destination, 'utf8');
-    expect(written.startsWith(`---\nsource: '${currentStamp}'\n---\n`)).toBe(true);
+    expect(written.startsWith(`---\nsource: '${currentPackageSpecifier}'\n---\n`)).toBe(true);
     expect(written).toContain('# nmr: agent guidance');
     expect(written).not.toContain('0.0.0-source');
   });
@@ -61,70 +89,35 @@ describe('sync', () => {
     expect(fs.existsSync(path.join(tmpDir, '.agents', 'nmr'))).toBe(true);
   });
 
-  it('overwrites an existing destination with a stale stamp', () => {
+  it('rewrites a destination whose body differs', () => {
     const destination = path.join(tmpDir, DESTINATION_RELATIVE_PATH);
     fs.mkdirSync(path.dirname(destination), { recursive: true });
-    fs.writeFileSync(destination, `---\nsource: '@williamthorsen/nmr@0.0.1-stale'\n---\nold body\n`);
+    fs.writeFileSync(destination, `---\nsource: '${STALE_PACKAGE_SPECIFIER}'\n---\nold body\n`);
 
-    sync(tmpDir);
+    const result = sync(tmpDir);
 
+    expect(result.changed).toBe(true);
     const written = fs.readFileSync(destination, 'utf8');
-    expect(written).toContain(currentStamp);
+    expect(written).toContain(currentPackageSpecifier);
     expect(written).not.toContain('0.0.1-stale');
     expect(written).not.toContain('old body');
   });
-});
 
-describe('check', () => {
-  let tmpDir: string;
-
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nmr-agent-files-check-'));
-  });
-
-  afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  it('returns ok when the destination matches the installed version', () => {
+  it('does not rewrite when the body already matches, preserving the existing specifier', () => {
+    const destination = path.join(tmpDir, DESTINATION_RELATIVE_PATH);
     sync(tmpDir);
-    const result = check(tmpDir);
-    expect(result.ok).toBe(true);
-  });
+    rewritePackageSpecifier(destination, STALE_PACKAGE_SPECIFIER);
 
-  it('returns a missing-file reason when the destination does not exist', () => {
-    const result = check(tmpDir);
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toContain('.agents/nmr/AGENTS.md is missing');
-      expect(result.reason).toContain('nmr sync-agent-files');
-    }
-  });
+    const result = sync(tmpDir);
 
-  it('returns a malformed-frontmatter reason when the stamp cannot be parsed', () => {
-    const destination = path.join(tmpDir, DESTINATION_RELATIVE_PATH);
-    fs.mkdirSync(path.dirname(destination), { recursive: true });
-    fs.writeFileSync(destination, 'no frontmatter here\n');
-
-    const result = check(tmpDir);
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toContain('Cannot parse version stamp');
-      expect(result.reason).toContain('nmr sync-agent-files');
-    }
-  });
-
-  it('returns an out-of-sync reason when the stamp does not match', () => {
-    const destination = path.join(tmpDir, DESTINATION_RELATIVE_PATH);
-    fs.mkdirSync(path.dirname(destination), { recursive: true });
-    fs.writeFileSync(destination, `---\nsource: '@williamthorsen/nmr@99.99.99'\n---\nbody\n`);
-
-    const result = check(tmpDir);
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toContain('out of sync');
-      expect(result.reason).toContain('99.99.99');
-      expect(result.reason).toContain(currentStamp);
-    }
+    expect(result.changed).toBe(false);
+    expect(result.path).toBe(destination);
+    expect(fs.readFileSync(destination, 'utf8')).toContain(STALE_PACKAGE_SPECIFIER);
   });
 });
+
+/** Rewrites the destination's frontmatter package specifier to `specifier`, leaving the body untouched. */
+function rewritePackageSpecifier(destination: string, specifier: string): void {
+  const content = fs.readFileSync(destination, 'utf8');
+  fs.writeFileSync(destination, content.replace(currentPackageSpecifier, specifier));
+}

--- a/packages/nmr/src/commands/sync-agent-files.ts
+++ b/packages/nmr/src/commands/sync-agent-files.ts
@@ -10,11 +10,83 @@ const PACKAGE_NAME = '@williamthorsen/nmr';
 const DESTINATION_RELATIVE_PATH = '.agents/nmr/AGENTS.md';
 const SOURCE_FILENAME = 'AGENTS.md';
 
+/** Matches a leading frontmatter block; capture group 1 is the body between the `---` fences. */
+const FRONTMATTER_REGEX = /^---\n((?:.*\n)*?)---\n/;
+
 /**
- * Absolute path to the source AGENTS.md bundled with the installed nmr package.
- * Walks up from this file's directory until it finds a sibling AGENTS.md, so
- * the same code works whether invoked from compiled dist (3 levels up) or from
- * source during tests (2 levels up).
+ * Verifies that `{destinationDir}/.agents/nmr/AGENTS.md` exists and its body (frontmatter stripped) matches the body
+ * the installed nmr version renders. Gates on content only; the `source:` package specifier is informational and not
+ * compared.
+ */
+export function check(destinationDir: string): CheckResult {
+  const destinationPath = getDestinationPath(destinationDir);
+
+  if (!existsSync(destinationPath)) {
+    return {
+      ok: false,
+      reason: `${DESTINATION_RELATIVE_PATH} is missing. Run \`nmr sync-agent-files\`.`,
+    };
+  }
+
+  const expectedBody = stripFrontmatter(readFileSync(getSourcePath(), 'utf8'));
+  const foundBody = stripFrontmatter(readFileSync(destinationPath, 'utf8'));
+
+  if (foundBody !== expectedBody) {
+    return {
+      ok: false,
+      reason: `${DESTINATION_RELATIVE_PATH} content is out of date. Run \`nmr sync-agent-files\`.`,
+    };
+  }
+
+  return { ok: true };
+}
+
+export interface SyncResult {
+  path: string;
+  /** The installed package specifier (`name@version`); matches the file's own only when `changed` is true. */
+  packageSpecifier: string;
+  changed: boolean;
+}
+
+/**
+ * Renders the bundled AGENTS.md into `{destinationDir}/.agents/nmr/AGENTS.md`, replacing the source frontmatter with
+ * the installed package specifier. Idempotent on content: Rewrites only when the destination is missing or its body
+ * differs, otherwise leaves the file (and its existing specifier) untouched. Creates parent directories as needed.
+ */
+export function sync(destinationDir: string): SyncResult {
+  const body = stripFrontmatter(readFileSync(getSourcePath(), 'utf8'));
+  const packageSpecifier = buildPackageSpecifier();
+  const destinationPath = getDestinationPath(destinationDir);
+
+  if (existsSync(destinationPath) && stripFrontmatter(readFileSync(destinationPath, 'utf8')) === body) {
+    return { path: destinationPath, packageSpecifier, changed: false };
+  }
+
+  const output = `---\nsource: '${packageSpecifier}'\n---\n${body}`;
+  mkdirSync(path.dirname(destinationPath), { recursive: true });
+  writeFileSync(destinationPath, output, 'utf8');
+
+  return { path: destinationPath, packageSpecifier, changed: true };
+}
+
+export type CheckResult = { ok: true } | { ok: false; reason: string };
+
+// region | Helpers
+
+/** Returns the installed package specifier in `name@version` form, e.g. `@williamthorsen/nmr@0.14.2`. */
+function buildPackageSpecifier(): string {
+  return `${PACKAGE_NAME}@${VERSION}`;
+}
+
+/** Returns the managed AGENTS.md path within `destinationDir`. */
+function getDestinationPath(destinationDir: string): string {
+  return path.join(destinationDir, DESTINATION_RELATIVE_PATH);
+}
+
+/**
+ * Returns the absolute path to the source AGENTS.md bundled with the installed nmr package. Walks up from this file's
+ * directory until it finds a sibling AGENTS.md, so the same code works whether invoked from compiled dist (3 levels
+ * up) or from source during tests (2 levels up).
  */
 function getSourcePath(): string {
   let dir = path.dirname(fileURLToPath(import.meta.url));
@@ -26,88 +98,9 @@ function getSourcePath(): string {
   throw new Error(`Could not locate ${SOURCE_FILENAME} in any parent of ${fileURLToPath(import.meta.url)}`);
 }
 
-function getDestinationPath(destinationDir: string): string {
-  return path.join(destinationDir, DESTINATION_RELATIVE_PATH);
-}
-
-function currentSourceStamp(): string {
-  return `${PACKAGE_NAME}@${VERSION}`;
-}
-
-/** Matches a leading frontmatter block; capture group 1 is the body between the `---` fences. */
-const FRONTMATTER_REGEX = /^---\n((?:.*\n)*?)---\n/;
-
-/** Strip leading frontmatter block from a file body, if present. */
+/** Returns the content with its leading frontmatter block removed, if present. */
 function stripFrontmatter(content: string): string {
   return content.replace(FRONTMATTER_REGEX, '');
 }
 
-/** Extract the `source:` value from a file's frontmatter, or null if absent/malformed. */
-export function parseSourceStamp(content: string): string | null {
-  const frontmatterMatch = FRONTMATTER_REGEX.exec(content);
-  if (!frontmatterMatch) return null;
-  const frontmatterBody = frontmatterMatch[1] ?? '';
-  const sourceMatch = /^source:\s*['"]([^'"]+)['"]\s*$/m.exec(frontmatterBody);
-  return sourceMatch?.[1] ?? null;
-}
-
-export interface SyncResult {
-  written: string;
-  stamp: string;
-}
-
-/**
- * Copies the bundled AGENTS.md into `{destinationDir}/.agents/nmr/AGENTS.md`,
- * replacing the source frontmatter with a fresh version stamp. Overwrites
- * unconditionally and creates parent directories as needed.
- */
-export function sync(destinationDir: string): SyncResult {
-  const sourcePath = getSourcePath();
-  const sourceContent = readFileSync(sourcePath, 'utf8');
-  const body = stripFrontmatter(sourceContent);
-  const stamp = currentSourceStamp();
-  const output = `---\nsource: '${stamp}'\n---\n${body}`;
-
-  const destinationPath = getDestinationPath(destinationDir);
-  mkdirSync(path.dirname(destinationPath), { recursive: true });
-  writeFileSync(destinationPath, output, 'utf8');
-
-  return { written: destinationPath, stamp };
-}
-
-export type CheckResult = { ok: true; stamp: string } | { ok: false; reason: string };
-
-/**
- * Verifies that `{destinationDir}/.agents/nmr/AGENTS.md` exists, has a well-formed
- * frontmatter stamp, and matches the installed nmr version.
- */
-export function check(destinationDir: string): CheckResult {
-  const destinationPath = getDestinationPath(destinationDir);
-  const expected = currentSourceStamp();
-
-  if (!existsSync(destinationPath)) {
-    return {
-      ok: false,
-      reason: `${DESTINATION_RELATIVE_PATH} is missing. Run \`nmr sync-agent-files\`.`,
-    };
-  }
-
-  const content = readFileSync(destinationPath, 'utf8');
-  const found = parseSourceStamp(content);
-
-  if (found === null) {
-    return {
-      ok: false,
-      reason: `Cannot parse version stamp in ${DESTINATION_RELATIVE_PATH}. Run \`nmr sync-agent-files\`.`,
-    };
-  }
-
-  if (found !== expected) {
-    return {
-      ok: false,
-      reason: `${DESTINATION_RELATIVE_PATH} is out of sync (file: ${found}, installed: ${expected}). Run \`nmr sync-agent-files\`.`,
-    };
-  }
-
-  return { ok: true, stamp: expected };
-}
+// endregion | Helpers


### PR DESCRIPTION
## What

Fixes an issue where `nmr sync-agent-files --check` failed after an nmr upgrade even when the managed agent guidance was identical. The check now passes whenever the guidance content is current, even if the version has changed.

## Why

Every nmr release advances the version recorded in each consumer's managed agent guidance, so the check failed across every repository on the toolchain on each upgrade — even when the guidance text was identical. The recurring no-op failure trained maintainers to ignore `check:strict` rather than trust it.

## Details

### 🐛 Bug fixes

- `nmr sync-agent-files --check` gates on the rendered guidance content rather than the recorded version, so a version-only difference no longer fails the check.
- `nmr sync-agent-files` is idempotent: it rewrites the managed file only when the guidance content differs, leaving the file and its existing version marker untouched otherwise.

### ♻️ Refactoring

- The `sync-agent-files` CLI parses `--check` through the shared `parseArgs` schema and splits its command logic into named helpers.
- The version marker is modeled consistently as a package specifier (`name@version`) across the command and its result types.

### 🧪 Tests

- Added regression coverage: the check passes when the content matches but the recorded version is older, and fails when the content differs even though the recorded version matches; plus a sync-idempotency case that preserves the existing marker. Removed the obsolete version-mismatch and malformed-marker cases.

### 📚 Documentation

- Reworded the managed guidance so it ties a re-sync to a guidance change rather than to every nmr upgrade.

Closes #415
