### PR TITLE
#440 Unify prepare help text into a testable module

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -549,15 +549,15 @@ The first release that ships under the new renderer will produce a one-time nois
 
 Run release preparation with automatic workspace discovery.
 
-| Flag                         | Description                                                                                                                                        |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--dry-run`                  | Preview changes without writing files                                                                                                              |
-| `--bump=major\|minor\|patch` | Override the bump type for all workspaces                                                                                                          |
-| `--set-version=X.Y.Z`        | Set an explicit canonical semver version; bypasses commit-derived bumps. Requires `--only` in monorepo mode.                                       |
-| `--force`                    | Release even when no commits or no bump-worthy commits exist since the last tag (defaults to patch; combine with `--bump=X` for a different level) |
-| `--only=name1,name2`         | Only process the named workspaces (monorepo only; rejected when a `project` block is configured)                                                   |
-| `--with-release-notes`       | Write per-workspace release-notes previews under `{workspacePath}/docs/`                                                                           |
-| `--help`, `-h`               | Show help                                                                                                                                          |
+| Flag                         | Description                                                                                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--dry-run`                  | Preview changes without writing files                                                                                                                        |
+| `--bump=major\|minor\|patch` | Override the bump type for all workspaces                                                                                                                    |
+| `--set-version=X.Y.Z`        | Set an explicit canonical semver version; bypasses commit-derived bumps. Requires `--only` in monorepo mode (rejected when a `project` block is configured). |
+| `--force`                    | Release even when no commits or no bump-worthy commits exist since the last tag (defaults to patch; combine with `--bump=X` for a different level)           |
+| `--only=name1,name2`         | Only process the named workspaces (monorepo only; rejected when a `project` block is configured)                                                             |
+| `--with-release-notes`       | Write per-workspace release-notes previews under `{workspacePath}/docs/`                                                                                     |
+| `--help`, `-h`               | Show help                                                                                                                                                    |
 
 Workspace names for `--only` match the package directory name (e.g., `arrays`, `release-kit`).
 

