### PR TITLE
#436 Prevent CLI output truncation when piped before exit

### DIFF
--- a/packages/nmr/src/__tests__/cli.test.ts
+++ b/packages/nmr/src/__tests__/cli.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -75,6 +75,26 @@ describe('nmr CLI', () => {
     } catch {
       // Swallow warmup failure — tests will surface real issues themselves.
     }
+  });
+
+  // The bin (`cli.ts`) sets `process.exitCode` and returns rather than calling `process.exit()`, so output drains
+  // before the process exits. These spawn the real built bin to observe the kernel exit code and prompt termination;
+  // the in-process `runNmr` tests bypass the bin wrapper and cannot exercise that behavior.
+  describe('process exit behavior via the real bin (subprocess)', () => {
+    it('exits 0 for --help', () => {
+      const result = spawnSync('node', [CLI_PATH, '--help'], { cwd: MONOREPO_ROOT, timeout: 15_000, encoding: 'utf8' });
+      // A lingering-handle hang would hit the timeout and leave status null, failing this assertion.
+      expect(result.status).toBe(0);
+    });
+
+    it('exits 1 for an unknown command', () => {
+      const result = spawnSync('node', [CLI_PATH, 'definitely-not-a-real-command'], {
+        cwd: MONOREPO_ROOT,
+        timeout: 15_000,
+        encoding: 'utf8',
+      });
+      expect(result.status).toBe(1);
+    });
   });
 
   it('shows help with --help flag', async () => {

--- a/packages/nmr/src/cli-build.ts
+++ b/packages/nmr/src/cli-build.ts
@@ -1,6 +1,3 @@
-/* eslint n/no-process-exit: off */
-/* eslint unicorn/no-process-exit: off */
-
 import { buildPackage } from './commands/build.ts';
 
 try {
@@ -10,5 +7,5 @@ try {
   // itself, before nmr-core's dist exists. It must not import `@williamthorsen/nmr-core`, so it
   // cannot route through `reportError` and prints the message directly.
   process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
+  process.exitCode = 1;
 }

--- a/packages/nmr/src/cli-ensure-prepublish-hooks.ts
+++ b/packages/nmr/src/cli-ensure-prepublish-hooks.ts
@@ -1,6 +1,3 @@
-/* eslint n/no-process-exit: off */
-/* eslint unicorn/no-process-exit: off */
-
 import { parseArgsOrExit, reportError } from '@williamthorsen/nmr-core';
 
 import { DEFAULT_HOOK, ensurePrepublishHooks } from './commands/ensure-prepublish-hooks.ts';
@@ -44,9 +41,9 @@ try {
   if (result.hasFailures) {
     const missing = result.packages.filter((p) => p.action === 'missing').length;
     process.stderr.write(`\n${missing} package(s) missing prepublishOnly. Use --fix to add it.\n`);
-    process.exit(1);
+    process.exitCode = 1;
   }
 } catch (error) {
   reportError(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  process.exitCode = 1;
 }

--- a/packages/nmr/src/cli-report-overrides.ts
+++ b/packages/nmr/src/cli-report-overrides.ts
@@ -1,6 +1,3 @@
-/* eslint n/no-process-exit: off */
-/* eslint unicorn/no-process-exit: off */
-
 import { reportError } from '@williamthorsen/nmr-core';
 
 import { reportOverrides } from './commands/report-overrides.ts';
@@ -11,5 +8,5 @@ try {
   reportOverrides(monorepoRoot);
 } catch (error) {
   reportError(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  process.exitCode = 1;
 }

--- a/packages/nmr/src/cli-sync-pnpm-version.ts
+++ b/packages/nmr/src/cli-sync-pnpm-version.ts
@@ -1,6 +1,3 @@
-/* eslint n/no-process-exit: off */
-/* eslint unicorn/no-process-exit: off */
-
 import { reportError } from '@williamthorsen/nmr-core';
 
 import { syncPnpmVersion } from './commands/sync-pnpm-version.ts';
@@ -11,5 +8,5 @@ try {
   syncPnpmVersion(monorepoRoot);
 } catch (error) {
   reportError(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  process.exitCode = 1;
 }

--- a/packages/nmr/src/cli.ts
+++ b/packages/nmr/src/cli.ts
@@ -1,6 +1,3 @@
-/* eslint n/no-process-exit: off */
-/* eslint unicorn/no-process-exit: off */
-
 import process from 'node:process';
 
 import { runCli } from './runCli.ts';
@@ -13,8 +10,8 @@ try {
     stdout: process.stdout,
     stderr: process.stderr,
   });
-  process.exit(exitCode);
+  process.exitCode = exitCode;
 } catch (error: unknown) {
   process.stderr.write(`${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`);
-  process.exit(1);
+  process.exitCode = 1;
 }

--- a/packages/v11y-check/src/bin/__tests__/v11y.test.ts
+++ b/packages/v11y-check/src/bin/__tests__/v11y.test.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// The bin (`v11y.ts`) sets `process.exitCode` and falls through rather than calling `process.exit()`, so output drains
+// before the process exits. These spawn the real built bin to observe the kernel exit code and prompt termination;
+// `route.test.ts` covers `routeCommand` in isolation and cannot exercise the bin's exit behavior.
+const BIN_PATH = path.resolve(import.meta.dirname, '..', '..', '..', 'dist', 'esm', 'bin', 'v11y.js');
+
+describe('v11y bin process exit', () => {
+  beforeAll(() => {
+    // Warm node + the v11y dist so the first measured spawn does not pay cold-start cost near the timeout.
+    spawnSync('node', [BIN_PATH, '--help'], { stdio: 'ignore', timeout: 15_000 });
+  });
+
+  it('exits 0 for --version', () => {
+    const result = spawnSync('node', [BIN_PATH, '--version'], { timeout: 15_000, encoding: 'utf8' });
+    // A lingering-handle hang would hit the timeout and leave status null, failing this assertion.
+    expect(result.status).toBe(0);
+  });
+
+  it('exits 1 for an unknown command', () => {
+    const result = spawnSync('node', [BIN_PATH, 'definitely-not-a-real-command'], {
+      timeout: 15_000,
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(1);
+  });
+});

--- a/packages/v11y-check/src/bin/v11y.ts
+++ b/packages/v11y-check/src/bin/v11y.ts
@@ -1,5 +1,4 @@
-/* eslint n/hashbang: off, n/no-process-exit: off */
-/* eslint unicorn/no-process-exit: off */
+/* eslint n/hashbang: off */
 
 import process from 'node:process';
 
@@ -13,4 +12,4 @@ try {
   process.stderr.write(`v11y: unexpected error: ${message}\n`);
   exitCode = 1;
 }
-process.exit(exitCode);
+process.exitCode = exitCode;


### PR DESCRIPTION
## What

Fixes an issue where large output from the `nmr` and `v11y` commands could be truncated when captured through a pipe — for example, by a CI job.

## Why

A command that wrote a large amount of output to a pipe and then exited immediately could drop the tail of that output, so a CI job or script capturing `nmr` or `v11y` output could silently receive a truncated result. No failure had been observed, but the truncation was a real latent risk worth closing on the toolkit's command entry points.

## Details

### 🐛 Bug fixes

- The `nmr` (`cli.ts`) and `v11y` (`v11y.ts`) bins, plus four secondary nmr bins (`cli-build`, `cli-report-overrides`, `cli-sync-pnpm-version`, `cli-ensure-prepublish-hooks`), set `process.exitCode` and fall through to a natural exit instead of calling `process.exit()`, so the event loop drains buffered `stdout`/`stderr` before the process ends. The now-dead `n/no-process-exit` and `unicorn/no-process-exit` eslint-disable headers were removed from each.
- `cli-sync-agent-files.ts` and `release-kit` are deliberately untouched: their `process.exit()` calls have statements running after them, so they need restructuring rather than a mechanical swap and are deferred to the CLI-framework migration spike (#445).

### 🧪 Tests

- Subprocess tests for `nmr` (`cli.test.ts`) and `v11y` (new `bin/__tests__/v11y.test.ts`) spawn the real built bin and assert the kernel exit code (0 for `--help`/`--version`, 1 for an unknown command) and prompt termination; a `spawnSync` timeout makes a lingering-handle hang fail the assertion rather than pass silently.

Closes #436
