### PR TITLE
#422 Auto-activate integration test variant from config presence

### DIFF
--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -154,11 +154,12 @@ These scripts are available out of the box. Repo-wide config (tier 2) and per-pa
 
 #### Integration test variant
 
-Packages with a `vitest.integration.config.ts` file get different test commands. Use the `--int-test` flag to select this variant.
+A package gets this variant automatically when it contains a `vitest.integration.config.ts` file: `test` and `test:coverage` run the standalone (non-integration) suite, and integration tests run only when invoked explicitly. Activation is detected per package, so it applies under the recursive `nmr ci` fan-out. Opting in requires **both** `vitest.integration.config.ts` and `vitest.standalone.config.ts`, since the standalone scripts reference the latter.
 
 | Command            | Runs                                                               |
 | ------------------ | ------------------------------------------------------------------ |
 | `test`             | `pnpm exec vitest --config=vitest.standalone.config.ts`            |
+| `test:all`         | `pnpm exec vitest`                                                 |
 | `test:coverage`    | `pnpm exec vitest --config=vitest.standalone.config.ts --coverage` |
 | `test:integration` | `pnpm exec vitest --config=vitest.integration.config.ts`           |
 | `test:watch`       | `pnpm exec vitest --config=vitest.standalone.config.ts --watch`    |
@@ -272,7 +273,6 @@ nmr [flags] <command> [args...]
 | `-q, --quiet`            | Suppress info messages; show full output on failure | —       |
 | `-?, --help`             | Show available commands                             | —       |
 | `-V, --version`          | Show version number                                 | —       |
-| `--int-test`             | Use integration test scripts                        | —       |
 
 ### Examples
 

--- a/packages/nmr/src/__tests__/help.test.ts
+++ b/packages/nmr/src/__tests__/help.test.ts
@@ -18,7 +18,6 @@ describe(generateHelp, () => {
     expect(help).toContain('-R, --recursive');
     expect(help).toContain('-w, --workspace-root');
     expect(help).toContain('-?, --help');
-    expect(help).toContain('--int-test');
   });
 
   it('includes workspace commands section', () => {

--- a/packages/nmr/src/__tests__/resolve-scripts.test.ts
+++ b/packages/nmr/src/__tests__/resolve-scripts.test.ts
@@ -14,21 +14,23 @@ describe('getDefaultWorkspaceScripts', () => {
     expect(scripts.typecheck).toBe('tsgo --noEmit');
   });
 
-  it('uses standard test scripts when --int-test is false', () => {
+  it('uses standard test scripts when useIntTests is false', () => {
     const scripts = getDefaultWorkspaceScripts(false);
 
     expect(scripts.test).toBe('pnpm exec vitest');
     expect(scripts['test:coverage']).toBe('pnpm exec vitest --coverage');
     expect(scripts['test:watch']).toBe('pnpm exec vitest --watch');
     expect(scripts['test:integration']).toBeUndefined();
+    expect(scripts['test:all']).toBeUndefined();
   });
 
-  it('uses integration test scripts when --int-test is true', () => {
+  it('uses integration test scripts when useIntTests is true', () => {
     const scripts = getDefaultWorkspaceScripts(true);
 
     expect(scripts.test).toBe('pnpm exec vitest --config=vitest.standalone.config.ts');
     expect(scripts['test:coverage']).toBe('pnpm exec vitest --config=vitest.standalone.config.ts --coverage');
     expect(scripts['test:integration']).toBe('pnpm exec vitest --config=vitest.integration.config.ts');
+    expect(scripts['test:all']).toBe('pnpm exec vitest');
   });
 });
 

--- a/packages/nmr/src/__tests__/resolver.test.ts
+++ b/packages/nmr/src/__tests__/resolver.test.ts
@@ -10,6 +10,7 @@ import {
   buildWorkspaceRegistry,
   describeScript,
   expandScript,
+  hasIntegrationTestConfig,
   resolveScript,
 } from '../resolver.ts';
 
@@ -259,5 +260,71 @@ describe('resolveScript', () => {
     const result = resolveScript('test', registry, tmpDir, false);
 
     expect(result).toStrictEqual({ command: 'vitest', source: 'default' });
+  });
+});
+
+describe(hasIntegrationTestConfig, () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nmr-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('returns false when the package has no integration config', () => {
+    expect(hasIntegrationTestConfig(tmpDir)).toBe(false);
+  });
+
+  it('returns true when the package has a vitest.integration.config.ts', () => {
+    fs.writeFileSync(path.join(tmpDir, 'vitest.integration.config.ts'), '');
+    expect(hasIntegrationTestConfig(tmpDir)).toBe(true);
+  });
+});
+
+// End-to-end at the resolution layer: presence of vitest.integration.config.ts selects the integration variant. This
+// stands in for a real `pnpm --recursive exec nmr ...` run, which is impractical here because temp fixtures have no
+// installed vitest; recursion correctness follows from hasIntegrationTestConfig being evaluated per package on each
+// invocation's packageDir.
+describe('integration variant auto-activation (resolution layer)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nmr-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('resolves the integration variant when the package has vitest.integration.config.ts', () => {
+    fs.writeFileSync(path.join(tmpDir, 'vitest.integration.config.ts'), '');
+    const registry = buildWorkspaceRegistry({}, hasIntegrationTestConfig(tmpDir));
+
+    expect(resolveScript('test', registry, tmpDir, false)).toStrictEqual({
+      command: 'pnpm exec vitest --config=vitest.standalone.config.ts',
+      source: 'default',
+    });
+    expect(resolveScript('test:integration', registry, tmpDir, false)).toStrictEqual({
+      command: 'pnpm exec vitest --config=vitest.integration.config.ts',
+      source: 'default',
+    });
+    expect(resolveScript('test:all', registry, tmpDir, false)).toStrictEqual({
+      command: 'pnpm exec vitest',
+      source: 'default',
+    });
+  });
+
+  it('resolves the standard variant when the package has no integration config', () => {
+    const registry = buildWorkspaceRegistry({}, hasIntegrationTestConfig(tmpDir));
+
+    expect(resolveScript('test', registry, tmpDir, false)).toStrictEqual({
+      command: 'pnpm exec vitest',
+      source: 'default',
+    });
+    expect(resolveScript('test:integration', registry, tmpDir, false)).toBeUndefined();
+    expect(resolveScript('test:all', registry, tmpDir, false)).toBeUndefined();
   });
 });

