### PR TITLE
#458 Replace the raw attw script with an nmr-attw wrapper

### DIFF
--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -133,7 +133,7 @@ These scripts are available out of the box. Repo-wide config (tier 2) and per-pa
 
 | Command         | Runs                                                             |
 | --------------- | ---------------------------------------------------------------- |
-| `attw`          | `attw --pack --profile esm-only`                                 |
+| `attw`          | `nmr-attw`                                                       |
 | `build`         | `compile`                                                        |
 | `check`         | `typecheck`, `fmt:check`, `lint:check`, `test`                   |
 | `check:strict`  | `typecheck`, `fmt:check`, `lint:strict`, `test:coverage`, `attw` |
@@ -343,6 +343,20 @@ Compile a single package's `src` tree to `dist/esm` with the TypeScript compiler
 
 ```bash
 nmr-compile
+```
+
+### `nmr-attw`
+
+Validate a package's published type-resolution surface with [`@arethetypeswrong/cli`](https://github.com/arethetypeswrong/arethetypeswrong.github.io). This is the default `attw` script — run it from a package directory. It wraps attw so that it behaves well across a monorepo:
+
+- **Skips packages with no publishable entry point** (neither `main` nor `exports`) — a message and exit 0, before attw runs. A package with no importable surface has nothing for attw to resolve, so running it would false-positive with `NoResolution`. A private package that _does_ declare `exports` is still checked.
+- **Leaves no `.tgz` in the working tree.** attw analyzes a packed tarball; nmr-attw packs into a temp directory instead of the package directory, so nothing litters the tree.
+- **Condenses output** to a terse per-package result on success and full attw diagnostics only on failure. Pass `--verbose` to print the full attw output on success too.
+
+`@arethetypeswrong/cli` is not bundled — a package that declares an entry point must have it installed; nmr-attw reports an actionable message if it is missing. Any other flags are forwarded to attw (the profile defaults to `esm-only`).
+
+```bash
+nmr-attw
 ```
 
 ### `ensure-prepublish-hooks`

--- a/packages/nmr/bin/nmr-attw.js
+++ b/packages/nmr/bin/nmr-attw.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+try {
+  await import('../dist/esm/cli-attw.js');
+} catch (error) {
+  if (error.code === 'ERR_MODULE_NOT_FOUND') {
+    process.stderr.write('nmr-attw: build output not found — run `pnpm run build` first\n');
+  } else {
+    process.stderr.write(`nmr-attw: failed to load: ${error.message}\n`);
+  }
+  process.exit(1);
+}

