### PR TITLE
#427 Route all CLI error reporting through a single stderr helper

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ export default [
       'n/no-extraneous-import': 'off',
       'n/no-missing-import': 'off',
       'n/no-unpublished-import': 'off',
+      'no-console': ['error', { allow: ['debug', 'info', 'warn'] }],
     },
   },
   {

--- a/packages/nmr-core/src/__tests__/parseArgs.test.ts
+++ b/packages/nmr-core/src/__tests__/parseArgs.test.ts
@@ -213,7 +213,7 @@ describe(parseArgsOrExit, () => {
     vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -230,14 +230,14 @@ describe(parseArgsOrExit, () => {
   it('prints a usage error and exits with code 1 on a parse failure', () => {
     expect(() => parseArgsOrExit(['--unknown'], mixedSchema)).toThrow(ExitError);
 
-    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Unknown option: --unknown\n');
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it('prints a usage error and exits with code 1 on an unexpected positional', () => {
     expect(() => parseArgsOrExit(['extra'], mixedSchema)).toThrow(ExitError);
 
-    expect(console.error).toHaveBeenCalledWith('Error: Unexpected positional argument: extra');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Unexpected positional argument: extra\n');
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 

--- a/packages/nmr-core/src/__tests__/terminal.test.ts
+++ b/packages/nmr-core/src/__tests__/terminal.test.ts
@@ -1,7 +1,21 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { reportWriteResult } from '../terminal.ts';
+import { reportError, reportWriteResult } from '../terminal.ts';
 import type { WriteResult } from '../writeFileWithCheck.ts';
+
+describe(reportError, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes a canonical Error line with a trailing newline to stderr', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    reportError('something went wrong');
+
+    expect(spy).toHaveBeenCalledWith('Error: something went wrong\n');
+  });
+});
 
 describe(reportWriteResult, () => {
   afterEach(() => {
@@ -74,7 +88,7 @@ describe(reportWriteResult, () => {
   });
 
   it('prints error for failed outcome', () => {
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     const result: WriteResult = { filePath: 'some/file.ts', outcome: 'failed' };
 
     reportWriteResult(result, false);
@@ -83,7 +97,7 @@ describe(reportWriteResult, () => {
   });
 
   it('prints error with detail when failed outcome has an error', () => {
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     const result: WriteResult = {
       filePath: 'some/file.ts',
       outcome: 'failed',

--- a/packages/nmr-core/src/index.ts
+++ b/packages/nmr-core/src/index.ts
@@ -10,6 +10,6 @@ export type {
 } from './parseArgs.ts';
 export { parseArgs, parseArgsOrExit, ParseError } from './parseArgs.ts';
 export { readPackageVersion } from './readPackageVersion.ts';
-export { printError, printSkip, printStep, printSuccess, reportWriteResult } from './terminal.ts';
+export { printError, printSkip, printStep, printSuccess, reportError, reportWriteResult } from './terminal.ts';
 export type { WriteOutcome, WriteResult } from './writeFileWithCheck.ts';
 export { writeFileWithCheck } from './writeFileWithCheck.ts';

--- a/packages/nmr-core/src/parseArgs.ts
+++ b/packages/nmr-core/src/parseArgs.ts
@@ -1,6 +1,8 @@
 import process from 'node:process';
 import { parseArgs as nodeParseArgs } from 'node:util';
 
+import { reportError } from './terminal.ts';
+
 /** Schema entry describing a single CLI flag. */
 export interface FlagDefinition {
   long: string;
@@ -136,7 +138,7 @@ export function parseArgsOrExit<S extends FlagSchema>(
     return parseArgs(argv, schema, options);
   } catch (error: unknown) {
     if (error instanceof ParseError) {
-      console.error(`Error: ${error.message}`);
+      reportError(error.message);
       process.exit(1);
     }
     throw error;

--- a/packages/nmr-core/src/terminal.ts
+++ b/packages/nmr-core/src/terminal.ts
@@ -1,5 +1,7 @@
 // Terminal output helpers for styled CLI messages.
 
+import process from 'node:process';
+
 import type { WriteResult } from './writeFileWithCheck.ts';
 
 /** Print a step label with a right-arrow prefix. */
@@ -19,7 +21,12 @@ export function printSkip(message: string): void {
 
 /** Print an error message to stderr. */
 export function printError(message: string): void {
-  console.error(`  ❌ ${message}`);
+  process.stderr.write(`  ❌ ${message}\n`);
+}
+
+/** Write a canonical `Error: <message>` line to stderr — the single sanctioned door for this output shape. */
+export function reportError(message: string): void {
+  process.stderr.write(`Error: ${message}\n`);
 }
 
 /** Print a terminal message for a write result based on its outcome. */

--- a/packages/nmr/src/cli-build.ts
+++ b/packages/nmr/src/cli-build.ts
@@ -6,6 +6,6 @@ import { buildPackage } from './commands/build.ts';
 try {
   await buildPackage(process.cwd());
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
   process.exit(1);
 }

--- a/packages/nmr/src/cli-ensure-prepublish-hooks.ts
+++ b/packages/nmr/src/cli-ensure-prepublish-hooks.ts
@@ -43,10 +43,10 @@ try {
 
   if (result.hasFailures) {
     const missing = result.packages.filter((p) => p.action === 'missing').length;
-    console.error(`\n${missing} package(s) missing prepublishOnly. Use --fix to add it.`);
+    process.stderr.write(`\n${missing} package(s) missing prepublishOnly. Use --fix to add it.\n`);
     process.exit(1);
   }
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
   process.exit(1);
 }

--- a/packages/nmr/src/cli-report-overrides.ts
+++ b/packages/nmr/src/cli-report-overrides.ts
@@ -8,6 +8,6 @@ try {
   const monorepoRoot = findMonorepoRoot();
   reportOverrides(monorepoRoot);
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
   process.exit(1);
 }

--- a/packages/nmr/src/cli-sync-agent-files.ts
+++ b/packages/nmr/src/cli-sync-agent-files.ts
@@ -15,7 +15,7 @@ const { flags } = parseArgsOrExit(process.argv.slice(2), flagSchema);
 try {
   runCommand(flags.check);
 } catch (error: unknown) {
-  console.error(error instanceof Error ? error.message : String(error));
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
   process.exit(1);
 }
 
@@ -38,7 +38,7 @@ function runCommand(checkOnly: boolean): void {
     console.info('✓ .agents/nmr/AGENTS.md is in sync');
     process.exit(0);
   }
-  console.error(result.reason);
+  process.stderr.write(`${result.reason}\n`);
   process.exit(1);
 }
 

--- a/packages/nmr/src/cli-sync-pnpm-version.ts
+++ b/packages/nmr/src/cli-sync-pnpm-version.ts
@@ -8,6 +8,6 @@ try {
   const monorepoRoot = findMonorepoRoot();
   syncPnpmVersion(monorepoRoot);
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
   process.exit(1);
 }

--- a/packages/release-kit/src/__tests__/commitCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/commitCommand.unit.test.ts
@@ -31,7 +31,7 @@ describe(commitCommand, () => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
     vi.spyOn(console, 'info').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -146,6 +146,6 @@ describe(commitCommand, () => {
 
   it('exits with error for unknown flags', () => {
     expect(() => commitCommand(['--unknown'])).toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Unknown option'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Unknown option'));
   });
 });

--- a/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
@@ -59,7 +59,7 @@ describe(createGithubReleaseCommand, () => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
     vi.spyOn(console, 'info').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -142,7 +142,7 @@ describe(createGithubReleaseCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Unknown option: --unknown\n');
   });
 
   it('exits with code 1 when no release tags are found on HEAD', async () => {
@@ -159,8 +159,8 @@ describe(createGithubReleaseCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith(
-      'Error: No release tags found on HEAD. Create tags with `release-kit tag` first.',
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      'Error: No release tags found on HEAD. Create tags with `release-kit tag` first.\n',
     );
   });
 
@@ -179,7 +179,9 @@ describe(createGithubReleaseCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error: Unknown tag "core-v9.9.9" in --tags. Available: core-v1.3.0');
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      'Error: Unknown tag "core-v9.9.9" in --tags. Available: core-v1.3.0\n',
+    );
   });
 
   it('exits with code 1 when discoverWorkspaces throws', async () => {
@@ -196,7 +198,7 @@ describe(createGithubReleaseCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error discovering workspaces: discovery failed');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error discovering workspaces: discovery failed\n');
   });
 
   it('does not exit when --tags is explicit and every skip is no-entry', async () => {
@@ -218,7 +220,7 @@ describe(createGithubReleaseCommand, () => {
 
     await createGithubReleaseCommand(['--tags=core-v1.3.0,extra-v0.1.0']);
 
-    expect(console.error).not.toHaveBeenCalled();
+    expect(process.stderr.write).not.toHaveBeenCalled();
     expect(console.info).toHaveBeenCalledWith(
       'Skipped 2 tag(s) with no releasable content: core-v1.3.0 (no-entry), extra-v0.1.0 (no-entry).',
     );
@@ -234,7 +236,7 @@ describe(createGithubReleaseCommand, () => {
 
     await createGithubReleaseCommand(['--tags=core-v1.3.0']);
 
-    expect(console.error).not.toHaveBeenCalled();
+    expect(process.stderr.write).not.toHaveBeenCalled();
     expect(console.info).toHaveBeenCalledWith(
       'Skipped 1 tag(s) with no releasable content: core-v1.3.0 (no-audience-content).',
     );
@@ -250,7 +252,7 @@ describe(createGithubReleaseCommand, () => {
 
     await createGithubReleaseCommand(['--tags=core-v1.3.0']);
 
-    expect(console.error).not.toHaveBeenCalled();
+    expect(process.stderr.write).not.toHaveBeenCalled();
     expect(console.info).toHaveBeenCalledWith('Skipped 1 tag(s) with no releasable content: core-v1.3.0 (empty-body).');
   });
 
@@ -269,7 +271,7 @@ describe(createGithubReleaseCommand, () => {
 
     await createGithubReleaseCommand(['--tags=core-v1.3.0,extra-v0.1.0']);
 
-    expect(console.error).not.toHaveBeenCalled();
+    expect(process.stderr.write).not.toHaveBeenCalled();
     expect(console.info).toHaveBeenCalledWith('Skipped 1 tag(s) with no releasable content: extra-v0.1.0 (no-entry).');
   });
 
@@ -300,7 +302,7 @@ describe(createGithubReleaseCommand, () => {
 
     await createGithubReleaseCommand(['--tags=core-v1.3.0,extra-v0.1.0']);
 
-    expect(console.error).not.toHaveBeenCalled();
+    expect(process.stderr.write).not.toHaveBeenCalled();
     expect(console.info).toHaveBeenCalledWith(
       'Skipped 1 tag(s) with no releasable content: extra-v0.1.0 (no-audience-content).',
     );
@@ -322,14 +324,14 @@ describe(createGithubReleaseCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error creating GitHub Releases: gh release failed');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error creating GitHub Releases: gh release failed\n');
   });
 
   it('exits with code 1 when resolveReleaseNotesConfig fails to load config', async () => {
     mockResolveReleaseNotesConfig.mockImplementation(() => {
       // Mirror the strictLoad path: the production code calls process.exit(1) inside the resolver,
       // which the spy converts into ExitError. Throwing it here matches that observable behavior.
-      console.error('Error: failed to load config: read failure');
+      process.stderr.write('Error: failed to load config: read failure\n');
       throw new ExitError(1);
     });
 
@@ -346,7 +348,7 @@ describe(createGithubReleaseCommand, () => {
     expect(thrown?.code).toBe(1);
     expect(mockResolveReleaseNotesConfig).toHaveBeenCalledWith({ strictLoad: true });
     expect(mockCreateGithubReleases).not.toHaveBeenCalled();
-    expect(console.error).toHaveBeenCalledWith('Error: failed to load config: read failure');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: failed to load config: read failure\n');
   });
 
   describe('--tags parsing', () => {
@@ -364,7 +366,7 @@ describe(createGithubReleaseCommand, () => {
 
       expect(thrown).toBeInstanceOf(ExitError);
       expect(thrown?.code).toBe(1);
-      expect(console.error).toHaveBeenCalledWith('Error: Missing value for option: --tags');
+      expect(process.stderr.write).toHaveBeenCalledWith('Error: Missing value for option: --tags\n');
       expect(mockCreateGithubReleases).not.toHaveBeenCalled();
     });
 

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -85,7 +85,7 @@ describe(prepareCommand, () => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
     vi.spyOn(console, 'info').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
   });
 
@@ -169,7 +169,7 @@ describe(prepareCommand, () => {
     mockDiscoverWorkspaces.mockResolvedValue(undefined);
 
     await expect(prepareCommand(['--only=foo'])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--only is only supported'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('--only is only supported'));
   });
 
   it('exits with error for --force without --bump on a single-package repo', async () => {
@@ -179,7 +179,7 @@ describe(prepareCommand, () => {
     mockDiscoverWorkspaces.mockResolvedValue(undefined);
 
     await expect(prepareCommand(['--force'])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--force without --bump'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('--force without --bump'));
     expect(mockReleasePrepare).not.toHaveBeenCalled();
   });
 
@@ -199,7 +199,7 @@ describe(prepareCommand, () => {
 
   it('exits with error for --only with an unknown workspace name in monorepo mode', async () => {
     await expect(prepareCommand(['--only=arrays,nonexistent'])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('nonexistent'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('nonexistent'));
     expect(mockReleasePrepareMono).not.toHaveBeenCalled();
   });
 
@@ -223,9 +223,9 @@ describe(prepareCommand, () => {
     });
 
     await expect(prepareCommand(['--only=arrays'])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('stranded by the release'));
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('strings'));
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('downstream of arrays'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('stranded by the release'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('strings'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('downstream of arrays'));
     expect(mockReleasePrepareMono).not.toHaveBeenCalled();
   });
 
@@ -233,16 +233,16 @@ describe(prepareCommand, () => {
     mockLoadConfig.mockRejectedValue(new Error('parse error'));
 
     await expect(prepareCommand([])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error loading config'));
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('parse error'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Error loading config'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('parse error'));
   });
 
   it('exits with error when config is invalid', async () => {
     mockLoadConfig.mockResolvedValue({ unknownField: true });
 
     await expect(prepareCommand([])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith('Invalid config:');
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('unknownField'));
+    expect(process.stderr.write).toHaveBeenCalledWith('Invalid config:\n');
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('unknownField'));
   });
 
   it('writes release tags after successful preparation', async () => {
@@ -288,8 +288,10 @@ describe(prepareCommand, () => {
     });
 
     await expect(prepareCommand([])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith("workspace 'arrays' release stage: bumpAllVersions failed: ENOENT");
-    expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      "workspace 'arrays' release stage: bumpAllVersions failed: ENOENT\n",
+    );
+    expect(process.stderr.write).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
   });
 
   it('prints validation errors verbatim without an outer "Error preparing release:" prefix', async () => {
@@ -298,8 +300,10 @@ describe(prepareCommand, () => {
     });
 
     await expect(prepareCommand([])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith('--set-version 0.3.0 is not greater than current version 0.5.0');
-    expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      '--set-version 0.3.0 is not greater than current version 0.5.0\n',
+    );
+    expect(process.stderr.write).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
   });
 
   it('exits with a distinct error when writing release tags fails', async () => {
@@ -311,9 +315,9 @@ describe(prepareCommand, () => {
     mockReleasePrepareMono.mockReturnValue(makePrepareResult({ tags: ['arrays-v1.0.0'] }));
 
     await expect(prepareCommand([])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('release tags'));
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
-    expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('release tags'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
+    expect(process.stderr.write).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
   });
 
   it('exits with a distinct error when writing release summary fails', async () => {
@@ -327,8 +331,8 @@ describe(prepareCommand, () => {
     });
 
     await expect(prepareCommand([])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('release summary'));
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('release summary'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
   });
 
   it('prints release tags file path when tags are produced', async () => {
@@ -386,7 +390,7 @@ describe(prepareCommand, () => {
 
     await prepareCommand([]);
 
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Run 'release-kit commit'"));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining("Run 'release-kit commit'"));
   });
 
   it('does not print follow-up message during dry run', async () => {
@@ -394,7 +398,7 @@ describe(prepareCommand, () => {
 
     await prepareCommand(['--dry-run']);
 
-    expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining("Run 'release-kit commit'"));
+    expect(process.stderr.write).not.toHaveBeenCalledWith(expect.stringContaining("Run 'release-kit commit'"));
   });
 
   it('applies workspace exclusion from config', async () => {
@@ -426,7 +430,7 @@ describe(prepareCommand, () => {
     });
 
     await expect(prepareCommand([])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('uncommitted changes'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('uncommitted changes'));
   });
 
   it('skips the clean-tree check when --no-git-checks is provided', async () => {
@@ -460,13 +464,13 @@ describe(prepareCommand, () => {
 
   it('exits with an error when --set-version is used without --only in monorepo mode', async () => {
     await expect(prepareCommand(['--set-version=1.0.0'])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--set-version requires --only'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('--set-version requires --only'));
     expect(mockReleasePrepareMono).not.toHaveBeenCalled();
   });
 
   it('exits with an error when --only matches multiple workspaces under --set-version', async () => {
     await expect(prepareCommand(['--only=arrays,strings', '--set-version=1.0.0'])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('exactly one workspace'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('exactly one workspace'));
     expect(mockReleasePrepareMono).not.toHaveBeenCalled();
   });
 
@@ -475,7 +479,7 @@ describe(prepareCommand, () => {
     // (which runs before the --set-version narrowing check), so the error mentions the
     // unknown name rather than the "exactly one workspace" message.
     await expect(prepareCommand(['--only=nonexistent', '--set-version=1.0.0'])).rejects.toThrow(ExitError);
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('nonexistent'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('nonexistent'));
     expect(mockReleasePrepareMono).not.toHaveBeenCalled();
   });
 
@@ -536,7 +540,7 @@ describe(prepareCommand, () => {
 
     it('rejects --only with an error before any release work runs', async () => {
       await expect(prepareCommand(['--only=arrays'])).rejects.toThrow(ExitError);
-      expect(console.error).toHaveBeenCalledWith(
+      expect(process.stderr.write).toHaveBeenCalledWith(
         expect.stringContaining('--only cannot be combined with a project release'),
       );
       expect(mockReleasePrepareMono).not.toHaveBeenCalled();
@@ -549,16 +553,16 @@ describe(prepareCommand, () => {
 
     it('rejects --set-version with the project-aware error (not the transitive --only error)', async () => {
       await expect(prepareCommand(['--set-version=1.2.3'])).rejects.toThrow(ExitError);
-      expect(console.error).toHaveBeenCalledWith(
+      expect(process.stderr.write).toHaveBeenCalledWith(
         expect.stringContaining('--set-version cannot be combined with a project release'),
       );
-      expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('requires --only'));
+      expect(process.stderr.write).not.toHaveBeenCalledWith(expect.stringContaining('requires --only'));
       expect(mockReleasePrepareMono).not.toHaveBeenCalled();
     });
 
     it('rejects --set-version + --only with the project-aware error (project rule wins over --only rule)', async () => {
       await expect(prepareCommand(['--set-version=1.2.3', '--only=arrays'])).rejects.toThrow(ExitError);
-      expect(console.error).toHaveBeenCalledWith(
+      expect(process.stderr.write).toHaveBeenCalledWith(
         expect.stringContaining('--set-version cannot be combined with a project release'),
       );
       expect(mockReleasePrepareMono).not.toHaveBeenCalled();

--- a/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
@@ -96,7 +96,7 @@ describe(publishCommand, () => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
     vi.spyOn(console, 'info').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
@@ -169,7 +169,7 @@ describe(publishCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Unknown option: --unknown\n');
     expect(mockPublishPackage).not.toHaveBeenCalled();
   });
 
@@ -187,8 +187,8 @@ describe(publishCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith(
-      'Error: No release tags found on HEAD. Create tags with `release-kit tag` first.',
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      'Error: No release tags found on HEAD. Create tags with `release-kit tag` first.\n',
     );
   });
 
@@ -240,7 +240,9 @@ describe(publishCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error: Unknown tag "missing-v9.9.9" in --tags. Available: core-v1.3.0');
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: core-v1.3.0\n',
+    );
   });
 
   it('exits with code 1 when --only is passed (flag removed)', async () => {
@@ -255,7 +257,7 @@ describe(publishCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --only');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Unknown option: --only\n');
   });
 
   it('exits with code 1 when publishPackage throws', async () => {
@@ -274,7 +276,7 @@ describe(publishCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('publish failed');
+    expect(process.stderr.write).toHaveBeenCalledWith('publish failed\n');
   });
 
   it('does not invoke any GitHub Release path during publish', async () => {
@@ -385,8 +387,8 @@ describe(publishCommand, () => {
 
       expect(thrown).toBeInstanceOf(ExitError);
       expect(thrown?.code).toBe(1);
-      expect(console.error).toHaveBeenCalledWith('Invalid config:');
-      expect(console.error).toHaveBeenCalledWith("  ❌ Unknown field: 'bogus'");
+      expect(process.stderr.write).toHaveBeenCalledWith('Invalid config:\n');
+      expect(process.stderr.write).toHaveBeenCalledWith("  ❌ Unknown field: 'bogus'\n");
       expect(mockPublishPackage).not.toHaveBeenCalled();
     });
   });
@@ -530,8 +532,8 @@ describe(publishCommand, () => {
 
       expect(thrown).toBeInstanceOf(ExitError);
       expect(thrown?.code).toBe(1);
-      expect(console.error).toHaveBeenCalledWith(
-        'Error: basic-v1.0.0 (packages/basic) cannot be published: package.json#private is true.',
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        'Error: basic-v1.0.0 (packages/basic) cannot be published: package.json#private is true.\n',
       );
       expect(mockPublishPackage).not.toHaveBeenCalled();
     });
@@ -554,11 +556,11 @@ describe(publishCommand, () => {
 
       expect(thrown).toBeInstanceOf(ExitError);
       expect(thrown?.code).toBe(1);
-      expect(console.error).toHaveBeenCalledWith(
-        'Error: basic-v1.0.0 (packages/basic) cannot be published: package.json#private is true.',
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        'Error: basic-v1.0.0 (packages/basic) cannot be published: package.json#private is true.\n',
       );
-      expect(console.error).toHaveBeenCalledWith(
-        'Error: internal-v2.0.0 (packages/internal) cannot be published: package.json#private is true.',
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        'Error: internal-v2.0.0 (packages/internal) cannot be published: package.json#private is true.\n',
       );
       expect(mockPublishPackage).not.toHaveBeenCalled();
     });
@@ -587,8 +589,8 @@ describe(publishCommand, () => {
       // The presence of an unpublishable tag in --tags is an error: exit 1, no publishes.
       expect(thrown).toBeInstanceOf(ExitError);
       expect(thrown?.code).toBe(1);
-      expect(console.error).toHaveBeenCalledWith(
-        'Error: basic-v1.0.0 (packages/basic) cannot be published: package.json#private is true.',
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        'Error: basic-v1.0.0 (packages/basic) cannot be published: package.json#private is true.\n',
       );
       expect(mockPublishPackage).not.toHaveBeenCalled();
     });
@@ -611,7 +613,7 @@ describe(publishCommand, () => {
 
       expect(thrown).toBeInstanceOf(ExitError);
       expect(thrown?.code).toBe(1);
-      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('uncommitted changes'));
+      expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('uncommitted changes'));
       expect(mockResolveReleaseTags).not.toHaveBeenCalled();
       expect(mockPublishPackage).not.toHaveBeenCalled();
     });

--- a/packages/release-kit/src/__tests__/pushCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/pushCommand.unit.test.ts
@@ -34,7 +34,7 @@ describe(pushCommand, () => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
     vi.spyOn(console, 'info').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -106,7 +106,7 @@ describe(pushCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --only');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Unknown option: --only\n');
   });
 
   it('exits with code 1 on unknown flags', async () => {
@@ -121,7 +121,7 @@ describe(pushCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Unknown option: --unknown\n');
     expect(mockPushRelease).not.toHaveBeenCalled();
   });
 
@@ -141,7 +141,7 @@ describe(pushCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('push failed');
+    expect(process.stderr.write).toHaveBeenCalledWith('push failed\n');
   });
 
   it('skips pushRelease when no tags are resolved', async () => {

--- a/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareMono.unit.test.ts
@@ -1824,8 +1824,9 @@ describe(releasePrepareMono, () => {
       });
       setupNoBaseline(['core-v0.2.7', 'core-v0.2.8'], 'feat: addabc');
       const messages: string[] = [];
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation((msg: string) => {
-        messages.push(msg);
+      const errorSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+        messages.push(String(chunk));
+        return true;
       });
 
       releasePrepareMono(config, { dryRun: true });
@@ -1857,8 +1858,9 @@ describe(releasePrepareMono, () => {
       });
       setupNoBaseline(['core-v0.2.7'], 'feat: addabc');
       const messages: string[] = [];
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation((msg: string) => {
-        messages.push(msg);
+      const errorSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+        messages.push(String(chunk));
+        return true;
       });
 
       releasePrepareMono(config, { dryRun: true });
@@ -1884,8 +1886,9 @@ describe(releasePrepareMono, () => {
       });
       setupNoBaseline([], 'feat: addabc');
       const messages: string[] = [];
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation((msg: string) => {
-        messages.push(msg);
+      const errorSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+        messages.push(String(chunk));
+        return true;
       });
 
       releasePrepareMono(config, { dryRun: true });
@@ -1926,8 +1929,9 @@ describe(releasePrepareMono, () => {
       // Only tags in the repo belong to the sibling `arrays` workspace. `core` has no baseline.
       setupNoBaseline(['node-monorepo-arrays-v1.0.0', 'node-monorepo-arrays-v1.1.0'], 'feat: addabc');
       const messages: string[] = [];
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation((msg: string) => {
-        messages.push(msg);
+      const errorSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+        messages.push(String(chunk));
+        return true;
       });
 
       releasePrepareMono(config, { dryRun: true });
@@ -1966,8 +1970,9 @@ describe(releasePrepareMono, () => {
       });
       setupNoBaseline(['arrays-v0.5.0', 'arrays-v0.6.0'], 'feat: addabc');
       const messages: string[] = [];
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation((msg: string) => {
-        messages.push(msg);
+      const errorSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+        messages.push(String(chunk));
+        return true;
       });
 
       releasePrepareMono(config, { dryRun: true });
@@ -2003,8 +2008,9 @@ describe(releasePrepareMono, () => {
       });
       setupNoBaseline(['core-v0.2.7', 'arrays-v0.1.0'], 'feat: addabc');
       const messages: string[] = [];
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation((msg: string) => {
-        messages.push(msg);
+      const errorSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+        messages.push(String(chunk));
+        return true;
       });
 
       releasePrepareMono(config, { dryRun: true });

--- a/packages/release-kit/src/__tests__/releasePrepareProject.int.test.ts
+++ b/packages/release-kit/src/__tests__/releasePrepareProject.int.test.ts
@@ -404,10 +404,9 @@ describe('releasePrepareProject (integration)', () => {
 
     const previousCwd = process.cwd();
     process.chdir(fixture.repoDir);
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((msg: unknown) => {
-      if (typeof msg === 'string') {
-        errors.push(msg);
-      }
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      errors.push(String(chunk));
+      return true;
     });
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
       exitCode = typeof code === 'number' ? code : undefined;
@@ -419,7 +418,7 @@ describe('releasePrepareProject (integration)', () => {
     } catch {
       // Expected: process.exit threw.
     } finally {
-      consoleErrorSpy.mockRestore();
+      stderrSpy.mockRestore();
       exitSpy.mockRestore();
       process.chdir(previousCwd);
     }

--- a/packages/release-kit/src/__tests__/resolveCommandTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveCommandTags.unit.test.ts
@@ -65,7 +65,7 @@ describe(resolveCommandTags, () => {
     vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -137,8 +137,8 @@ describe(resolveCommandTags, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith(
-      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: nmr-core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0',
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: nmr-core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0\n',
     );
   });
 
@@ -154,8 +154,8 @@ describe(resolveCommandTags, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith(
-      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: nmr-core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0',
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      'Error: Unknown tag "missing-v9.9.9" in --tags. Available: nmr-core-v1.3.0, cli-v0.5.0, release-kit-v2.1.0\n',
     );
   });
 
@@ -173,8 +173,8 @@ describe(resolveCommandTags, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith(
-      'Error: No release tags found on HEAD. Create tags with `release-kit tag` first.',
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      'Error: No release tags found on HEAD. Create tags with `release-kit tag` first.\n',
     );
   });
 
@@ -192,7 +192,7 @@ describe(resolveCommandTags, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error discovering workspaces: workspace read failure');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error discovering workspaces: workspace read failure\n');
     expect(mockResolveReleaseTags).not.toHaveBeenCalled();
   });
 
@@ -212,8 +212,8 @@ describe(resolveCommandTags, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith(
-      "Error resolving workspaces: packages/core/package.json is missing a 'name' field (required for tag derivation).",
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      "Error resolving workspaces: packages/core/package.json is missing a 'name' field (required for tag derivation).\n",
     );
     expect(mockResolveReleaseTags).not.toHaveBeenCalled();
   });

--- a/packages/release-kit/src/__tests__/resolveReleaseNotesConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveReleaseNotesConfig.unit.test.ts
@@ -33,7 +33,7 @@ describe(resolveReleaseNotesConfig, () => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
     vi.spyOn(console, 'warn').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -72,7 +72,7 @@ describe(resolveReleaseNotesConfig, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error: failed to load config: config read failure');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: failed to load config: config read failure\n');
   });
 
   it('returns defaults when raw config is undefined', async () => {
@@ -107,8 +107,8 @@ describe(resolveReleaseNotesConfig, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Invalid config:');
-    expect(console.error).toHaveBeenCalledWith("  \u274C Unknown field: 'bogus'");
+    expect(process.stderr.write).toHaveBeenCalledWith('Invalid config:\n');
+    expect(process.stderr.write).toHaveBeenCalledWith("  \u274C Unknown field: 'bogus'\n");
   });
 
   it('logs each warning from validateConfig', async () => {

--- a/packages/release-kit/src/__tests__/tagCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/tagCommand.unit.test.ts
@@ -22,7 +22,7 @@ describe(tagCommand, () => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
     vi.spyOn(console, 'info').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -66,7 +66,7 @@ describe(tagCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('Error: Unknown option: --unknown');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Unknown option: --unknown\n');
     expect(mockCreateTags).not.toHaveBeenCalled();
   });
 
@@ -86,6 +86,6 @@ describe(tagCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('No tags file found. Run `release-kit prepare` first.');
+    expect(process.stderr.write).toHaveBeenCalledWith('No tags file found. Run `release-kit prepare` first.\n');
   });
 });

--- a/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
+++ b/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
@@ -29,7 +29,7 @@ describe(writeReleaseNotesPreviews, () => {
   beforeEach(() => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'info').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -295,6 +295,6 @@ describe(writeReleaseNotesPreviews, () => {
 
     expect(result.injectedReadme?.outcome).toBe('failed');
     expect(result.injectedReadme?.error).toBe('EACCES');
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error writing'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Error writing'));
   });
 });

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -2,7 +2,7 @@
 /* eslint n/hashbang: off, n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgsOrExit, readPackageVersion } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit, readPackageVersion, reportError } from '@williamthorsen/nmr-core';
 
 import { checkWorkTypesDrift } from '../checkWorkTypesDrift.ts';
 import { commitCommand } from '../commitCommand.ts';
@@ -325,7 +325,7 @@ if (command === 'commit') {
   try {
     commitCommand(flags);
   } catch (error: unknown) {
-    console.error(error instanceof Error ? error.message : String(error));
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
   process.exit(0);
@@ -377,7 +377,7 @@ if (command === 'show-tag-prefixes') {
     process.exit(0);
   }
   if (flags.length > 0) {
-    console.error(`Error: Unknown option: ${flags[0]}`);
+    reportError(`Unknown option: ${flags[0]}`);
     process.exit(1);
   }
 
@@ -434,7 +434,7 @@ if (command === 'sync-labels') {
     }
 
     if (subflags.length > 0) {
-      console.error(`Error: Unknown option: ${subflags[0]}`);
+      reportError(`Unknown option: ${subflags[0]}`);
       process.exit(1);
     }
 
@@ -449,7 +449,7 @@ if (command === 'sync-labels') {
     }
 
     if (subflags.length > 0) {
-      console.error(`Error: Unknown option: ${subflags[0]}`);
+      reportError(`Unknown option: ${subflags[0]}`);
       process.exit(1);
     }
 
@@ -457,7 +457,7 @@ if (command === 'sync-labels') {
     process.exit(exitCode);
   }
 
-  console.error(`Error: Unknown subcommand: ${subcommand}`);
+  reportError(`Unknown subcommand: ${subcommand}`);
   showSyncLabelsHelp();
   process.exit(1);
 }
@@ -477,19 +477,19 @@ if (command === 'overrides') {
       process.exit(0);
     }
     if (subflags.length > 0) {
-      console.error(`Error: Unknown option: ${subflags[0]}`);
+      reportError(`Unknown option: ${subflags[0]}`);
       process.exit(1);
     }
     const result = await validateOverridesCommand();
     if (result.exitCode === 0) {
       console.info(result.message);
     } else {
-      console.error(result.message);
+      process.stderr.write(`${result.message}\n`);
     }
     process.exit(result.exitCode);
   }
 
-  console.error(`Error: Unknown subcommand: ${subcommand}`);
+  reportError(`Unknown subcommand: ${subcommand}`);
   showOverridesHelp();
   process.exit(1);
 }
@@ -509,14 +509,14 @@ if (command === 'work-types') {
       process.exit(0);
     }
     if (subflags.length > 0) {
-      console.error(`Error: Unknown option: ${subflags[0]}`);
+      reportError(`Unknown option: ${subflags[0]}`);
       process.exit(1);
     }
     const result = await checkWorkTypesDrift();
     if (result.exitCode === 0) {
       console.info(result.message);
     } else {
-      console.error(result.message);
+      process.stderr.write(`${result.message}\n`);
     }
     process.exit(result.exitCode);
   }
@@ -527,23 +527,23 @@ if (command === 'work-types') {
       process.exit(0);
     }
     if (subflags.length > 0) {
-      console.error(`Error: Unknown option: ${subflags[0]}`);
+      reportError(`Unknown option: ${subflags[0]}`);
       process.exit(1);
     }
     const result = await syncWorkTypes();
     if (result.exitCode === 0) {
       console.info(result.message);
     } else {
-      console.error(result.message);
+      process.stderr.write(`${result.message}\n`);
     }
     process.exit(result.exitCode);
   }
 
-  console.error(`Error: Unknown subcommand: ${subcommand}`);
+  reportError(`Unknown subcommand: ${subcommand}`);
   showWorkTypesHelp();
   process.exit(1);
 }
 
-console.error(`Error: Unknown command: ${command}`);
+reportError(`Unknown command: ${command}`);
 showUsage();
 process.exit(1);

--- a/packages/release-kit/src/createGithubReleaseCommand.ts
+++ b/packages/release-kit/src/createGithubReleaseCommand.ts
@@ -31,7 +31,7 @@ export async function createGithubReleaseCommand(argv: string[]): Promise<void> 
   try {
     outcome = createGithubReleases(resolvedTags, changelogJsonOutputPath, dryRun, sectionOrder);
   } catch (error: unknown) {
-    console.error(`Error creating GitHub Releases: ${error instanceof Error ? error.message : String(error)}`);
+    process.stderr.write(`Error creating GitHub Releases: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -2,7 +2,7 @@
 /* eslint unicorn/no-process-exit: off */
 
 import type { WriteResult } from '@williamthorsen/nmr-core';
-import { parseArgs as coreParseArgs, writeFileWithCheck } from '@williamthorsen/nmr-core';
+import { parseArgs as coreParseArgs, reportError, writeFileWithCheck } from '@williamthorsen/nmr-core';
 
 import { assertCleanWorkingTree } from './assertCleanWorkingTree.ts';
 import { buildDependencyGraph } from './buildDependencyGraph.ts';
@@ -172,7 +172,7 @@ export async function prepareCommand(argv: string[]): Promise<void> {
   try {
     ({ dryRun, force, noGitChecks, bumpOverride, only, setVersion, withReleaseNotes } = parseArgs(argv));
   } catch (error: unknown) {
-    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    reportError(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
   const options = {
@@ -192,7 +192,7 @@ export async function prepareCommand(argv: string[]): Promise<void> {
     try {
       assertCleanWorkingTree();
     } catch (error: unknown) {
-      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      reportError(error instanceof Error ? error.message : String(error));
       process.exit(1);
     }
   }
@@ -204,7 +204,7 @@ export async function prepareCommand(argv: string[]): Promise<void> {
   try {
     discoveredPaths = await discoverWorkspaces();
   } catch (error: unknown) {
-    console.error(`Error discovering workspaces: ${error instanceof Error ? error.message : String(error)}`);
+    process.stderr.write(`Error discovering workspaces: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 
@@ -223,7 +223,7 @@ function runSinglePackageMode(
   dryRun: boolean,
 ): void {
   if (only !== undefined) {
-    console.error('Error: --only is only supported for monorepo configurations');
+    reportError('--only is only supported for monorepo configurations');
     process.exit(1);
   }
 
@@ -234,8 +234,8 @@ function runSinglePackageMode(
   // than letting the user discover the gap from a missing release. `--force --bump=X` is
   // accepted because the `--bump` override carries the release through unconditionally.
   if (options.force && options.bumpOverride === undefined) {
-    console.error(
-      'Error: --force without --bump is only supported for monorepo configurations. ' +
+    reportError(
+      '--force without --bump is only supported for monorepo configurations. ' +
         'Use --bump=major|minor|patch to set the level for a single-package release.',
     );
     process.exit(1);
@@ -260,7 +260,7 @@ function runMonorepoMode(
     const rootPackage = readRootPackageVersion();
     config = mergeMonorepoConfig(discoveredPaths, userConfig, rootPackage);
   } catch (error: unknown) {
-    console.error(`Error resolving workspaces: ${error instanceof Error ? error.message : String(error)}`);
+    process.stderr.write(`Error resolving workspaces: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 
@@ -271,8 +271,8 @@ function runMonorepoMode(
   // rejection so a user passing `--set-version` (the primary intent) sees the project-aware
   // error rather than the secondary `--only` error when both flags are supplied.
   if (setVersion !== undefined && config.project !== undefined) {
-    console.error(
-      'Error: --set-version cannot be combined with a project release. ' +
+    reportError(
+      '--set-version cannot be combined with a project release. ' +
         '--set-version operates on a single workspace; a project release rolls up every ' +
         'contributing workspace. To use --set-version, run on a config without a `project` block.',
     );
@@ -284,8 +284,8 @@ function runMonorepoMode(
   // around which workspaces participate in the project bump. A consumer that needs to release
   // a single workspace must do so on a config without a `project` block.
   if (only !== undefined && config.project !== undefined) {
-    console.error(
-      'Error: --only cannot be combined with a project release. ' +
+    reportError(
+      '--only cannot be combined with a project release. ' +
         'To release a single workspace, use a config without a `project` block, ' +
         'or run a full `prepare` (no --only) to include the project release.',
     );
@@ -298,7 +298,7 @@ function runMonorepoMode(
     // Validate all names before mutating config
     for (const name of only) {
       if (!knownNames.includes(name)) {
-        console.error(`Error: Unknown workspace "${name}". Known workspaces: ${knownNames.join(', ')}`);
+        reportError(`Unknown workspace "${name}". Known workspaces: ${knownNames.join(', ')}`);
         process.exit(1);
       }
     }
@@ -317,13 +317,15 @@ function runMonorepoMode(
     });
 
     if (violations !== undefined) {
-      console.error('Error: --only excludes packages with changes that would be stranded by the release.');
-      console.error('The following packages must be added to --only or have their dependencies removed:');
+      process.stderr.write('Error: --only excludes packages with changes that would be stranded by the release.\n');
+      process.stderr.write('The following packages must be added to --only or have their dependencies removed:\n');
       for (const violation of violations) {
         const since = violation.tag ?? 'the beginning';
-        console.error(`  - ${violation.dir} (downstream of ${violation.downstreamOf}; has commits since ${since})`);
+        process.stderr.write(
+          `  - ${violation.dir} (downstream of ${violation.downstreamOf}; has commits since ${since})\n`,
+        );
       }
-      console.error('Alternatively, run `release-kit prepare` without --only to release everything.');
+      process.stderr.write('Alternatively, run `release-kit prepare` without --only to release everything.\n');
       process.exit(1);
     }
 
@@ -333,13 +335,11 @@ function runMonorepoMode(
   // --set-version requires exactly one target workspace in monorepo mode.
   if (setVersion !== undefined) {
     if (only === undefined) {
-      console.error('Error: --set-version requires --only in monorepo mode');
+      reportError('--set-version requires --only in monorepo mode');
       process.exit(1);
     }
     if (config.workspaces.length !== 1) {
-      console.error(
-        `Error: --set-version requires --only to match exactly one workspace; matched ${config.workspaces.length}`,
-      );
+      reportError(`--set-version requires --only to match exactly one workspace; matched ${config.workspaces.length}`);
       process.exit(1);
     }
   }
@@ -361,7 +361,7 @@ async function loadAndValidateConfig(): Promise<ReleaseKitConfig | undefined> {
   try {
     rawConfig = await loadConfig();
   } catch (error: unknown) {
-    console.error(`Error loading config: ${error instanceof Error ? error.message : String(error)}`);
+    process.stderr.write(`Error loading config: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 
@@ -371,9 +371,9 @@ async function loadAndValidateConfig(): Promise<ReleaseKitConfig | undefined> {
 
   const { config, errors, warnings } = validateConfig(rawConfig);
   if (errors.length > 0) {
-    console.error('Invalid config:');
+    process.stderr.write('Invalid config:\n');
     for (const err of errors) {
-      console.error(`  ❌ ${err}`);
+      process.stderr.write(`  ❌ ${err}\n`);
     }
     process.exit(1);
   }
@@ -391,7 +391,7 @@ function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
   try {
     result = execute();
   } catch (error: unknown) {
-    console.error(error instanceof Error ? error.message : String(error));
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 
@@ -400,7 +400,7 @@ function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
   const writeResult = writeReleaseTags(result.tags, dryRun);
 
   if (writeResult?.outcome === 'failed') {
-    console.error(`Error writing release tags: ${writeResult.error ?? 'unknown error'}`);
+    process.stderr.write(`Error writing release tags: ${writeResult.error ?? 'unknown error'}\n`);
     process.exit(1);
   }
 
@@ -422,7 +422,7 @@ function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
     });
 
     if (summaryResult.outcome === 'failed') {
-      console.error(`Error writing release summary: ${summaryResult.error ?? 'unknown error'}`);
+      process.stderr.write(`Error writing release summary: ${summaryResult.error ?? 'unknown error'}\n`);
       process.exit(1);
     }
 
@@ -434,6 +434,6 @@ function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
   }
 
   if (writeResult && !dryRun) {
-    console.error(`\nRun 'release-kit commit' to create the release commit.`);
+    process.stderr.write(`\nRun 'release-kit commit' to create the release commit.\n`);
   }
 }

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -4,7 +4,7 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { parseArgsOrExit } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit, reportError } from '@williamthorsen/nmr-core';
 
 import { assertCleanWorkingTree } from './assertCleanWorkingTree.ts';
 import { detectPackageManager } from './detectPackageManager.ts';
@@ -38,7 +38,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
     try {
       assertCleanWorkingTree();
     } catch (error: unknown) {
-      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      reportError(error instanceof Error ? error.message : String(error));
       process.exit(1);
     }
   }
@@ -104,7 +104,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
         console.warn(`  ${t}`);
       }
     }
-    console.error(error instanceof Error ? error.message : String(error));
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 }
@@ -126,7 +126,7 @@ function filterPublishableTags(resolvedTags: ResolvedTag[], isExplicit: boolean)
 
   if (isExplicit && unpublishable.length > 0) {
     for (const { tag, workspacePath } of unpublishable) {
-      console.error(`Error: ${tag} (${workspacePath}) cannot be published: package.json#private is true.`);
+      reportError(`${tag} (${workspacePath}) cannot be published: package.json#private is true.`);
     }
     process.exit(1);
   }

--- a/packages/release-kit/src/pushCommand.ts
+++ b/packages/release-kit/src/pushCommand.ts
@@ -48,7 +48,7 @@ export async function pushCommand(argv: string[]): Promise<void> {
       }
     }
   } catch (error: unknown) {
-    console.error(error instanceof Error ? error.message : String(error));
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 }

--- a/packages/release-kit/src/releasePrepareMono.ts
+++ b/packages/release-kit/src/releasePrepareMono.ts
@@ -829,10 +829,10 @@ function maybeEmitBaselineHint(
 
   const totalTags = candidates.reduce((sum, candidate) => sum + candidate.tagCount, 0);
   const example = candidates[0]?.exampleTags[0] ?? `${candidates[0]?.prefix ?? ''}?`;
-  console.error(
+  process.stderr.write(
     `Hint: no baseline tag found for ${workspace.dir} under '${workspace.tagPrefix}', but ` +
       `${totalTags} candidate-shaped tags exist (e.g., ${example}). ` +
-      "Run 'release-kit show-tag-prefixes' to check for undeclared legacy prefixes.",
+      "Run 'release-kit show-tag-prefixes' to check for undeclared legacy prefixes.\n",
   );
   state.emitted = true;
 }

--- a/packages/release-kit/src/resolveCommandTags.ts
+++ b/packages/release-kit/src/resolveCommandTags.ts
@@ -1,6 +1,8 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
+import { reportError } from '@williamthorsen/nmr-core';
+
 import { deriveWorkspaceConfig } from './deriveWorkspaceConfig.ts';
 import { discoverWorkspaces } from './discoverWorkspaces.ts';
 import type { ResolvedTag } from './resolveReleaseTags.ts';
@@ -25,7 +27,7 @@ export async function resolveCommandTags(tags: string[] | undefined): Promise<Re
   try {
     discoveredPaths = await discoverWorkspaces();
   } catch (error: unknown) {
-    console.error(`Error discovering workspaces: ${error instanceof Error ? error.message : String(error)}`);
+    process.stderr.write(`Error discovering workspaces: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 
@@ -41,7 +43,7 @@ export async function resolveCommandTags(tags: string[] | undefined): Promise<Re
       workspaces = discoveredPaths.map((workspacePath) => deriveWorkspaceConfig(workspacePath));
     }
   } catch (error: unknown) {
-    console.error(`Error resolving workspaces: ${error instanceof Error ? error.message : String(error)}`);
+    process.stderr.write(`Error resolving workspaces: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 
@@ -56,7 +58,7 @@ export async function resolveCommandTags(tags: string[] | undefined): Promise<Re
   }
 
   if (resolvedTags.length === 0) {
-    console.error('Error: No release tags found on HEAD. Create tags with `release-kit tag` first.');
+    reportError('No release tags found on HEAD. Create tags with `release-kit tag` first.');
     process.exit(1);
   }
 
@@ -65,7 +67,7 @@ export async function resolveCommandTags(tags: string[] | undefined): Promise<Re
     const availableTagNames = resolvedTags.map((t) => t.tag);
     for (const name of tags) {
       if (!availableTagNames.includes(name)) {
-        console.error(`Error: Unknown tag "${name}" in --tags. Available: ${availableTagNames.join(', ')}`);
+        reportError(`Unknown tag "${name}" in --tags. Available: ${availableTagNames.join(', ')}`);
         process.exit(1);
       }
     }

--- a/packages/release-kit/src/resolveReleaseNotesConfig.ts
+++ b/packages/release-kit/src/resolveReleaseNotesConfig.ts
@@ -1,6 +1,8 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
+import { reportError } from '@williamthorsen/nmr-core';
+
 import { DEFAULT_CHANGELOG_JSON_CONFIG, DEFAULT_RELEASE_NOTES_CONFIG } from './defaults.ts';
 import { loadConfig, resolveWorkTypes } from './loadConfig.ts';
 import type { ReleaseNotesConfig } from './types.ts';
@@ -39,7 +41,7 @@ export async function resolveReleaseNotesConfig(
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     if (strictLoad) {
-      console.error(`Error: failed to load config: ${message}`);
+      reportError(`failed to load config: ${message}`);
       process.exit(1);
     }
     console.warn(`Warning: failed to load config; using defaults: ${message}`);
@@ -55,9 +57,9 @@ export async function resolveReleaseNotesConfig(
 
   const { config, errors, warnings } = validateConfig(rawConfig);
   if (errors.length > 0) {
-    console.error('Invalid config:');
+    process.stderr.write('Invalid config:\n');
     for (const err of errors) {
-      console.error(`  ❌ ${err}`);
+      process.stderr.write(`  ❌ ${err}\n`);
     }
     process.exit(1);
   }

--- a/packages/release-kit/src/sync-labels/__tests__/generateCommand.test.ts
+++ b/packages/release-kit/src/sync-labels/__tests__/generateCommand.test.ts
@@ -41,7 +41,7 @@ describe(generateCommand, () => {
 
   it('returns 1 when no config file is found', async () => {
     mockLoadSyncLabelsConfig.mockResolvedValue(undefined);
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     const exitCode = await generateCommand();
 
@@ -51,7 +51,7 @@ describe(generateCommand, () => {
 
   it('returns 1 when config loading throws', async () => {
     mockLoadSyncLabelsConfig.mockRejectedValue(new Error('parse failure'));
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     const exitCode = await generateCommand();
 
@@ -64,7 +64,7 @@ describe(generateCommand, () => {
     mockResolveLabels.mockImplementation(() => {
       throw new Error('Label name collision');
     });
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     const exitCode = await generateCommand();
 
@@ -96,7 +96,7 @@ describe(generateCommand, () => {
     mockMkdirSync.mockImplementation(() => {
       throw new Error('EACCES');
     });
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     const exitCode = await generateCommand();
 

--- a/packages/release-kit/src/sync-labels/__tests__/initCommand.test.ts
+++ b/packages/release-kit/src/sync-labels/__tests__/initCommand.test.ts
@@ -60,7 +60,7 @@ describe(syncLabelsInitCommand, () => {
   it('returns 1 when workspace discovery throws', async () => {
     mockDiscoverWorkspaces.mockRejectedValue(new Error('filesystem error'));
     vi.spyOn(console, 'info').mockImplementation(() => undefined);
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     const exitCode = await syncLabelsInitCommand({ dryRun: false, force: false });
 
@@ -82,7 +82,7 @@ describe(syncLabelsInitCommand, () => {
     mockDiscoverWorkspaces.mockResolvedValue(undefined);
     mockWriteFileWithCheck.mockReturnValue({ outcome: 'failed', filePath: 'some/file' });
     vi.spyOn(console, 'info').mockImplementation(() => undefined);
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     const exitCode = await syncLabelsInitCommand({ dryRun: false, force: false });
 

--- a/packages/release-kit/src/sync-labels/__tests__/syncCommand.test.ts
+++ b/packages/release-kit/src/sync-labels/__tests__/syncCommand.test.ts
@@ -25,7 +25,7 @@ describe(syncLabelsCommand, () => {
       if (cmd === 'gh --version') throw new Error('command not found: gh');
       return Buffer.from('');
     });
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     const result = syncLabelsCommand();
 
@@ -36,7 +36,7 @@ describe(syncLabelsCommand, () => {
   it('returns 1 when workflow file does not exist', () => {
     mockExecSync.mockReturnValue(Buffer.from('gh version 2.0.0'));
     mockExistsSync.mockReturnValue(false);
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     const result = syncLabelsCommand();
 
@@ -61,7 +61,7 @@ describe(syncLabelsCommand, () => {
       throw new Error('workflow dispatch failed');
     });
     mockExistsSync.mockReturnValue(true);
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     const result = syncLabelsCommand();
 

--- a/packages/release-kit/src/sync-labels/generateCommand.ts
+++ b/packages/release-kit/src/sync-labels/generateCommand.ts
@@ -36,12 +36,14 @@ export async function generateCommand(): Promise<number> {
     config = await loadSyncLabelsConfig();
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`Error loading config: ${message}`);
+    process.stderr.write(`Error loading config: ${message}\n`);
     return 1;
   }
 
   if (config === undefined) {
-    console.error(`No config file found at ${SYNC_LABELS_CONFIG_PATH}. Run \`release-kit sync-labels init\` first.`);
+    process.stderr.write(
+      `No config file found at ${SYNC_LABELS_CONFIG_PATH}. Run \`release-kit sync-labels init\` first.\n`,
+    );
     return 1;
   }
 
@@ -50,7 +52,7 @@ export async function generateCommand(): Promise<number> {
     labels = resolveLabels(config);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`Error resolving labels: ${message}`);
+    process.stderr.write(`Error resolving labels: ${message}\n`);
     return 1;
   }
 
@@ -66,7 +68,7 @@ export async function generateCommand(): Promise<number> {
     writeFileSync(LABELS_OUTPUT_PATH, content, 'utf8');
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`Error writing ${LABELS_OUTPUT_PATH}: ${message}`);
+    process.stderr.write(`Error writing ${LABELS_OUTPUT_PATH}: ${message}\n`);
     return 1;
   }
 

--- a/packages/release-kit/src/sync-labels/initCommand.ts
+++ b/packages/release-kit/src/sync-labels/initCommand.ts
@@ -32,7 +32,7 @@ export async function syncLabelsInitCommand({ dryRun, force }: InitOptions): Pro
     workspacePaths = await discoverWorkspaces();
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`  Failed to discover workspaces: ${message}`);
+    process.stderr.write(`  Failed to discover workspaces: ${message}\n`);
     return 1;
   }
 
@@ -55,7 +55,7 @@ export async function syncLabelsInitCommand({ dryRun, force }: InitOptions): Pro
   reportWriteResult(configResult, dryRun);
 
   if (workflowResult.outcome === 'failed' || configResult.outcome === 'failed') {
-    console.error('Failed to scaffold one or more files.');
+    process.stderr.write('Failed to scaffold one or more files.\n');
     return 1;
   }
 

--- a/packages/release-kit/src/sync-labels/syncCommand.ts
+++ b/packages/release-kit/src/sync-labels/syncCommand.ts
@@ -1,6 +1,8 @@
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 
+import { reportError } from '@williamthorsen/nmr-core';
+
 /** Workflow file that must exist before triggering. */
 const WORKFLOW_FILE = '.github/workflows/sync-labels.yaml';
 
@@ -22,12 +24,12 @@ function checkGhAvailable(): boolean {
  */
 export function syncLabelsCommand(): number {
   if (!checkGhAvailable()) {
-    console.error('Error: The `gh` CLI is not installed or not in PATH. Install it from https://cli.github.com/');
+    reportError('The `gh` CLI is not installed or not in PATH. Install it from https://cli.github.com/');
     return 1;
   }
 
   if (!existsSync(WORKFLOW_FILE)) {
-    console.error(`Error: ${WORKFLOW_FILE} not found. Run \`release-kit sync-labels init\` first.`);
+    reportError(`${WORKFLOW_FILE} not found. Run \`release-kit sync-labels init\` first.`);
     return 1;
   }
 
@@ -35,7 +37,7 @@ export function syncLabelsCommand(): number {
     execSync('gh workflow run sync-labels.yaml', { stdio: 'inherit' });
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`Error triggering workflow: ${message}`);
+    process.stderr.write(`Error triggering workflow: ${message}\n`);
     return 1;
   }
 

--- a/packages/release-kit/src/tagCommand.ts
+++ b/packages/release-kit/src/tagCommand.ts
@@ -18,7 +18,7 @@ export function tagCommand(argv: string[]): void {
   try {
     createTags({ dryRun, noGitChecks });
   } catch (error: unknown) {
-    console.error(error instanceof Error ? error.message : String(error));
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
 }

--- a/packages/release-kit/src/writeReleaseNotesPreviews.ts
+++ b/packages/release-kit/src/writeReleaseNotesPreviews.ts
@@ -118,7 +118,7 @@ function writePreviewFile(filePath: string, content: string, dryRun: boolean): P
   const result = writeFileWithCheck(filePath, content, { dryRun: false, overwrite: true });
 
   if (result.outcome === 'failed') {
-    console.error(`Error writing ${filePath}: ${result.error ?? 'unknown error'}`);
+    process.stderr.write(`Error writing ${filePath}: ${result.error ?? 'unknown error'}\n`);
     return { filePath, outcome: 'failed', ...(result.error === undefined ? {} : { error: result.error }) };
   }
 

--- a/packages/v11y-check/src/bin/route.ts
+++ b/packages/v11y-check/src/bin/route.ts
@@ -1,6 +1,4 @@
-import process from 'node:process';
-
-import { parseArgs, readPackageVersion } from '@williamthorsen/nmr-core';
+import { parseArgs, readPackageVersion, reportError } from '@williamthorsen/nmr-core';
 
 import { auditCommand, checkCommand, extractMessage, syncCommand } from '../cli.ts';
 import { initCommand } from '../init/initCommand.ts';
@@ -140,10 +138,10 @@ export async function routeCommand(args: string[]): Promise<number> {
   if (command !== undefined && !command.startsWith('-')) {
     const typoMatch = findTypoMatch(command);
     if (typoMatch !== undefined) {
-      process.stderr.write(`Error: Unknown command '${command}'. Did you mean 'v11y ${typoMatch}'?\n`);
+      reportError(`Unknown command '${command}'. Did you mean 'v11y ${typoMatch}'?`);
       return 1;
     }
-    process.stderr.write(`Error: Unknown command '${command}'.\n`);
+    reportError(`Unknown command '${command}'.`);
     return 1;
   }
 
@@ -172,14 +170,14 @@ async function handleSubcommand(
   try {
     options = parseSharedFlags(flags);
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    reportError(extractMessage(error));
     return 1;
   }
 
   try {
     return await handler(options);
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    reportError(extractMessage(error));
     return 1;
   }
 }
@@ -200,7 +198,7 @@ function handleInit(flags: string[]): number {
   try {
     parsed = parseArgs(flags, initFlagSchema);
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    reportError(extractMessage(error));
     return 1;
   }
 

--- a/packages/v11y-check/src/cli.ts
+++ b/packages/v11y-check/src/cli.ts
@@ -1,5 +1,7 @@
 import process from 'node:process';
 
+import { reportError } from '@williamthorsen/nmr-core';
+
 import type { LoadConfigResult } from './config.ts';
 import { loadConfig } from './config.ts';
 import type { AllowedVuln, CheckResult, ScopeCheckResult } from './format-check.ts';
@@ -28,7 +30,7 @@ export async function auditCommand(options: CommandOptions): Promise<number> {
   try {
     loaded = await loadConfig(options.configPath);
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    reportError(extractMessage(error));
     return 1;
   }
 
@@ -84,7 +86,7 @@ export async function auditCommand(options: CommandOptions): Promise<number> {
       return exitCode;
     });
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    reportError(extractMessage(error));
     return 1;
   }
 }
@@ -104,7 +106,7 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
   try {
     loaded = await loadConfig(options.configPath);
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    reportError(extractMessage(error));
     return 1;
   }
 
@@ -184,7 +186,7 @@ export async function checkCommand(options: CommandOptions): Promise<number> {
       return hasUnallowed ? 1 : 0;
     });
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    reportError(extractMessage(error));
     return 1;
   }
 }
@@ -201,7 +203,7 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
   try {
     loaded = await loadConfig(options.configPath);
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    reportError(extractMessage(error));
     return 1;
   }
 
@@ -211,7 +213,7 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
   if (configSource === 'defaults') {
     const { configResult } = scaffoldConfig({ dryRun: false, force: false });
     if (configResult.outcome === 'failed') {
-      process.stderr.write(`Error: Failed to create config file\n`);
+      reportError('Failed to create config file');
       return 1;
     }
     loaded = await loadConfig(options.configPath);
@@ -253,7 +255,7 @@ export async function syncCommand(options: CommandOptions): Promise<number> {
       return 0;
     });
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    reportError(extractMessage(error));
     return 1;
   }
 }


### PR DESCRIPTION
## What

Consolidates error reporting across the CLIs so every command reports errors the same way, and guards against the previous inconsistency returning. The error messages and exit codes users see are unchanged.

## Why

CLI error output was emitted two different ways across the commands, with nothing to keep the two from drifting apart. That left no single place to govern the canonical `Error:` message format — a prerequisite for the deferred wording-normalization work — and allowed the inconsistency to be reintroduced unnoticed.

## Details

### ♻️ Refactoring

- Added `reportError` to nmr-core, which writes the canonical `Error: <message>` line to stderr; every canonical error site across nmr-core, release-kit, and v11y-check now routes through it.
- Converted non-canonical error sites (`Error <verb>…:` shapes, bare-message catches, multi-line `Invalid config:` dumps, the post-prepare hint) to direct `process.stderr.write`, reproducing the prior bytes including the trailing newline.
- Migrated nmr-core's `printError` from `console.error` to `process.stderr.write`.
- Tightened the repo-wide ESLint `no-console` rule to forbid `console.error` (and `console.log`), making the divergent path un-typeable; the `scripts/**` exemption is preserved.

### 🧪 Tests

- Migrated ~20 test files to spy on `process.stderr.write` (accounting for the trailing newline) instead of `console.error`, retaining exact-string assertions so byte-level parity is enforced.
- Added a focused test asserting `reportError`'s canonical `Error: <message>\n` output.

Closes #427
