### PR TITLE
#444 Document single-package --force rejection in release-kit prepare

### DIFF
--- a/packages/release-kit/README.md
+++ b/packages/release-kit/README.md
@@ -549,15 +549,15 @@ The first release that ships under the new renderer will produce a one-time nois
 
 Run release preparation with automatic workspace discovery.
 
-| Flag                         | Description                                                                                                                                                  |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--dry-run`                  | Preview changes without writing files                                                                                                                        |
-| `--bump=major\|minor\|patch` | Override the bump type for all workspaces                                                                                                                    |
-| `--set-version=X.Y.Z`        | Set an explicit canonical semver version; bypasses commit-derived bumps. Requires `--only` in monorepo mode (rejected when a `project` block is configured). |
-| `--force`                    | Release even when no commits or no bump-worthy commits exist since the last tag (defaults to patch; combine with `--bump=X` for a different level)           |
-| `--only=name1,name2`         | Only process the named workspaces (monorepo only; rejected when a `project` block is configured)                                                             |
-| `--with-release-notes`       | Write per-workspace release-notes previews under `{workspacePath}/docs/`                                                                                     |
-| `--help`, `-h`               | Show help                                                                                                                                                    |
+| Flag                         | Description                                                                                                                                                                                                                                                             |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--dry-run`                  | Preview changes without writing files                                                                                                                                                                                                                                   |
+| `--bump=major\|minor\|patch` | Override the bump type for all workspaces                                                                                                                                                                                                                               |
+| `--set-version=X.Y.Z`        | Set an explicit canonical semver version; bypasses commit-derived bumps. Requires `--only` in monorepo mode (rejected when a `project` block is configured).                                                                                                            |
+| `--force`                    | Release even when no commits or no bump-worthy commits exist since the last tag. In monorepo/project mode, defaults to patch (combine with `--bump=X` for a different level); in single-package mode, a bare `--force` is rejected — pass `--bump=major\|minor\|patch`. |
+| `--only=name1,name2`         | Only process the named workspaces (monorepo only; rejected when a `project` block is configured)                                                                                                                                                                        |
+| `--with-release-notes`       | Write per-workspace release-notes previews under `{workspacePath}/docs/`                                                                                                                                                                                                |
+| `--help`, `-h`               | Show help                                                                                                                                                                                                                                                               |
 
 Workspace names for `--only` match the package directory name (e.g., `arrays`, `release-kit`).
 

--- a/packages/release-kit/src/__tests__/prepareHelp.unit.test.ts
+++ b/packages/release-kit/src/__tests__/prepareHelp.unit.test.ts
@@ -28,6 +28,14 @@ describe(prepareHelpText, () => {
     const caveats = prepareHelpText.match(/rejected when a 'project' block is configured/g);
     expect(caveats).toHaveLength(2);
   });
+
+  it('documents the single-package --force rejection caveat', () => {
+    expect(prepareHelpText).toContain('single-package mode');
+    // Tie the reject-stem to the caveat's distinctive `bare --force` marker (which appears
+    // nowhere else in the help text), order-independent so an active/passive rewording does
+    // not trip the guard while a dropped caveat still does.
+    expect(prepareHelpText).toMatch(/bare --force[^.]*reject|reject[^.]*bare --force/i);
+  });
 });
 
 describe(showPrepareHelp, () => {

--- a/packages/release-kit/src/help/prepareHelp.ts
+++ b/packages/release-kit/src/help/prepareHelp.ts
@@ -14,8 +14,10 @@ Options:
   --set-version=X.Y.Z   Set an explicit version; bypasses commit-derived bumps.
                          Requires --only in monorepo mode (rejected when a 'project' block is configured).
   --force               Release even when no commits or no bump-worthy commits exist
-                         since the last tag. Defaults to patch when --bump is not given;
-                         use --bump=X to release at a different level.
+                         since the last tag. In monorepo and project mode, defaults to
+                         patch when --bump is not given; use --bump=X for a different
+                         level. In single-package mode, a bare --force is rejected —
+                         pass --bump=major|minor|patch.
   --no-git-checks, -n   Skip the clean-working-tree check
   --only=name1,name2    Only process the named workspaces (comma-separated, monorepo only;
                          rejected when a 'project' block is configured)


### PR DESCRIPTION
## What

The `release-kit prepare` `--force` documentation now correctly describes per-mode behavior: a bare `--force` is rejected in a single-package repo, where an explicit `--bump` level must be passed, while the "defaults to patch" shortcut applies only in monorepo and project mode.

## Why

In single-package mode, `release-kit prepare` rejects a bare `--force` at runtime, but the `--force` help text and README option table described the "defaults to patch" force model — which only monorepo and project mode implement — as if it applied everywhere. Single-package users were promised behavior the command actually refuses, so the documentation contradicted the tool.

## Details

### 🧪 Tests

- Extend the prepare help drift-guard test to assert the help text documents the single-package `--force` caveat. The assertion ties the reject-stem to the caveat's distinctive `bare --force` marker, order-independent, so a benign active/passive rewording does not trip the guard while a dropped caveat still does.

### 📚 Documentation

- Scope the "defaults to patch" claim to monorepo and project mode in both the `--force` help entry and the README `release-kit prepare` option table.
- Document that single-package mode rejects a bare `--force`, directing users to pass `--bump=major|minor|patch`.

Closes #444
