### PR TITLE
#423 Migrate ensure-prepublish-hooks to nmr-core parseArgs

### DIFF
--- a/packages/nmr/src/cli-ensure-prepublish-hooks.ts
+++ b/packages/nmr/src/cli-ensure-prepublish-hooks.ts
@@ -1,42 +1,18 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
+import { parseArgsOrExit } from '@williamthorsen/nmr-core';
+
 import { DEFAULT_HOOK, ensurePrepublishHooks } from './commands/ensure-prepublish-hooks.ts';
 import { findMonorepoRoot } from './context.ts';
 
-let fix = false;
-let dryRun = false;
-let command: string | undefined;
+const flagSchema = {
+  fix: { long: '--fix', type: 'boolean' as const },
+  dryRun: { long: '--dry-run', type: 'boolean' as const },
+  command: { long: '--command', type: 'string' as const },
+};
 
-const args = process.argv.slice(2);
-for (let i = 0; i < args.length; i++) {
-  const arg = args[i];
-  switch (arg) {
-    case '--fix':
-      fix = true;
-
-      break;
-
-    case '--dry-run':
-      dryRun = true;
-
-      break;
-
-    case '--command':
-      i++;
-      command = args[i];
-      if (!command) {
-        console.error('--command requires a value');
-        process.exit(1);
-      }
-
-      break;
-
-    default:
-      console.error(`Unknown argument: ${arg}`);
-      process.exit(1);
-  }
-}
+const { fix, dryRun, command } = parseArgsOrExit(process.argv.slice(2), flagSchema).flags;
 
 try {
   const monorepoRoot = findMonorepoRoot();


### PR DESCRIPTION
## What

`ensure-prepublish-hooks` now parses its arguments with `nmr-core`'s shared `parseArgs` utilities instead of a hand-rolled `for`/`switch` loop, removing the last bespoke argument parser in the `nmr` package. Every `nmr` CLI now shares one argument-parsing and error-reporting path; as a side effect, stray positional arguments are ignored rather than rejected, while unknown flags and a missing `--command` value still exit non-zero.

## Why

`ensure-prepublish-hooks` was the last command in the `nmr` package still using a hand-rolled argument parser, so its invalid-argument errors diverged from the rest of the suite. Consolidating it onto the shared parser makes argument-error behavior consistent across every `nmr` CLI.

## Details

### ♻️ Refactoring

- Replaced the hand-rolled `for`/`switch` argument loop with `nmr-core`'s shared `parseArgsOrExit` and a declarative flag schema, removing the bespoke `--command requires a value` check.

Closes #423