--- a/packages/nmr/src/default-scripts.ts
+++ b/packages/nmr/src/default-scripts.ts
@@ -27,6 +27,7 @@ export const commonWorkspaceScripts: ScriptRegistry = {
  */
 export const integrationTestScripts: ScriptRegistry = {
   test: 'pnpm exec vitest --config=vitest.standalone.config.ts',
+  'test:all': 'pnpm exec vitest',
   'test:coverage': 'pnpm exec vitest --config=vitest.standalone.config.ts --coverage',
   'test:integration': 'pnpm exec vitest --config=vitest.integration.config.ts',
   'test:watch': 'pnpm exec vitest --config=vitest.standalone.config.ts --watch',

--- a/packages/nmr/src/help.ts
+++ b/packages/nmr/src/help.ts
@@ -32,7 +32,6 @@ export function generateHelp(config: NmrConfig, packageDir: string | undefined, 
     '  -w, --workspace-root     Run root command regardless of cwd',
     '  -q, --quiet              Suppress output on success; show full output on failure',
     '  -?, --help               Show this help',
-    '      --int-test           Use integration test scripts',
     '',
     'Workspace commands:',
   ];

--- a/packages/nmr/src/resolver.ts
+++ b/packages/nmr/src/resolver.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import type { NmrConfig } from './config.ts';
@@ -104,6 +104,16 @@ export function readPackageJsonScripts(packageDir: string): Record<string, strin
     }
     throw error;
   }
