### PR TITLE
#426 Rewrite parseArgs on node:util with typed error and exit API

### DIFF
--- a/packages/nmr-core/src/__tests__/parseArgs.test.ts
+++ b/packages/nmr-core/src/__tests__/parseArgs.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { FlagSchema } from '../parseArgs.ts';
-import { parseArgs } from '../parseArgs.ts';
+import type { FlagSchema, ParseErrorKind } from '../parseArgs.ts';
+import { parseArgs, parseArgsOrExit, ParseError } from '../parseArgs.ts';
 
 const emptySchema = {} satisfies FlagSchema;
 
@@ -10,6 +10,23 @@ const mixedSchema = {
   output: { long: '--output', type: 'string' as const, short: '-o' },
   verbose: { long: '--verbose', type: 'boolean' as const, short: '-v' },
 };
+
+/** Asserts that parsing throws a `ParseError` with the given kind and flag, and returns it. */
+function expectParseError(argv: string[], schema: FlagSchema, kind: ParseErrorKind, flag: string): ParseError {
+  let thrown: unknown;
+  try {
+    parseArgs(argv, schema);
+  } catch (error: unknown) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(ParseError);
+  if (!(thrown instanceof ParseError)) {
+    throw new Error('expected parseArgs to throw a ParseError');
+  }
+  expect(thrown.kind).toBe(kind);
+  expect(thrown.flag).toBe(flag);
+  return thrown;
+}
 
 describe(parseArgs, () => {
   describe('empty argv', () => {
@@ -23,15 +40,11 @@ describe(parseArgs, () => {
 
   describe('boolean flags', () => {
     it('sets boolean flag to true when present via long form', () => {
-      const result = parseArgs(['--dry-run'], mixedSchema);
-
-      expect(result.flags.dryRun).toBe(true);
+      expect(parseArgs(['--dry-run'], mixedSchema).flags.dryRun).toBe(true);
     });
 
     it('sets boolean flag to true when present via short alias', () => {
-      const result = parseArgs(['-v'], mixedSchema);
-
-      expect(result.flags.verbose).toBe(true);
+      expect(parseArgs(['-v'], mixedSchema).flags.verbose).toBe(true);
     });
 
     it('defaults boolean flags to false when absent', () => {
@@ -41,74 +54,69 @@ describe(parseArgs, () => {
       expect(result.flags.verbose).toBe(false);
     });
 
-    it('throws when boolean flag is given a value via = form', () => {
-      expect(() => parseArgs(['--dry-run=true'], mixedSchema)).toThrow("flag '--dry-run' does not accept a value");
+    it('throws unexpected-value when a boolean flag is given a value via = form', () => {
+      const error = expectParseError(['--dry-run=true'], mixedSchema, 'unexpected-value', '--dry-run');
+      expect(error.message).toBe('Option does not accept a value: --dry-run');
     });
   });
 
   describe('string flags', () => {
     it('parses --flag=value form', () => {
-      const result = parseArgs(['--output=dist/out.js'], mixedSchema);
-
-      expect(result.flags.output).toBe('dist/out.js');
+      expect(parseArgs(['--output=dist/out.js'], mixedSchema).flags.output).toBe('dist/out.js');
     });
 
     it('parses --flag value (space-separated) form', () => {
-      const result = parseArgs(['--output', 'dist/out.js'], mixedSchema);
-
-      expect(result.flags.output).toBe('dist/out.js');
+      expect(parseArgs(['--output', 'dist/out.js'], mixedSchema).flags.output).toBe('dist/out.js');
     });
 
     it('parses short alias with space-separated value', () => {
-      const result = parseArgs(['-o', 'dist/out.js'], mixedSchema);
-
-      expect(result.flags.output).toBe('dist/out.js');
+      expect(parseArgs(['-o', 'dist/out.js'], mixedSchema).flags.output).toBe('dist/out.js');
     });
 
-    it('throws when --flag= has an empty value', () => {
-      expect(() => parseArgs(['--output='], mixedSchema)).toThrow('--output requires a value');
+    it('throws missing-value when --flag= has an empty value', () => {
+      const error = expectParseError(['--output='], mixedSchema, 'missing-value', '--output');
+      expect(error.message).toBe('Missing value for option: --output');
     });
 
-    it('throws when string flag is at end of argv with no value', () => {
-      expect(() => parseArgs(['--output'], mixedSchema)).toThrow('--output requires a value');
+    it('throws missing-value when a string flag is at end of argv with no value', () => {
+      expectParseError(['--output'], mixedSchema, 'missing-value', '--output');
     });
 
-    it('throws when string flag is followed by another flag', () => {
-      expect(() => parseArgs(['--output', '--dry-run'], mixedSchema)).toThrow('--output requires a value');
+    it('throws missing-value when a string flag is followed by another flag', () => {
+      expectParseError(['--output', '--dry-run'], mixedSchema, 'missing-value', '--output');
     });
 
     it('defaults string flags to undefined when absent', () => {
-      const result = parseArgs([], mixedSchema);
+      expect(parseArgs([], mixedSchema).flags.output).toBeUndefined();
+    });
 
-      expect(result.flags.output).toBeUndefined();
+    it('treats bare - as a valid string value (stdin convention)', () => {
+      expect(parseArgs(['--output', '-'], mixedSchema).flags.output).toBe('-');
     });
   });
 
   describe('unknown flags', () => {
-    it('throws for unknown long flag', () => {
-      expect(() => parseArgs(['--unknown'], mixedSchema)).toThrow("unknown flag '--unknown'");
+    it('throws unknown-flag for an unknown long flag', () => {
+      const error = expectParseError(['--unknown'], mixedSchema, 'unknown-flag', '--unknown');
+      expect(error.message).toBe('Unknown option: --unknown');
     });
 
-    it('throws for unknown short flag', () => {
-      expect(() => parseArgs(['-x'], mixedSchema)).toThrow("unknown flag '-x'");
+    it('throws unknown-flag for an unknown short flag, echoing the typed form', () => {
+      expectParseError(['-x'], mixedSchema, 'unknown-flag', '-x');
     });
 
-    it('throws for unknown long flag with = form', () => {
-      expect(() => parseArgs(['--unknown=val'], mixedSchema)).toThrow("unknown flag '--unknown'");
+    it('throws unknown-flag for an unknown long flag in = form', () => {
+      expectParseError(['--unknown=val'], mixedSchema, 'unknown-flag', '--unknown');
     });
   });
 
   describe('positionals', () => {
     it('collects positional arguments in order', () => {
-      const result = parseArgs(['foo', 'bar', 'baz'], emptySchema);
-
-      expect(result.positionals).toStrictEqual(['foo', 'bar', 'baz']);
+      expect(parseArgs(['foo', 'bar', 'baz'], emptySchema).positionals).toStrictEqual(['foo', 'bar', 'baz']);
     });
 
     it('treats bare - as a positional, not a flag', () => {
-      const result = parseArgs(['-'], emptySchema);
-
-      expect(result.positionals).toStrictEqual(['-']);
+      expect(parseArgs(['-'], emptySchema).positionals).toStrictEqual(['-']);
     });
 
     it('collects positionals interleaved with flags', () => {
@@ -129,29 +137,69 @@ describe(parseArgs, () => {
     });
 
     it('treats everything after -- as positionals', () => {
-      const result = parseArgs(['--', '--unknown'], emptySchema);
-
-      expect(result.positionals).toStrictEqual(['--unknown']);
-    });
-  });
-
-  describe('string flag accepts bare - as a value', () => {
-    it('treats - as a valid string value (stdin convention)', () => {
-      const result = parseArgs(['--output', '-'], mixedSchema);
-
-      expect(result.flags.output).toBe('-');
+      expect(parseArgs(['--', '--unknown'], emptySchema).positionals).toStrictEqual(['--unknown']);
     });
   });
 
   describe('empty schema', () => {
     it('treats all non-flag args as positionals', () => {
-      const result = parseArgs(['a', 'b'], emptySchema);
-
-      expect(result.positionals).toStrictEqual(['a', 'b']);
+      expect(parseArgs(['a', 'b'], emptySchema).positionals).toStrictEqual(['a', 'b']);
     });
 
-    it('throws on any flag', () => {
-      expect(() => parseArgs(['--anything'], emptySchema)).toThrow("unknown flag '--anything'");
+    it('throws unknown-flag on any flag', () => {
+      expectParseError(['--anything'], emptySchema, 'unknown-flag', '--anything');
     });
+  });
+
+  describe('short-flag clustering', () => {
+    const clusterSchema = {
+      all: { long: '--all', type: 'boolean' as const, short: '-a' },
+      build: { long: '--build', type: 'boolean' as const, short: '-b' },
+    };
+
+    it('expands clustered short boolean flags', () => {
+      const result = parseArgs(['-ab'], clusterSchema);
+
+      expect(result.flags.all).toBe(true);
+      expect(result.flags.build).toBe(true);
+    });
+
+    it('throws unknown-flag for an unknown flag inside a cluster', () => {
+      expectParseError(['-ax'], clusterSchema, 'unknown-flag', '-x');
+    });
+  });
+});
+
+describe(parseArgsOrExit, () => {
+  /** Sentinel error thrown by the mocked process.exit. */
+  class ExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+      super(`process.exit(${code})`);
+    }
+  }
+
+  beforeEach(() => {
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new ExitError(typeof code === 'number' ? code : undefined);
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the parsed result when parsing succeeds', () => {
+    const result = parseArgsOrExit(['--dry-run'], mixedSchema);
+
+    expect(result.flags.dryRun).toBe(true);
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it('prints a usage error and exits with code 1 on a parse failure', () => {
+    expect(() => parseArgsOrExit(['--unknown'], mixedSchema)).toThrow(ExitError);
+
+    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/nmr-core/src/index.ts
+++ b/packages/nmr-core/src/index.ts
@@ -1,7 +1,7 @@
 export const PACKAGE_NAME = '@williamthorsen/nmr-core';
 export { findPackageRoot } from './findPackageRoot.ts';
-export type { FlagDefinition, FlagSchema, ParsedArgs, ParsedFlags } from './parseArgs.ts';
-export { parseArgs, translateParseError } from './parseArgs.ts';
+export type { FlagDefinition, FlagSchema, ParsedArgs, ParsedFlags, ParseErrorKind } from './parseArgs.ts';
+export { parseArgs, parseArgsOrExit, ParseError } from './parseArgs.ts';
 export { readPackageVersion } from './readPackageVersion.ts';
 export { printError, printSkip, printStep, printSuccess, reportWriteResult } from './terminal.ts';
 export type { WriteOutcome, WriteResult } from './writeFileWithCheck.ts';

--- a/packages/nmr-core/src/parseArgs.ts
+++ b/packages/nmr-core/src/parseArgs.ts
@@ -1,3 +1,6 @@
+import process from 'node:process';
+import { parseArgs as nodeParseArgs } from 'node:util';
+
 /** Schema entry describing a single CLI flag. */
 export interface FlagDefinition {
   long: string;
@@ -19,157 +22,116 @@ export interface ParsedArgs<S extends FlagSchema> {
   positionals: string[];
 }
 
-/** Handle a `--flag=value` argument, returning the key and value to assign. */
-function handleEqualsForm(
-  arg: string,
-  eqIndex: number,
-  longToKey: Map<string, string>,
-  definitions: Map<string, FlagDefinition>,
-): { key: string; value: string } {
-  const longFlag = arg.slice(0, eqIndex);
-  const key = longToKey.get(longFlag);
-  if (key === undefined) {
-    throw new Error(`unknown flag '${longFlag}'`);
-  }
-  const def = definitions.get(key);
-  if (def?.type === 'boolean') {
-    throw new Error(`flag '${longFlag}' does not accept a value`);
-  }
-  const value = arg.slice(eqIndex + 1);
-  if (value === '') {
-    throw new Error(`${longFlag} requires a value`);
-  }
-  return { key, value };
-}
-
-/** Handle a bare `--flag` or `-f` argument, returning the key, value, and index advancement. */
-function handleBareFlag(
-  arg: string,
-  index: number,
-  argv: string[],
-  longToKey: Map<string, string>,
-  shortToKey: Map<string, string>,
-  definitions: Map<string, FlagDefinition>,
-): { key: string; value: boolean | string; advance: number } {
-  const key = longToKey.get(arg) ?? shortToKey.get(arg);
-  if (key === undefined) {
-    throw new Error(`unknown flag '${arg}'`);
-  }
-  const def = definitions.get(key);
-  if (def?.type === 'boolean') {
-    return { key, value: true, advance: 0 };
-  }
-  // String flag: consume next argument as value.
-  const next = argv[index + 1];
-  if (next === undefined || (next.startsWith('-') && next !== '-')) {
-    throw new Error(`${def?.long} requires a value`);
-  }
-  return { key, value: next, advance: 1 };
-}
+/** Discriminates the failure modes `parseArgs` reports. */
+export type ParseErrorKind = 'unknown-flag' | 'missing-value' | 'unexpected-value';
 
 /**
- * Build the lookup tables needed for flag resolution from a schema.
+ * Error thrown by `parseArgs` on invalid input.
  *
- * Returns maps from long/short forms to schema keys, and from schema keys to definitions.
+ * Carries the failure `kind` and the offending `flag` (as the user typed it); its `message` is
+ * composed from those fields, so error wording is uniform across every kind.
  */
-function buildLookupTables(schema: FlagSchema): {
-  longToKey: Map<string, string>;
-  shortToKey: Map<string, string>;
-  definitions: Map<string, FlagDefinition>;
-} {
-  const longToKey = new Map<string, string>();
-  const shortToKey = new Map<string, string>();
-  const definitions = new Map<string, FlagDefinition>();
+export class ParseError extends Error {
+  readonly kind: ParseErrorKind;
+  readonly flag: string;
 
-  for (const [key, def] of Object.entries(schema)) {
-    longToKey.set(def.long, key);
-    definitions.set(key, def);
-    if (def.short !== undefined) {
-      shortToKey.set(def.short, key);
-    }
+  constructor(kind: ParseErrorKind, flag: string) {
+    super(formatParseErrorMessage(kind, flag));
+    this.name = 'ParseError';
+    this.kind = kind;
+    this.flag = flag;
   }
-
-  return { longToKey, shortToKey, definitions };
-}
-
-/**
- * Internal implementation that works with untyped records.
- *
- * Separated from the public API to isolate the dynamic key manipulation
- * from the generic type boundary.
- */
-function parseArgsInternal(
-  argv: string[],
-  schema: FlagSchema,
-): { flags: Record<string, boolean | string | undefined>; positionals: string[] } {
-  const { longToKey, shortToKey, definitions } = buildLookupTables(schema);
-
-  const flags: Record<string, boolean | string | undefined> = {};
-  for (const [key, def] of Object.entries(schema)) {
-    flags[key] = def.type === 'boolean' ? false : undefined;
-  }
-
-  const positionals: string[] = [];
-  let pastDelimiter = false;
-
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i] ?? '';
-
-    if (pastDelimiter) {
-      positionals.push(arg);
-      continue;
-    }
-
-    if (arg === '--') {
-      pastDelimiter = true;
-      continue;
-    }
-
-    // Check for --long=value form.
-    const eqIndex = arg.indexOf('=');
-    if (eqIndex !== -1 && arg.startsWith('--')) {
-      const { key, value } = handleEqualsForm(arg, eqIndex, longToKey, definitions);
-      flags[key] = value;
-      continue;
-    }
-
-    // Check for --long or -short form.
-    if (arg.startsWith('-') && arg !== '-') {
-      const { key, value, advance } = handleBareFlag(arg, i, argv, longToKey, shortToKey, definitions);
-      flags[key] = value;
-      i += advance;
-      continue;
-    }
-
-    // Positional (includes bare `-`).
-    positionals.push(arg);
-  }
-
-  return { flags, positionals };
 }
 
 /**
  * Parse a pre-sliced argv array against a flag schema.
  *
- * Throws `Error` with a human-readable message on unknown flags or missing string-flag values.
- * Does not call `console` or `process.exit`.
+ * Delegates tokenizing to `node:util.parseArgs` (non-strict, with tokens) and validates the token
+ * stream against the schema. Throws `ParseError` on an unknown flag, a missing string-flag value, or
+ * a value supplied to a boolean flag. Does not write output or exit.
  */
 export function parseArgs<S extends FlagSchema>(argv: string[], schema: S): ParsedArgs<S> {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- The internal parser works with dynamic keys; the generic return type is guaranteed by schema-driven initialization.
-  return parseArgsInternal(argv, schema) as ParsedArgs<S>;
+  const nodeOptions: Record<string, { type: 'boolean' | 'string'; short?: string }> = {};
+  const byName = new Map<string, { key: string; def: FlagDefinition }>();
+  const flags: Record<string, boolean | string | undefined> = {};
+
+  for (const [key, def] of Object.entries(schema)) {
+    const name = def.long.replace(/^--/, '');
+    nodeOptions[name] =
+      def.short === undefined ? { type: def.type } : { type: def.type, short: def.short.replace(/^-/, '') };
+    byName.set(name, { key, def });
+    flags[key] = def.type === 'boolean' ? false : undefined;
+  }
+
+  const { tokens } = nodeParseArgs({
+    args: argv,
+    options: nodeOptions,
+    strict: false,
+    allowPositionals: true,
+    tokens: true,
+  });
+
+  const positionals: string[] = [];
+  for (const token of tokens) {
+    if (token.kind === 'positional') {
+      positionals.push(token.value);
+      continue;
+    }
+    // Skip the `--` terminator: node emits the trailing arguments as their own positional tokens.
+    if (token.kind !== 'option') {
+      continue;
+    }
+
+    const entry = byName.get(token.name);
+    if (entry === undefined) {
+      throw new ParseError('unknown-flag', token.rawName);
+    }
+
+    if (entry.def.type === 'boolean') {
+      if (token.value !== undefined) {
+        throw new ParseError('unexpected-value', token.rawName);
+      }
+      flags[entry.key] = true;
+      continue;
+    }
+
+    const value = token.value;
+    // Reject an absent value, an empty `--flag=`, and a value that is actually the next flag (`-` alone is a valid value).
+    if (value === undefined || value === '' || (!token.inlineValue && value.startsWith('-') && value !== '-')) {
+      throw new ParseError('missing-value', token.rawName);
+    }
+    flags[entry.key] = value;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Schema-driven initialization guarantees the generic return shape; TypeScript cannot infer it through the dynamic key writes.
+  return { flags, positionals } as ParsedArgs<S>;
 }
 
 /**
- * Translate a `parseArgs` error into a user-facing message.
+ * Parse argv, or print a usage error to stderr and exit non-zero.
  *
- * Rewrites the internal `"unknown flag '--x'"` format to `"Unknown option: --x"`;
- * passes other messages through unchanged.
+ * The canonical "parse or die" entry point for CLI commands that terminate on invalid input.
  */
-export function translateParseError(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  const flagMatch = message.match(/^unknown flag '(.+)'$/);
-  if (flagMatch?.[1] !== undefined) {
-    return `Unknown option: ${flagMatch[1]}`;
+export function parseArgsOrExit<S extends FlagSchema>(argv: string[], schema: S): ParsedArgs<S> {
+  try {
+    return parseArgs(argv, schema);
+  } catch (error: unknown) {
+    if (error instanceof ParseError) {
+      console.error(`Error: ${error.message}`);
+      process.exit(1);
+    }
+    throw error;
   }
-  return message;
+}
+
+/** Compose the user-facing message for a parse failure, uniformly cased across all kinds. */
+function formatParseErrorMessage(kind: ParseErrorKind, flag: string): string {
+  switch (kind) {
+    case 'unknown-flag':
+      return `Unknown option: ${flag}`;
+    case 'missing-value':
+      return `Missing value for option: ${flag}`;
+    case 'unexpected-value':
+      return `Option does not accept a value: ${flag}`;
+  }
 }

--- a/packages/nmr/src/cli-sync-agent-files.ts
+++ b/packages/nmr/src/cli-sync-agent-files.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs, type ParsedArgs, translateParseError } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit } from '@williamthorsen/nmr-core';
 
 import { check, sync } from './commands/sync-agent-files.ts';
 import { findMonorepoRoot } from './context.ts';
@@ -10,7 +10,7 @@ const flagSchema = {
   check: { long: '--check', type: 'boolean' as const },
 };
 
-const { flags } = parseArgsOrExit(process.argv.slice(2));
+const { flags } = parseArgsOrExit(process.argv.slice(2), flagSchema);
 
 try {
   runCommand(flags.check);
@@ -20,16 +20,6 @@ try {
 }
 
 // region | Helpers
-
-/** Parses argv against the flag schema, printing a usage error and exiting on failure. */
-function parseArgsOrExit(argv: string[]): ParsedArgs<typeof flagSchema> {
-  try {
-    return parseArgs(argv, flagSchema);
-  } catch (error: unknown) {
-    console.error(`Error: ${translateParseError(error)}`);
-    process.exit(1);
-  }
-}
 
 /** Runs sync (default) or check (`--check`), printing the outcome and exiting with the right code. */
 function runCommand(checkOnly: boolean): void {

--- a/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
@@ -350,7 +350,7 @@ describe(createGithubReleaseCommand, () => {
   });
 
   describe('--tags parsing', () => {
-    it('rejects --tags= (empty value) with a clear "requires a value" error', async () => {
+    it('rejects --tags= (empty value) with a missing-value error', async () => {
       // The shared parseArgs helper rejects empty `--flag=` values before the command sees them,
       // so the user gets a precise error rather than a confusing "Unknown tag" downstream.
       let thrown: ExitError | undefined;
@@ -364,7 +364,7 @@ describe(createGithubReleaseCommand, () => {
 
       expect(thrown).toBeInstanceOf(ExitError);
       expect(thrown?.code).toBe(1);
-      expect(console.error).toHaveBeenCalledWith('Error: --tags requires a value');
+      expect(console.error).toHaveBeenCalledWith('Error: Missing value for option: --tags');
       expect(mockCreateGithubReleases).not.toHaveBeenCalled();
     });
 

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -604,7 +604,7 @@ describe(parseArgs, () => {
   });
 
   it('throws when --only value is empty', () => {
-    expect(() => parseArgs(['--only='])).toThrow('--only requires');
+    expect(() => parseArgs(['--only='])).toThrow('Missing value for option: --only');
   });
 
   it('accepts a canonical semver value for --set-version', () => {
@@ -621,7 +621,7 @@ describe(parseArgs, () => {
   });
 
   it('throws when --set-version is empty', () => {
-    expect(() => parseArgs(['--set-version='])).toThrow('--set-version requires');
+    expect(() => parseArgs(['--set-version='])).toThrow('Missing value for option: --set-version');
   });
 
   it('throws when --set-version is combined with --bump', () => {

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -2,7 +2,7 @@
 /* eslint n/hashbang: off, n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs, readPackageVersion, translateParseError } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit, readPackageVersion } from '@williamthorsen/nmr-core';
 
 import { checkWorkTypesDrift } from '../checkWorkTypesDrift.ts';
 import { commitCommand } from '../commitCommand.ts';
@@ -397,15 +397,7 @@ if (command === 'init') {
     withConfig: { long: '--with-config', type: 'boolean' as const },
   };
 
-  let parsed;
-  try {
-    parsed = parseArgs(flags, initFlagSchema);
-  } catch (error: unknown) {
-    console.error(`Error: ${translateParseError(error)}`);
-    process.exit(1);
-  }
-
-  const { dryRun, force, withConfig } = parsed.flags;
+  const { dryRun, force, withConfig } = parseArgsOrExit(flags, initFlagSchema).flags;
   const exitCode = initCommand({ dryRun, force, withConfig });
   process.exit(exitCode);
 }
@@ -430,15 +422,7 @@ if (command === 'sync-labels') {
       force: { long: '--force', type: 'boolean' as const },
     };
 
-    let syncParsed;
-    try {
-      syncParsed = parseArgs(subflags, syncLabelsInitFlagSchema);
-    } catch (error: unknown) {
-      console.error(`Error: ${translateParseError(error)}`);
-      process.exit(1);
-    }
-
-    const { dryRun, force } = syncParsed.flags;
+    const { dryRun, force } = parseArgsOrExit(subflags, syncLabelsInitFlagSchema).flags;
     const exitCode = await syncLabelsInitCommand({ dryRun, force });
     process.exit(exitCode);
   }

--- a/packages/release-kit/src/commitCommand.ts
+++ b/packages/release-kit/src/commitCommand.ts
@@ -1,10 +1,7 @@
-/* eslint n/no-process-exit: off */
-/* eslint unicorn/no-process-exit: off */
-
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
-import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit } from '@williamthorsen/nmr-core';
 
 import { RELEASE_SUMMARY_FILE, RELEASE_TAGS_FILE } from './prepareCommand.ts';
 
@@ -19,15 +16,7 @@ const commitFlagSchema = {
  * changes, and creates a release commit with a formatted message.
  */
 export function commitCommand(argv: string[]): void {
-  let parsed;
-  try {
-    parsed = parseArgs(argv, commitFlagSchema);
-  } catch (error: unknown) {
-    console.error(`Error: ${translateParseError(error)}`);
-    process.exit(1);
-  }
-
-  const dryRun = parsed.flags.dryRun;
+  const dryRun = parseArgsOrExit(argv, commitFlagSchema).flags.dryRun;
 
   // Read tags file.
   let tagsContent: string;

--- a/packages/release-kit/src/createGithubReleaseCommand.ts
+++ b/packages/release-kit/src/createGithubReleaseCommand.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit } from '@williamthorsen/nmr-core';
 
 import { createGithubReleases } from './createGithubRelease.ts';
 import { parseRequestedTags } from './parseRequestedTags.ts';
@@ -18,13 +18,7 @@ const createGithubReleaseFlagSchema = {
  * for tags on HEAD (or a comma-separated `--tags` subset), without requiring npm publish.
  */
 export async function createGithubReleaseCommand(argv: string[]): Promise<void> {
-  let parsed;
-  try {
-    parsed = parseArgs(argv, createGithubReleaseFlagSchema);
-  } catch (error: unknown) {
-    console.error(`Error: ${translateParseError(error)}`);
-    process.exit(1);
-  }
+  const parsed = parseArgsOrExit(argv, createGithubReleaseFlagSchema);
 
   const { dryRun } = parsed.flags;
   const requestedTags = parseRequestedTags(parsed.flags.tags);

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -2,7 +2,7 @@
 /* eslint unicorn/no-process-exit: off */
 
 import type { WriteResult } from '@williamthorsen/nmr-core';
-import { parseArgs as coreParseArgs, translateParseError, writeFileWithCheck } from '@williamthorsen/nmr-core';
+import { parseArgs as coreParseArgs, writeFileWithCheck } from '@williamthorsen/nmr-core';
 
 import { assertCleanWorkingTree } from './assertCleanWorkingTree.ts';
 import { buildDependencyGraph } from './buildDependencyGraph.ts';
@@ -87,14 +87,7 @@ export function parseArgs(argv: string[]): {
   setVersion: string | undefined;
   withReleaseNotes: boolean;
 } {
-  let parsed;
-  try {
-    parsed = coreParseArgs(argv, prepareFlagSchema);
-  } catch (error: unknown) {
-    throw new Error(translateParseError(error));
-  }
-
-  const { flags } = parsed;
+  const { flags } = coreParseArgs(argv, prepareFlagSchema);
 
   if (flags.help) {
     showHelp();

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -4,7 +4,7 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit } from '@williamthorsen/nmr-core';
 
 import { assertCleanWorkingTree } from './assertCleanWorkingTree.ts';
 import { detectPackageManager } from './detectPackageManager.ts';
@@ -27,13 +27,7 @@ const publishFlagSchema = {
  * detect the package manager, validate `--tags`, and publish each tag with inject/restore lifecycle.
  */
 export async function publishCommand(argv: string[]): Promise<void> {
-  let parsed;
-  try {
-    parsed = parseArgs(argv, publishFlagSchema);
-  } catch (error: unknown) {
-    console.error(`Error: ${translateParseError(error)}`);
-    process.exit(1);
-  }
+  const parsed = parseArgsOrExit(argv, publishFlagSchema);
 
   const { dryRun, noGitChecks, provenance } = parsed.flags;
 

--- a/packages/release-kit/src/pushCommand.ts
+++ b/packages/release-kit/src/pushCommand.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit } from '@williamthorsen/nmr-core';
 
 import { parseRequestedTags } from './parseRequestedTags.ts';
 import { pushRelease } from './pushRelease.ts';
@@ -18,13 +18,7 @@ const pushFlagSchema = {
  * the release commit and each tag individually.
  */
 export async function pushCommand(argv: string[]): Promise<void> {
-  let parsed;
-  try {
-    parsed = parseArgs(argv, pushFlagSchema);
-  } catch (error: unknown) {
-    console.error(`Error: ${translateParseError(error)}`);
-    process.exit(1);
-  }
+  const parsed = parseArgsOrExit(argv, pushFlagSchema);
 
   const { dryRun, tagsOnly } = parsed.flags;
   const requestedTags = parseRequestedTags(parsed.flags.tags);

--- a/packages/release-kit/src/tagCommand.ts
+++ b/packages/release-kit/src/tagCommand.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgs, translateParseError } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit } from '@williamthorsen/nmr-core';
 
 import { createTags } from './createTags.ts';
 
@@ -13,15 +13,7 @@ const tagFlagSchema = {
 /** Orchestrate the CLI `tag` command: parse flags and delegate to `createTags`. */
 export function tagCommand(argv: string[]): void {
   // Help flags are handled upstream in the CLI entry point (bin/release-kit.ts).
-  let parsed;
-  try {
-    parsed = parseArgs(argv, tagFlagSchema);
-  } catch (error: unknown) {
-    console.error(`Error: ${translateParseError(error)}`);
-    process.exit(1);
-  }
-
-  const { dryRun, noGitChecks } = parsed.flags;
+  const { dryRun, noGitChecks } = parseArgsOrExit(argv, tagFlagSchema).flags;
 
   try {
     createTags({ dryRun, noGitChecks });

--- a/packages/v11y-check/src/bin/route.ts
+++ b/packages/v11y-check/src/bin/route.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 
-import { parseArgs, readPackageVersion, translateParseError } from '@williamthorsen/nmr-core';
+import { parseArgs, readPackageVersion } from '@williamthorsen/nmr-core';
 
 import { auditCommand, checkCommand, extractMessage, syncCommand } from '../cli.ts';
 import { initCommand } from '../init/initCommand.ts';
@@ -172,7 +172,7 @@ async function handleSubcommand(
   try {
     options = parseSharedFlags(flags);
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${translateParseError(error)}\n`);
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
     return 1;
   }
 
@@ -200,7 +200,7 @@ function handleInit(flags: string[]): number {
   try {
     parsed = parseArgs(flags, initFlagSchema);
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${translateParseError(error)}\n`);
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
     return 1;
   }
 


### PR DESCRIPTION
## What

Adds `parseArgsOrExit` to `@williamthorsen/nmr-core`: a single call that parses CLI flags or, on bad input, prints a usage error and exits. A new typed `ParseError` names the failure and the offending flag, and `parseArgs` now throws it. The `translateParseError` export is removed. Across the bundled `release-kit`, `v11y`, and `nmr` CLIs, a flag mistake now produces a uniformly worded error. Clustered short flags such as `-ab` are now accepted; an empty `--flag=` is still rejected.

## Why

Every CLI repeated the same parse / translate / exit boilerplate, and error wording was inconsistent across commands. The parser also hand-rolled ~130 lines of argument tokenizing that Node now provides natively, so edge cases were maintained in-house instead of offloaded to the platform.

## Details

### 🎉 Features

- 🚨 **Breaking:** `@williamthorsen/nmr-core` adds `parseArgsOrExit` and a typed `ParseError` (with the failure kind and offending flag), and removes `translateParseError`. `parseArgs` keeps its signature and return shape but now throws `ParseError`.
- Clustered short flags (`-ab`) are accepted (expanded to `-a -b`); an empty `--flag=` is rejected as a missing value.

### ♻️ Refactoring

- `parseArgs` delegates tokenizing to `node:util.parseArgs`, deleting the hand-rolled tokenizer; all ~10 CLI call sites across `release-kit`, `v11y-check`, and `nmr` adopt the new API, removing inline parse-error boilerplate. `ParseError.message` is the single source of error wording, so output is uniform across every CLI.

### 🧪 Tests

- nmr-core tests cover the new error kinds and both parsing-behavior changes; affected call-site tests are updated to the new error wording.

Closes #426