--- a/packages/nmr/package.json
+++ b/packages/nmr/package.json
@@ -29,6 +29,7 @@
   "bin": {
     "ensure-prepublish-hooks": "bin/ensure-prepublish-hooks.js",
     "nmr": "bin/nmr.js",
+    "nmr-attw": "bin/nmr-attw.js",
     "nmr-compile": "bin/nmr-compile.js",
     "nmr-report-overrides": "bin/nmr-report-overrides.js",
     "nmr-sync-agent-files": "bin/nmr-sync-agent-files.js",

--- a/packages/nmr/src/__tests__/resolve-scripts.test.ts
+++ b/packages/nmr/src/__tests__/resolve-scripts.test.ts
@@ -24,7 +24,7 @@ describe('getDefaultWorkspaceScripts', () => {
   it('defines attw and includes it in check:strict but not check', () => {
     const scripts = getDefaultWorkspaceScripts(false);
 
-    expect(scripts.attw).toBe('attw --pack --profile esm-only');
+    expect(scripts.attw).toBe('nmr-attw');
     expect(scripts['check:strict']).toContain('attw');
     expect(scripts.check).not.toContain('attw');
   });

--- a/packages/nmr/src/cli-attw.ts
+++ b/packages/nmr/src/cli-attw.ts
@@ -1,0 +1,16 @@
+import { reportError } from '@williamthorsen/nmr-core';
+
+import { runAttw } from './commands/attw.ts';
+
+try {
+  process.exitCode = runAttw({
+    packageDir: process.cwd(),
+    argv: process.argv.slice(2),
+    stdout: process.stdout,
+    stderr: process.stderr,
+    env: process.env,
+  });
+} catch (error) {
+  reportError(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packages/nmr/src/commands/__tests__/attw.int.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.int.test.ts
@@ -1,0 +1,93 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runAttw } from '../attw.ts';
+
+// attw is a root devDependency; skip these when its binary isn't linked (e.g. a bare `vitest` run
+// outside the pnpm-populated PATH) rather than reporting the missing-binary path as a failure.
+const MONOREPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..', '..', '..');
+const ATTW_BIN = path.join(MONOREPO_ROOT, 'node_modules', '.bin', 'attw');
+const attwAvailable = existsSync(ATTW_BIN);
+
+function collect(stream: PassThrough): () => string {
+  let buffer = '';
+  stream.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString('utf8');
+  });
+  return () => buffer;
+}
+
+describe.skipIf(!attwAvailable)('runAttw (integration)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'nmr-attw-int-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writePackage(files: Record<string, string>): void {
+    for (const [name, content] of Object.entries(files)) {
+      writeFileSync(path.join(dir, name), content);
+    }
+  }
+
+  it('passes a well-typed ESM package with a terse line and no leftover tarball', () => {
+    writePackage({
+      'package.json': JSON.stringify({
+        name: 'good-pkg',
+        version: '1.0.0',
+        type: 'module',
+        exports: { '.': { types: './index.d.ts', import: './index.js' } },
+      }),
+      'index.js': 'export const value = 1;\n',
+      'index.d.ts': 'export declare const value: number;\n',
+    });
+    const stdout = new PassThrough();
+    const readOut = collect(stdout);
+
+    const exitCode = runAttw({
+      packageDir: dir,
+      argv: ['--no-definitely-typed'],
+      stdout,
+      stderr: new PassThrough(),
+      env: process.env,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(readOut()).toContain('✓ good-pkg: types OK');
+    expect(readdirSync(dir).some((file) => file.endsWith('.tgz'))).toBe(false);
+  }, 30_000);
+
+  it('fails a package whose types are genuinely wrong, printing diagnostics and no leftover tarball', () => {
+    // The package declares `exports` (so it is not skipped) and ships types, but the ESM entry point
+    // contains CommonJS syntax — a real attw failure (UnexpectedModuleSyntax), distinct both from the
+    // no-entry-point skip case and from "no types"/"missing file", which attw treats as exit 0.
+    writePackage({
+      'package.json': JSON.stringify({
+        name: 'bad-pkg',
+        version: '1.0.0',
+        type: 'module',
+        exports: { '.': { types: './index.d.ts', default: './index.js' } },
+      }),
+      'index.js': 'module.exports.value = 1;\n',
+      'index.d.ts': 'export declare const value: number;\n',
+    });
+    const stdout = new PassThrough();
+    const readOut = collect(stdout);
+    const stderr = new PassThrough();
+    const readErr = collect(stderr);
+
+    const exitCode = runAttw({ packageDir: dir, argv: ['--no-definitely-typed'], stdout, stderr, env: process.env });
+
+    expect(exitCode).not.toBe(0);
+    expect(readOut() + readErr()).not.toBe('');
+    expect(readdirSync(dir).some((file) => file.endsWith('.tgz'))).toBe(false);
+  }, 30_000);
+});

--- a/packages/nmr/src/commands/__tests__/attw.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.test.ts
@@ -1,0 +1,209 @@
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { attwSpawnErrorMessage, buildAttwArgs, formatAttwResult, runAttw, type SpawnSyncFn } from '../attw.ts';
+
+describe(buildAttwArgs, () => {
+  it('appends the default profile when none is supplied', () => {
+    expect(buildAttwArgs([])).toStrictEqual({ verbose: false, attwArgs: ['--profile', 'esm-only'] });
+  });
+
+  it('consumes --verbose without forwarding it', () => {
+    expect(buildAttwArgs(['--verbose'])).toStrictEqual({ verbose: true, attwArgs: ['--profile', 'esm-only'] });
+  });
+
+  it('consumes -v without forwarding it', () => {
+    expect(buildAttwArgs(['-v'])).toStrictEqual({ verbose: true, attwArgs: ['--profile', 'esm-only'] });
+  });
+
+  it('preserves a caller-supplied --profile', () => {
+    expect(buildAttwArgs(['--profile', 'strict'])).toStrictEqual({ verbose: false, attwArgs: ['--profile', 'strict'] });
+  });
+
+  it('preserves a caller-supplied --profile= form', () => {
+    expect(buildAttwArgs(['--profile=strict'])).toStrictEqual({ verbose: false, attwArgs: ['--profile=strict'] });
+  });
+
+  it('forwards unrelated args and appends the default profile', () => {
+    expect(buildAttwArgs(['--ignore-rules', 'cjs-only-exports-default'])).toStrictEqual({
+      verbose: false,
+      attwArgs: ['--ignore-rules', 'cjs-only-exports-default', '--profile', 'esm-only'],
+    });
+  });
+});
+
+describe(formatAttwResult, () => {
+  const base = {
+    label: 'pkg',
+    verbose: false,
+    attwStatus: 0,
+    attwStdout: 'TABLE',
+    attwStderr: '',
+  };
+
+  it('prints a terse confirmation on success', () => {
+    expect(formatAttwResult(base)).toStrictEqual({ status: 0, stdout: '✓ pkg: types OK\n', stderr: '' });
+  });
+
+  it('prints full output on a verbose success', () => {
+    expect(formatAttwResult({ ...base, verbose: true })).toStrictEqual({ status: 0, stdout: 'TABLE', stderr: '' });
+  });
+
+  it('prints full diagnostics on failure', () => {
+    expect(formatAttwResult({ ...base, attwStatus: 1, attwStderr: 'ERR' })).toStrictEqual({
+      status: 1,
+      stdout: 'TABLE',
+      stderr: 'ERR',
+    });
+  });
+
+  it('maps a null exit status to 1', () => {
+    expect(formatAttwResult({ ...base, attwStatus: null, verbose: true }).status).toBe(1);
+  });
+});
+
+describe(attwSpawnErrorMessage, () => {
+  it('returns an install hint when attw is not found (ENOENT)', () => {
+    expect(attwSpawnErrorMessage('pkg', makeMissingBinaryError('spawn attw ENOENT'))).toContain(
+      'install @arethetypeswrong/cli',
+    );
+  });
+
+  it('returns the underlying error for any other spawn failure', () => {
+    expect(attwSpawnErrorMessage('pkg', new Error('boom'))).toContain('boom');
+  });
+});
+
+describe(runAttw, () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'nmr-attw-skip-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('skips a no-entry-point package without invoking attw or leaving a tarball', () => {
+    writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'no-entry', version: '1.0.0' }));
+    const stdout = new PassThrough();
+    let out = '';
+    stdout.on('data', (chunk: Buffer) => {
+      out += chunk.toString('utf8');
+    });
+
+    const exitCode = runAttw({ packageDir: dir, argv: [], stdout, stderr: new PassThrough(), env: process.env });
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain('⛔ no-entry: No publishable entry point (no "main"/"exports"). Skipping attw.');
+    expect(readdirSync(dir).some((file) => file.endsWith('.tgz'))).toBe(false);
+  });
+
+  it('surfaces the underlying error when npm pack fails to spawn', () => {
+    writeEntryPackage(dir);
+
+    const { exitCode, err } = runWithSpawn(
+      dir,
+      makeSpawnStub({ packError: makeMissingBinaryError('spawn npm ENOENT') }),
+    );
+
+    expect(exitCode).toBe(1);
+    expect(err).toContain('spawn npm ENOENT');
+  });
+
+  it('forwards npm pack output on a non-zero pack exit', () => {
+    writeEntryPackage(dir);
+
+    const { exitCode, err } = runWithSpawn(dir, makeSpawnStub({ packStatus: 1 }));
+
+    expect(exitCode).toBe(1);
+    expect(err).toContain('npm ERR! pack failed');
+  });
+
+  it('reports when npm pack produces no tarball', () => {
+    writeEntryPackage(dir);
+
+    const { exitCode, err } = runWithSpawn(dir, makeSpawnStub({ writeTarball: false }));
+
+    expect(exitCode).toBe(1);
+    expect(err).toContain('produced no tarball');
+  });
+
+  it('emits the install hint when the attw binary is missing', () => {
+    writeEntryPackage(dir);
+
+    const { exitCode, err } = runWithSpawn(
+      dir,
+      makeSpawnStub({ attwError: makeMissingBinaryError('spawn attw ENOENT') }),
+    );
+
+    expect(exitCode).toBe(1);
+    expect(err).toContain('install @arethetypeswrong/cli');
+  });
+});
+
+// region | Helpers
+
+/** Accumulates everything written to `stream` and returns a getter for the text captured so far. */
+function collectStream(stream: PassThrough): () => string {
+  let buffer = '';
+  stream.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString('utf8');
+  });
+  return () => buffer;
+}
+
+/** Builds an Error carrying `code: 'ENOENT'`, mimicking `spawnSync`'s result when a command binary can't be found. */
+function makeMissingBinaryError(message: string): Error {
+  return Object.assign(new Error(message), { code: 'ENOENT' });
+}
+
+/**
+ * Builds a call-aware `spawnSync` stub that routes `npm` and `attw` invocations to canned results, so the wrapper's
+ * subprocess-error branches run without a real subprocess. A successful `npm pack` writes a stand-in tarball into
+ * `--pack-destination` so the flow reaches the attw step.
+ */
+function makeSpawnStub(config: {
+  packError?: Error;
+  packStatus?: number;
+  writeTarball?: boolean;
+  attwError?: Error;
+  attwStatus?: number;
+}): SpawnSyncFn {
+  return (command, args) => {
+    if (command === 'npm') {
+      if (config.packError) return { error: config.packError, status: null, stdout: '', stderr: '' };
+      const status = config.packStatus ?? 0;
+      if (status === 0 && (config.writeTarball ?? true)) {
+        const dest = args[args.indexOf('--pack-destination') + 1];
+        if (dest !== undefined) writeFileSync(path.join(dest, 'pkg-1.0.0.tgz'), '');
+      }
+      return { status, stdout: '', stderr: status === 0 ? '' : 'npm ERR! pack failed' };
+    }
+    if (config.attwError) return { error: config.attwError, status: null, stdout: '', stderr: '' };
+    return { status: config.attwStatus ?? 0, stdout: '', stderr: '' };
+  };
+}
+
+/** Writes a minimal `package.json` declaring an `exports` entry point into `dir`, so `runAttw` clears the skip guard. */
+function writeEntryPackage(dir: string): void {
+  writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: 'p', version: '1.0.0', exports: { '.': './index.js' } }),
+  );
+}
+
+/** Runs `runAttw` against `dir` with an injected `spawn`, capturing stderr; returns the exit code and error text. */
+function runWithSpawn(dir: string, spawn: SpawnSyncFn): { exitCode: number; err: string } {
+  const stderr = new PassThrough();
+  const readErr = collectStream(stderr);
+  const exitCode = runAttw({ packageDir: dir, argv: [], stdout: new PassThrough(), stderr, env: process.env, spawn });
+  return { exitCode, err: readErr() };
+}
+
+// endregion | Helpers

