### PR TITLE
#434 Normalize CLI error wording to the canonical Error: format

### DIFF
--- a/packages/nmr-core/src/__tests__/terminal.test.ts
+++ b/packages/nmr-core/src/__tests__/terminal.test.ts
@@ -1,19 +1,38 @@
+import { PassThrough } from 'node:stream';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { reportError, reportWriteResult } from '../terminal.ts';
+import { formatErrorLine, reportError, reportWriteResult } from '../terminal.ts';
 import type { WriteResult } from '../writeFileWithCheck.ts';
+
+describe(formatErrorLine, () => {
+  it('renders the canonical Error line without a trailing newline', () => {
+    expect(formatErrorLine('something went wrong')).toBe('Error: something went wrong');
+  });
+});
 
 describe(reportError, () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('writes a canonical Error line with a trailing newline to stderr', () => {
+  it('writes a canonical Error line with a trailing newline to stderr by default', () => {
     const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     reportError('something went wrong');
 
     expect(spy).toHaveBeenCalledWith('Error: something went wrong\n');
+  });
+
+  it('writes to a provided stream instead of stderr', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const stream = new PassThrough();
+    const writeSpy = vi.spyOn(stream, 'write');
+
+    reportError('something went wrong', stream);
+
+    expect(writeSpy).toHaveBeenCalledWith('Error: something went wrong\n');
+    expect(stderrSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/nmr-core/src/index.ts
+++ b/packages/nmr-core/src/index.ts
@@ -10,6 +10,14 @@ export type {
 } from './parseArgs.ts';
 export { parseArgs, parseArgsOrExit, ParseError } from './parseArgs.ts';
 export { readPackageVersion } from './readPackageVersion.ts';
-export { printError, printSkip, printStep, printSuccess, reportError, reportWriteResult } from './terminal.ts';
+export {
+  formatErrorLine,
+  printError,
+  printSkip,
+  printStep,
+  printSuccess,
+  reportError,
+  reportWriteResult,
+} from './terminal.ts';
 export type { WriteOutcome, WriteResult } from './writeFileWithCheck.ts';
 export { writeFileWithCheck } from './writeFileWithCheck.ts';

--- a/packages/nmr-core/src/terminal.ts
+++ b/packages/nmr-core/src/terminal.ts
@@ -1,35 +1,49 @@
 // Terminal output helpers for styled CLI messages.
 
 import process from 'node:process';
+import type { Writable } from 'node:stream';
 
 import type { WriteResult } from './writeFileWithCheck.ts';
 
-/** Print a step label with a right-arrow prefix. */
-export function printStep(message: string): void {
-  console.info(`\n> ${message}`);
+/**
+ * Renders the canonical `Error: <message>` line (without a trailing newline) — the single
+ * definition of this shape. Use it where the line is a value rather than a write target,
+ * e.g. a command that returns its message for the caller to print.
+ */
+export function formatErrorLine(message: string): string {
+  return `Error: ${message}`;
 }
 
-/** Print a success message with a checkmark emoji prefix. */
-export function printSuccess(message: string): void {
-  console.info(`  ✅ ${message}`);
-}
-
-/** Print a skip/warning message to stdout. */
-export function printSkip(message: string): void {
-  console.info(`  ⚠️ ${message}`);
-}
-
-/** Print an error message to stderr. */
+/** Prints an error message to stderr. */
 export function printError(message: string): void {
   process.stderr.write(`  ❌ ${message}\n`);
 }
 
-/** Write a canonical `Error: <message>` line to stderr — the single sanctioned door for this output shape. */
-export function reportError(message: string): void {
-  process.stderr.write(`Error: ${message}\n`);
+/** Prints a skip/warning message to stdout. */
+export function printSkip(message: string): void {
+  console.info(`  ⚠️ ${message}`);
 }
 
-/** Print a terminal message for a write result based on its outcome. */
+/** Prints a step label with a right-arrow prefix. */
+export function printStep(message: string): void {
+  console.info(`\n> ${message}`);
+}
+
+/** Prints a success message with a checkmark emoji prefix. */
+export function printSuccess(message: string): void {
+  console.info(`  ✅ ${message}`);
+}
+
+/**
+ * Writes the canonical `Error: <message>` line to a stream (stderr by default) — the single
+ * sanctioned door for this output shape. Pass an injected stream for in-process CLIs that
+ * route output through a `Writable` rather than touching `process.stderr` directly.
+ */
+export function reportError(message: string, stream: Writable = process.stderr): void {
+  stream.write(`${formatErrorLine(message)}\n`);
+}
+
+/** Prints a terminal message for a write result based on its outcome. */
 export function reportWriteResult(result: WriteResult, dryRun: boolean): void {
   switch (result.outcome) {
     case 'created':

--- a/packages/nmr/src/__tests__/cli.test.ts
+++ b/packages/nmr/src/__tests__/cli.test.ts
@@ -102,6 +102,12 @@ describe('nmr CLI', () => {
     expect(exitCode).toBe(1);
   });
 
+  it('exits 1 with a canonical Error line when -F has no argument', async () => {
+    const { stderr, exitCode } = await runNmr('-F');
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Error: -F/--filter requires a pattern argument');
+  });
+
   it('resolves root package.json scripts at monorepo root', async () => {
     const { exitCode } = await runNmr('postinstall');
     expect(exitCode).toBe(0);
@@ -201,7 +207,7 @@ describe('nmr CLI', () => {
     it('still exits with error for unknown command when quiet', async () => {
       const { stderr, exitCode } = await runNmr('--quiet nonexistent-command');
       expect(exitCode).toBe(1);
-      expect(stderr).toContain('Unknown command');
+      expect(stderr).toContain('Error: Unknown command');
     });
   });
 

--- a/packages/nmr/src/__tests__/runner.test.ts
+++ b/packages/nmr/src/__tests__/runner.test.ts
@@ -92,7 +92,7 @@ describe(runCommand, () => {
       expect(code).toBe(1);
     });
 
-    it('returns 1 and writes the spawn error message when spawn fails', () => {
+    it('returns 1 and writes the canonical Error line for the spawn error when spawn fails', () => {
       mockedSpawnSync.mockReturnValue(
         spawnResult({ status: null, error: Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) }),
       );
@@ -100,7 +100,7 @@ describe(runCommand, () => {
       const code = runCommand('nonexistent-bin');
 
       expect(code).toBe(1);
-      expect(stderrWriteSpy).toHaveBeenCalledWith(expect.stringContaining('ENOENT'));
+      expect(stderrWriteSpy).toHaveBeenCalledWith('Error: ENOENT\n');
     });
 
     it('forwards captured stdout into a caller-supplied PassThrough stream', () => {

--- a/packages/nmr/src/cli-build.ts
+++ b/packages/nmr/src/cli-build.ts
@@ -6,6 +6,9 @@ import { buildPackage } from './commands/build.ts';
 try {
   await buildPackage(process.cwd());
 } catch (error) {
+  // This file is the build bootstrap: nmr-core's `prepare` runs it (via tsx) to build nmr-core
+  // itself, before nmr-core's dist exists. It must not import `@williamthorsen/nmr-core`, so it
+  // cannot route through `reportError` and prints the message directly.
   process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
   process.exit(1);
 }

--- a/packages/nmr/src/cli-ensure-prepublish-hooks.ts
+++ b/packages/nmr/src/cli-ensure-prepublish-hooks.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgsOrExit } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit, reportError } from '@williamthorsen/nmr-core';
 
 import { DEFAULT_HOOK, ensurePrepublishHooks } from './commands/ensure-prepublish-hooks.ts';
 import { findMonorepoRoot } from './context.ts';
@@ -47,6 +47,6 @@ try {
     process.exit(1);
   }
 } catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  reportError(error instanceof Error ? error.message : String(error));
   process.exit(1);
 }

--- a/packages/nmr/src/cli-report-overrides.ts
+++ b/packages/nmr/src/cli-report-overrides.ts
@@ -1,6 +1,8 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
+import { reportError } from '@williamthorsen/nmr-core';
+
 import { reportOverrides } from './commands/report-overrides.ts';
 import { findMonorepoRoot } from './context.ts';
 
@@ -8,6 +10,6 @@ try {
   const monorepoRoot = findMonorepoRoot();
   reportOverrides(monorepoRoot);
 } catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  reportError(error instanceof Error ? error.message : String(error));
   process.exit(1);
 }

--- a/packages/nmr/src/cli-sync-agent-files.ts
+++ b/packages/nmr/src/cli-sync-agent-files.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgsOrExit } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit, reportError } from '@williamthorsen/nmr-core';
 
 import { check, sync } from './commands/sync-agent-files.ts';
 import { findMonorepoRoot } from './context.ts';
@@ -15,7 +15,7 @@ const { flags } = parseArgsOrExit(process.argv.slice(2), flagSchema);
 try {
   runCommand(flags.check);
 } catch (error: unknown) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  reportError(error instanceof Error ? error.message : String(error));
   process.exit(1);
 }
 

--- a/packages/nmr/src/cli-sync-pnpm-version.ts
+++ b/packages/nmr/src/cli-sync-pnpm-version.ts
@@ -1,6 +1,8 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
+import { reportError } from '@williamthorsen/nmr-core';
+
 import { syncPnpmVersion } from './commands/sync-pnpm-version.ts';
 import { findMonorepoRoot } from './context.ts';
 
@@ -8,6 +10,6 @@ try {
   const monorepoRoot = findMonorepoRoot();
   syncPnpmVersion(monorepoRoot);
 } catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  reportError(error instanceof Error ? error.message : String(error));
   process.exit(1);
 }

--- a/packages/nmr/src/runCli.ts
+++ b/packages/nmr/src/runCli.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import type { Writable } from 'node:stream';
 
-import { readPackageVersion } from '@williamthorsen/nmr-core';
+import { readPackageVersion, reportError } from '@williamthorsen/nmr-core';
 
 import { resolveContext } from './context.ts';
 import { generateHelp } from './help.ts';
@@ -42,7 +42,7 @@ export async function runCli(options: RunCliOptions): Promise<RunCliResult> {
 
   const parseResult = parseArgs(args);
   if (!parseResult.ok) {
-    stderr.write(`${parseResult.error}\n`);
+    reportError(parseResult.error, stderr);
     return { exitCode: 1 };
   }
   const { parsed } = parseResult;
@@ -94,7 +94,7 @@ export async function runCli(options: RunCliOptions): Promise<RunCliResult> {
     if (env.NMR_RUN_IF_PRESENT === '1') {
       return { exitCode: 0 };
     }
-    stderr.write(`Unknown command: ${command}\n`);
+    reportError(`Unknown command: ${command}`, stderr);
     return { exitCode: 1 };
   }
 
@@ -156,7 +156,7 @@ function parseArgs(args: string[]): ParseResult {
       i++;
       const filterValue = args[i];
       if (filterValue === undefined) {
-        return { ok: false, error: 'Error: -F/--filter requires a pattern argument' };
+        return { ok: false, error: '-F/--filter requires a pattern argument' };
       }
       parsed.filter = filterValue;
       i++;

--- a/packages/nmr/src/runner.ts
+++ b/packages/nmr/src/runner.ts
@@ -2,6 +2,8 @@ import { spawnSync } from 'node:child_process';
 import process from 'node:process';
 import type { Writable } from 'node:stream';
 
+import { reportError } from '@williamthorsen/nmr-core';
+
 export interface RunCommandOptions {
   /** When true, suppress output on success and write captured output to stderr on failure. */
   quiet?: boolean;
@@ -45,7 +47,7 @@ export function runCommand(command: string, cwd?: string, options?: RunCommandOp
   // there are no captured buffers to forward, and a silent exit 1 would be the classic silent-failure trap.
   // Quiet means "no chatter on success", not "swallow catastrophic configuration errors".
   if (result.error) {
-    stderr.write(`${result.error.message}\n`);
+    reportError(result.error.message, stderr);
     return 1;
   }
 

--- a/packages/release-kit/src/__tests__/checkWorkTypesDrift.unit.test.ts
+++ b/packages/release-kit/src/__tests__/checkWorkTypesDrift.unit.test.ts
@@ -101,7 +101,7 @@ describe(checkWorkTypesDrift, () => {
       fetch: fakeFetch,
     });
     expect(result.exitCode).toBe(2);
-    expect(result.message).toMatch(/HTTP 500/);
+    expect(result.message).toMatch(/Error: Failed to fetch upstream work-types\.json: HTTP 500/);
   });
 
   it('exits 2 on a network error (rejected fetch)', async () => {
@@ -112,7 +112,7 @@ describe(checkWorkTypesDrift, () => {
       fetch: fakeFetch,
     });
     expect(result.exitCode).toBe(2);
-    expect(result.message).toMatch(/Network error/);
+    expect(result.message).toMatch(/Error: Failed to fetch upstream work-types\.json: ECONNREFUSED/);
   });
 
   it('exits 3 on a schema mismatch (upstream JSON missing tiers/types)', async () => {

--- a/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/createGithubReleaseCommand.unit.test.ts
@@ -198,7 +198,7 @@ describe(createGithubReleaseCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(process.stderr.write).toHaveBeenCalledWith('Error discovering workspaces: discovery failed\n');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Failed to discover workspaces: discovery failed\n');
   });
 
   it('does not exit when --tags is explicit and every skip is no-entry', async () => {
@@ -324,14 +324,14 @@ describe(createGithubReleaseCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(process.stderr.write).toHaveBeenCalledWith('Error creating GitHub Releases: gh release failed\n');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Failed to create GitHub Releases: gh release failed\n');
   });
 
   it('exits with code 1 when resolveReleaseNotesConfig fails to load config', async () => {
     mockResolveReleaseNotesConfig.mockImplementation(() => {
       // Mirror the strictLoad path: the production code calls process.exit(1) inside the resolver,
       // which the spy converts into ExitError. Throwing it here matches that observable behavior.
-      process.stderr.write('Error: failed to load config: read failure\n');
+      process.stderr.write('Error: Failed to load config: read failure\n');
       throw new ExitError(1);
     });
 
@@ -348,7 +348,7 @@ describe(createGithubReleaseCommand, () => {
     expect(thrown?.code).toBe(1);
     expect(mockResolveReleaseNotesConfig).toHaveBeenCalledWith({ strictLoad: true });
     expect(mockCreateGithubReleases).not.toHaveBeenCalled();
-    expect(process.stderr.write).toHaveBeenCalledWith('Error: failed to load config: read failure\n');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Failed to load config: read failure\n');
   });
 
   describe('--tags parsing', () => {

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -233,7 +233,7 @@ describe(prepareCommand, () => {
     mockLoadConfig.mockRejectedValue(new Error('parse error'));
 
     await expect(prepareCommand([])).rejects.toThrow(ExitError);
-    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Error loading config'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Failed to load config'));
     expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('parse error'));
   });
 
@@ -282,26 +282,26 @@ describe(prepareCommand, () => {
     );
   });
 
-  it('prints stage-attributed errors verbatim without an outer "Error preparing release:" prefix', async () => {
+  it('prints stage-attributed errors with the canonical Error prefix and no "Error preparing release:" wrapper', async () => {
     mockReleasePrepareMono.mockImplementation(() => {
       throw new Error("workspace 'arrays' release stage: bumpAllVersions failed: ENOENT");
     });
 
     await expect(prepareCommand([])).rejects.toThrow(ExitError);
     expect(process.stderr.write).toHaveBeenCalledWith(
-      "workspace 'arrays' release stage: bumpAllVersions failed: ENOENT\n",
+      "Error: workspace 'arrays' release stage: bumpAllVersions failed: ENOENT\n",
     );
     expect(process.stderr.write).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
   });
 
-  it('prints validation errors verbatim without an outer "Error preparing release:" prefix', async () => {
+  it('prints validation errors with the canonical Error prefix and no "Error preparing release:" wrapper', async () => {
     mockReleasePrepareMono.mockImplementation(() => {
       throw new Error('--set-version 0.3.0 is not greater than current version 0.5.0');
     });
 
     await expect(prepareCommand([])).rejects.toThrow(ExitError);
     expect(process.stderr.write).toHaveBeenCalledWith(
-      '--set-version 0.3.0 is not greater than current version 0.5.0\n',
+      'Error: --set-version 0.3.0 is not greater than current version 0.5.0\n',
     );
     expect(process.stderr.write).not.toHaveBeenCalledWith(expect.stringContaining('Error preparing release'));
   });

--- a/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/publishCommand.unit.test.ts
@@ -276,7 +276,7 @@ describe(publishCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(process.stderr.write).toHaveBeenCalledWith('publish failed\n');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: publish failed\n');
   });
 
   it('does not invoke any GitHub Release path during publish', async () => {

--- a/packages/release-kit/src/__tests__/pushCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/pushCommand.unit.test.ts
@@ -141,7 +141,7 @@ describe(pushCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(process.stderr.write).toHaveBeenCalledWith('push failed\n');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: push failed\n');
   });
 
   it('skips pushRelease when no tags are resolved', async () => {

--- a/packages/release-kit/src/__tests__/resolveCommandTags.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveCommandTags.unit.test.ts
@@ -192,7 +192,7 @@ describe(resolveCommandTags, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(process.stderr.write).toHaveBeenCalledWith('Error discovering workspaces: workspace read failure\n');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Failed to discover workspaces: workspace read failure\n');
     expect(mockResolveReleaseTags).not.toHaveBeenCalled();
   });
 
@@ -213,7 +213,7 @@ describe(resolveCommandTags, () => {
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
     expect(process.stderr.write).toHaveBeenCalledWith(
-      "Error resolving workspaces: packages/core/package.json is missing a 'name' field (required for tag derivation).\n",
+      "Error: Failed to resolve workspaces: packages/core/package.json is missing a 'name' field (required for tag derivation).\n",
     );
     expect(mockResolveReleaseTags).not.toHaveBeenCalled();
   });

--- a/packages/release-kit/src/__tests__/resolveReleaseNotesConfig.unit.test.ts
+++ b/packages/release-kit/src/__tests__/resolveReleaseNotesConfig.unit.test.ts
@@ -72,7 +72,7 @@ describe(resolveReleaseNotesConfig, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(process.stderr.write).toHaveBeenCalledWith('Error: failed to load config: config read failure\n');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: Failed to load config: config read failure\n');
   });
 
   it('returns defaults when raw config is undefined', async () => {

--- a/packages/release-kit/src/__tests__/syncWorkTypes.unit.test.ts
+++ b/packages/release-kit/src/__tests__/syncWorkTypes.unit.test.ts
@@ -89,7 +89,7 @@ describe(syncWorkTypes, () => {
       fetch: fakeFetch,
     });
     expect(result.exitCode).toBe(2);
-    expect(result.message).toMatch(/HTTP 500/);
+    expect(result.message).toMatch(/Error: Failed to fetch upstream work-types\.json: HTTP 500/);
   });
 
   it('exits 2 with a network-error diagnostic when fetch rejects', async () => {
@@ -100,7 +100,7 @@ describe(syncWorkTypes, () => {
       fetch: fakeFetch,
     });
     expect(result.exitCode).toBe(2);
-    expect(result.message).toMatch(/Network error/);
+    expect(result.message).toMatch(/Error: Failed to fetch upstream work-types\.json: ECONNREFUSED/);
   });
 
   it('exits 2 with a write-failure diagnostic when the local path is not writable', async () => {
@@ -113,7 +113,7 @@ describe(syncWorkTypes, () => {
       fetch: fakeFetch,
     });
     expect(result.exitCode).toBe(2);
-    expect(result.message).toMatch(/Failed to write/);
+    expect(result.message).toMatch(/Error: Failed to write/);
     expect(result.message).toContain(localPath);
   });
 

--- a/packages/release-kit/src/__tests__/tagCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/tagCommand.unit.test.ts
@@ -86,6 +86,6 @@ describe(tagCommand, () => {
 
     expect(thrown).toBeInstanceOf(ExitError);
     expect(thrown?.code).toBe(1);
-    expect(process.stderr.write).toHaveBeenCalledWith('No tags file found. Run `release-kit prepare` first.\n');
+    expect(process.stderr.write).toHaveBeenCalledWith('Error: No tags file found. Run `release-kit prepare` first.\n');
   });
 });

--- a/packages/release-kit/src/__tests__/validateOverridesCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/validateOverridesCommand.unit.test.ts
@@ -128,7 +128,7 @@ describe(validateOverridesCommand, () => {
       validate: () => ({ errors: [], warnings: [] }),
     });
     expect(result.exitCode).toBe(2);
-    expect(result.message).toContain('Error loading config');
+    expect(result.message).toContain('Error: Failed to load config');
     expect(result.message).toContain('boom');
   });
 
@@ -141,6 +141,8 @@ describe(validateOverridesCommand, () => {
     });
     expect(result.exitCode).toBe(2);
     expect(result.message).toContain('Invalid config');
+    // The structured validation report is a verdict, not a command failure — it stays unprefixed.
+    expect(result.message).not.toContain('Error:');
   });
 
   it('passes a project-only scope to validate in single-package mode', async () => {

--- a/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
+++ b/packages/release-kit/src/__tests__/writeReleaseNotesPreviews.unit.test.ts
@@ -11,7 +11,8 @@ vi.mock('node:fs', () => ({
   readFileSync: mockReadFileSync,
 }));
 
-vi.mock('@williamthorsen/nmr-core', () => ({
+vi.mock('@williamthorsen/nmr-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@williamthorsen/nmr-core')>()),
   writeFileWithCheck: mockWriteFileWithCheck,
 }));
 
@@ -295,6 +296,6 @@ describe(writeReleaseNotesPreviews, () => {
 
     expect(result.injectedReadme?.outcome).toBe('failed');
     expect(result.injectedReadme?.error).toBe('EACCES');
-    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Error writing'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Failed to write'));
   });
 });

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -325,7 +325,7 @@ if (command === 'commit') {
   try {
     commitCommand(flags);
   } catch (error: unknown) {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
   process.exit(0);

--- a/packages/release-kit/src/checkWorkTypesDrift.ts
+++ b/packages/release-kit/src/checkWorkTypesDrift.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { formatErrorLine } from '@williamthorsen/nmr-core';
+
 import { buildFetchInit, errorMessage, hasExpectedTopLevelShape } from './workTypesUtils.ts';
 
 /** URL of the upstream canonical `work-types.json` published by codeassembly. */
@@ -74,7 +76,7 @@ export async function checkWorkTypesDrift(
   } catch (error) {
     return {
       exitCode: 2,
-      message: `Network error fetching upstream work-types.json: ${errorMessage(error)}`,
+      message: formatErrorLine(`Failed to fetch upstream work-types.json: ${errorMessage(error)}`),
     };
   }
 
@@ -88,7 +90,9 @@ export async function checkWorkTypesDrift(
   if (!response.ok) {
     return {
       exitCode: 2,
-      message: `Failed to fetch upstream work-types.json: HTTP ${response.status} ${response.statusText}`,
+      message: formatErrorLine(
+        `Failed to fetch upstream work-types.json: HTTP ${response.status} ${response.statusText}`,
+      ),
     };
   }
 

--- a/packages/release-kit/src/createGithubReleaseCommand.ts
+++ b/packages/release-kit/src/createGithubReleaseCommand.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgsOrExit } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit, reportError } from '@williamthorsen/nmr-core';
 
 import { createGithubReleases } from './createGithubRelease.ts';
 import { parseRequestedTags } from './parseRequestedTags.ts';
@@ -31,7 +31,7 @@ export async function createGithubReleaseCommand(argv: string[]): Promise<void> 
   try {
     outcome = createGithubReleases(resolvedTags, changelogJsonOutputPath, dryRun, sectionOrder);
   } catch (error: unknown) {
-    process.stderr.write(`Error creating GitHub Releases: ${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(`Failed to create GitHub Releases: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
 

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -204,7 +204,7 @@ export async function prepareCommand(argv: string[]): Promise<void> {
   try {
     discoveredPaths = await discoverWorkspaces();
   } catch (error: unknown) {
-    process.stderr.write(`Error discovering workspaces: ${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(`Failed to discover workspaces: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
 
@@ -260,7 +260,7 @@ function runMonorepoMode(
     const rootPackage = readRootPackageVersion();
     config = mergeMonorepoConfig(discoveredPaths, userConfig, rootPackage);
   } catch (error: unknown) {
-    process.stderr.write(`Error resolving workspaces: ${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(`Failed to resolve workspaces: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
 
@@ -317,7 +317,7 @@ function runMonorepoMode(
     });
 
     if (violations !== undefined) {
-      process.stderr.write('Error: --only excludes packages with changes that would be stranded by the release.\n');
+      reportError('--only excludes packages with changes that would be stranded by the release.');
       process.stderr.write('The following packages must be added to --only or have their dependencies removed:\n');
       for (const violation of violations) {
         const since = violation.tag ?? 'the beginning';
@@ -361,7 +361,7 @@ async function loadAndValidateConfig(): Promise<ReleaseKitConfig | undefined> {
   try {
     rawConfig = await loadConfig();
   } catch (error: unknown) {
-    process.stderr.write(`Error loading config: ${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(`Failed to load config: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
 
@@ -391,7 +391,7 @@ function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
   try {
     result = execute();
   } catch (error: unknown) {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 
@@ -400,7 +400,7 @@ function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
   const writeResult = writeReleaseTags(result.tags, dryRun);
 
   if (writeResult?.outcome === 'failed') {
-    process.stderr.write(`Error writing release tags: ${writeResult.error ?? 'unknown error'}\n`);
+    reportError(`Failed to write release tags: ${writeResult.error ?? 'unknown error'}`);
     process.exit(1);
   }
 
@@ -422,7 +422,7 @@ function runAndReport(execute: () => PrepareResult, dryRun: boolean): void {
     });
 
     if (summaryResult.outcome === 'failed') {
-      process.stderr.write(`Error writing release summary: ${summaryResult.error ?? 'unknown error'}\n`);
+      reportError(`Failed to write release summary: ${summaryResult.error ?? 'unknown error'}`);
       process.exit(1);
     }
 

--- a/packages/release-kit/src/publishCommand.ts
+++ b/packages/release-kit/src/publishCommand.ts
@@ -104,7 +104,7 @@ export async function publishCommand(argv: string[]): Promise<void> {
         console.warn(`  ${t}`);
       }
     }
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 }

--- a/packages/release-kit/src/pushCommand.ts
+++ b/packages/release-kit/src/pushCommand.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgsOrExit } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit, reportError } from '@williamthorsen/nmr-core';
 
 import { parseRequestedTags } from './parseRequestedTags.ts';
 import { pushRelease } from './pushRelease.ts';
@@ -48,7 +48,7 @@ export async function pushCommand(argv: string[]): Promise<void> {
       }
     }
   } catch (error: unknown) {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 }

--- a/packages/release-kit/src/resolveCommandTags.ts
+++ b/packages/release-kit/src/resolveCommandTags.ts
@@ -27,7 +27,7 @@ export async function resolveCommandTags(tags: string[] | undefined): Promise<Re
   try {
     discoveredPaths = await discoverWorkspaces();
   } catch (error: unknown) {
-    process.stderr.write(`Error discovering workspaces: ${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(`Failed to discover workspaces: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
 
@@ -43,7 +43,7 @@ export async function resolveCommandTags(tags: string[] | undefined): Promise<Re
       workspaces = discoveredPaths.map((workspacePath) => deriveWorkspaceConfig(workspacePath));
     }
   } catch (error: unknown) {
-    process.stderr.write(`Error resolving workspaces: ${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(`Failed to resolve workspaces: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
 

--- a/packages/release-kit/src/resolveReleaseNotesConfig.ts
+++ b/packages/release-kit/src/resolveReleaseNotesConfig.ts
@@ -41,7 +41,7 @@ export async function resolveReleaseNotesConfig(
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     if (strictLoad) {
-      reportError(`failed to load config: ${message}`);
+      reportError(`Failed to load config: ${message}`);
       process.exit(1);
     }
     console.warn(`Warning: failed to load config; using defaults: ${message}`);

--- a/packages/release-kit/src/sync-labels/__tests__/generateCommand.test.ts
+++ b/packages/release-kit/src/sync-labels/__tests__/generateCommand.test.ts
@@ -46,7 +46,7 @@ describe(generateCommand, () => {
     const exitCode = await generateCommand();
 
     expect(exitCode).toBe(1);
-    expect(spy).toHaveBeenCalledWith(expect.stringContaining('No config file found'));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Error: No config file found'));
   });
 
   it('returns 1 when config loading throws', async () => {

--- a/packages/release-kit/src/sync-labels/generateCommand.ts
+++ b/packages/release-kit/src/sync-labels/generateCommand.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
+import { reportError } from '@williamthorsen/nmr-core';
 import { stringify } from 'yaml';
 
 import { loadSyncLabelsConfig, SYNC_LABELS_CONFIG_PATH } from './loadSyncLabelsConfig.ts';
@@ -36,14 +37,12 @@ export async function generateCommand(): Promise<number> {
     config = await loadSyncLabelsConfig();
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Error loading config: ${message}\n`);
+    reportError(`Failed to load config: ${message}`);
     return 1;
   }
 
   if (config === undefined) {
-    process.stderr.write(
-      `No config file found at ${SYNC_LABELS_CONFIG_PATH}. Run \`release-kit sync-labels init\` first.\n`,
-    );
+    reportError(`No config file found at ${SYNC_LABELS_CONFIG_PATH}. Run \`release-kit sync-labels init\` first.`);
     return 1;
   }
 
@@ -52,7 +51,7 @@ export async function generateCommand(): Promise<number> {
     labels = resolveLabels(config);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Error resolving labels: ${message}\n`);
+    reportError(`Failed to resolve labels: ${message}`);
     return 1;
   }
 
@@ -68,7 +67,7 @@ export async function generateCommand(): Promise<number> {
     writeFileSync(LABELS_OUTPUT_PATH, content, 'utf8');
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Error writing ${LABELS_OUTPUT_PATH}: ${message}\n`);
+    reportError(`Failed to write ${LABELS_OUTPUT_PATH}: ${message}`);
     return 1;
   }
 

--- a/packages/release-kit/src/sync-labels/syncCommand.ts
+++ b/packages/release-kit/src/sync-labels/syncCommand.ts
@@ -37,7 +37,7 @@ export function syncLabelsCommand(): number {
     execSync('gh workflow run sync-labels.yaml', { stdio: 'inherit' });
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Error triggering workflow: ${message}\n`);
+    reportError(`Failed to trigger workflow: ${message}`);
     return 1;
   }
 

--- a/packages/release-kit/src/syncWorkTypes.ts
+++ b/packages/release-kit/src/syncWorkTypes.ts
@@ -2,6 +2,8 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { formatErrorLine } from '@williamthorsen/nmr-core';
+
 import { UPSTREAM_WORK_TYPES_URL } from './checkWorkTypesDrift.ts';
 import { isRecord } from './typeGuards.ts';
 import { buildFetchInit, errorMessage, hasExpectedTopLevelShape } from './workTypesUtils.ts';
@@ -68,14 +70,16 @@ export async function syncWorkTypes(dependencies: SyncWorkTypesDependencies = {}
   } catch (error) {
     return {
       exitCode: 2,
-      message: `Network error fetching upstream work-types.json: ${errorMessage(error)}`,
+      message: formatErrorLine(`Failed to fetch upstream work-types.json: ${errorMessage(error)}`),
     };
   }
 
   if (!response.ok) {
     return {
       exitCode: 2,
-      message: `Failed to fetch upstream work-types.json: HTTP ${response.status} ${response.statusText}`,
+      message: formatErrorLine(
+        `Failed to fetch upstream work-types.json: HTTP ${response.status} ${response.statusText}`,
+      ),
     };
   }
 
@@ -126,7 +130,7 @@ export async function syncWorkTypes(dependencies: SyncWorkTypesDependencies = {}
   } catch (error) {
     return {
       exitCode: 2,
-      message: `Failed to write ${localPath}: ${errorMessage(error)}`,
+      message: formatErrorLine(`Failed to write ${localPath}: ${errorMessage(error)}`),
     };
   }
   return {

--- a/packages/release-kit/src/tagCommand.ts
+++ b/packages/release-kit/src/tagCommand.ts
@@ -1,7 +1,7 @@
 /* eslint n/no-process-exit: off */
 /* eslint unicorn/no-process-exit: off */
 
-import { parseArgsOrExit } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit, reportError } from '@williamthorsen/nmr-core';
 
 import { createTags } from './createTags.ts';
 
@@ -18,7 +18,7 @@ export function tagCommand(argv: string[]): void {
   try {
     createTags({ dryRun, noGitChecks });
   } catch (error: unknown) {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    reportError(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 }

--- a/packages/release-kit/src/validateOverridesCommand.ts
+++ b/packages/release-kit/src/validateOverridesCommand.ts
@@ -1,3 +1,5 @@
+import { formatErrorLine } from '@williamthorsen/nmr-core';
+
 import { buildChangelogEntries } from './buildChangelogEntries.ts';
 import {
   resolveOverridePath,
@@ -70,9 +72,17 @@ export async function validateOverridesCommand(
   const buildEntries = dependencies.buildEntries ?? defaultBuildEntries;
   const validate = dependencies.validate ?? validateAllChangelogOverrides;
 
+  let rawConfig: unknown;
+  try {
+    rawConfig = await load();
+  } catch (error: unknown) {
+    return { exitCode: 2, message: formatErrorLine(`Failed to load config: ${errorMessage(error)}`) };
+  }
+
   let userConfig: ReleaseKitConfig | undefined;
   try {
-    userConfig = await loadAndValidateConfig(load);
+    // An invalid config is a verdict, not a failed operation — surfaced bare, unlike the load failure above.
+    userConfig = validateLoadedConfig(rawConfig);
   } catch (error: unknown) {
     return { exitCode: 2, message: errorMessage(error) };
   }
@@ -81,7 +91,7 @@ export async function validateOverridesCommand(
   try {
     discoveredPaths = await discover();
   } catch (error: unknown) {
-    return { exitCode: 2, message: `Error discovering workspaces: ${errorMessage(error)}` };
+    return { exitCode: 2, message: formatErrorLine(`Failed to discover workspaces: ${errorMessage(error)}`) };
   }
 
   let inputs: ValidateAllChangelogOverridesInputs;
@@ -91,7 +101,7 @@ export async function validateOverridesCommand(
         ? buildSinglePackageInputs(userConfig, buildEntries)
         : buildMonorepoInputs(discoveredPaths, userConfig, buildEntries);
   } catch (error: unknown) {
-    return { exitCode: 2, message: `Error resolving overrides scope: ${errorMessage(error)}` };
+    return { exitCode: 2, message: formatErrorLine(`Failed to resolve overrides scope: ${errorMessage(error)}`) };
   }
 
   const result = validate(inputs);
@@ -178,15 +188,8 @@ function flattenEntriesToHashes(entries: readonly ChangelogEntry[]): string[] {
   return hashes;
 }
 
-/** Load and validate the user's config file, throwing a descriptive error on any problem. */
-async function loadAndValidateConfig(load: () => Promise<unknown>): Promise<ReleaseKitConfig | undefined> {
-  let rawConfig: unknown;
-  try {
-    rawConfig = await load();
-  } catch (error: unknown) {
-    throw new Error(`Error loading config: ${errorMessage(error)}`);
-  }
-
+/** Validate already-loaded config content, throwing an `Invalid config:` report on validation errors. */
+function validateLoadedConfig(rawConfig: unknown): ReleaseKitConfig | undefined {
   if (rawConfig === undefined) {
     return undefined;
   }

--- a/packages/release-kit/src/writeReleaseNotesPreviews.ts
+++ b/packages/release-kit/src/writeReleaseNotesPreviews.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { writeFileWithCheck } from '@williamthorsen/nmr-core';
+import { reportError, writeFileWithCheck } from '@williamthorsen/nmr-core';
 
 import { extractVersion } from './changelogJsonUtils.ts';
 import { dim } from './format.ts';
@@ -118,7 +118,7 @@ function writePreviewFile(filePath: string, content: string, dryRun: boolean): P
   const result = writeFileWithCheck(filePath, content, { dryRun: false, overwrite: true });
 
   if (result.outcome === 'failed') {
-    process.stderr.write(`Error writing ${filePath}: ${result.error ?? 'unknown error'}\n`);
+    reportError(`Failed to write ${filePath}: ${result.error ?? 'unknown error'}`);
     return { filePath, outcome: 'failed', ...(result.error === undefined ? {} : { error: result.error }) };
   }
 


### PR DESCRIPTION
## What

Single-line error messages from the `nmr` and `release-kit` commands now print in one uniform shape, so the same class of failure reads the same way no matter which command produced it. Previously the wording varied, which made error output harder to scan and harder for scripts to match against. Richer output, such as multi-line validation reports and the stack trace from an unexpected crash, is unchanged.

## Why

Command failures across the `nmr` and `release-kit` CLIs were worded inconsistently — some printed unlabeled, others used `Error <gerund>:` phrasings — which is a papercut for anyone scanning output and a poor template for the sibling CLI utilities that copy this code. A predecessor change unified the error-reporting mechanism; this change finishes the job by unifying the wording.

## Details

### ♻️ Refactoring

- Split the canonical error line into a pure `formatErrorLine` and a stream-aware `reportError` in `nmr-core`, so the `Error: <message>` shape has one definition consumed by both write-to-stream and return-a-string callers.
- Routed every in-scope single-line command failure across `nmr` and `release-kit` through the helper — including the injected-stream sites (`runCli` unknown-command and parse errors, `runner` spawn errors) and the `validateOverrides` / `work-types` return-message commands — and reworded `Error <gerund>:` phrasings to the uniform `Failed to <verb>:` form.
- Lifted `validateOverridesCommand`'s config load out of its validation helper so the `Error:` prefix is applied at the caller, uniform with the sibling discover/resolve failures, rather than baked into a thrown message that assumed how its caller would print it.
- Left intentionally-distinct shapes unchanged: top-level crash handlers (stack traces), multi-line validation reports (`Invalid config:`), and check verdicts.

### 🧪 Tests

- Added coverage for `formatErrorLine`, the injected-stream `reportError` path, and the `-F` parse-error path; updated output assertions across the `nmr` and `release-kit` suites to the canonical wording.

Closes #434
