### PR TITLE
#462 Condense nmr-attw failure output into an actionable summary

### DIFF
--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -351,9 +351,9 @@ Validate a package's published type-resolution surface with [`@arethetypeswrong/
 
 - **Skips packages with no publishable entry point** (neither `main` nor `exports`) — a message and exit 0, before attw runs. A package with no importable surface has nothing for attw to resolve, so running it would false-positive with `NoResolution`. A private package that _does_ declare `exports` is still checked.
 - **Leaves no `.tgz` in the working tree.** attw analyzes a packed tarball; nmr-attw packs into a temp directory instead of the package directory, so nothing litters the tree.
-- **Condenses output.** On success, a terse per-package confirmation; on failure, a per-package verdict naming the problem kind with a concrete fix hint, driven by attw's machine-readable (`--format json`) output and matching attw's own pass/fail verdict. Pass `--verbose` to print attw's full diagnostics instead — on success and failure alike.
+- **Condenses output.** On success, a terse per-package confirmation; on failure, a per-package verdict naming the problem kind with a concrete fix hint, driven by attw's machine-readable (`--format json`) output and matching attw's own pass/fail verdict. Every condensed failure closes with a pointer to `--verbose`, which prints attw's full diagnostics instead — on success and failure alike.
 
-`@arethetypeswrong/cli` is not bundled — a package that declares an entry point must have it installed; nmr-attw reports an actionable message if it is missing. Any other flags are forwarded to attw (the profile defaults to `esm-only`).
+`@arethetypeswrong/cli` is not bundled — a package that declares an entry point must have it installed; nmr-attw reports an actionable message if it is missing. Any other flags are forwarded to attw (the profile defaults to `esm-only`). Supplying `--format` yourself turns off condensing and prints attw's output in the format you asked for, since the wrapper can only condense the machine-readable form it selects itself.
 
 ```bash
 nmr-attw

--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -351,7 +351,7 @@ Validate a package's published type-resolution surface with [`@arethetypeswrong/
 
 - **Skips packages with no publishable entry point** (neither `main` nor `exports`) — a message and exit 0, before attw runs. A package with no importable surface has nothing for attw to resolve, so running it would false-positive with `NoResolution`. A private package that _does_ declare `exports` is still checked.
 - **Leaves no `.tgz` in the working tree.** attw analyzes a packed tarball; nmr-attw packs into a temp directory instead of the package directory, so nothing litters the tree.
-- **Condenses output** to a terse per-package result on success and full attw diagnostics only on failure. Pass `--verbose` to print the full attw output on success too.
+- **Condenses output.** On success, a terse per-package confirmation; on failure, a per-package verdict naming the problem kind with a concrete fix hint, driven by attw's machine-readable (`--format json`) output and matching attw's own pass/fail verdict. Pass `--verbose` to print attw's full diagnostics instead — on success and failure alike.
 
 `@arethetypeswrong/cli` is not bundled — a package that declares an entry point must have it installed; nmr-attw reports an actionable message if it is missing. Any other flags are forwarded to attw (the profile defaults to `esm-only`).
 

--- a/packages/nmr/src/commands/__tests__/attw.int.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.int.test.ts
@@ -65,10 +65,10 @@ describe.skipIf(!attwAvailable)('runAttw (integration)', () => {
     expect(readdirSync(dir).some((file) => file.endsWith('.tgz'))).toBe(false);
   }, 30_000);
 