--- a/packages/nmr/src/commands/attw.ts
+++ b/packages/nmr/src/commands/attw.ts
@@ -1,0 +1,163 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { Writable } from 'node:stream';
+
+import { hasPublishableEntryPoint, readPackageJson } from '../helpers/package-json.ts';
+
+const DEFAULT_PROFILE = 'esm-only';
+
+/**
+ * The `spawnSync` surface the wrapper depends on, narrowed to a single signature
+ * so a test can inject a stub in place of the real `npm`/`attw` subprocesses.
+ */
+export type SpawnSyncFn = (
+  command: string,
+  args: string[],
+  options: { cwd: string; encoding: 'utf8'; env: NodeJS.ProcessEnv },
+) => Pick<SpawnSyncReturns<string>, 'error' | 'status' | 'stdout' | 'stderr'>;
+
+/** @internal */
+export interface RunAttwOptions {
+  /** Directory of the workspace package to check. */
+  packageDir: string;
+  /** Post-command CLI args, forwarded to attw. `--verbose`/`-v` is consumed here. */
+  argv: string[];
+  /** Stream for normal output (skip notice, terse confirmation, attw diagnostics). */
+  stdout: Writable;
+  /** Stream for error output (pack failures, missing-binary hint). */
+  stderr: Writable;
+  /** Environment for the `npm pack` and `attw` subprocesses. */
+  env: NodeJS.ProcessEnv;
+  /** Subprocess runner, defaulting to `spawnSync`; injected in tests. */
+  spawn?: SpawnSyncFn;
+}
+
+/**
+ * Runs `attw` against a workspace package's packed contents, but only when the
+ * package declares a publishable entry point. Packs into an isolated temp dir so
+ * no `.tgz` ever lands in the working tree, and condenses attw's output to a terse
+ * per-package result on success, full diagnostics on failure.
+ *
+ * Returns the exit code: 0 for a skipped or passing package, attw's own code on a
+ * finding, and 1 for a pack failure or a missing attw binary.
+ */
+export function runAttw(options: RunAttwOptions): number {
+  const { packageDir, argv, stdout, stderr, env } = options;
+  const spawn: SpawnSyncFn = options.spawn ?? ((command, args, spawnOptions) => spawnSync(command, args, spawnOptions));
+
+  const pkg = readPackageJson(packageDir);
+  const label = pkg.name ?? path.basename(packageDir);
+
+  if (!hasPublishableEntryPoint(pkg)) {
+    stdout.write(`⛔ ${label}: No publishable entry point (no "main"/"exports"). Skipping attw.\n`);
+    return 0;
+  }
+
+  const { verbose, attwArgs } = buildAttwArgs(argv);
+
+  // Pack into a throwaway temp dir rather than letting `attw --pack` write the
+  // tarball into the package dir, whose only cleanup is on attw's happy path.
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'nmr-attw-'));
+  try {
+    const pack = spawn('npm', ['pack', '--pack-destination', tempDir], { cwd: packageDir, encoding: 'utf8', env });
+    if (pack.error !== undefined) {
+      stderr.write(`nmr-attw: npm pack failed for ${label}: ${pack.error.message}\n`);
+      return 1;
+    }
+    if (pack.status !== 0) {
+      stderr.write(pack.stderr || `nmr-attw: npm pack failed for ${label}\n`);
+      return pack.status ?? 1;
+    }
+
+    const tarball = readdirSync(tempDir).find((file) => file.endsWith('.tgz'));
+    if (tarball === undefined) {
+      stderr.write(`nmr-attw: npm pack produced no tarball for ${label}\n`);
+      return 1;
+    }
+
+    const attw = spawn('attw', [path.join(tempDir, tarball), ...attwArgs], {
+      cwd: packageDir,
+      encoding: 'utf8',
+      env,
+    });
+    if (attw.error !== undefined) {
+      stderr.write(attwSpawnErrorMessage(label, attw.error));
+      return 1;
+    }
+
+    const outcome = formatAttwResult({
+      label,
+      verbose,
+      attwStatus: attw.status,
+      attwStdout: attw.stdout,
+      attwStderr: attw.stderr,
+    });
+    if (outcome.stdout) stdout.write(outcome.stdout);
+    if (outcome.stderr) stderr.write(outcome.stderr);
+    return outcome.status;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Splits post-command args into the wrapper's own `--verbose`/`-v` flag and the
+ * args forwarded to attw, appending the default `--profile` when the caller
+ * supplied none.
+ */
+export function buildAttwArgs(argv: string[]): { verbose: boolean; attwArgs: string[] } {
+  let verbose = false;
+  const attwArgs: string[] = [];
+  for (const arg of argv) {
+    if (arg === '--verbose' || arg === '-v') {
+      verbose = true;
+      continue;
+    }
+    attwArgs.push(arg);
+  }
+  if (!attwArgs.some((arg) => arg === '--profile' || arg.startsWith('--profile='))) {
+    attwArgs.push('--profile', DEFAULT_PROFILE);
+  }
+  return { verbose, attwArgs };
+}
+
+interface AttwOutcome {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Decides what the wrapper writes and returns from attw's captured result: full
+ * diagnostics on failure, and a terse confirmation on success unless `--verbose`.
+ */
+export function formatAttwResult(params: {
+  label: string;
+  verbose: boolean;
+  attwStatus: number | null;
+  attwStdout: string;
+  attwStderr: string;
+}): AttwOutcome {
+  const { label, verbose, attwStatus, attwStdout, attwStderr } = params;
+
+  const status = attwStatus ?? 1;
+  if (status === 0 && !verbose) {
+    return { status: 0, stdout: `✓ ${label}: types OK\n`, stderr: '' };
+  }
+  return { status, stdout: attwStdout, stderr: attwStderr };
+}
+
+/**
+ * Builds the message for a failed attw spawn: an actionable install hint when the
+ * binary is missing (`ENOENT`), otherwise the underlying spawn error. A missing
+ * binary means a package that *does* declare an entry point can't be validated —
+ * `@arethetypeswrong/cli` isn't installed.
+ */
+export function attwSpawnErrorMessage(label: string, error: Error): string {
+  if ('code' in error && error.code === 'ENOENT') {
+    return `⚠ ${label}: attw not found — install @arethetypeswrong/cli to validate published types.\n`;
+  }
+  return `nmr-attw: failed to run attw for ${label}: ${error.message}\n`;
+}

--- a/packages/nmr/src/default-scripts.ts
+++ b/packages/nmr/src/default-scripts.ts
@@ -5,7 +5,7 @@ export type ScriptRegistry = Record<string, ScriptValue>;
  * Workspace scripts shared by all test configurations.
  */
 export const commonWorkspaceScripts: ScriptRegistry = {
-  attw: 'attw --pack --profile esm-only',
+  attw: 'nmr-attw',
   build: ['compile'],
   check: ['typecheck', 'fmt:check', 'lint:check', 'test'],
   'check:strict': ['typecheck', 'fmt:check', 'lint:strict', 'test:coverage', 'attw'],

--- a/packages/nmr/src/helpers/__tests__/package-json.test.ts
+++ b/packages/nmr/src/helpers/__tests__/package-json.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { hasPublishableEntryPoint, readPackageJson } from '../package-json.ts';
+
+describe(hasPublishableEntryPoint, () => {
+  it('returns false when neither main nor exports is declared', () => {
+    expect(hasPublishableEntryPoint({})).toBe(false);
+  });
+
+  it('returns true when only main is declared', () => {
+    expect(hasPublishableEntryPoint({ main: './index.js' })).toBe(true);
+  });
+
+  it('returns true when exports is declared as an object', () => {
+    expect(hasPublishableEntryPoint({ exports: { '.': './index.js' } })).toBe(true);
+  });
+
+  it('returns true when exports is declared as a string', () => {
+    expect(hasPublishableEntryPoint({ exports: './index.js' })).toBe(true);
+  });
+
+  it('returns true when both main and exports are declared', () => {
+    expect(hasPublishableEntryPoint({ main: './index.js', exports: { '.': './index.js' } })).toBe(true);
+  });
+});
+
+describe(readPackageJson, () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'nmr-pkgjson-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('parses main and exports fields', () => {
+    writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name: 'p', main: './index.js', exports: { '.': './index.js' } }),
+    );
+
+    const pkg = readPackageJson(dir);
+
+    expect(pkg.main).toBe('./index.js');
+    expect(pkg.exports).toStrictEqual({ '.': './index.js' });
+    expect(hasPublishableEntryPoint(pkg)).toBe(true);
+  });
+
+  it('reports no entry point for a bin-only package', () => {
+    writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'p', bin: { p: './cli.js' } }));
+
+    expect(hasPublishableEntryPoint(readPackageJson(dir))).toBe(false);
+  });
+});

