### PR TITLE
#435 Consolidate prepare parsing onto parseArgsOrExit

### DIFF
--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -576,18 +576,23 @@ describe(parseArgs, () => {
       throw new ExitError(typeof code === 'number' ? code : undefined);
     });
     vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('throws for an invalid bump type', () => {
-    expect(() => parseArgs(['--bump=invalid'])).toThrow('Invalid bump type');
+  it('exits with an error for an invalid bump type', () => {
+    expect(() => parseArgs(['--bump=invalid'])).toThrow(ExitError);
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Invalid bump type'));
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it('throws for an unknown flag with the flag name in the message', () => {
-    expect(() => parseArgs(['--foo'])).toThrow('Unknown option: --foo');
+  it('exits with an error for an unknown flag with the flag name in the message', () => {
+    expect(() => parseArgs(['--foo'])).toThrow(ExitError);
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Unknown option: --foo'));
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it('exits with code 0 when --help is provided', () => {
@@ -607,8 +612,10 @@ describe(parseArgs, () => {
     expect(result.bumpOverride).toBeUndefined();
   });
 
-  it('throws when --only value is empty', () => {
-    expect(() => parseArgs(['--only='])).toThrow('Missing value for option: --only');
+  it('exits with an error when --only value is empty', () => {
+    expect(() => parseArgs(['--only='])).toThrow(ExitError);
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Missing value for option: --only'));
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it('accepts a canonical semver value for --set-version', () => {
@@ -616,28 +623,40 @@ describe(parseArgs, () => {
     expect(result.setVersion).toBe('1.0.0');
   });
 
-  it('throws when --set-version has a pre-release suffix', () => {
-    expect(() => parseArgs(['--set-version=1.0.0-alpha'])).toThrow('Invalid --set-version');
+  it('exits with an error when --set-version has a pre-release suffix', () => {
+    expect(() => parseArgs(['--set-version=1.0.0-alpha'])).toThrow(ExitError);
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Invalid --set-version'));
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it('throws when --set-version is not canonical N.N.N', () => {
-    expect(() => parseArgs(['--set-version=1.0'])).toThrow('Invalid --set-version');
+  it('exits with an error when --set-version is not canonical N.N.N', () => {
+    expect(() => parseArgs(['--set-version=1.0'])).toThrow(ExitError);
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Invalid --set-version'));
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it('throws when --set-version is empty', () => {
-    expect(() => parseArgs(['--set-version='])).toThrow('Missing value for option: --set-version');
-  });
-
-  it('throws when --set-version is combined with --bump', () => {
-    expect(() => parseArgs(['--set-version=1.0.0', '--bump=minor'])).toThrow(
-      '--set-version cannot be combined with --bump',
+  it('exits with an error when --set-version is empty', () => {
+    expect(() => parseArgs(['--set-version='])).toThrow(ExitError);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Missing value for option: --set-version'),
     );
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it('throws when --set-version is combined with --force', () => {
-    expect(() => parseArgs(['--set-version=1.0.0', '--force'])).toThrow(
-      '--set-version cannot be combined with --force',
+  it('exits with an error when --set-version is combined with --bump', () => {
+    expect(() => parseArgs(['--set-version=1.0.0', '--bump=minor'])).toThrow(ExitError);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('--set-version cannot be combined with --bump'),
     );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('exits with an error when --set-version is combined with --force', () => {
+    expect(() => parseArgs(['--set-version=1.0.0', '--force'])).toThrow(ExitError);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('--set-version cannot be combined with --force'),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it('parses --no-git-checks flag', () => {

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -2,7 +2,7 @@
 /* eslint unicorn/no-process-exit: off */
 
 import type { WriteResult } from '@williamthorsen/nmr-core';
-import { parseArgs as coreParseArgs, reportError, writeFileWithCheck } from '@williamthorsen/nmr-core';
+import { parseArgsOrExit, reportError, writeFileWithCheck } from '@williamthorsen/nmr-core';
 
 import { assertCleanWorkingTree } from './assertCleanWorkingTree.ts';
 import { buildDependencyGraph } from './buildDependencyGraph.ts';
@@ -77,7 +77,7 @@ const prepareFlagSchema = {
   help: { long: '--help', type: 'boolean' as const, short: '-h' },
 };
 
-/** Parses CLI arguments into structured options. Throws on invalid input. */
+/** Parses CLI arguments into structured options. Prints a usage error and exits on invalid input. */
 export function parseArgs(argv: string[]): {
   dryRun: boolean;
   force: boolean;
@@ -87,7 +87,7 @@ export function parseArgs(argv: string[]): {
   setVersion: string | undefined;
   withReleaseNotes: boolean;
 } {
-  const { flags } = coreParseArgs(argv, prepareFlagSchema);
+  const { flags } = parseArgsOrExit(argv, prepareFlagSchema);
 
   if (flags.help) {
     showHelp();
@@ -97,7 +97,8 @@ export function parseArgs(argv: string[]): {
   let bumpOverride: ReleaseType | undefined;
   if (flags.bump !== undefined) {
     if (!isReleaseType(flags.bump)) {
-      throw new Error(`Invalid bump type "${flags.bump}". Must be one of: ${VALID_BUMP_TYPES.join(', ')}`);
+      reportError(`Invalid bump type "${flags.bump}". Must be one of: ${VALID_BUMP_TYPES.join(', ')}`);
+      process.exit(1);
     }
     bumpOverride = flags.bump;
   }
@@ -105,9 +106,10 @@ export function parseArgs(argv: string[]): {
   let setVersion: string | undefined;
   if (flags.setVersion !== undefined) {
     if (!CANONICAL_SEMVER_PATTERN.test(flags.setVersion)) {
-      throw new Error(
+      reportError(
         `Invalid --set-version value "${flags.setVersion}". Must be canonical semver (N.N.N, no pre-release suffix).`,
       );
+      process.exit(1);
     }
     setVersion = flags.setVersion;
   }
@@ -118,11 +120,13 @@ export function parseArgs(argv: string[]): {
   }
 
   if (setVersion !== undefined && bumpOverride !== undefined) {
-    throw new Error('--set-version cannot be combined with --bump');
+    reportError('--set-version cannot be combined with --bump');
+    process.exit(1);
   }
 
   if (setVersion !== undefined && flags.force) {
-    throw new Error('--set-version cannot be combined with --force');
+    reportError('--set-version cannot be combined with --force');
+    process.exit(1);
   }
 
   return {
@@ -162,19 +166,7 @@ export function writeReleaseTags(tags: string[], dryRun: boolean): WriteResult |
  * 6. Writes `.release-tags` for CI consumption.
  */
 export async function prepareCommand(argv: string[]): Promise<void> {
-  let dryRun: boolean;
-  let force: boolean;
-  let noGitChecks: boolean;
-  let bumpOverride: ReleaseType | undefined;
-  let only: string[] | undefined;
-  let setVersion: string | undefined;
-  let withReleaseNotes: boolean;
-  try {
-    ({ dryRun, force, noGitChecks, bumpOverride, only, setVersion, withReleaseNotes } = parseArgs(argv));
-  } catch (error: unknown) {
-    reportError(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  }
+  const { dryRun, force, noGitChecks, bumpOverride, only, setVersion, withReleaseNotes } = parseArgs(argv);
   const options = {
     dryRun,
     force,


### PR DESCRIPTION
## What

Makes `release-kit`'s `prepare` command report invalid arguments the same way its other commands already do. The error message and exit code a user sees for a bad argument are unchanged.

## Why

`prepare` was the last release-kit command still wrapping argument parsing in its own try/catch, diverging from the shared parse-or-exit path every other command uses. The duplicated handler was an inconsistency that made the command's failure behavior harder to follow and to keep aligned with its siblings.

## Details

### ♻️ Refactoring

- Route `prepare`'s flag parsing through the shared `parseArgsOrExit` helper, so parse failures (unknown flag, missing value, unexpected positional) report and exit inside it.
- Convert the four semantic-validation failures — invalid `--bump`, malformed `--set-version`, and the `--set-version`/`--bump` and `--set-version`/`--force` conflicts — from thrown errors to `reportError` + `process.exit(1)` in place, matching the die-in-place idiom the command's other guards already use.
- Remove the call-site try/catch in `prepareCommand`; the parsed result is destructured directly.
- Update the `parseArgs` doc comment to record the throws → exits contract.

### 🧪 Tests

- Convert the `parseArgs` error-path assertions from a thrown message to asserting the `ExitError`, the `Error: <message>` stderr line, and exit code `1` — locking the exit-code parity the refactor promises.

Closes #435