--- a/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareCommand.unit.test.ts
@@ -595,13 +595,12 @@ describe(parseArgs, () => {
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it('exits with code 0 when --help is provided', () => {
-    expect(() => parseArgs(['--help'])).toThrow(ExitError);
-    expect(process.exit).toHaveBeenCalledWith(0);
-    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('npx @williamthorsen/release-kit prepare'));
-    expect(console.info).toHaveBeenCalledWith(
-      expect.stringContaining('Release even when no commits or no bump-worthy commits exist'),
-    );
+  it('rejects --help=value as an unknown option', () => {
+    // The bin dispatcher only intercepts bare `--help`/`-h`; the `=value` form slips past it
+    // and reaches parseArgs, where `--help` is no longer a known flag.
+    expect(() => parseArgs(['--help=value'])).toThrow(ExitError);
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Unknown option: --help'));
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it('accepts --force without --bump and defaults force to true', () => {
@@ -682,11 +681,6 @@ describe(parseArgs, () => {
   it('defaults withReleaseNotes to false', () => {
     const result = parseArgs([]);
     expect(result.withReleaseNotes).toBe(false);
-  });
-
-  it('documents --with-release-notes in --help output', () => {
-    expect(() => parseArgs(['--help'])).toThrow(ExitError);
-    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('--with-release-notes'));
   });
 });
 

--- a/packages/release-kit/src/__tests__/prepareHelp.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareHelp.unit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { prepareHelpText, showPrepareHelp } from '../help/prepareHelp.ts';
+import { prepareFlagSchema } from '../prepareCommand.ts';
+
+describe(prepareHelpText, () => {
+  it('documents every long flag in prepareFlagSchema', () => {
+    for (const flag of Object.values(prepareFlagSchema)) {
+      expect(prepareHelpText).toContain(flag.long);
+    }
+  });
+
+  it('documents no unrecognized --flag tokens', () => {
+    // `--help` is documented but handled by the bin dispatcher, so it is not in the schema.
+    const known = new Set<string>([...Object.values(prepareFlagSchema).map((flag) => flag.long), '--help']);
+    const documented = prepareHelpText.match(/--[a-z][a-z-]*/g) ?? [];
+    for (const token of documented) {
+      expect(known).toContain(token);
+    }
+  });
+
+  it('documents --force and its release-even-without-commits behavior', () => {
+    expect(prepareHelpText).toContain('--force');
+    expect(prepareHelpText).toContain('Release even when no commits');
+  });
+
+  it('documents the project-block caveat on both --set-version and --only', () => {
+    const caveats = prepareHelpText.match(/rejected when a 'project' block is configured/g);
+    expect(caveats).toHaveLength(2);
+  });
+});
+
+describe(showPrepareHelp, () => {
+  it('prints the help text', () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    showPrepareHelp();
+
+    expect(info).toHaveBeenCalledWith(prepareHelpText);
+    info.mockRestore();
+  });
+});

--- a/packages/release-kit/src/bin/release-kit.ts
+++ b/packages/release-kit/src/bin/release-kit.ts
@@ -7,6 +7,7 @@ import { parseArgsOrExit, readPackageVersion, reportError } from '@williamthorse
 import { checkWorkTypesDrift } from '../checkWorkTypesDrift.ts';
 import { commitCommand } from '../commitCommand.ts';
 import { createGithubReleaseCommand } from '../createGithubReleaseCommand.ts';
+import { showPrepareHelp } from '../help/prepareHelp.ts';
 import { initCommand } from '../init/initCommand.ts';
 import { prepareCommand } from '../prepareCommand.ts';
 import { publishCommand } from '../publishCommand.ts';
@@ -108,25 +109,6 @@ Options:
   --force         Overwrite existing files instead of skipping them
   --dry-run       Preview changes without writing files
   --help, -h      Show this help message
-`);
-}
-
-function showPrepareHelp(): void {
-  console.info(`
-Usage: release-kit prepare [options]
-
-Run release preparation with automatic workspace discovery.
-
-Options:
-  --dry-run             Run without modifying any files
-  --bump=major|minor|patch  Override the bump type for all workspaces
-  --set-version=X.Y.Z   Set an explicit version; bypasses commit-derived bumps. Requires --only in monorepo mode.
-  --no-git-checks, -n   Skip the clean-working-tree check
-  --only=name1,name2    Only process the named workspaces (comma-separated, monorepo only)
-  --with-release-notes  Also write per-workspace release-notes previews under {workspacePath}/docs/
-                         (docs/README.v{version}.md and docs/RELEASE_NOTES.v{version}.md).
-                         Recommended .gitignore entry: packages/*/docs/*.v*.md (or docs/*.v*.md).
-  --help, -h            Show this help message
 `);
 }
 

--- a/packages/release-kit/src/help/prepareHelp.ts
+++ b/packages/release-kit/src/help/prepareHelp.ts
@@ -1,0 +1,31 @@
+/**
+ * Single source of truth for the `release-kit prepare` help text. Imported by the bin
+ * dispatcher and asserted by the help drift guard test; kept free of import-time side
+ * effects so both can load it.
+ */
+export const prepareHelpText = `
+Usage: release-kit prepare [options]
+
+Run release preparation with automatic workspace discovery.
+
+Options:
+  --dry-run             Run without modifying any files
+  --bump=major|minor|patch  Override the bump type for all workspaces
+  --set-version=X.Y.Z   Set an explicit version; bypasses commit-derived bumps.
+                         Requires --only in monorepo mode (rejected when a 'project' block is configured).
+  --force               Release even when no commits or no bump-worthy commits exist
+                         since the last tag. Defaults to patch when --bump is not given;
+                         use --bump=X to release at a different level.
+  --no-git-checks, -n   Skip the clean-working-tree check
+  --only=name1,name2    Only process the named workspaces (comma-separated, monorepo only;
+                         rejected when a 'project' block is configured)
+  --with-release-notes  Also write per-workspace release-notes previews under {workspacePath}/docs/
+                         (docs/README.v{version}.md and docs/RELEASE_NOTES.v{version}.md).
+                         Recommended .gitignore entry: packages/*/docs/*.v*.md (or docs/*.v*.md).
+  --help, -h            Show this help message
+`;
+
+/** Prints the prepare command's help text. */
+export function showPrepareHelp(): void {
+  console.info(prepareHelpText);
+}

--- a/packages/release-kit/src/prepareCommand.ts
+++ b/packages/release-kit/src/prepareCommand.ts
@@ -39,30 +39,7 @@ function isReleaseType(value: string): value is ReleaseType {
   return VALID_BUMP_TYPES.includes(value);
 }
 
-/** Displays CLI usage information. */
-function showHelp(): void {
-  console.info(`
-Usage: npx @williamthorsen/release-kit prepare [options]
-
-Options:
-  --dry-run             Run without modifying any files
-  --bump=major|minor|patch  Override the bump type for all workspaces
-  --set-version=X.Y.Z   Set an explicit version; bypasses commit-derived bumps.
-                         Requires --only in monorepo mode (rejected when a 'project' block is configured).
-  --force               Release even when no commits or no bump-worthy commits exist
-                         since the last tag. Defaults to patch when --bump is not given;
-                         use --bump=X to release at a different level.
-  --no-git-checks, -n   Skip the clean-working-tree check
-  --only=name1,name2    Only process the named workspaces (comma-separated, monorepo only;
-                         rejected when a 'project' block is configured)
-  --with-release-notes  Also write per-workspace release-notes previews under {workspacePath}/docs/
-                         (docs/README.v{version}.md and docs/RELEASE_NOTES.v{version}.md).
-                         Recommended .gitignore entry: packages/*/docs/*.v*.md (or docs/*.v*.md).
-  --help                Show this help message
-`);
-}
-
-const prepareFlagSchema = {
+export const prepareFlagSchema = {
   dryRun: { long: '--dry-run', type: 'boolean' as const },
   force: { long: '--force', type: 'boolean' as const },
   noGitChecks: {
@@ -74,7 +51,6 @@ const prepareFlagSchema = {
   setVersion: { long: '--set-version', type: 'string' as const },
   only: { long: '--only', type: 'string' as const },
   withReleaseNotes: { long: '--with-release-notes', type: 'boolean' as const },
-  help: { long: '--help', type: 'boolean' as const, short: '-h' },
 };
 
 /** Parses CLI arguments into structured options. Prints a usage error and exits on invalid input. */
@@ -88,11 +64,6 @@ export function parseArgs(argv: string[]): {
   withReleaseNotes: boolean;
 } {
   const { flags } = parseArgsOrExit(argv, prepareFlagSchema);
-
-  if (flags.help) {
-    showHelp();
-    process.exit(0);
-  }
 
   let bumpOverride: ReleaseType | undefined;
   if (flags.bump !== undefined) {


### PR DESCRIPTION
## What

Running `release-kit prepare --help` now lists the complete set of options. The `--force` flag and the restriction that `--set-version` and `--only` cannot be used when a project block is configured were previously missing from the help and are now shown there; the same `--set-version` restriction was added to the package README's `prepare` reference.

## Why

Users running `release-kit prepare --help` saw an incomplete options list — the supported `--force` flag and the `--set-version`/`--only` project-block restrictions were absent — and nothing kept the help in sync with the command's actual flags, so it could drift further out of date.

## Details

### ♻️ Refactoring

- Consolidated two drifted copies of the prepare help text into a single side-effect-free module (`src/help/prepareHelp.ts`) imported by the bin dispatcher, removing the dispatcher's duplicate copy.
- Removed the unreachable `showHelp()`, `help` flag, and `if (flags.help)` branch from `prepareCommand`, and exported `prepareFlagSchema` so the help can be validated against it.
- Reconciled the README `--set-version` row with the unified help.

### 🧪 Tests

- Added a schema-driven drift guard (`prepareHelp.unit.test.ts`) asserting the help documents every flag in `prepareFlagSchema`, contains no unrecognized `--flag` tokens, and carries the `--force` description and both project-block caveats.
- Removed two tests covering the deleted internal help path; added a regression test pinning the `--help=value` → "Unknown option" behavior.

Closes #440