--- a/packages/nmr/src/helpers/package-json.ts
+++ b/packages/nmr/src/helpers/package-json.ts
@@ -8,6 +8,8 @@ export interface PackageJson {
   private?: boolean;
   version?: string;
   packageManager?: string;
+  main?: string;
+  exports?: unknown;
   scripts?: Record<string, string>;
   pnpm?: { overrides?: Record<string, string> };
 }
@@ -30,6 +32,8 @@ export function readPackageJson(dir: string): PackageJson {
   if (parsed.private === true) pkg.private = true;
   if (typeof parsed.version === 'string') pkg.version = parsed.version;
   if (typeof parsed.packageManager === 'string') pkg.packageManager = parsed.packageManager;
+  if (typeof parsed.main === 'string') pkg.main = parsed.main;
+  if (parsed.exports !== undefined) pkg.exports = parsed.exports;
   if (isObject(parsed.scripts)) {
     const scripts: Record<string, string> = {};
     for (const [key, val] of Object.entries(parsed.scripts)) {
@@ -49,6 +53,15 @@ export function readPackageJson(dir: string): PackageJson {
   }
 
   return pkg;
+}
+
+/**
+ * Reports whether a package declares a publishable entry point — a `main` or an
+ * `exports` field. A package with neither has no importable surface for attw to
+ * resolve (a `bin`-only package included), so attw would false-positive on it.
+ */
+export function hasPublishableEntryPoint(pkg: PackageJson): boolean {
+  return pkg.main !== undefined || pkg.exports !== undefined;
 }
 
 /**


### PR DESCRIPTION
## What

Fixes the issues that made the default `nmr attw` check fail across monorepos:

- packages with no published API failed with a false `NoResolution` error;
- the check left stray `.tgz` files in the working tree ;
- output was a verbose per-package table; now output is terse on success, full diagnostics only on failure (`--verbose` to force full output);
- a missing `@arethetypeswrong/cli` gave a raw command-not-found; now a hint is given.

## Why

Across consuming monorepos, `nmr attw` failed on any package with no published API — private scripts, config, internal bundles — breaking the standard `check:strict` and `ci` flow in nearly every repo and forcing per-package workarounds. The check also required `@arethetypeswrong/cli` even where nothing needed validating, buried its signal in a per-package table across the recursive fan-out, and left `.tgz` files scattered in the working tree. These are integration defects in how nmr wired attw in, not flaws in attw itself.

## Details

### 🐛 Bug fixes

- Packages that declare neither `main` nor `exports` are skipped with a message and a clean exit instead of failing as unresolvable; a private package that declares `exports` is still checked, and a `bin`-only package (no importable surface) is skipped.
- The check packs into an isolated temporary directory rather than the package directory, so no `.tgz` is left in the working tree — on success, failure, or interrupt.
- Output is condensed to a terse per-package result on success and full diagnostics only on failure; `--verbose` forces full output on success.
- A package that declares an entry point but has no `attw` binary installed receives an actionable install hint instead of a raw command-not-found.

### 📝 Documentation

- The nmr README documents the `nmr-attw` behavior — the entry-point skip, tarball isolation, condensed output, `--verbose`, and the missing-binary hint — and reflects the updated default `attw` script.

### 🧪 Tests

- Unit tests cover the skip path, argument handling, output formatting, the missing-binary hint, and the subprocess-error branches (pack spawn failure, non-zero pack exit, and no-tarball) via an injected spawn seam; integration tests exercise the real pack-and-check flow for a well-typed and a genuinely mistyped package, each asserting the working tree stays clean afterward.

Closes #458
