### PR TITLE
#456 Relocate nmr-compile's build cache out of the published dist

### DIFF
--- a/.agents/PROJECT.md
+++ b/.agents/PROJECT.md
@@ -57,7 +57,7 @@ Use `nmr {command}` for all monorepo scripts. Use `pnpm run {script}` only for s
 
 - A single TypeScript compiler-API emit via the nmr-managed `nmr-compile` bin (`packages/nmr/src/commands/build.ts`), the default `compile` script
 - Emits `.js` and `.d.ts` together; AST-based rewriting turns relative `.ts`→`.js` specifiers and tsconfig `paths` aliases into runnable relative `.js` in both outputs
-- `typescript` is a peer dependency (`>=5.7.0`); content-hash caching in `dist/esm/.cache` skips rebuild when sources haven't changed
+- `typescript` is a peer dependency (`>=5.7.0`); content-hash caching under `node_modules/.cache/nmr-compile/` skips rebuild when sources haven't changed
 - Published types are validated by `attw` (the `attw` script, part of `check:strict`)
 - ESM-only output (`type: "module"` in all packages)
 
@@ -75,4 +75,4 @@ Use `nmr {command}` for all monorepo scripts. Use `pnpm run {script}` only for s
 ## Gotchas
 
 - **Bootstrap ordering**: nmr is both a workspace dependency and the script runner. After a fresh clone or if nmr's build output is missing, run `pnpm run bootstrap` from the root before using `nmr` commands.
-- **Build caching**: The content-hash cache (`dist/esm/.cache`) means a rebuild won't run if only non-source files change. Delete the cache file to force a rebuild.
+- **Build caching**: The content-hash cache (under `node_modules/.cache/nmr-compile/`) means a rebuild won't run if only non-source files change. Delete the cache file — or the package's `node_modules` — to force a rebuild.

--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -337,7 +337,7 @@ nmr sync-pnpm-version
 
 ### `nmr-compile`
 
-Compile a single package's `src` tree to `dist/esm` with the TypeScript compiler API, emitting `.js` and `.d.ts` in one pass. Because the compiler parses each source file, every relative import form — static, re-export, dynamic `import()`, and bare side-effect — is rewritten from `.ts` to `.js` in both outputs, and `.ts` occurrences inside strings and comments are left intact. tsconfig `paths` aliases are resolved to runnable relative `.js` specifiers in both outputs, sourced from the package's tsconfig. The build is skipped when no input has changed (a content-and-path hash is cached in `dist/esm/.cache`). This is the default `compile` script — run it from a package directory.
+Compile a single package's `src` tree to `dist/esm` with the TypeScript compiler API, emitting `.js` and `.d.ts` in one pass. Because the compiler parses each source file, every relative import form — static, re-export, dynamic `import()`, and bare side-effect — is rewritten from `.ts` to `.js` in both outputs, and `.ts` occurrences inside strings and comments are left intact. tsconfig `paths` aliases are resolved to runnable relative `.js` specifiers in both outputs, sourced from the package's tsconfig. The build is skipped when no input has changed (a content-and-path hash is cached under `node_modules/.cache/nmr-compile/`, outside the published output). This is the default `compile` script — run it from a package directory.
 
 `typescript` is a peer dependency (`>=5.7.0`, required for `rewriteRelativeImportExtensions`); the consuming repo provides it. Relative imports in source must carry explicit `.ts` extensions for them to be rewritten.
 

--- a/packages/nmr/src/commands/__tests__/build.int.test.ts
+++ b/packages/nmr/src/commands/__tests__/build.int.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import * as ts from 'typescript';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildPackage } from '../build.ts';
+import { buildPackage, resolveBuildCachePath } from '../build.ts';
 
 // Default the compiler API to the real implementation so the regression suite compiles for real;
 // the cache-integrity tests override createProgram per-call to simulate a failing or transient compile.
