### PR TITLE
#414 Remove inapplicable bootstrap fallback from agent guidance

### DIFF
--- a/.agents/nmr/AGENTS.md
+++ b/.agents/nmr/AGENTS.md
@@ -24,10 +24,6 @@ Run `nmr` with no command (from the monorepo root or any workspace package) to l
 
 Avoid `npx nmr`. Inside git worktrees, `npx` can resolve a different nmr binary from outside the working tree.
 
-### Bootstrap fallback
-
-If `nmr` itself fails to run (fresh clone, missing build output), run `pnpm run bootstrap` from the repo root first.
-
 ## Root vs. workspace context
 
 nmr walks up to find `pnpm-workspace.yaml`, then decides which registry to use based on whether your cwd is inside a workspace package. The same command name (e.g. `build`, `test`, `check:strict`) often exists in both registries with different behavior; the root version typically delegates across all workspaces. Use `-w` to force the root registry from inside a package dir, and `-F <pkg>` to run a single package's script from anywhere.

--- a/packages/nmr/AGENTS.md
+++ b/packages/nmr/AGENTS.md
@@ -24,10 +24,6 @@ Run `nmr` with no command (from the monorepo root or any workspace package) to l
 
 Avoid `npx nmr`. Inside git worktrees, `npx` can resolve a different nmr binary from outside the working tree.
 
-### Bootstrap fallback
-
-If `nmr` itself fails to run (fresh clone, missing build output), run `pnpm run bootstrap` from the repo root first.
-
 ## Root vs. workspace context
 
 nmr walks up to find `pnpm-workspace.yaml`, then decides which registry to use based on whether your cwd is inside a workspace package. The same command name (e.g. `build`, `test`, `check:strict`) often exists in both registries with different behavior; the root version typically delegates across all workspaces. Use `-w` to force the root registry from inside a package dir, and `-F <pkg>` to run a single package's script from anywhere.


### PR DESCRIPTION
## What

Fixes an issue where the agent guidance bundled with nmr told coding agents to run a recovery step that exists only in the nmr repo itself.

## Why

nmr's bundled agent guidance is consumed by coding agents that follow instructions literally. The bootstrap recovery step it documented applied only when nmr is built from source, so registry-install consumers (the common case) were being directed to a `bootstrap` script that does not exist.

## Details

### 🐛 Bug fixes

- Removed the "Bootstrap fallback" section from the bundled agent-guidance template and regenerated the synced copy. Repo-specific build recovery remains documented in each consuming repo's own project guidance.

Closes #414
