### PR TITLE
#430 Reject unexpected positional arguments by default

### DIFF
--- a/packages/nmr-core/src/__tests__/parseArgs.test.ts
+++ b/packages/nmr-core/src/__tests__/parseArgs.test.ts
@@ -48,7 +48,7 @@ describe(parseArgs, () => {
     });
 
     it('defaults boolean flags to false when absent', () => {
-      const result = parseArgs(['positional'], mixedSchema);
+      const result = parseArgs(['--output', 'dist/out.js'], mixedSchema);
 
       expect(result.flags.dryRun).toBe(false);
       expect(result.flags.verbose).toBe(false);
@@ -111,39 +111,70 @@ describe(parseArgs, () => {
   });
 
   describe('positionals', () => {
-    it('collects positional arguments in order', () => {
-      expect(parseArgs(['foo', 'bar', 'baz'], emptySchema).positionals).toStrictEqual(['foo', 'bar', 'baz']);
+    it('rejects an unexpected positional by default', () => {
+      const error = expectParseError(['foo'], emptySchema, 'unexpected-positional', 'foo');
+      expect(error.message).toBe('Unexpected positional argument: foo');
     });
 
-    it('treats bare - as a positional, not a flag', () => {
-      expect(parseArgs(['-'], emptySchema).positionals).toStrictEqual(['-']);
+    it('reports the first positional when several are present', () => {
+      expectParseError(['foo', 'bar', 'baz'], emptySchema, 'unexpected-positional', 'foo');
     });
 
-    it('collects positionals interleaved with flags', () => {
-      const result = parseArgs(['foo', '--dry-run', 'bar'], mixedSchema);
+    it('rejects a positional interleaved with valid flags, reporting the positional', () => {
+      expectParseError(['foo', '--dry-run', 'bar'], mixedSchema, 'unexpected-positional', 'foo');
+    });
+
+    it('rejects bare - as an unexpected positional by default', () => {
+      expectParseError(['-'], emptySchema, 'unexpected-positional', '-');
+    });
+
+    it('collects positionals in order when allowPositionals is set', () => {
+      expect(parseArgs(['foo', 'bar', 'baz'], emptySchema, { allowPositionals: true }).positionals).toStrictEqual([
+        'foo',
+        'bar',
+        'baz',
+      ]);
+    });
+
+    it('collects positionals interleaved with flags when allowPositionals is set', () => {
+      const result = parseArgs(['foo', '--dry-run', 'bar'], mixedSchema, { allowPositionals: true });
 
       expect(result.positionals).toStrictEqual(['foo', 'bar']);
       expect(result.flags.dryRun).toBe(true);
     });
+
+    it('treats bare - as a positional, not a flag, when allowPositionals is set', () => {
+      expect(parseArgs(['-'], emptySchema, { allowPositionals: true }).positionals).toStrictEqual(['-']);
+    });
   });
 
   describe('-- delimiter', () => {
-    it('stops flag parsing after --', () => {
-      const result = parseArgs(['--dry-run', '--', '--output', 'val'], mixedSchema);
+    it('rejects positionals after -- by default', () => {
+      expectParseError(['--dry-run', '--', '--output', 'val'], mixedSchema, 'unexpected-positional', '--output');
+    });
+
+    it('collects everything after -- as positionals when allowPositionals is set', () => {
+      const result = parseArgs(['--dry-run', '--', '--output', 'val'], mixedSchema, { allowPositionals: true });
 
       expect(result.flags.dryRun).toBe(true);
       expect(result.flags.output).toBeUndefined();
       expect(result.positionals).toStrictEqual(['--output', 'val']);
     });
 
-    it('treats everything after -- as positionals', () => {
-      expect(parseArgs(['--', '--unknown'], emptySchema).positionals).toStrictEqual(['--unknown']);
+    it('treats everything after -- as positionals when allowPositionals is set', () => {
+      expect(parseArgs(['--', '--unknown'], emptySchema, { allowPositionals: true }).positionals).toStrictEqual([
+        '--unknown',
+      ]);
     });
   });
 
   describe('empty schema', () => {
-    it('treats all non-flag args as positionals', () => {
-      expect(parseArgs(['a', 'b'], emptySchema).positionals).toStrictEqual(['a', 'b']);
+    it('rejects non-flag args as unexpected positionals by default', () => {
+      expectParseError(['a', 'b'], emptySchema, 'unexpected-positional', 'a');
+    });
+
+    it('treats all non-flag args as positionals when allowPositionals is set', () => {
+      expect(parseArgs(['a', 'b'], emptySchema, { allowPositionals: true }).positionals).toStrictEqual(['a', 'b']);
     });
 
     it('throws unknown-flag on any flag', () => {
@@ -201,5 +232,19 @@ describe(parseArgsOrExit, () => {
 
     expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
     expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('prints a usage error and exits with code 1 on an unexpected positional', () => {
+    expect(() => parseArgsOrExit(['extra'], mixedSchema)).toThrow(ExitError);
+
+    expect(console.error).toHaveBeenCalledWith('Error: Unexpected positional argument: extra');
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('returns the parsed result when positionals are allowed', () => {
+    const result = parseArgsOrExit(['extra'], emptySchema, { allowPositionals: true });
+
+    expect(result.positionals).toStrictEqual(['extra']);
+    expect(process.exit).not.toHaveBeenCalled();
   });
 });

--- a/packages/nmr-core/src/index.ts
+++ b/packages/nmr-core/src/index.ts
@@ -1,6 +1,13 @@
 export const PACKAGE_NAME = '@williamthorsen/nmr-core';
 export { findPackageRoot } from './findPackageRoot.ts';
-export type { FlagDefinition, FlagSchema, ParsedArgs, ParsedFlags, ParseErrorKind } from './parseArgs.ts';
+export type {
+  FlagDefinition,
+  FlagSchema,
+  ParseArgsOptions,
+  ParsedArgs,
+  ParsedFlags,
+  ParseErrorKind,
+} from './parseArgs.ts';
 export { parseArgs, parseArgsOrExit, ParseError } from './parseArgs.ts';
 export { readPackageVersion } from './readPackageVersion.ts';
 export { printError, printSkip, printStep, printSuccess, reportWriteResult } from './terminal.ts';

--- a/packages/nmr-core/src/parseArgs.ts
+++ b/packages/nmr-core/src/parseArgs.ts
@@ -22,14 +22,21 @@ export interface ParsedArgs<S extends FlagSchema> {
   positionals: string[];
 }
 
+/** Options controlling how `parseArgs` handles input beyond the flag schema. */
+export interface ParseArgsOptions {
+  /** When true, positionals are collected; otherwise an unexpected positional throws. Defaults to false. */
+  allowPositionals?: boolean;
+}
+
 /** Discriminates the failure modes `parseArgs` reports. */
-export type ParseErrorKind = 'unknown-flag' | 'missing-value' | 'unexpected-value';
+export type ParseErrorKind = 'unknown-flag' | 'missing-value' | 'unexpected-value' | 'unexpected-positional';
 
 /**
  * Error thrown by `parseArgs` on invalid input.
  *
- * Carries the failure `kind` and the offending `flag` (as the user typed it); its `message` is
- * composed from those fields, so error wording is uniform across every kind.
+ * Carries the failure `kind` and the offending token in `flag` — a flag as the user typed it, or the
+ * positional value for `'unexpected-positional'`. Its `message` is composed from those fields, so error
+ * wording is uniform across every kind.
  */
 export class ParseError extends Error {
   readonly kind: ParseErrorKind;
@@ -47,10 +54,15 @@ export class ParseError extends Error {
  * Parse a pre-sliced argv array against a flag schema.
  *
  * Delegates tokenizing to `node:util.parseArgs` (non-strict, with tokens) and validates the token
- * stream against the schema. Throws `ParseError` on an unknown flag, a missing string-flag value, or
- * a value supplied to a boolean flag. Does not write output or exit.
+ * stream against the schema. Throws `ParseError` on an unknown flag, a missing string-flag value, a
+ * value supplied to a boolean flag, or — unless `options.allowPositionals` is set — an unexpected
+ * positional argument. Does not write output or exit.
  */
-export function parseArgs<S extends FlagSchema>(argv: string[], schema: S): ParsedArgs<S> {
+export function parseArgs<S extends FlagSchema>(
+  argv: string[],
+  schema: S,
+  options: ParseArgsOptions = {},
+): ParsedArgs<S> {
   const nodeOptions: Record<string, { type: 'boolean' | 'string'; short?: string }> = {};
   const byName = new Map<string, { key: string; def: FlagDefinition }>();
   const flags: Record<string, boolean | string | undefined> = {};
@@ -74,6 +86,9 @@ export function parseArgs<S extends FlagSchema>(argv: string[], schema: S): Pars
   const positionals: string[] = [];
   for (const token of tokens) {
     if (token.kind === 'positional') {
+      if (options.allowPositionals !== true) {
+        throw new ParseError('unexpected-positional', token.value);
+      }
       positionals.push(token.value);
       continue;
     }
@@ -112,9 +127,13 @@ export function parseArgs<S extends FlagSchema>(argv: string[], schema: S): Pars
  *
  * The canonical "parse or die" entry point for CLI commands that terminate on invalid input.
  */
-export function parseArgsOrExit<S extends FlagSchema>(argv: string[], schema: S): ParsedArgs<S> {
+export function parseArgsOrExit<S extends FlagSchema>(
+  argv: string[],
+  schema: S,
+  options: ParseArgsOptions = {},
+): ParsedArgs<S> {
   try {
-    return parseArgs(argv, schema);
+    return parseArgs(argv, schema, options);
   } catch (error: unknown) {
     if (error instanceof ParseError) {
       console.error(`Error: ${error.message}`);
@@ -133,5 +152,7 @@ function formatParseErrorMessage(kind: ParseErrorKind, flag: string): string {
       return `Missing value for option: ${flag}`;
     case 'unexpected-value':
       return `Option does not accept a value: ${flag}`;
+    case 'unexpected-positional':
+      return `Unexpected positional argument: ${flag}`;
   }
 }


### PR DESCRIPTION
## What

Commands built on nmr-core now reject unexpected positional arguments by default. Commands that take positional arguments can opt back in to accept them.

## Why

The parser already rejected unknown flags loudly but accepted stray positionals silently — an asymmetry that turned typos into silent misbehavior. For the zero-positional commands that make up most of the suite, a fat-fingered token was simply dropped: `ensure-prepublish-hooks fix` (meant as `--fix`) ran check-only and exited 0. Treating input the parser cannot account for the same way in both cases closes that failure mode.

## Details

### 🎉 Features

- `parseArgs` and `parseArgsOrExit` gain an optional `options` argument with `allowPositionals` (default `false`). With the default, an unexpected positional throws a `ParseError` of the new kind `'unexpected-positional'` — reporting the first offending token, including tokens after a `--` terminator — routed through the same uniform `Error:` message path as the other kinds (`Unexpected positional argument: <token>`). With `allowPositionals: true`, positionals are collected and returned exactly as before.
- A repo-wide audit confirmed no `nmr`, `release-kit`, or `v11y-check` call site reads `.positionals` or passes a subcommand token into the parser, so no site needed to opt in and none was changed. The stricter default strictly improves behavior at existing call sites — `v11y check extra` and `release-kit init extra` now fail loud instead of dropping `extra`.

### 🧪 Tests

- The `parseArgs` suite's positional, `--`-delimiter, and empty-schema cases were inverted to assert reject-by-default, with opt-in variants added alongside; new cases cover the `'unexpected-positional'` kind (lone, multiple, interleaved-with-flags, bare `-`, and post-`--` tokens) and both `parseArgsOrExit` paths.

Closes #430