+}
+
+/**
+ * Returns true when a workspace opts into the integration test variant by
+ * providing a `vitest.integration.config.ts`. Detected per workspace, it
+ * engages under the recursive `nmr ci` fan-out so integration tests stay out of
+ * the default `test`/`test:coverage` runs.
+ */
+export function hasIntegrationTestConfig(packageDir: string): boolean {
+  return existsSync(path.join(packageDir, 'vitest.integration.config.ts'));
 }
 
 /**

--- a/packages/nmr/src/runCli.ts
+++ b/packages/nmr/src/runCli.ts
@@ -7,7 +7,13 @@ import { resolveContext } from './context.ts';
 import { generateHelp } from './help.ts';
 import { isHookName } from './helpers/hook-name.ts';
 import type { ScriptRegistry } from './resolve-scripts.ts';
-import { applyDevBin, buildRootRegistry, buildWorkspaceRegistry, resolveScript } from './resolver.ts';
+import {
+  applyDevBin,
+  buildRootRegistry,
+  buildWorkspaceRegistry,
+  hasIntegrationTestConfig,
+  resolveScript,
+} from './resolver.ts';
 import { runCommand } from './runner.ts';
 
 const VERSION = readPackageVersion(import.meta.url);
@@ -87,7 +93,9 @@ export async function runCli(options: RunCliOptions): Promise<RunCliResult> {
     return { exitCode };
   }
 
-  const registry = useRoot ? buildRootRegistry(context.config) : buildWorkspaceRegistry(context.config, parsed.intTest);
+  const registry = useRoot
+    ? buildRootRegistry(context.config)
+    : buildWorkspaceRegistry(context.config, hasIntegrationTestConfig(packageDir));
   const resolved = resolveScript(command, registry, packageDir, parsed.workspaceRoot);
 
   if (!resolved) {
@@ -129,7 +137,6 @@ interface ParsedArgs {
   workspaceRoot: boolean;
   help: boolean;
   version: boolean;
-  intTest: boolean;
   command?: string;
   passthrough: string[];
 }
@@ -143,7 +150,6 @@ function parseArgs(args: string[]): ParseResult {
     workspaceRoot: false,
     help: false,
     version: false,
-    intTest: false,
     passthrough: [],
   };
 
@@ -184,11 +190,6 @@ function parseArgs(args: string[]): ParseResult {
     }
     if (arg === '-q' || arg === '--quiet') {
       parsed.quiet = true;
-      i++;
-      continue;
-    }
-    if (arg === '--int-test') {
-      parsed.intTest = true;
       i++;
       continue;
     }

--- a/packages/release-kit/package.json
+++ b/packages/release-kit/package.json
@@ -35,10 +35,6 @@
     "build:post": "node scripts/copy-work-types.js",
     "prepare": "tsx ../nmr/src/cli-build.ts && tsc --project tsconfig.generate-typings.json",
     "prepublishOnly": "nmr build",
-    "test": "pnpm exec vitest --config=vitest.standalone.config.ts",
-    "test:coverage": "pnpm exec vitest --config=vitest.standalone.config.ts --coverage",
-    "test:integration": "pnpm exec vitest --config=vitest.integration.config.ts",
-    "test:watch": "pnpm exec vitest --config=vitest.standalone.config.ts --watch",
     "work-types:check": "pnpm exec release-kit work-types check",
     "work-types:sync": "pnpm exec release-kit work-types sync"
   },

--- a/packages/v11y-check/package.json
+++ b/packages/v11y-check/package.json
@@ -38,11 +38,7 @@
     "templates"
   ],
   "scripts": {
-    "prepare": "tsx ../nmr/src/cli-build.ts && tsc --project tsconfig.generate-typings.json",
-    "test": "pnpm exec vitest --config=vitest.standalone.config.ts",
-    "test:coverage": "pnpm exec vitest --config=vitest.standalone.config.ts --coverage",
-    "test:integration": "pnpm exec vitest --config=vitest.integration.config.ts",
-    "test:watch": "pnpm exec vitest --config=vitest.standalone.config.ts --watch"
+    "prepare": "tsx ../nmr/src/cli-build.ts && tsc --project tsconfig.generate-typings.json"
   },
   "dependencies": {
     "@williamthorsen/nmr-core": "workspace:*",


### PR DESCRIPTION
## What

A package can now separate its integration tests from its standalone suite simply by including a `vitest.integration.config.ts` (alongside a `vitest.standalone.config.ts`). The `--int-test` flag that previously enabled this is removed — that config-file pairing is now the only way to activate the separation. In such a package, `test` and `test:coverage` run only the standalone suite and skip integration tests, while a new `test:all` runs both suites together. The separation now holds even when tests run across every package at once, so a full-workspace `test` run still keeps integration tests out of the default suite. Packages that previously hand-copied these test scripts no longer need to.

## Why

The integration test variant could be selected only with the per-invocation `--int-test` flag, which could not thread through the `pnpm --recursive exec nmr` fan-out that `nmr ci` runs — so integration tests could not be kept out of CI's default `test`/`test:coverage` runs, which defeated the variant's purpose. To get the variant at all, two in-repo packages had hand-copied its scripts into their own `package.json`.

## Details

### 🎉 Features

- 🚨 **Breaking:** The `--int-test` flag is removed. A package now activates the integration test variant solely by containing a `vitest.integration.config.ts` (opting in also requires a `vitest.standalone.config.ts`, which the variant's standalone scripts reference). Detection runs per package, so the variant engages under the recursive `nmr ci` fan-out that the flag could never reach.
- Add `test:all` (`pnpm exec vitest`) to the integration variant, running unit and integration tests together in one command.

### ♻️ Refactoring

- Remove the now-redundant `test`, `test:coverage`, `test:integration`, and `test:watch` overrides from `release-kit` and `v11y-check`. Both ship `vitest.integration.config.ts`, so they inherit the identical commands from nmr via auto-activation and additionally gain `test:all`.

### 🧪 Tests

- Add unit coverage for `hasIntegrationTestConfig` and for auto-activation at the resolution layer (config present → integration variant exposing `test:integration` and `test:all`; absent → standard variant with both omitted); update the `resolve-scripts` and `help` tests for the new `test:all` entry and the flag's removal.

Closes #422