-  it('fails a package whose types are genuinely wrong, printing diagnostics and no leftover tarball', () => {
-    // The package declares `exports` (so it is not skipped) and ships types, but the ESM entry point
-    // contains CommonJS syntax — a real attw failure (UnexpectedModuleSyntax), distinct both from the
-    // no-entry-point skip case and from "no types"/"missing file", which attw treats as exit 0.
+  // The package declares `exports` (so it is not skipped) and ships types, but the ESM entry point
+  // contains CommonJS syntax — a real attw failure, distinct both from the no-entry-point skip case
+  // and from "no types"/"missing file", which attw treats as exit 0.
+  function writeBadPackage(): void {
     writePackage({
       'package.json': JSON.stringify({
         name: 'bad-pkg',
@@ -79,15 +79,51 @@ describe.skipIf(!attwAvailable)('runAttw (integration)', () => {
       'index.js': 'module.exports.value = 1;\n',
       'index.d.ts': 'export declare const value: number;\n',
     });
+  }
+
+  it('condenses a genuine failure to a terse verdict pointing at --verbose, with no leftover tarball', () => {
+    writeBadPackage();
+    const stdout = new PassThrough();
+    const readOut = collect(stdout);
+
+    const exitCode = runAttw({
+      packageDir: dir,
+      argv: ['--no-definitely-typed'],
+      stdout,
+      stderr: new PassThrough(),
+      env: process.env,
+    });
+
+    const out = readOut();
+    expect(exitCode).not.toBe(0);
+    expect(out).toContain('✗ bad-pkg');
+    expect(out).toContain('nmr attw --verbose');
+    // The condensed verdict must not dump attw's raw JSON or its full per-subpath firehose.
+    expect(out).not.toContain('"analysis"');
+    expect(out.trim().split('\n').length).toBeLessThanOrEqual(8);
+    expect(readdirSync(dir).some((file) => file.endsWith('.tgz'))).toBe(false);
+  }, 30_000);
+
+  it('passes attw full diagnostics through unchanged under --verbose', () => {
+    writeBadPackage();
     const stdout = new PassThrough();
     const readOut = collect(stdout);
     const stderr = new PassThrough();
     const readErr = collect(stderr);
 
-    const exitCode = runAttw({ packageDir: dir, argv: ['--no-definitely-typed'], stdout, stderr, env: process.env });
+    const exitCode = runAttw({
+      packageDir: dir,
+      argv: ['--no-definitely-typed', '--verbose'],
+      stdout,
+      stderr,
+      env: process.env,
+    });
 
+    const out = readOut() + readErr();
     expect(exitCode).not.toBe(0);
-    expect(readOut() + readErr()).not.toBe('');
-    expect(readdirSync(dir).some((file) => file.endsWith('.tgz'))).toBe(false);
+    expect(out).toContain('bad-pkg');
+    // Raw attw output, not the wrapper's condensed verdict.
+    expect(out).not.toContain('✗ bad-pkg —');
+    expect(out).not.toContain('nmr attw --verbose');
   }, 30_000);
 });

--- a/packages/nmr/src/commands/__tests__/attw.int.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.int.test.ts
@@ -38,6 +38,36 @@ describe.skipIf(!attwAvailable)('runAttw (integration)', () => {
     }
   }
 
+  /**
+   * Writes a package of `entryPointCount` entry points, each shipping types alongside an ESM entry point
+   * whose body is CommonJS — a real attw failure on every entry point. attw's JSON carries the full
+   * resolution tree per entry point, so the payload grows ~18 KB per entry point.
+   */
+  function writeFailingPackage(name: string, entryPointCount: number): void {
+    const exports: Record<string, { types: string; default: string }> = {};
+    const files: Record<string, string> = {};
+    for (let index = 0; index < entryPointCount; index += 1) {
+      const subpath = index === 0 ? '.' : `./e${index}`;
+      const base = index === 0 ? 'index' : `e${index}`;
+      exports[subpath] = { types: `./${base}.d.ts`, default: `./${base}.js` };
+      files[`${base}.js`] = 'module.exports.value = 1;\n';
+      files[`${base}.d.ts`] = 'export declare const value: number;\n';
+    }
+    writePackage({
+      'package.json': JSON.stringify({ name, version: '1.0.0', type: 'module', exports }),
+      ...files,
+    });
+  }
+
+  function run(argv: string[]): { exitCode: number; out: string; err: string } {
+    const stdout = new PassThrough();
+    const readOut = collect(stdout);
+    const stderr = new PassThrough();
+    const readErr = collect(stderr);
+    const exitCode = runAttw({ packageDir: dir, argv, stdout, stderr, env: process.env });
+    return { exitCode, out: readOut(), err: readErr() };
+  }
+
   it('passes a well-typed ESM package with a terse line and no leftover tarball', () => {
     writePackage({
       'package.json': JSON.stringify({
@@ -49,81 +79,62 @@ describe.skipIf(!attwAvailable)('runAttw (integration)', () => {
       'index.js': 'export const value = 1;\n',
       'index.d.ts': 'export declare const value: number;\n',
     });
-    const stdout = new PassThrough();
-    const readOut = collect(stdout);
 
-    const exitCode = runAttw({
-      packageDir: dir,
-      argv: ['--no-definitely-typed'],
-      stdout,
-      stderr: new PassThrough(),
-      env: process.env,
-    });
+    const { exitCode, out } = run(['--no-definitely-typed']);
 
     expect(exitCode).toBe(0);
-    expect(readOut()).toContain('✓ good-pkg: types OK');
+    expect(out).toContain('✓ good-pkg: types OK');
     expect(readdirSync(dir).some((file) => file.endsWith('.tgz'))).toBe(false);
   }, 30_000);
 
-  // The package declares `exports` (so it is not skipped) and ships types, but the ESM entry point
-  // contains CommonJS syntax — a real attw failure, distinct both from the no-entry-point skip case
-  // and from "no types"/"missing file", which attw treats as exit 0.
-  function writeBadPackage(): void {
-    writePackage({
-      'package.json': JSON.stringify({
-        name: 'bad-pkg',
-        version: '1.0.0',
-        type: 'module',
-        exports: { '.': { types: './index.d.ts', default: './index.js' } },
-      }),
-      'index.js': 'module.exports.value = 1;\n',
-      'index.d.ts': 'export declare const value: number;\n',
-    });
-  }
-
   it('condenses a genuine failure to a terse verdict pointing at --verbose, with no leftover tarball', () => {
-    writeBadPackage();
-    const stdout = new PassThrough();
-    const readOut = collect(stdout);
+    writeFailingPackage('bad-pkg', 1);
 
-    const exitCode = runAttw({
-      packageDir: dir,
-      argv: ['--no-definitely-typed'],
-      stdout,
-      stderr: new PassThrough(),
-      env: process.env,
-    });
+    const { exitCode, out } = run(['--no-definitely-typed']);
 
-    const out = readOut();
     expect(exitCode).not.toBe(0);
-    expect(out).toContain('✗ bad-pkg');
-    expect(out).toContain('nmr attw --verbose');
+    expect(out).toContain('✗ bad-pkg —');
+    expect(out).toContain('Run `nmr attw --verbose`');
     // The condensed verdict must not dump attw's raw JSON or its full per-subpath firehose.
     expect(out).not.toContain('"analysis"');
     expect(out.trim().split('\n').length).toBeLessThanOrEqual(8);
     expect(readdirSync(dir).some((file) => file.endsWith('.tgz'))).toBe(false);
   }, 30_000);
 
-  it('passes attw full diagnostics through unchanged under --verbose', () => {
-    writeBadPackage();
-    const stdout = new PassThrough();
-    const readOut = collect(stdout);
-    const stderr = new PassThrough();
-    const readErr = collect(stderr);
+  it('condenses a package whose JSON exceeds the 64 KiB pipe capacity', () => {
+    // attw's JSON branch exits via process.exit(), which truncates an async pipe write at 64 KiB. Five
+    // entry points put the payload well past that, so a piped stdout would arrive unparseable and the
+    // verdict would silently collapse to the generic fallback.
+    writeFailingPackage('big-pkg', 5);
 
-    const exitCode = runAttw({
-      packageDir: dir,
-      argv: ['--no-definitely-typed', '--verbose'],
-      stdout,
-      stderr,
-      env: process.env,
-    });
+    const { exitCode, out } = run(['--no-definitely-typed']);
 
-    const out = readOut() + readErr();
     expect(exitCode).not.toBe(0);
-    expect(out).toContain('bad-pkg');
+    expect(out).toContain('✗ big-pkg —');
+    expect(out).not.toContain('attw reported problems');
+  }, 60_000);
+
+  it('passes attw full diagnostics through unchanged under --verbose', () => {
+    writeFailingPackage('bad-pkg', 1);
+
+    const { exitCode, out, err } = run(['--no-definitely-typed', '--verbose']);
+
+    const combined = out + err;
+    expect(exitCode).not.toBe(0);
+    expect(combined).toContain('bad-pkg');
     // Raw attw output, not the wrapper's condensed verdict.
+    expect(combined).not.toContain('✗ bad-pkg —');
+    expect(combined).not.toContain('Run `nmr attw --verbose`');
+  }, 30_000);
+
+  it('passes attw output through unchanged when the caller chooses the format', () => {
+    writeFailingPackage('bad-pkg', 1);
+
+    const { exitCode, out } = run(['--no-definitely-typed', '--format', 'json']);
+
+    expect(exitCode).not.toBe(0);
+    // The caller asked attw for JSON, so they get attw's JSON — not the wrapper's condensed verdict.
+    expect(out).toContain('"analysis"');
     expect(out).not.toContain('✗ bad-pkg —');
-    expect(out).not.toContain('nmr attw --verbose');
   }, 30_000);
 });

--- a/packages/nmr/src/commands/__tests__/attw.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.test.ts
@@ -8,30 +8,51 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { attwSpawnErrorMessage, buildAttwArgs, formatAttwResult, runAttw, type SpawnSyncFn } from '../attw.ts';
 
 describe(buildAttwArgs, () => {
-  it('appends the default profile when none is supplied', () => {
-    expect(buildAttwArgs([])).toStrictEqual({ verbose: false, attwArgs: ['--profile', 'esm-only'] });
+  it('appends the default profile and requests JSON when nothing is supplied', () => {
+    expect(buildAttwArgs([])).toStrictEqual({
+      verbose: false,
+      profile: 'esm-only',
+      attwArgs: ['--profile', 'esm-only', '--format', 'json'],
+    });
   });
 
-  it('consumes --verbose without forwarding it', () => {
-    expect(buildAttwArgs(['--verbose'])).toStrictEqual({ verbose: true, attwArgs: ['--profile', 'esm-only'] });
+  it('consumes --verbose without forwarding it and omits --format json', () => {
+    expect(buildAttwArgs(['--verbose'])).toStrictEqual({
+      verbose: true,
+      profile: 'esm-only',
+      attwArgs: ['--profile', 'esm-only'],
+    });
   });
 
-  it('consumes -v without forwarding it', () => {
-    expect(buildAttwArgs(['-v'])).toStrictEqual({ verbose: true, attwArgs: ['--profile', 'esm-only'] });
+  it('consumes -v without forwarding it and omits --format json', () => {
+    expect(buildAttwArgs(['-v'])).toStrictEqual({
+      verbose: true,
+      profile: 'esm-only',
+      attwArgs: ['--profile', 'esm-only'],
+    });
   });
 
-  it('preserves a caller-supplied --profile', () => {
-    expect(buildAttwArgs(['--profile', 'strict'])).toStrictEqual({ verbose: false, attwArgs: ['--profile', 'strict'] });
+  it('preserves a caller-supplied --profile and reports it', () => {
+    expect(buildAttwArgs(['--profile', 'strict'])).toStrictEqual({
+      verbose: false,
+      profile: 'strict',
+      attwArgs: ['--profile', 'strict', '--format', 'json'],
+    });
   });
 
-  it('preserves a caller-supplied --profile= form', () => {
-    expect(buildAttwArgs(['--profile=strict'])).toStrictEqual({ verbose: false, attwArgs: ['--profile=strict'] });
+  it('preserves a caller-supplied --profile= form and reports it', () => {
+    expect(buildAttwArgs(['--profile=strict'])).toStrictEqual({
+      verbose: false,
+      profile: 'strict',
+      attwArgs: ['--profile=strict', '--format', 'json'],
+    });
   });
 
   it('forwards unrelated args and appends the default profile', () => {
     expect(buildAttwArgs(['--ignore-rules', 'cjs-only-exports-default'])).toStrictEqual({
       verbose: false,
-      attwArgs: ['--ignore-rules', 'cjs-only-exports-default', '--profile', 'esm-only'],
+      profile: 'esm-only',
+      attwArgs: ['--ignore-rules', 'cjs-only-exports-default', '--profile', 'esm-only', '--format', 'json'],
     });
   });
 });
@@ -44,17 +65,18 @@ describe(formatAttwResult, () => {
     attwStdout: 'TABLE',
     attwStderr: '',
   };
+  const esmOnlyIgnored = ['node10', 'node16-cjs'];
 
   it('prints a terse confirmation on success', () => {
     expect(formatAttwResult(base)).toStrictEqual({ status: 0, stdout: '✓ pkg: types OK\n', stderr: '' });
   });
 
-  it('prints full output on a verbose success', () => {
+  it('passes attw output through unchanged on a verbose success', () => {
     expect(formatAttwResult({ ...base, verbose: true })).toStrictEqual({ status: 0, stdout: 'TABLE', stderr: '' });
   });
 
-  it('prints full diagnostics on failure', () => {
-    expect(formatAttwResult({ ...base, attwStatus: 1, attwStderr: 'ERR' })).toStrictEqual({
+  it('passes attw diagnostics through unchanged on a verbose failure', () => {
+    expect(formatAttwResult({ ...base, verbose: true, attwStatus: 1, attwStderr: 'ERR' })).toStrictEqual({
       status: 1,
       stdout: 'TABLE',
       stderr: 'ERR',
@@ -63,6 +85,81 @@ describe(formatAttwResult, () => {
 
   it('maps a null exit status to 1', () => {
     expect(formatAttwResult({ ...base, attwStatus: null, verbose: true }).status).toBe(1);
+  });
+
+  it('renders a condensed verdict with a fix hint on a JSON failure', () => {
+    const result = formatAttwResult({
+      ...base,
+      attwStatus: 1,
+      attwStdout: attwJson([{ kind: 'FallbackCondition', entrypoint: '.', resolutionKind: 'node16-esm' }]),
+      ignoredResolutions: esmOnlyIgnored,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('✗ pkg — types resolve via a fallback condition (1 entry point)');
+    expect(result.stdout).toContain('Fix: in package.json "exports", put "types" before "import"');
+    expect(result.stderr).toBe('');
+  });
+
+  it('collapses a kind repeated across subpaths into an entry-point count', () => {
+    const result = formatAttwResult({
+      ...base,
+      attwStatus: 1,
+      attwStdout: attwJson([
+        { kind: 'FallbackCondition', entrypoint: '.', resolutionKind: 'node16-esm' },
+        { kind: 'FallbackCondition', entrypoint: './sub', resolutionKind: 'node16-esm' },
+      ]),
+      ignoredResolutions: esmOnlyIgnored,
+    });
+
+    expect(result.stdout).toContain('(2 entry points)');
+  });
+
+  it('drops problems on resolutions the profile ignores', () => {
+    const result = formatAttwResult({
+      ...base,
+      attwStatus: 1,
+      attwStdout: attwJson([
+        { kind: 'FallbackCondition', entrypoint: '.', resolutionKind: 'node10' },
+        { kind: 'FallbackCondition', entrypoint: './kept', resolutionKind: 'node16-esm' },
+      ]),
+      ignoredResolutions: esmOnlyIgnored,
+    });
+
+    expect(result.stdout).toContain('(1 entry point)');
+  });
+
+  it('falls back to an explicit failure notice when every problem is filtered out', () => {
+    const result = formatAttwResult({
+      ...base,
+      attwStatus: 1,
+      attwStdout: attwJson([{ kind: 'FallbackCondition', entrypoint: '.', resolutionKind: 'node10' }]),
+      attwStderr: 'raw',
+      ignoredResolutions: esmOnlyIgnored,
+    });
+
+    expect(result.stdout).toContain('✗ pkg: attw reported problems');
+    expect(result.stdout).toContain('nmr attw --verbose');
+    expect(result.stderr).toBe('raw');
+  });
+
+  it('falls back to an explicit failure notice when attw output is not JSON', () => {
+    const result = formatAttwResult({ ...base, attwStatus: 1, attwStdout: 'not json', attwStderr: 'raw' });
+
+    expect(result.stdout).toContain('✗ pkg: attw reported problems');
+    expect(result.stderr).toBe('raw');
+  });
+
+  it('uses the raw kind and a generic hint for an unmapped problem kind', () => {
+    const result = formatAttwResult({
+      ...base,
+      attwStatus: 1,
+      attwStdout: attwJson([{ kind: 'FalseCJS' }]),
+      ignoredResolutions: esmOnlyIgnored,
+    });
+
+    expect(result.stdout).toContain('✗ pkg — FalseCJS (1 occurrence)');
+    expect(result.stdout).toContain('Fix: run `nmr attw --verbose`');
   });
 });
 
@@ -161,6 +258,11 @@ function collectStream(stream: PassThrough): () => string {
 /** Builds an Error carrying `code: 'ENOENT'`, mimicking `spawnSync`'s result when a command binary can't be found. */
 function makeMissingBinaryError(message: string): Error {
   return Object.assign(new Error(message), { code: 'ENOENT' });
+}
+
+/** Serializes a minimal attw `--format json` payload carrying just the problems the wrapper reads. */
+function attwJson(problems: Array<{ kind: string; entrypoint?: string; resolutionKind?: string }>): string {
+  return JSON.stringify({ analysis: { problems } });
 }
 
 /**

--- a/packages/nmr/src/commands/__tests__/attw.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.test.ts
@@ -332,18 +332,18 @@ function makeSpawnStub(config: {
 }): SpawnSyncFn {
   return (command, args, options) => {
     if (command === 'npm') {
-      if (config.packError) return { error: config.packError, status: null, stdout: '', stderr: '' };
+      if (config.packError) return { error: config.packError, status: null, stderr: '' };
       const status = config.packStatus ?? 0;
       if (status === 0 && (config.writeTarball ?? true)) {
         const dest = args[args.indexOf('--pack-destination') + 1];
         if (dest !== undefined) writeFileSync(path.join(dest, 'pkg-1.0.0.tgz'), '');
       }
-      return { status, stdout: '', stderr: status === 0 ? '' : 'npm ERR! pack failed' };
+      return { status, stderr: status === 0 ? '' : 'npm ERR! pack failed' };
     }
-    if (config.attwError) return { error: config.attwError, status: null, stdout: '', stderr: '' };
+    if (config.attwError) return { error: config.attwError, status: null, stderr: '' };
     const fd = options.stdio?.[1];
     if (fd !== undefined && config.attwStdout !== undefined) writeSync(fd, config.attwStdout);
-    return { status: config.attwStatus ?? 0, stdout: '', stderr: '' };
+    return { status: config.attwStatus ?? 0, stderr: '' };
   };
 }
 

--- a/packages/nmr/src/commands/__tests__/attw.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync, writeSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -10,7 +10,7 @@ import { attwSpawnErrorMessage, buildAttwArgs, formatAttwResult, runAttw, type S
 describe(buildAttwArgs, () => {
   it('appends the default profile and requests JSON when nothing is supplied', () => {
     expect(buildAttwArgs([])).toStrictEqual({
-      verbose: false,
+      passthrough: false,
       profile: 'esm-only',
       attwArgs: ['--profile', 'esm-only', '--format', 'json'],
     });
@@ -18,7 +18,7 @@ describe(buildAttwArgs, () => {
 
   it('consumes --verbose without forwarding it and omits --format json', () => {
     expect(buildAttwArgs(['--verbose'])).toStrictEqual({
-      verbose: true,
+      passthrough: true,
       profile: 'esm-only',
       attwArgs: ['--profile', 'esm-only'],
     });
@@ -26,7 +26,7 @@ describe(buildAttwArgs, () => {
 
   it('consumes -v without forwarding it and omits --format json', () => {
     expect(buildAttwArgs(['-v'])).toStrictEqual({
-      verbose: true,
+      passthrough: true,
       profile: 'esm-only',
       attwArgs: ['--profile', 'esm-only'],
     });
@@ -34,7 +34,7 @@ describe(buildAttwArgs, () => {
 
   it('preserves a caller-supplied --profile and reports it', () => {
     expect(buildAttwArgs(['--profile', 'strict'])).toStrictEqual({
-      verbose: false,
+      passthrough: false,
       profile: 'strict',
       attwArgs: ['--profile', 'strict', '--format', 'json'],
     });
@@ -42,15 +42,39 @@ describe(buildAttwArgs, () => {
 
   it('preserves a caller-supplied --profile= form and reports it', () => {
     expect(buildAttwArgs(['--profile=strict'])).toStrictEqual({
-      verbose: false,
+      passthrough: false,
       profile: 'strict',
       attwArgs: ['--profile=strict', '--format', 'json'],
     });
   });
 
+  it('honors a caller-supplied --format instead of overriding it, and passes attw output through', () => {
+    expect(buildAttwArgs(['--format', 'table'])).toStrictEqual({
+      passthrough: true,
+      profile: 'esm-only',
+      attwArgs: ['--format', 'table', '--profile', 'esm-only'],
+    });
+  });
+
+  it('honors a caller-supplied --format= form', () => {
+    expect(buildAttwArgs(['--format=table'])).toStrictEqual({
+      passthrough: true,
+      profile: 'esm-only',
+      attwArgs: ['--format=table', '--profile', 'esm-only'],
+    });
+  });
+
+  it('honors the -f short form of --format', () => {
+    expect(buildAttwArgs(['-f', 'table'])).toStrictEqual({
+      passthrough: true,
+      profile: 'esm-only',
+      attwArgs: ['-f', 'table', '--profile', 'esm-only'],
+    });
+  });
+
   it('forwards unrelated args and appends the default profile', () => {
     expect(buildAttwArgs(['--ignore-rules', 'cjs-only-exports-default'])).toStrictEqual({
-      verbose: false,
+      passthrough: false,
       profile: 'esm-only',
       attwArgs: ['--ignore-rules', 'cjs-only-exports-default', '--profile', 'esm-only', '--format', 'json'],
     });
@@ -60,7 +84,7 @@ describe(buildAttwArgs, () => {
 describe(formatAttwResult, () => {
   const base = {
     label: 'pkg',
-    verbose: false,
+    passthrough: false,
     attwStatus: 0,
     attwStdout: 'TABLE',
     attwStderr: '',
@@ -71,12 +95,12 @@ describe(formatAttwResult, () => {
     expect(formatAttwResult(base)).toStrictEqual({ status: 0, stdout: '✓ pkg: types OK\n', stderr: '' });
   });
 
-  it('passes attw output through unchanged on a verbose success', () => {
-    expect(formatAttwResult({ ...base, verbose: true })).toStrictEqual({ status: 0, stdout: 'TABLE', stderr: '' });
+  it('passes attw output through unchanged on a passthrough success', () => {
+    expect(formatAttwResult({ ...base, passthrough: true })).toStrictEqual({ status: 0, stdout: 'TABLE', stderr: '' });
   });
 
-  it('passes attw diagnostics through unchanged on a verbose failure', () => {
-    expect(formatAttwResult({ ...base, verbose: true, attwStatus: 1, attwStderr: 'ERR' })).toStrictEqual({
+  it('passes attw diagnostics through unchanged on a passthrough failure', () => {
+    expect(formatAttwResult({ ...base, passthrough: true, attwStatus: 1, attwStderr: 'ERR' })).toStrictEqual({
       status: 1,
       stdout: 'TABLE',
       stderr: 'ERR',
@@ -84,7 +108,7 @@ describe(formatAttwResult, () => {
   });
 
   it('maps a null exit status to 1', () => {
-    expect(formatAttwResult({ ...base, attwStatus: null, verbose: true }).status).toBe(1);
+    expect(formatAttwResult({ ...base, attwStatus: null, passthrough: true }).status).toBe(1);
   });
 
   it('renders a condensed verdict with a fix hint on a JSON failure', () => {
@@ -99,6 +123,17 @@ describe(formatAttwResult, () => {
     expect(result.stdout).toContain('✗ pkg — types resolve via a fallback condition (1 entry point)');
     expect(result.stdout).toContain('Fix: in package.json "exports", put "types" before "import"');
     expect(result.stderr).toBe('');
+  });
+
+  it('points a mapped-kind verdict at --verbose for the diagnostics it discarded', () => {
+    const result = formatAttwResult({
+      ...base,
+      attwStatus: 1,
+      attwStdout: attwJson([{ kind: 'FallbackCondition', entrypoint: '.', resolutionKind: 'node16-esm' }]),
+      ignoredResolutions: esmOnlyIgnored,
+    });
+
+    expect(result.stdout).toContain('Run `nmr attw --verbose`');
   });
 
   it('collapses a kind repeated across subpaths into an entry-point count', () => {
@@ -139,7 +174,7 @@ describe(formatAttwResult, () => {
     });
 
     expect(result.stdout).toContain('✗ pkg: attw reported problems');
-    expect(result.stdout).toContain('nmr attw --verbose');
+    expect(result.stdout).toContain('Run `nmr attw --verbose`');
     expect(result.stderr).toBe('raw');
   });
 
@@ -150,7 +185,7 @@ describe(formatAttwResult, () => {
     expect(result.stderr).toBe('raw');
   });
 
-  it('uses the raw kind and a generic hint for an unmapped problem kind', () => {
+  it('names the raw kind and omits the Fix line for an unmapped problem kind', () => {
     const result = formatAttwResult({
       ...base,
       attwStatus: 1,
@@ -159,7 +194,8 @@ describe(formatAttwResult, () => {
     });
 
     expect(result.stdout).toContain('✗ pkg — FalseCJS (1 occurrence)');
-    expect(result.stdout).toContain('Fix: run `nmr attw --verbose`');
+    expect(result.stdout).not.toContain('Fix:');
+    expect(result.stdout).toContain('Run `nmr attw --verbose`');
   });
 });
 
@@ -242,6 +278,21 @@ describe(runAttw, () => {
     expect(exitCode).toBe(1);
     expect(err).toContain('install @arethetypeswrong/cli');
   });
+
+  it('reads attw output from the file it redirected stdout to, not from the captured pipe', () => {
+    writeEntryPackage(dir);
+
+    const { exitCode, out } = runWithSpawn(
+      dir,
+      makeSpawnStub({
+        attwStatus: 1,
+        attwStdout: attwJson([{ kind: 'FallbackCondition', entrypoint: '.', resolutionKind: 'node16-esm' }]),
+      }),
+    );
+
+    expect(exitCode).toBe(1);
+    expect(out).toContain('✗ p — types resolve via a fallback condition (1 entry point)');
+  });
 });
 
 // region | Helpers
@@ -268,7 +319,8 @@ function attwJson(problems: Array<{ kind: string; entrypoint?: string; resolutio
 /**
  * Builds a call-aware `spawnSync` stub that routes `npm` and `attw` invocations to canned results, so the wrapper's
  * subprocess-error branches run without a real subprocess. A successful `npm pack` writes a stand-in tarball into
- * `--pack-destination` so the flow reaches the attw step.
+ * `--pack-destination` so the flow reaches the attw step, and the attw call writes `attwStdout` to the file descriptor
+ * the wrapper supplied — the same channel the real attw writes to.
  */
 function makeSpawnStub(config: {
   packError?: Error;
@@ -276,8 +328,9 @@ function makeSpawnStub(config: {
   writeTarball?: boolean;
   attwError?: Error;
   attwStatus?: number;
+  attwStdout?: string;
 }): SpawnSyncFn {
-  return (command, args) => {
+  return (command, args, options) => {
     if (command === 'npm') {
       if (config.packError) return { error: config.packError, status: null, stdout: '', stderr: '' };
       const status = config.packStatus ?? 0;
@@ -288,6 +341,8 @@ function makeSpawnStub(config: {
       return { status, stdout: '', stderr: status === 0 ? '' : 'npm ERR! pack failed' };
     }
     if (config.attwError) return { error: config.attwError, status: null, stdout: '', stderr: '' };
+    const fd = options.stdio?.[1];
+    if (fd !== undefined && config.attwStdout !== undefined) writeSync(fd, config.attwStdout);
     return { status: config.attwStatus ?? 0, stdout: '', stderr: '' };
   };
 }
@@ -300,12 +355,14 @@ function writeEntryPackage(dir: string): void {
   );
 }
 
-/** Runs `runAttw` against `dir` with an injected `spawn`, capturing stderr; returns the exit code and error text. */
-function runWithSpawn(dir: string, spawn: SpawnSyncFn): { exitCode: number; err: string } {
+/** Runs `runAttw` against `dir` with an injected `spawn`; returns the exit code and the captured streams. */
+function runWithSpawn(dir: string, spawn: SpawnSyncFn): { exitCode: number; out: string; err: string } {
+  const stdout = new PassThrough();
+  const readOut = collectStream(stdout);
   const stderr = new PassThrough();
   const readErr = collectStream(stderr);
-  const exitCode = runAttw({ packageDir: dir, argv: [], stdout: new PassThrough(), stderr, env: process.env, spawn });
-  return { exitCode, err: readErr() };
+  const exitCode = runAttw({ packageDir: dir, argv: [], stdout, stderr, env: process.env, spawn });
+  return { exitCode, out: readOut(), err: readErr() };
 }
 
 // endregion | Helpers

--- a/packages/nmr/src/commands/attw.ts
+++ b/packages/nmr/src/commands/attw.ts
@@ -1,5 +1,5 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
-import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { closeSync, mkdtempSync, openSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { Writable } from 'node:stream';
@@ -25,8 +25,11 @@ const PROFILE_IGNORED_RESOLUTIONS: Record<string, readonly string[]> = {
 export type SpawnSyncFn = (
   command: string,
   args: string[],
-  options: { cwd: string; encoding: 'utf8'; env: NodeJS.ProcessEnv },
+  options: { cwd: string; encoding: 'utf8'; env: NodeJS.ProcessEnv; stdio?: SpawnStdio },
 ) => Pick<SpawnSyncReturns<string>, 'error' | 'status' | 'stdout' | 'stderr'>;
+
+/** `stdio` triple as the wrapper uses it: attw's stdout goes to an open file descriptor. */
+export type SpawnStdio = ['ignore', number, 'pipe'];
 
 /** @internal */
 export interface RunAttwOptions {
@@ -66,7 +69,7 @@ export function runAttw(options: RunAttwOptions): number {
     return 0;
   }
 
-  const { verbose, profile, attwArgs } = buildAttwArgs(argv);
+  const { passthrough, profile, attwArgs } = buildAttwArgs(argv);
 
   // Pack into a throwaway temp dir rather than letting `attw --pack` write the
   // tarball into the package dir, whose only cleanup is on attw's happy path.
@@ -88,11 +91,23 @@ export function runAttw(options: RunAttwOptions): number {
       return 1;
     }
 
-    const attw = spawn('attw', [path.join(tempDir, tarball), ...attwArgs], {
-      cwd: packageDir,
-      encoding: 'utf8',
-      env,
-    });
+    // attw calls `process.exit()` immediately after writing its JSON, discarding whatever is still
+    // buffered in an async pipe write — its output truncates at the 64 KiB pipe capacity, which a
+    // package of four or more entry points exceeds. Writes to a regular file are synchronous, so
+    // attw's stdout is routed through one and read back.
+    const attwStdoutPath = path.join(tempDir, 'attw-stdout');
+    const fd = openSync(attwStdoutPath, 'w');
+    let attw: ReturnType<SpawnSyncFn>;
+    try {
+      attw = spawn('attw', [path.join(tempDir, tarball), ...attwArgs], {
+        cwd: packageDir,
+        encoding: 'utf8',
+        env,
+        stdio: ['ignore', fd, 'pipe'],
+      });
+    } finally {
+      closeSync(fd);
+    }
     if (attw.error !== undefined) {
       stderr.write(attwSpawnErrorMessage(label, attw.error));
       return 1;
@@ -100,9 +115,9 @@ export function runAttw(options: RunAttwOptions): number {
 
     const outcome = formatAttwResult({
       label,
-      verbose,
+      passthrough,
       attwStatus: attw.status,
-      attwStdout: attw.stdout,
+      attwStdout: readFileSync(attwStdoutPath, 'utf8'),
       attwStderr: attw.stderr,
       ignoredResolutions: ignoredResolutionsForProfile(profile),
     });
@@ -116,12 +131,12 @@ export function runAttw(options: RunAttwOptions): number {
 
 /**
  * Splits post-command args into the wrapper's own `--verbose`/`-v` flag and the args forwarded to
- * attw. Appends the default `--profile` when the caller supplied none, and requests `--format json`
- * on the non-verbose path so the wrapper can render its own condensed verdict; `--verbose` keeps
- * attw's human diagnostics. Also reports the effective profile so the caller can mirror attw's
- * resolution filter.
+ * attw, appending the default `--profile` when the caller supplied none and reporting the effective
+ * profile. Requests `--format json` so the wrapper can render its own condensed verdict, except in
+ * passthrough mode — `--verbose`, or a caller-supplied `--format`, whose chosen format the wrapper
+ * has no way to condense — where attw's own output is emitted unchanged.
  */
-export function buildAttwArgs(argv: string[]): { verbose: boolean; profile: string; attwArgs: string[] } {
+export function buildAttwArgs(argv: string[]): { passthrough: boolean; profile: string; attwArgs: string[] } {
   let verbose = false;
   const attwArgs: string[] = [];
   for (const arg of argv) {
@@ -132,13 +147,14 @@ export function buildAttwArgs(argv: string[]): { verbose: boolean; profile: stri
     attwArgs.push(arg);
   }
   const profile = resolveProfile(attwArgs);
-  if (!attwArgs.some((arg) => arg === '--profile' || arg.startsWith('--profile='))) {
+  if (!hasFlag(attwArgs, '--profile')) {
     attwArgs.push('--profile', DEFAULT_PROFILE);
   }
-  if (!verbose) {
+  const passthrough = verbose || hasFlag(attwArgs, '--format', '-f');
+  if (!passthrough) {
     attwArgs.push('--format', 'json');
   }
-  return { verbose, profile, attwArgs };
+  return { passthrough, profile, attwArgs };
 }
 
 interface AttwOutcome {
@@ -148,24 +164,24 @@ interface AttwOutcome {
 }
 
 /**
- * Decides what the wrapper writes and returns from attw's captured result. On `--verbose`, attw's raw
- * diagnostics pass through unchanged. Otherwise: a terse confirmation on success, and on failure a
+ * Decides what the wrapper writes and returns from attw's captured result. In passthrough mode attw's
+ * own output is emitted unchanged. Otherwise: a terse confirmation on success, and on failure a
  * condensed, actionable verdict parsed from attw's `--format json` output — falling back to an explicit
  * failure notice when that output is absent, unparseable, or filtered empty by the profile.
  */
 export function formatAttwResult(params: {
   label: string;
-  verbose: boolean;
+  passthrough: boolean;
   attwStatus: number | null;
   attwStdout: string;
   attwStderr: string;
   /** Resolution kinds the active profile ignores; problems on them are dropped to match attw's exit code. */
   ignoredResolutions?: readonly string[];
 }): AttwOutcome {
-  const { label, verbose, attwStatus, attwStdout, attwStderr, ignoredResolutions = [] } = params;
+  const { label, passthrough, attwStatus, attwStdout, attwStderr, ignoredResolutions = [] } = params;
 
   const status = attwStatus ?? 1;
-  if (verbose) {
+  if (passthrough) {
     return { status, stdout: attwStdout, stderr: attwStderr };
   }
   if (status === 0) {
@@ -195,13 +211,19 @@ const PROBLEM_KIND_LABELS: Record<string, string> = {
   FallbackCondition: 'types resolve via a fallback condition',
 };
 
-/** Actionable fix hint per attw problem kind; unmapped kinds fall back to the generic hint. */
+/** Actionable fix hint per attw problem kind; a kind with no hint gets no `Fix:` line. */
 const FIX_HINTS: Record<string, string> = {
   FallbackCondition:
     'in package.json "exports", put "types" before "import" and point it at the built declaration (e.g. "types": "./dist/esm/index.d.ts")',
 };
 
-const GENERIC_FIX_HINT = 'run `nmr attw --verbose` for full diagnostics';
+/** Closes every condensed failure: the condensed verdict is the only place the discarded detail is offered. */
+const VERBOSE_TRAILER = "    Run `nmr attw --verbose` for attw's full diagnostics.";
+
+/** Reports whether the args carry any of the given flags, in either the space or `=` form. */
+function hasFlag(args: string[], ...flags: string[]): boolean {
+  return args.some((arg) => flags.some((flag) => arg === flag || arg.startsWith(`${flag}=`)));
+}
 
 /** Resolution kinds the given profile drops from its verdict, or none for an unrecognized profile. */
 function ignoredResolutionsForProfile(profile: string): readonly string[] {
@@ -248,6 +270,11 @@ function isAttwProblem(value: unknown): value is AttwJsonProblem {
 /**
  * Reduces attw's parsed problems to one entry per kind, dropping resolutions the profile ignores (to
  * match attw's exit code) and collapsing a kind's repeats across export subpaths into a count.
+ *
+ * attw's exit code also discounts kinds named by `--ignore-rules`, which this filter does not mirror,
+ * so such a kind still appears in the breakdown. That is cosmetic: the exit status decides pass/fail,
+ * and a rule-ignored kind can only ever surface alongside a genuinely counted one — were it the sole
+ * problem, attw would have exited 0 and no breakdown would be rendered.
  */
 function summarizeAttwFailure(attwStdout: string, ignoredResolutions: readonly string[]): ProblemSummary[] {
   const problems = parseAttwProblems(attwStdout) ?? [];
@@ -274,19 +301,23 @@ function summarizeAttwFailure(attwStdout: string, ignoredResolutions: readonly s
   });
 }
 
-/** Renders the per-kind condensed verdict: one `✗` line plus an indented fix hint for each kind. */
+/**
+ * Renders the per-kind condensed verdict: a `✗` line per kind, an indented fix hint for each kind that
+ * has one, and a closing pointer to the diagnostics the condensing discarded.
+ */
 function renderAttwFailure(label: string, summary: ProblemSummary[]): string {
   const lines = summary.flatMap(({ kind, count, unit }) => {
     const phrase = PROBLEM_KIND_LABELS[kind] ?? kind;
-    const plural = count === 1 ? '' : 's';
-    return [`✗ ${label} — ${phrase} (${count} ${unit}${plural})`, `    Fix: ${FIX_HINTS[kind] ?? GENERIC_FIX_HINT}`];
+    const verdict = `✗ ${label} — ${phrase} (${count} ${unit}${count === 1 ? '' : 's'})`;
+    const hint = FIX_HINTS[kind];
+    return hint === undefined ? [verdict] : [verdict, `    Fix: ${hint}`];
   });
-  return `${lines.join('\n')}\n`;
+  return `${[...lines, VERBOSE_TRAILER].join('\n')}\n`;
 }
 
 /** Renders the failure notice used when attw's JSON can't be parsed or the profile filters it empty. */
 function renderAttwFailureFallback(label: string): string {
-  return `✗ ${label}: attw reported problems · run \`nmr attw --verbose\` for full diagnostics\n`;
+  return `✗ ${label}: attw reported problems.\n${VERBOSE_TRAILER}\n`;
 }
 
 /**

--- a/packages/nmr/src/commands/attw.ts
+++ b/packages/nmr/src/commands/attw.ts
@@ -21,12 +21,15 @@ const PROFILE_IGNORED_RESOLUTIONS: Record<string, readonly string[]> = {
 /**
  * The `spawnSync` surface the wrapper depends on, narrowed to a single signature
  * so a test can inject a stub in place of the real `npm`/`attw` subprocesses.
+ *
+ * `spawnSync` returns null for a stream redirected to a file descriptor, so a captured `stdout` is not
+ * available here; `runAttw` reads attw's output back from the file.
  */
 export type SpawnSyncFn = (
   command: string,
   args: string[],
   options: { cwd: string; encoding: 'utf8'; env: NodeJS.ProcessEnv; stdio?: SpawnStdio },
-) => Pick<SpawnSyncReturns<string>, 'error' | 'status' | 'stdout' | 'stderr'>;
+) => Pick<SpawnSyncReturns<string>, 'error' | 'status' | 'stderr'>;
 
 /** `stdio` triple as the wrapper uses it: attw's stdout goes to an open file descriptor. */
 export type SpawnStdio = ['ignore', number, 'pipe'];
@@ -271,10 +274,9 @@ function isAttwProblem(value: unknown): value is AttwJsonProblem {
  * Reduces attw's parsed problems to one entry per kind, dropping resolutions the profile ignores (to
  * match attw's exit code) and collapsing a kind's repeats across export subpaths into a count.
  *
- * attw's exit code also discounts kinds named by `--ignore-rules`, which this filter does not mirror,
- * so such a kind still appears in the breakdown. That is cosmetic: the exit status decides pass/fail,
- * and a rule-ignored kind can only ever surface alongside a genuinely counted one — were it the sole
- * problem, attw would have exited 0 and no breakdown would be rendered.
+ * The filter mirrors the profile's ignored resolutions but not the kinds named by `--ignore-rules`, so
+ * a rule-ignored kind can still appear in the breakdown. Pass/fail is anchored on attw's exit status,
+ * not on this summary.
  */
 function summarizeAttwFailure(attwStdout: string, ignoredResolutions: readonly string[]): ProblemSummary[] {
   const problems = parseAttwProblems(attwStdout) ?? [];

--- a/packages/nmr/src/commands/attw.ts
+++ b/packages/nmr/src/commands/attw.ts
@@ -9,6 +9,16 @@ import { hasPublishableEntryPoint, readPackageJson } from '../helpers/package-js
 const DEFAULT_PROFILE = 'esm-only';
 
 /**
+ * attw resolution kinds each profile drops from its verdict, mirroring attw's own `profiles` table.
+ * The wrapper applies the same filter so its condensed verdict matches attw's exit code.
+ */
+const PROFILE_IGNORED_RESOLUTIONS: Record<string, readonly string[]> = {
+  strict: [],
+  node16: ['node10'],
+  'esm-only': ['node10', 'node16-cjs'],
+};
+
+/**
  * The `spawnSync` surface the wrapper depends on, narrowed to a single signature
  * so a test can inject a stub in place of the real `npm`/`attw` subprocesses.
  */
@@ -38,7 +48,8 @@ export interface RunAttwOptions {
  * Runs `attw` against a workspace package's packed contents, but only when the
  * package declares a publishable entry point. Packs into an isolated temp dir so
  * no `.tgz` ever lands in the working tree, and condenses attw's output to a terse
- * per-package result on success, full diagnostics on failure.
+ * per-package result on success and a condensed, actionable verdict on failure
+ * (attw's full diagnostics stay behind `--verbose`).
  *
  * Returns the exit code: 0 for a skipped or passing package, attw's own code on a
  * finding, and 1 for a pack failure or a missing attw binary.
@@ -55,7 +66,7 @@ export function runAttw(options: RunAttwOptions): number {
     return 0;
   }
 
-  const { verbose, attwArgs } = buildAttwArgs(argv);
+  const { verbose, profile, attwArgs } = buildAttwArgs(argv);
 
   // Pack into a throwaway temp dir rather than letting `attw --pack` write the
   // tarball into the package dir, whose only cleanup is on attw's happy path.
@@ -93,6 +104,7 @@ export function runAttw(options: RunAttwOptions): number {
       attwStatus: attw.status,
       attwStdout: attw.stdout,
       attwStderr: attw.stderr,
+      ignoredResolutions: ignoredResolutionsForProfile(profile),
     });
     if (outcome.stdout) stdout.write(outcome.stdout);
     if (outcome.stderr) stderr.write(outcome.stderr);
@@ -103,11 +115,13 @@ export function runAttw(options: RunAttwOptions): number {
 }
 
 /**
- * Splits post-command args into the wrapper's own `--verbose`/`-v` flag and the
- * args forwarded to attw, appending the default `--profile` when the caller
- * supplied none.
+ * Splits post-command args into the wrapper's own `--verbose`/`-v` flag and the args forwarded to
+ * attw. Appends the default `--profile` when the caller supplied none, and requests `--format json`
+ * on the non-verbose path so the wrapper can render its own condensed verdict; `--verbose` keeps
+ * attw's human diagnostics. Also reports the effective profile so the caller can mirror attw's
+ * resolution filter.
  */
-export function buildAttwArgs(argv: string[]): { verbose: boolean; attwArgs: string[] } {
+export function buildAttwArgs(argv: string[]): { verbose: boolean; profile: string; attwArgs: string[] } {
   let verbose = false;
   const attwArgs: string[] = [];
   for (const arg of argv) {
@@ -117,10 +131,14 @@ export function buildAttwArgs(argv: string[]): { verbose: boolean; attwArgs: str
     }
     attwArgs.push(arg);
   }
+  const profile = resolveProfile(attwArgs);
   if (!attwArgs.some((arg) => arg === '--profile' || arg.startsWith('--profile='))) {
     attwArgs.push('--profile', DEFAULT_PROFILE);
   }
-  return { verbose, attwArgs };
+  if (!verbose) {
+    attwArgs.push('--format', 'json');
+  }
+  return { verbose, profile, attwArgs };
 }
 
 interface AttwOutcome {
@@ -130,8 +148,10 @@ interface AttwOutcome {
 }
 
 /**
- * Decides what the wrapper writes and returns from attw's captured result: full
- * diagnostics on failure, and a terse confirmation on success unless `--verbose`.
+ * Decides what the wrapper writes and returns from attw's captured result. On `--verbose`, attw's raw
+ * diagnostics pass through unchanged. Otherwise: a terse confirmation on success, and on failure a
+ * condensed, actionable verdict parsed from attw's `--format json` output — falling back to an explicit
+ * failure notice when that output is absent, unparseable, or filtered empty by the profile.
  */
 export function formatAttwResult(params: {
   label: string;
@@ -139,14 +159,134 @@ export function formatAttwResult(params: {
   attwStatus: number | null;
   attwStdout: string;
   attwStderr: string;
+  /** Resolution kinds the active profile ignores; problems on them are dropped to match attw's exit code. */
+  ignoredResolutions?: readonly string[];
 }): AttwOutcome {
-  const { label, verbose, attwStatus, attwStdout, attwStderr } = params;
+  const { label, verbose, attwStatus, attwStdout, attwStderr, ignoredResolutions = [] } = params;
 
   const status = attwStatus ?? 1;
-  if (status === 0 && !verbose) {
+  if (verbose) {
+    return { status, stdout: attwStdout, stderr: attwStderr };
+  }
+  if (status === 0) {
     return { status: 0, stdout: `✓ ${label}: types OK\n`, stderr: '' };
   }
-  return { status, stdout: attwStdout, stderr: attwStderr };
+  const summary = summarizeAttwFailure(attwStdout, ignoredResolutions);
+  if (summary.length > 0) {
+    return { status, stdout: renderAttwFailure(label, summary), stderr: '' };
+  }
+  return { status, stdout: renderAttwFailureFallback(label), stderr: attwStderr };
+}
+
+interface AttwJsonProblem {
+  kind: string;
+  entrypoint?: string;
+  resolutionKind?: string;
+}
+
+interface ProblemSummary {
+  kind: string;
+  count: number;
+  unit: 'entry point' | 'occurrence';
+}
+
+/** Human phrasing per attw problem kind; unmapped kinds fall back to the raw kind name. */
+const PROBLEM_KIND_LABELS: Record<string, string> = {
+  FallbackCondition: 'types resolve via a fallback condition',
+};
+
+/** Actionable fix hint per attw problem kind; unmapped kinds fall back to the generic hint. */
+const FIX_HINTS: Record<string, string> = {
+  FallbackCondition:
+    'in package.json "exports", put "types" before "import" and point it at the built declaration (e.g. "types": "./dist/esm/index.d.ts")',
+};
+
+const GENERIC_FIX_HINT = 'run `nmr attw --verbose` for full diagnostics';
+
+/** Resolution kinds the given profile drops from its verdict, or none for an unrecognized profile. */
+function ignoredResolutionsForProfile(profile: string): readonly string[] {
+  return PROFILE_IGNORED_RESOLUTIONS[profile] ?? [];
+}
+
+/** Reads the effective `--profile` value from attw args (space or `=` form), defaulting to `esm-only`. */
+function resolveProfile(args: string[]): string {
+  const spaceIndex = args.indexOf('--profile');
+  if (spaceIndex !== -1) return args[spaceIndex + 1] ?? DEFAULT_PROFILE;
+  const equalsArg = args.find((arg) => arg.startsWith('--profile='));
+  return equalsArg !== undefined ? equalsArg.slice('--profile='.length) : DEFAULT_PROFILE;
+}
+
+/**
+ * Extracts the problem list from attw's `--format json` stdout, or null when the output is empty, not
+ * valid JSON, or missing the expected fields.
+ */
+function parseAttwProblems(attwStdout: string): AttwJsonProblem[] | null {
+  const trimmed = attwStdout.trim();
+  if (trimmed === '') return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed) || !isRecord(parsed.analysis) || !Array.isArray(parsed.analysis.problems)) {
+    return null;
+  }
+  return parsed.analysis.problems.filter(isAttwProblem);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isAttwProblem(value: unknown): value is AttwJsonProblem {
+  return isRecord(value) && typeof value.kind === 'string';
+}
+
+/**
+ * Reduces attw's parsed problems to one entry per kind, dropping resolutions the profile ignores (to
+ * match attw's exit code) and collapsing a kind's repeats across export subpaths into a count.
+ */
+function summarizeAttwFailure(attwStdout: string, ignoredResolutions: readonly string[]): ProblemSummary[] {
+  const problems = parseAttwProblems(attwStdout) ?? [];
+  const relevant = problems.filter(
+    (problem) => problem.resolutionKind === undefined || !ignoredResolutions.includes(problem.resolutionKind),
+  );
+
+  const entrypointsByKind = new Map<string, Set<string>>();
+  const countsByKind = new Map<string, number>();
+  for (const problem of relevant) {
+    countsByKind.set(problem.kind, (countsByKind.get(problem.kind) ?? 0) + 1);
+    if (problem.entrypoint !== undefined) {
+      const entrypoints = entrypointsByKind.get(problem.kind) ?? new Set<string>();
+      entrypoints.add(problem.entrypoint);
+      entrypointsByKind.set(problem.kind, entrypoints);
+    }
+  }
+
+  return [...countsByKind.keys()].map((kind): ProblemSummary => {
+    const entrypoints = entrypointsByKind.get(kind);
+    return entrypoints !== undefined && entrypoints.size > 0
+      ? { kind, count: entrypoints.size, unit: 'entry point' }
+      : { kind, count: countsByKind.get(kind) ?? 0, unit: 'occurrence' };
+  });
+}
+
+/** Renders the per-kind condensed verdict: one `✗` line plus an indented fix hint for each kind. */
+function renderAttwFailure(label: string, summary: ProblemSummary[]): string {
+  const lines = summary.flatMap(({ kind, count, unit }) => {
+    const phrase = PROBLEM_KIND_LABELS[kind] ?? kind;
+    const plural = count === 1 ? '' : 's';
+    return [`✗ ${label} — ${phrase} (${count} ${unit}${plural})`, `    Fix: ${FIX_HINTS[kind] ?? GENERIC_FIX_HINT}`];
+  });
+  return `${lines.join('\n')}\n`;
+}
+
+/** Renders the failure notice used when attw's JSON can't be parsed or the profile filters it empty. */
+function renderAttwFailureFallback(label: string): string {
+  return `✗ ${label}: attw reported problems · run \`nmr attw --verbose\` for full diagnostics\n`;
 }
 
 /**


### PR DESCRIPTION
## What

Fixes an issue where a failing `nmr attw` run printed a wall of raw diagnostics and ended without stating that anything had failed, leaving a reader who scrolled to the bottom with no verdict and no guidance. A failing run now prints a short per-package verdict that names the problem, says how to fix it, and points to the full diagnostics. The verdict now also covers packages with four or more entry points, which previously reported only that problems existed, with no detail. `--verbose` still prints the full diagnostics, and passing `--format` turns the condensed verdict off and returns output in the format requested.

## Why

A real monorepo run produced roughly 157 lines across two failing packages, trailing off in per-export tables and a stray `undefined` — a reader reaching the bottom had no way to tell that the run had failed, let alone what to do about it. Only the success path had been condensed, which is backwards: failure is precisely when a terse, actionable summary is worth the most.

## Details

### 🐛 Bug fixes

- On a finding, `nmr attw` renders a per-package verdict naming the problem kind and a concrete fix hint, rather than attw's raw per-subpath diagnostics.
- Every condensed failure closes with a pointer to `--verbose`, so the discarded detail is always recoverable from the output that replaced it.
- Findings repeated across a package's export subpaths collapse into a single line with an entry-point count.
- The verdict matches attw's own pass/fail: resolutions the active profile excludes are not surfaced, and no finding is suppressed. Pass/fail follows attw's exit status, so an unreadable or empty summary degrades to an explicit failure notice and never to a false pass.
- Packages with four or more entry points now receive the full condensed verdict. Their diagnostics previously exceeded a 64 KiB limit and arrived truncated, collapsing the verdict to a bare notice that problems existed.
- Supplying `--format` prints attw's output in the requested format instead of silently overriding the flag with the wrapper's own choice.

### ♻️ Refactoring

- The wrapper's subprocess contract no longer exposes a captured standard-output stream that is never populated.

### 🧪 Tests

- Failure rendering is covered per problem kind, including profile-excluded resolutions, unparseable output, and an unmapped problem kind.
- An integration test packs a package whose diagnostics exceed the 64 KiB limit and asserts the condensed verdict, pinning the case that previously degraded to a bare notice.
- Integration tests cover the `--verbose` and caller-supplied `--format` paths, asserting that each returns attw's own output rather than the condensed verdict.

### 📚 Documentation

- The `nmr-attw` section of the package README describes the condensed failure output and the two ways to opt out of it.

Closes #462