@@ -35,6 +35,9 @@ function scaffoldPackage(
   extraCompilerOptions: Record<string, unknown> = {},
 ): void {
   fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'fixture', type: 'module' }));
+  // Give the fixture its own node_modules so the build cache resolves inside the temp dir (hermetic,
+  // cleaned up with it) rather than to some ancestor node_modules above the OS temp root.
+  fs.mkdirSync(path.join(dir, 'node_modules'), { recursive: true });
   const tsconfig = {
     ...TSCONFIG,
     compilerOptions: { ...TSCONFIG.compilerOptions, ...extraCompilerOptions },
@@ -60,6 +63,7 @@ function readOutput(dir: string, relativePath: string): string {
 function scaffoldExtendedBasePackage(rootDir: string): string {
   const packageDir = path.join(rootDir, 'pkg');
   fs.mkdirSync(path.join(packageDir, 'src', 'nested'), { recursive: true });
+  fs.mkdirSync(path.join(packageDir, 'node_modules'), { recursive: true });
   fs.writeFileSync(
     path.join(rootDir, 'tsconfig.base.json'),
     JSON.stringify({
@@ -315,12 +319,24 @@ describe('buildPackage caching', () => {
   it('writes a cache file and skips an unchanged rebuild', async () => {
     scaffoldPackage(dir, { 'index.ts': 'export const value = 1;\n' });
     await buildPackage(dir);
-    expect(fs.existsSync(path.join(dir, 'dist', 'esm', '.cache'))).toBe(true);
+    expect(fs.existsSync(resolveBuildCachePath(dir))).toBe(true);
 
     // Only the second (unchanged) build logs "No changes detected"; the first logs "Changes detected".
     await buildPackage(dir);
 
     expect(console.info).toHaveBeenCalledWith(expect.stringContaining('No changes detected'));
+  });
+
+  it('writes the cache under node_modules/.cache/nmr-compile, never inside dist', async () => {
+    scaffoldPackage(dir, { 'index.ts': 'export const value = 1;\n' });
+
+    await buildPackage(dir);
+
+    const cachePath = resolveBuildCachePath(dir);
+    expect(cachePath).toContain(path.join('node_modules', '.cache', 'nmr-compile'));
+    expect(fs.existsSync(cachePath)).toBe(true);
+    // The regression this guards: the digest must not land inside the published dist tree.
+    expect(fs.existsSync(path.join(dir, 'dist', 'esm', '.cache'))).toBe(false);
   });
 
   it('reports the package directory name and 📦 icon when changes are detected', async () => {
@@ -340,7 +356,7 @@ describe('buildPackage caching', () => {
 
     await expect(buildPackage(dir)).rejects.toThrow('compile failed');
 
-    expect(fs.existsSync(path.join(dir, 'dist', 'esm', '.cache'))).toBe(false);
+    expect(fs.existsSync(resolveBuildCachePath(dir))).toBe(false);
   });
 
   it('re-attempts and rebuilds after a transient compile failure instead of skipping', async () => {
@@ -356,13 +372,13 @@ describe('buildPackage caching', () => {
 
     expect(ts.createProgram).toHaveBeenCalledTimes(2);
     expect(fs.existsSync(path.join(dir, 'dist', 'esm', 'index.js'))).toBe(true);
-    expect(fs.existsSync(path.join(dir, 'dist', 'esm', '.cache'))).toBe(true);
+    expect(fs.existsSync(resolveBuildCachePath(dir))).toBe(true);
   });
 
   it('preserves an existing cache when a changed-source rebuild fails', async () => {
     scaffoldPackage(dir, { 'index.ts': 'export const value = 1;\n' });
     await buildPackage(dir);
-    const cachePath = path.join(dir, 'dist', 'esm', '.cache');
+    const cachePath = resolveBuildCachePath(dir);
     const lastGoodDigest = fs.readFileSync(cachePath, 'utf8');
 
     // A changed source forces the rebuild to be attempted rather than skipped; make that rebuild fail.
@@ -379,5 +395,48 @@ describe('buildPackage caching', () => {
     await buildPackage(dir);
     expect(readOutput(dir, 'index.js')).toContain('value = 2');
     expect(fs.readFileSync(cachePath, 'utf8')).not.toBe(lastGoodDigest);
+  });
+});
+
+describe('resolveBuildCachePath', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'nmr-cache-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("places the cache in the package's own node_modules when it has one", () => {
+    const packageDir = path.join(root, 'pkg');
+    fs.mkdirSync(path.join(packageDir, 'node_modules'), { recursive: true });
+
+    expect(path.dirname(resolveBuildCachePath(packageDir))).toBe(
+      path.join(packageDir, 'node_modules', '.cache', 'nmr-compile'),
+    );
+  });
+
+  it('falls back to the nearest ancestor node_modules for a package that has none', () => {
+    // Mirrors a zero-dependency workspace leaf (e.g. nmr-core): with no node_modules of its own, the
+    // cache must resolve to a hoisted ancestor rather than a stray directory beside dist.
+    fs.mkdirSync(path.join(root, 'node_modules'), { recursive: true });
+    const packageDir = path.join(root, 'packages', 'leaf');
+    fs.mkdirSync(packageDir, { recursive: true });
+
+    expect(path.dirname(resolveBuildCachePath(packageDir))).toBe(
+      path.join(root, 'node_modules', '.cache', 'nmr-compile'),
+    );
+  });
+
+  it('derives a stable, package-specific key', () => {
+    const a = path.join(root, 'a');
+    const b = path.join(root, 'b');
+    fs.mkdirSync(path.join(a, 'node_modules'), { recursive: true });
+    fs.mkdirSync(path.join(b, 'node_modules'), { recursive: true });
+
+    expect(resolveBuildCachePath(a)).toBe(resolveBuildCachePath(a));
+    expect(resolveBuildCachePath(a)).not.toBe(resolveBuildCachePath(b));
   });
 });

--- a/packages/nmr/src/commands/build.ts
+++ b/packages/nmr/src/commands/build.ts
@@ -10,7 +10,6 @@ export interface BuildOptions {
   entryGlobs?: string[];
   ignore?: string[];
   outdir?: string;
-  cacheFile?: string;
 }
 
 /** Output-shaping options folded into the build hash so a change to the emit shape busts the cache. */
@@ -26,7 +25,6 @@ const SKIPPED_ICON = '⏭️';
 const DEFAULT_ENTRY_GLOBS = ['src/**/*.ts'];
 const DEFAULT_IGNORE = ['**/__tests__/**'];
 const DEFAULT_OUTDIR = 'dist/esm/';
-const DEFAULT_CACHE_FILE = 'dist/esm/.cache';
 const SOURCE_ROOT = 'src';
 
 const MINIMUM_TYPESCRIPT_MAJOR = 5;
@@ -50,7 +48,7 @@ const JS_EXTENSION = '.js';
 export async function buildPackage(packageDir: string, options: BuildOptions = {}): Promise<void> {
   assertSupportedTypeScript();
 
-  const cacheFile = options.cacheFile ?? DEFAULT_CACHE_FILE;
+  const cachePath = resolveBuildCachePath(packageDir);
   const outdir = options.outdir ?? DEFAULT_OUTDIR;
   const emitConfig: EmitConfig = { outdir, declaration: true, rewriteRelativeImportExtensions: true };
 
@@ -64,7 +62,7 @@ export async function buildPackage(packageDir: string, options: BuildOptions = {
     packageDir,
     [...entryPoints, ...dependencies],
     emitConfig,
-    cacheFile,
+    cachePath,
   );
   if (!changed) {
     return;
@@ -74,7 +72,7 @@ export async function buildPackage(packageDir: string, options: BuildOptions = {
 
   // Persist the digest only after a successful build, so a failed compile cannot poison the cache
   // and cause the next run to skip a never-completed build.
-  await writeBuildCache(packageDir, cacheFile, currentHash);
+  await writeBuildCache(cachePath, currentHash);
 }
 
 /**
@@ -332,6 +330,41 @@ function getModuleSpecifier(node: ts.Node): ts.StringLiteralLike | undefined {
 // region | Cache
 
 /**
+ * Resolves the absolute path of a package's build-cache file. The cache lives under the conventional
+ * `node_modules/.cache/nmr-compile/` home rather than inside `dist`, so it stays git-ignored and is
+ * never swept into a published tarball by any `files` convention. The home is the nearest enclosing
+ * directory that already has a `node_modules` — the package's own when it has one, otherwise a hoisted
+ * ancestor (e.g. the workspace root for a zero-dependency package) — which avoids materializing a
+ * `node_modules` solely to hold the cache. The file name folds a digest of the absolute package path
+ * into a readable base name, so packages sharing a hoisted `node_modules` never collide while the path
+ * stays stable across runs for the same package.
+ */
+export function resolveBuildCachePath(packageDir: string): string {
+  const absolutePackageDir = path.resolve(packageDir);
+  const home = findNearestNodeModulesHost(absolutePackageDir) ?? absolutePackageDir;
+  const digest = createHash('sha256').update(absolutePackageDir).digest('hex').slice(0, 8);
+  const key = `${path.basename(absolutePackageDir)}-${digest}.hash`;
+  return path.join(home, 'node_modules', '.cache', 'nmr-compile', key);
+}
+
+/**
+ * Walks up from `startDir` (inclusive) to the filesystem root, returning the first directory that
+ * contains a `node_modules` entry, or `undefined` when none does.
+ */
+function findNearestNodeModulesHost(startDir: string): string | undefined {
+  let current = startDir;
+  let parent = path.dirname(current);
+  while (!existsSync(path.join(current, 'node_modules'))) {
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+    parent = path.dirname(current);
+  }
+  return current;
+}
+
+/**
  * Compares the current input digest against the cached one, reporting whether the inputs changed
  * and returning the freshly computed digest. Emits the 📦/⏭️ status but performs no write, so the
  * caller can persist the digest only after a successful build.
@@ -340,10 +373,9 @@ async function detectBuildChanges(
   packageDir: string,
   files: string[],
   emitConfig: EmitConfig,
-  cacheFile: string,
+  cachePath: string,
 ): Promise<{ changed: boolean; currentHash: string }> {
   const packageName = path.basename(packageDir);
-  const cachePath = path.join(packageDir, cacheFile);
   const previousHash = existsSync(cachePath) ? readFileSync(cachePath, 'utf8') : undefined;
   const currentHash = await computeBuildHash(packageDir, files, emitConfig);
 
@@ -357,8 +389,7 @@ async function detectBuildChanges(
 }
 
 /** Writes the build digest to the cache file, creating the cache directory if it does not exist. */
-async function writeBuildCache(packageDir: string, cacheFile: string, hash: string): Promise<void> {
-  const cachePath = path.join(packageDir, cacheFile);
+async function writeBuildCache(cachePath: string, hash: string): Promise<void> {
   await mkdir(path.dirname(cachePath), { recursive: true });
   await writeFile(cachePath, hash);
 }


### PR DESCRIPTION
## What

Fixes an issue where packages built with nmr-compile shipped an internal build-cache file inside their published npm tarball.

## Why

The cache lived under `dist/esm/.cache`, which the canonical `files: ["dist"]` publish convention sweeps into every consumer's tarball — leaking internal build state.

## Details

### 🐛 Bug fixes

- Relocated the content-hash cache from `dist/esm/.cache` to `node_modules/.cache/nmr-compile/`, which npm never publishes. Skip-when-unchanged incremental behavior is unchanged.

Closes #456
