### PR TITLE
#463 Fail a package that declares types but ships none

### DIFF
--- a/packages/nmr-core/package.json
+++ b/packages/nmr-core/package.json
@@ -21,7 +21,10 @@
   "author": "William Thorsen <william@thorsen.dev> (https://github.com/williamthorsen)",
   "type": "module",
   "exports": {
-    ".": "./dist/esm/index.js"
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "default": "./dist/esm/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -349,11 +349,40 @@ nmr-compile
 
 Validate a package's published type-resolution surface with [`@arethetypeswrong/cli`](https://github.com/arethetypeswrong/arethetypeswrong.github.io). This is the default `attw` script — run it from a package directory. It wraps attw so that it behaves well across a monorepo:
 
+- **Catches a missing type surface**, which attw alone cannot. See [verdicts](#verdicts) below.
 - **Skips packages with no publishable entry point** (neither `main` nor `exports`) — a message and exit 0, before attw runs. A package with no importable surface has nothing for attw to resolve, so running it would false-positive with `NoResolution`. A private package that _does_ declare `exports` is still checked.
 - **Leaves no `.tgz` in the working tree.** attw analyzes a packed tarball; nmr-attw packs into a temp directory instead of the package directory, so nothing litters the tree.
+- **Packs with `pnpm pack`**, so `publishConfig` field rewrites are applied and `workspace:` dependencies are resolved. The analyzed tarball is therefore the artifact consumers actually install — under `npm pack` it would carry the un-rewritten source manifest instead.
 - **Condenses output.** On success, a terse per-package confirmation; on failure, a per-package verdict naming the problem kind with a concrete fix hint, driven by attw's machine-readable (`--format json`) output and matching attw's own pass/fail verdict. Every condensed failure closes with a pointer to `--verbose`, which prints attw's full diagnostics instead — on success and failure alike.
 
 `@arethetypeswrong/cli` is not bundled — a package that declares an entry point must have it installed; nmr-attw reports an actionable message if it is missing. Any other flags are forwarded to attw (the profile defaults to `esm-only`). Supplying `--format` yourself turns off condensing and prints attw's output in the format you asked for, since the wrapper can only condense the machine-readable form it selects itself.
+
+#### Verdicts
+
+attw is a type-_resolution_ checker: given types, do they resolve correctly? It treats "no types" as out of scope, reporting it and exiting 0. So a package that declares a type entry point and ships no declarations — because the build emitted none, or `files`/`.npmignore` excluded them — looks exactly like a package that is untyped by design, and passes. Every TypeScript consumer of it silently receives `any`.
+
+nmr-attw closes that gap by crossing the packed manifest's type claim with what the tarball actually ships:
+
+| Declares types | Ships declarations | Verdict                                                           |
+| -------------- | ------------------ | ----------------------------------------------------------------- |
+| Yes            | No                 | ✗ **Fails**, naming the declared path. attw is not run.           |
+| No             | No                 | ℹ Reported, exit 0 — a valid JavaScript package. attw is not run. |
+| Either         | Yes                | Handed to attw, which validates that the types resolve.           |
+
+A package "declares types" when it has a top-level `types`/`typings` field, or a `types` condition in `exports`. The claim is read from the **packed** manifest, so a `publishConfig` rewrite is honored.
+
+A package typed only by _adjacency_ — `exports` naming `./dist/index.js`, with `./dist/index.d.ts` beside it and no `types` condition — declares nothing, so it lands in the second row and is not covered. Declare the types explicitly to bring it under the check, listing `types` **first** so it is matched before the condition that follows it:
+
+```json
+{
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  }
+}
+```
 
 ```bash
 nmr-attw

--- a/packages/nmr/README.md
+++ b/packages/nmr/README.md
@@ -357,6 +357,12 @@ Validate a package's published type-resolution surface with [`@arethetypeswrong/
 
 `@arethetypeswrong/cli` is not bundled — a package that declares an entry point must have it installed; nmr-attw reports an actionable message if it is missing. Any other flags are forwarded to attw (the profile defaults to `esm-only`). Supplying `--format` yourself turns off condensing and prints attw's output in the format you asked for, since the wrapper can only condense the machine-readable form it selects itself.
 
+The type-claim verdict below is nmr-attw's own, and it is emitted as text in every mode — `--verbose` and `--format` included — so that a package cannot pass in one mode and fail in another. attw's output, in whatever format you asked for, appears only on the third row, where the tarball ships types and attw is run at all.
+
+```bash
+nmr-attw
+```
+
 #### Verdicts
 
 attw is a type-_resolution_ checker: given types, do they resolve correctly? It treats "no types" as out of scope, reporting it and exiting 0. So a package that declares a type entry point and ships no declarations — because the build emitted none, or `files`/`.npmignore` excluded them — looks exactly like a package that is untyped by design, and passes. Every TypeScript consumer of it silently receives `any`.
@@ -382,10 +388,6 @@ A package typed only by _adjacency_ — `exports` naming `./dist/index.js`, with
     }
   }
 }
-```
-
-```bash
-nmr-attw
 ```
 
 ### `ensure-prepublish-hooks`

--- a/packages/nmr/package.json
+++ b/packages/nmr/package.json
@@ -22,9 +22,18 @@
   "author": "William Thorsen <william@thorsen.dev> (https://github.com/williamthorsen)",
   "type": "module",
   "exports": {
-    ".": "./dist/esm/index.js",
-    "./scripts": "./dist/esm/scripts.js",
-    "./tests": "./dist/esm/tests/consistency.js"
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./scripts": {
+      "types": "./dist/esm/scripts.d.ts",
+      "default": "./dist/esm/scripts.js"
+    },
+    "./tests": {
+      "types": "./dist/esm/tests/consistency.d.ts",
+      "default": "./dist/esm/tests/consistency.js"
+    }
   },
   "bin": {
     "ensure-prepublish-hooks": "bin/ensure-prepublish-hooks.js",

--- a/packages/nmr/src/commands/__tests__/attw.int.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.int.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -137,4 +137,93 @@ describe.skipIf(!attwAvailable)('runAttw (integration)', () => {
     expect(out).toContain('"analysis"');
     expect(out).not.toContain('✗ bad-pkg —');
   }, 30_000);
+
+  describe('type claim', () => {
+    /** Writes a package declaring types at `./index.d.ts` while shipping only the JavaScript entry point. */
+    function writeUnbuiltPackage(): void {
+      writePackage({
+        'package.json': JSON.stringify({
+          name: 'unbuilt-pkg',
+          version: '1.0.0',
+          type: 'module',
+          exports: { '.': { types: './index.d.ts', import: './index.js' } },
+        }),
+        'index.js': 'export const value = 1;\n',
+      });
+    }
+
+    it('fails a package that declares types but ships none', () => {
+      // attw reports this as untyped and exits 0, indistinguishably from a package untyped by design.
+      writeUnbuiltPackage();
+
+      const { exitCode, out } = run(['--no-definitely-typed']);
+
+      expect(exitCode).not.toBe(0);
+      expect(out).toContain('✗ unbuilt-pkg — declares types at "./index.d.ts"');
+      expect(out).not.toContain('types OK');
+    }, 30_000);
+
+    it('reaches the same verdict under --verbose', () => {
+      // A claim keyed on attw's JSON would exit 0 here and 1 by default, for the same package.
+      writeUnbuiltPackage();
+
+      const { exitCode, out } = run(['--no-definitely-typed', '--verbose']);
+
+      expect(exitCode).not.toBe(0);
+      expect(out).toContain('✗ unbuilt-pkg — declares types at "./index.d.ts"');
+    }, 30_000);
+
+    it('reaches the same verdict under a caller-supplied --format', () => {
+      writeUnbuiltPackage();
+
+      const { exitCode, out } = run(['--no-definitely-typed', '--format', 'json']);
+
+      expect(exitCode).not.toBe(0);
+      expect(out).toContain('✗ unbuilt-pkg — declares types at "./index.d.ts"');
+    }, 30_000);
+
+    it('reports a package that declares no types and ships none, without failing it', () => {
+      writePackage({
+        'package.json': JSON.stringify({
+          name: 'js-pkg',
+          version: '1.0.0',
+          type: 'module',
+          exports: { '.': { import: './index.js' } },
+        }),
+        'index.js': 'export const value = 1;\n',
+      });
+
+      const { exitCode, out } = run(['--no-definitely-typed']);
+
+      expect(exitCode).toBe(0);
+      expect(out).toContain('ℹ js-pkg: Ships no type declarations, and declares none.');
+      expect(out).not.toContain('types OK');
+    }, 30_000);
+
+    it('honors a publishConfig rewrite of the type claim', () => {
+      // The source manifest points at `src`, which is not published; `publishConfig` redirects both
+      // conditions to the built `dist`. Only `pnpm pack` applies that rewrite — under `npm pack` the
+      // tarball would carry the `src` claim, whose declaration it does not ship, and this would fail.
+      mkdirSync(path.join(dir, 'dist'));
+      writePackage({
+        'package.json': JSON.stringify({
+          name: 'rewritten-pkg',
+          version: '1.0.0',
+          type: 'module',
+          files: ['dist'],
+          exports: { '.': { types: './src/index.ts', import: './src/index.ts' } },
+          publishConfig: {
+            exports: { '.': { types: './dist/index.d.ts', import: './dist/index.js' } },
+          },
+        }),
+        'dist/index.js': 'export const value = 1;\n',
+        'dist/index.d.ts': 'export declare const value: number;\n',
+      });
+
+      const { exitCode, out } = run(['--no-definitely-typed']);
+
+      expect(exitCode).toBe(0);
+      expect(out).toContain('✓ rewritten-pkg: types OK');
+    }, 30_000);
+  });
 });

--- a/packages/nmr/src/commands/__tests__/attw.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.test.ts
@@ -455,11 +455,7 @@ function makeSpawnStub(config: {
   };
 }
 
-/**
- * Builds the reader's view of a packed tarball. The stubbed `pnpm pack` writes a placeholder `.tgz` that is
- * never decoded, so the tests state the packed contents directly — the real decoding is covered by
- * `tarball.int.test.ts` against tarballs `pnpm pack` actually produced.
- */
+/** Builds the reader's view of a packed tarball; the stubbed `pnpm pack` writes a `.tgz` that is never decoded. */
 function packedTarball(files: string[], packageJson: PackedTarball['packageJson']): PackedTarball {
   return { files: ['package.json', ...files], packageJson: { name: 'p', version: '1.0.0', ...packageJson } };
 }

--- a/packages/nmr/src/commands/__tests__/attw.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.test.ts
@@ -425,8 +425,8 @@ function attwJson(problems: Array<{ kind: string; entrypoint?: string; resolutio
 }
 
 /**
- * Builds a call-aware `spawnSync` stub that routes `npm` and `attw` invocations to canned results, so the wrapper's
- * subprocess-error branches run without a real subprocess. A successful `npm pack` writes a stand-in tarball into
+ * Builds a call-aware `spawnSync` stub that routes `pnpm` and `attw` invocations to canned results, so the wrapper's
+ * subprocess-error branches run without a real subprocess. A successful `pnpm pack` writes a stand-in tarball into
  * `--pack-destination` so the flow reaches the attw step, and the attw call writes `attwStdout` to the file descriptor
  * the wrapper supplied — the same channel the real attw writes to.
  */

--- a/packages/nmr/src/commands/__tests__/attw.test.ts
+++ b/packages/nmr/src/commands/__tests__/attw.test.ts
@@ -5,7 +5,15 @@ import { PassThrough } from 'node:stream';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { attwSpawnErrorMessage, buildAttwArgs, formatAttwResult, runAttw, type SpawnSyncFn } from '../attw.ts';
+import type { PackedTarball } from '../../helpers/tarball.ts';
+import {
+  attwSpawnErrorMessage,
+  buildAttwArgs,
+  checkTypeClaim,
+  formatAttwResult,
+  runAttw,
+  type SpawnSyncFn,
+} from '../attw.ts';
 
 describe(buildAttwArgs, () => {
   it('appends the default profile and requests JSON when nothing is supplied', () => {
@@ -199,6 +207,53 @@ describe(formatAttwResult, () => {
   });
 });
 
+describe(checkTypeClaim, () => {
+  it('defers to attw when the tarball ships types', () => {
+    const result = checkTypeClaim({ label: 'pkg', declaredPaths: ['./index.d.ts'], tarballHasTypes: true });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('defers to attw when the tarball ships types the package never declared', () => {
+    const result = checkTypeClaim({ label: 'pkg', declaredPaths: [], tarballHasTypes: true });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('fails a package that declares types but ships none, naming the declared path', () => {
+    const result = checkTypeClaim({ label: 'pkg', declaredPaths: ['./dist/index.d.ts'], tarballHasTypes: false });
+
+    expect(result?.status).toBe(1);
+    expect(result?.stdout).toContain('✗ pkg — declares types at "./dist/index.d.ts"');
+    expect(result?.stdout).toContain('ships no type declarations');
+    expect(result?.stdout).toContain('Fix: build the declarations before packing');
+  });
+
+  it('names every declared path when a package claims more than one', () => {
+    const result = checkTypeClaim({
+      label: 'pkg',
+      declaredPaths: ['./dist/index.d.ts', './dist/sub.d.ts'],
+      tarballHasTypes: false,
+    });
+
+    expect(result?.stdout).toContain('"./dist/index.d.ts", "./dist/sub.d.ts"');
+  });
+
+  it('omits the --verbose pointer, since a missing type surface leaves attw nothing to say', () => {
+    const result = checkTypeClaim({ label: 'pkg', declaredPaths: ['./index.d.ts'], tarballHasTypes: false });
+
+    expect(result?.stdout).not.toContain('--verbose');
+  });
+
+  it('reports an untyped package informationally rather than as types OK', () => {
+    const result = checkTypeClaim({ label: 'pkg', declaredPaths: [], tarballHasTypes: false });
+
+    expect(result?.status).toBe(0);
+    expect(result?.stdout).toContain('ℹ pkg: Ships no type declarations, and declares none.');
+    expect(result?.stdout).not.toContain('types OK');
+  });
+});
+
 describe(attwSpawnErrorMessage, () => {
   it('returns an install hint when attw is not found (ENOENT)', () => {
     expect(attwSpawnErrorMessage('pkg', makeMissingBinaryError('spawn attw ENOENT'))).toContain(
@@ -237,34 +292,45 @@ describe(runAttw, () => {
     expect(readdirSync(dir).some((file) => file.endsWith('.tgz'))).toBe(false);
   });
 
-  it('surfaces the underlying error when npm pack fails to spawn', () => {
+  it('surfaces the underlying error when pnpm pack fails to spawn', () => {
     writeEntryPackage(dir);
 
     const { exitCode, err } = runWithSpawn(
       dir,
-      makeSpawnStub({ packError: makeMissingBinaryError('spawn npm ENOENT') }),
+      makeSpawnStub({ packError: makeMissingBinaryError('spawn pnpm ENOENT') }),
     );
 
     expect(exitCode).toBe(1);
-    expect(err).toContain('spawn npm ENOENT');
+    expect(err).toContain('spawn pnpm ENOENT');
   });
 
-  it('forwards npm pack output on a non-zero pack exit', () => {
+  it('forwards pnpm pack output on a non-zero pack exit', () => {
     writeEntryPackage(dir);
 
     const { exitCode, err } = runWithSpawn(dir, makeSpawnStub({ packStatus: 1 }));
 
     expect(exitCode).toBe(1);
-    expect(err).toContain('npm ERR! pack failed');
+    expect(err).toContain('ERR_PNPM_PACK failed');
   });
 
-  it('reports when npm pack produces no tarball', () => {
+  it('reports when pnpm pack produces no tarball', () => {
     writeEntryPackage(dir);
 
     const { exitCode, err } = runWithSpawn(dir, makeSpawnStub({ writeTarball: false }));
 
     expect(exitCode).toBe(1);
     expect(err).toContain('produced no tarball');
+  });
+
+  it('surfaces the reason when the packed tarball cannot be read', () => {
+    writeEntryPackage(dir);
+
+    const { exitCode, err } = runWithSpawn(dir, makeSpawnStub({}), () => {
+      throw new Error('Could not read tarball /tmp/x.tgz: incorrect header check');
+    });
+
+    expect(exitCode).toBe(1);
+    expect(err).toContain('incorrect header check');
   });
 
   it('emits the install hint when the attw binary is missing', () => {
@@ -292,6 +358,48 @@ describe(runAttw, () => {
 
     expect(exitCode).toBe(1);
     expect(out).toContain('✗ p — types resolve via a fallback condition (1 entry point)');
+  });
+
+  it('fails a package whose packed manifest declares types the tarball does not ship, without running attw', () => {
+    writeEntryPackage(dir);
+    let attwRan = false;
+    const spawn: SpawnSyncFn = (command, args, options) => {
+      if (command !== 'pnpm') attwRan = true;
+      return makeSpawnStub({})(command, args, options);
+    };
+
+    const { exitCode, out } = runWithSpawn(dir, spawn, () => packedTarball(['index.js'], { types: './index.d.ts' }));
+
+    expect(exitCode).toBe(1);
+    expect(out).toContain('✗ p — declares types at "./index.d.ts"');
+    expect(attwRan).toBe(false);
+  });
+
+  it('reads the type claim from the packed manifest, not the source package.json', () => {
+    // The source declares no types; the packed manifest does, as a `publishConfig` rewrite would leave it.
+    writeEntryPackage(dir);
+
+    const { exitCode, out } = runWithSpawn(dir, makeSpawnStub({}), () =>
+      packedTarball(['index.js'], { exports: { '.': { types: './dist/index.d.ts', default: './dist/index.js' } } }),
+    );
+
+    expect(exitCode).toBe(1);
+    expect(out).toContain('✗ p — declares types at "./dist/index.d.ts"');
+  });
+
+  it('reports an untyped package informationally without running attw', () => {
+    writeEntryPackage(dir);
+    let attwRan = false;
+    const spawn: SpawnSyncFn = (command, args, options) => {
+      if (command !== 'pnpm') attwRan = true;
+      return makeSpawnStub({})(command, args, options);
+    };
+
+    const { exitCode, out } = runWithSpawn(dir, spawn, () => packedTarball(['index.js'], {}));
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain('ℹ p: Ships no type declarations, and declares none.');
+    expect(attwRan).toBe(false);
   });
 });
 
@@ -331,20 +439,36 @@ function makeSpawnStub(config: {
   attwStdout?: string;
 }): SpawnSyncFn {
   return (command, args, options) => {
-    if (command === 'npm') {
+    if (command === 'pnpm') {
       if (config.packError) return { error: config.packError, status: null, stderr: '' };
       const status = config.packStatus ?? 0;
       if (status === 0 && (config.writeTarball ?? true)) {
         const dest = args[args.indexOf('--pack-destination') + 1];
         if (dest !== undefined) writeFileSync(path.join(dest, 'pkg-1.0.0.tgz'), '');
       }
-      return { status, stderr: status === 0 ? '' : 'npm ERR! pack failed' };
+      return { status, stderr: status === 0 ? '' : 'ERR_PNPM_PACK failed' };
     }
     if (config.attwError) return { error: config.attwError, status: null, stderr: '' };
     const fd = options.stdio?.[1];
     if (fd !== undefined && config.attwStdout !== undefined) writeSync(fd, config.attwStdout);
     return { status: config.attwStatus ?? 0, stderr: '' };
   };
+}
+
+/**
+ * Builds the reader's view of a packed tarball. The stubbed `pnpm pack` writes a placeholder `.tgz` that is
+ * never decoded, so the tests state the packed contents directly — the real decoding is covered by
+ * `tarball.int.test.ts` against tarballs `pnpm pack` actually produced.
+ */
+function packedTarball(files: string[], packageJson: PackedTarball['packageJson']): PackedTarball {
+  return { files: ['package.json', ...files], packageJson: { name: 'p', version: '1.0.0', ...packageJson } };
+}
+
+/** A packed tarball shipping declarations, so `runAttw` passes the type-claim check and reaches attw. */
+function typedTarball(): PackedTarball {
+  return packedTarball(['index.js', 'index.d.ts'], {
+    exports: { '.': { types: './index.d.ts', default: './index.js' } },
+  });
 }
 
 /** Writes a minimal `package.json` declaring an `exports` entry point into `dir`, so `runAttw` clears the skip guard. */
@@ -355,13 +479,20 @@ function writeEntryPackage(dir: string): void {
   );
 }
 
-/** Runs `runAttw` against `dir` with an injected `spawn`; returns the exit code and the captured streams. */
-function runWithSpawn(dir: string, spawn: SpawnSyncFn): { exitCode: number; out: string; err: string } {
+/**
+ * Runs `runAttw` against `dir` with an injected `spawn` and tarball reader; returns the exit code and the
+ * captured streams. The reader defaults to a typed tarball, so a test that says nothing about types reaches attw.
+ */
+function runWithSpawn(
+  dir: string,
+  spawn: SpawnSyncFn,
+  readTarball: () => PackedTarball = typedTarball,
+): { exitCode: number; out: string; err: string } {
   const stdout = new PassThrough();
   const readOut = collectStream(stdout);
   const stderr = new PassThrough();
   const readErr = collectStream(stderr);
-  const exitCode = runAttw({ packageDir: dir, argv: [], stdout, stderr, env: process.env, spawn });
+  const exitCode = runAttw({ packageDir: dir, argv: [], stdout, stderr, env: process.env, spawn, readTarball });
   return { exitCode, out: readOut(), err: readErr() };
 }
 

--- a/packages/nmr/src/commands/attw.ts
+++ b/packages/nmr/src/commands/attw.ts
@@ -243,10 +243,8 @@ export function formatAttwResult(params: {
  * TypeScript consumer of it silently receives `any`. A package that declares none is a valid JavaScript
  * package, so it is reported but not failed.
  *
- * This runs in every output mode, `--verbose` included. It is derived from the tarball rather than from
- * attw's `analysis.types` precisely so that it can: that field reaches the wrapper only in the JSON
- * output that passthrough mode suppresses, so a check keyed on it would fail a package by default and
- * pass the very same package under `--verbose`.
+ * Must stay keyed on the tarball, not on attw's `analysis.types`: that field reaches the wrapper only in
+ * the JSON output passthrough mode suppresses, so a package would fail by default and pass under `--verbose`.
  */
 export function checkTypeClaim(params: {
   label: string;

--- a/packages/nmr/src/commands/attw.ts
+++ b/packages/nmr/src/commands/attw.ts
@@ -28,7 +28,7 @@ const PROFILE_IGNORED_RESOLUTIONS: Record<string, readonly string[]> = {
 
 /**
  * The `spawnSync` surface the wrapper depends on, narrowed to a single signature
- * so a test can inject a stub in place of the real `npm`/`attw` subprocesses.
+ * so a test can inject a stub in place of the real `pnpm`/`attw` subprocesses.
  *
  * `spawnSync` returns null for a stream redirected to a file descriptor, so a captured `stdout` is not
  * available here; `runAttw` reads attw's output back from the file.

--- a/packages/nmr/src/commands/attw.ts
+++ b/packages/nmr/src/commands/attw.ts
@@ -4,9 +4,17 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { Writable } from 'node:stream';
 
-import { hasPublishableEntryPoint, readPackageJson } from '../helpers/package-json.ts';
+import { getDeclaredTypesPaths, hasPublishableEntryPoint, readPackageJson } from '../helpers/package-json.ts';
+import { type PackedTarball, readPackedTarball } from '../helpers/tarball.ts';
 
 const DEFAULT_PROFILE = 'esm-only';
+
+/**
+ * File extensions TypeScript treats as type-bearing, mirroring attw's own `containsTypes()` scan of the
+ * tarball. Matching its predicate is what keeps nmr's verdict and attw's from ever disagreeing about
+ * whether a package is typed. The declaration forms (`.d.ts`, `.d.mts`, `.d.cts`) end with these.
+ */
+const TYPESCRIPT_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts'];
 
 /**
  * attw resolution kinds each profile drops from its verdict, mirroring attw's own `profiles` table.
@@ -44,10 +52,12 @@ export interface RunAttwOptions {
   stdout: Writable;
   /** Stream for error output (pack failures, missing-binary hint). */
   stderr: Writable;
-  /** Environment for the `npm pack` and `attw` subprocesses. */
+  /** Environment for the `pnpm pack` and `attw` subprocesses. */
   env: NodeJS.ProcessEnv;
   /** Subprocess runner, defaulting to `spawnSync`; injected in tests. */
   spawn?: SpawnSyncFn;
+  /** Packed-tarball reader, defaulting to the real one; injected in tests. */
+  readTarball?: (tarballPath: string) => PackedTarball;
 }
 
 /**
@@ -57,12 +67,17 @@ export interface RunAttwOptions {
  * per-package result on success and a condensed, actionable verdict on failure
  * (attw's full diagnostics stay behind `--verbose`).
  *
- * Returns the exit code: 0 for a skipped or passing package, attw's own code on a
- * finding, and 1 for a pack failure or a missing attw binary.
+ * Before attw runs, crosses the packed manifest's type claim with the tarball's contents to catch the
+ * case attw cannot see: a package that declares types and ships none. attw reports that as untyped and
+ * exits 0, indistinguishably from a package that is untyped by design.
+ *
+ * Returns the exit code: 0 for a skipped, untyped, or passing package, 1 for a declared-but-missing type
+ * surface, attw's own code on a finding, and 1 for a pack failure or a missing attw binary.
  */
 export function runAttw(options: RunAttwOptions): number {
   const { packageDir, argv, stdout, stderr, env } = options;
   const spawn: SpawnSyncFn = options.spawn ?? ((command, args, spawnOptions) => spawnSync(command, args, spawnOptions));
+  const readTarball = options.readTarball ?? readPackedTarball;
 
   const pkg = readPackageJson(packageDir);
   const label = pkg.name ?? path.basename(packageDir);
@@ -78,20 +93,42 @@ export function runAttw(options: RunAttwOptions): number {
   // tarball into the package dir, whose only cleanup is on attw's happy path.
   const tempDir = mkdtempSync(path.join(tmpdir(), 'nmr-attw-'));
   try {
-    const pack = spawn('npm', ['pack', '--pack-destination', tempDir], { cwd: packageDir, encoding: 'utf8', env });
+    // `pnpm pack`, not `npm pack`: only pnpm applies `publishConfig` field rewrites, so only its tarball
+    // carries the manifest consumers actually receive. Under `npm pack` both attw and the type-claim check
+    // below would read the un-rewritten source manifest.
+    const pack = spawn('pnpm', ['pack', '--pack-destination', tempDir], { cwd: packageDir, encoding: 'utf8', env });
     if (pack.error !== undefined) {
-      stderr.write(`nmr-attw: npm pack failed for ${label}: ${pack.error.message}\n`);
+      stderr.write(`nmr-attw: pnpm pack failed for ${label}: ${pack.error.message}\n`);
       return 1;
     }
     if (pack.status !== 0) {
-      stderr.write(pack.stderr || `nmr-attw: npm pack failed for ${label}\n`);
+      stderr.write(pack.stderr || `nmr-attw: pnpm pack failed for ${label}\n`);
       return pack.status ?? 1;
     }
 
     const tarball = readdirSync(tempDir).find((file) => file.endsWith('.tgz'));
     if (tarball === undefined) {
-      stderr.write(`nmr-attw: npm pack produced no tarball for ${label}\n`);
+      stderr.write(`nmr-attw: pnpm pack produced no tarball for ${label}\n`);
       return 1;
+    }
+
+    let packed: PackedTarball;
+    try {
+      packed = readTarball(path.join(tempDir, tarball));
+    } catch (error) {
+      stderr.write(`nmr-attw: ${error instanceof Error ? error.message : String(error)}\n`);
+      return 1;
+    }
+
+    const claim = checkTypeClaim({
+      label,
+      declaredPaths: getDeclaredTypesPaths(packed.packageJson),
+      tarballHasTypes: packed.files.some(hasTypeScriptExtension),
+    });
+    if (claim !== undefined) {
+      if (claim.stdout) stdout.write(claim.stdout);
+      if (claim.stderr) stderr.write(claim.stderr);
+      return claim.status;
     }
 
     // attw calls `process.exit()` immediately after writing its JSON, discarding whatever is still
@@ -195,6 +232,54 @@ export function formatAttwResult(params: {
     return { status, stdout: renderAttwFailure(label, summary), stderr: '' };
   }
   return { status, stdout: renderAttwFailureFallback(label), stderr: attwStderr };
+}
+
+/**
+ * Decides the verdict attw cannot reach, by crossing the packed manifest's type claim with what the
+ * tarball actually ships. Returns undefined when the tarball carries types — the case attw handles — and
+ * an outcome otherwise.
+ *
+ * A package that declares a type entry point and ships no declarations is broken unconditionally: every
+ * TypeScript consumer of it silently receives `any`. A package that declares none is a valid JavaScript
+ * package, so it is reported but not failed.
+ *
+ * This runs in every output mode, `--verbose` included. It is derived from the tarball rather than from
+ * attw's `analysis.types` precisely so that it can: that field reaches the wrapper only in the JSON
+ * output that passthrough mode suppresses, so a check keyed on it would fail a package by default and
+ * pass the very same package under `--verbose`.
+ */
+export function checkTypeClaim(params: {
+  label: string;
+  /** Every path the packed manifest declares type declarations at; empty when it claims none. */
+  declaredPaths: string[];
+  /** Whether the tarball ships any TypeScript file, by attw's own `containsTypes()` predicate. */
+  tarballHasTypes: boolean;
+}): AttwOutcome | undefined {
+  const { label, declaredPaths, tarballHasTypes } = params;
+
+  if (tarballHasTypes) return undefined;
+
+  if (declaredPaths.length === 0) {
+    return {
+      status: 0,
+      stdout: `ℹ ${label}: Ships no type declarations, and declares none. Nothing for attw to check.\n`,
+      stderr: '',
+    };
+  }
+
+  const declared = declaredPaths.map((declaredPath) => `"${declaredPath}"`).join(', ');
+  return {
+    status: 1,
+    stdout:
+      `✗ ${label} — declares types at ${declared}, but the packed tarball ships no type declarations\n` +
+      '    Fix: build the declarations before packing, and check that "files"/.npmignore does not exclude them.\n',
+    stderr: '',
+  };
+}
+
+/** Reports whether a path is one TypeScript treats as type-bearing. */
+function hasTypeScriptExtension(file: string): boolean {
+  return TYPESCRIPT_EXTENSIONS.some((extension) => file.endsWith(extension));
 }
 
 interface AttwJsonProblem {

--- a/packages/nmr/src/helpers/__tests__/package-json.test.ts
+++ b/packages/nmr/src/helpers/__tests__/package-json.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { hasPublishableEntryPoint, readPackageJson } from '../package-json.ts';
+import { getDeclaredTypesPaths, hasPublishableEntryPoint, readPackageJson } from '../package-json.ts';
 
 describe(hasPublishableEntryPoint, () => {
   it('returns false when neither main nor exports is declared', () => {
@@ -25,6 +25,73 @@ describe(hasPublishableEntryPoint, () => {
 
   it('returns true when both main and exports are declared', () => {
     expect(hasPublishableEntryPoint({ main: './index.js', exports: { '.': './index.js' } })).toBe(true);
+  });
+});
+
+describe(getDeclaredTypesPaths, () => {
+  it('returns nothing for a package that makes no type claim', () => {
+    expect(getDeclaredTypesPaths({ exports: { '.': './index.js' } })).toStrictEqual([]);
+  });
+
+  it('collects a top-level types field', () => {
+    expect(getDeclaredTypesPaths({ types: './index.d.ts' })).toStrictEqual(['./index.d.ts']);
+  });
+
+  it('collects the legacy typings field', () => {
+    expect(getDeclaredTypesPaths({ typings: './index.d.ts' })).toStrictEqual(['./index.d.ts']);
+  });
+
+  it('collects a types condition in exports', () => {
+    const pkg = { exports: { '.': { types: './index.d.ts', import: './index.js' } } };
+
+    expect(getDeclaredTypesPaths(pkg)).toStrictEqual(['./index.d.ts']);
+  });
+
+  it('collects a types condition nested under another condition', () => {
+    const pkg = { exports: { '.': { import: { types: './index.d.mts', default: './index.mjs' } } } };
+
+    expect(getDeclaredTypesPaths(pkg)).toStrictEqual(['./index.d.mts']);
+  });
+
+  it('collects a types condition that itself branches by condition', () => {
+    const pkg = { exports: { '.': { types: { import: './index.d.mts', require: './index.d.cts' } } } };
+
+    expect(getDeclaredTypesPaths(pkg)).toStrictEqual(['./index.d.mts', './index.d.cts']);
+  });
+
+  it('collects a types condition from every subpath', () => {
+    const pkg = {
+      exports: {
+        '.': { types: './index.d.ts', default: './index.js' },
+        './sub': { types: './sub.d.ts', default: './sub.js' },
+      },
+    };
+
+    expect(getDeclaredTypesPaths(pkg)).toStrictEqual(['./index.d.ts', './sub.d.ts']);
+  });
+
+  it('collects each alternative of an array target', () => {
+    const pkg = { exports: { '.': { types: ['./a.d.ts', './b.d.ts'] } } };
+
+    expect(getDeclaredTypesPaths(pkg)).toStrictEqual(['./a.d.ts', './b.d.ts']);
+  });
+
+  it('treats a "./types" subpath as a subpath, not a types condition', () => {
+    const pkg = { exports: { './types': './dist/types.js' } };
+
+    expect(getDeclaredTypesPaths(pkg)).toStrictEqual([]);
+  });
+
+  it('ignores a withdrawn subpath declared as null', () => {
+    const pkg = { exports: { '.': { types: './index.d.ts' }, './internal': null } };
+
+    expect(getDeclaredTypesPaths(pkg)).toStrictEqual(['./index.d.ts']);
+  });
+
+  it('deduplicates a path claimed more than once', () => {
+    const pkg = { types: './index.d.ts', exports: { '.': { types: './index.d.ts', default: './index.js' } } };
+
+    expect(getDeclaredTypesPaths(pkg)).toStrictEqual(['./index.d.ts']);
   });
 });
 

--- a/packages/nmr/src/helpers/__tests__/package-json.test.ts
+++ b/packages/nmr/src/helpers/__tests__/package-json.test.ts
@@ -76,6 +76,12 @@ describe(getDeclaredTypesPaths, () => {
     expect(getDeclaredTypesPaths(pkg)).toStrictEqual(['./a.d.ts', './b.d.ts']);
   });
 
+  it('collects a types condition from a fallback array of subpath targets', () => {
+    const pkg = { exports: { '.': [{ types: './a.d.ts', default: './a.js' }, './a.js'] } };
+
+    expect(getDeclaredTypesPaths(pkg)).toStrictEqual(['./a.d.ts']);
+  });
+
   it('treats a "./types" subpath as a subpath, not a types condition', () => {
     const pkg = { exports: { './types': './dist/types.js' } };
 

--- a/packages/nmr/src/helpers/__tests__/tarball.int.test.ts
+++ b/packages/nmr/src/helpers/__tests__/tarball.int.test.ts
@@ -10,8 +10,7 @@ import { readPackedTarball } from '../tarball.ts';
 /**
  * tar splits an over-long path across its `prefix` and `name` header fields, but only at a `/`. These two
  * fixtures take the two branches that fall out of that: a deep path, which splits, and an over-long
- * filename, which cannot and so forces a PAX extended header instead. Both encodings hide the real path
- * from a naive reader — and a hidden `.d.ts` reads as a missing declaration, failing a healthy package.
+ * filename, which cannot and so forces a PAX extended header instead.
  */
 const DEEP_DIR = 'dist/esm/commands/subcommands/generated/deeply/nested/directory/segments/split-across-prefix';
 const DEEP_TYPES_PATH = `${DEEP_DIR}/index.d.ts`;

--- a/packages/nmr/src/helpers/__tests__/tarball.int.test.ts
+++ b/packages/nmr/src/helpers/__tests__/tarball.int.test.ts
@@ -1,0 +1,106 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { readPackedTarball } from '../tarball.ts';
+
+/**
+ * tar splits an over-long path across its `prefix` and `name` header fields, but only at a `/`. These two
+ * fixtures take the two branches that fall out of that: a deep path, which splits, and an over-long
+ * filename, which cannot and so forces a PAX extended header instead. Both encodings hide the real path
+ * from a naive reader — and a hidden `.d.ts` reads as a missing declaration, failing a healthy package.
+ */
+const DEEP_DIR = 'dist/esm/commands/subcommands/generated/deeply/nested/directory/segments/split-across-prefix';
+const DEEP_TYPES_PATH = `${DEEP_DIR}/index.d.ts`;
+const LONG_BASENAME = `index-${'x'.repeat(110)}.d.ts`;
+const LONG_BASENAME_PATH = `dist/${LONG_BASENAME}`;
+
+describe(readPackedTarball, () => {
+  let tarballPath: string;
+  let dir: string;
+
+  // One pack for the whole suite: `pnpm pack` runs lifecycle scripts and dwarfs the assertions.
+  beforeAll(() => {
+    expect(`package/${DEEP_TYPES_PATH}`.length).toBeGreaterThan(100);
+    expect(LONG_BASENAME.length).toBeGreaterThan(100);
+
+    dir = mkdtempSync(path.join(tmpdir(), 'nmr-tarball-'));
+    mkdirSync(path.join(dir, DEEP_DIR), { recursive: true });
+    writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'tarball-fixture',
+        version: '1.0.0',
+        type: 'module',
+        files: ['dist'],
+        exports: { '.': { types: `./${DEEP_TYPES_PATH}`, default: `./${DEEP_DIR}/index.js` } },
+      }),
+    );
+    writeFileSync(path.join(dir, DEEP_DIR, 'index.js'), 'export const value = 1;\n');
+    writeFileSync(path.join(dir, DEEP_DIR, 'index.d.ts'), 'export declare const value: number;\n');
+    writeFileSync(path.join(dir, LONG_BASENAME_PATH), 'export declare const other: number;\n');
+
+    const pack = spawnSync('pnpm', ['pack', '--pack-destination', dir], { cwd: dir, encoding: 'utf8' });
+    expect(pack.status, pack.stderr).toBe(0);
+
+    const tarball = readdirSync(dir).find((file) => file.endsWith('.tgz'));
+    if (tarball === undefined) throw new Error('pnpm pack produced no tarball');
+    tarballPath = path.join(dir, tarball);
+
+    return () => rmSync(dir, { recursive: true, force: true });
+  }, 60_000);
+
+  it('reads the manifest from the tarball', () => {
+    const { packageJson } = readPackedTarball(tarballPath);
+
+    expect(packageJson.name).toBe('tarball-fixture');
+    expect(packageJson.version).toBe('1.0.0');
+  });
+
+  it('lists shipped files relative to the package root', () => {
+    const { files } = readPackedTarball(tarballPath);
+
+    expect(files).toContain('package.json');
+    expect(files).toContain(`${DEEP_DIR}/index.js`);
+  });
+
+  it('rejoins a deep path split across the tar prefix and name fields', () => {
+    const { files } = readPackedTarball(tarballPath);
+
+    expect(files).toContain(DEEP_TYPES_PATH);
+  });
+
+  it('recovers a filename too long to split, from its PAX extended header', () => {
+    // The packer writes this entry's ustar name as the placeholder `PaxHeader`; only the PAX payload
+    // carries the real path.
+    const { files } = readPackedTarball(tarballPath);
+
+    expect(files).toContain(LONG_BASENAME_PATH);
+    expect(files).not.toContain('PaxHeader');
+  });
+
+  it('throws for an archive that is not gzipped', () => {
+    const notGzipped = path.join(dir, 'plain.tgz');
+    writeFileSync(notGzipped, 'not a gzip stream');
+
+    expect(() => readPackedTarball(notGzipped)).toThrow(/Could not read tarball/);
+  });
+
+  it('throws for a tarball carrying no manifest', () => {
+    const manifestless = mkdtempSync(path.join(tmpdir(), 'nmr-tarball-empty-'));
+    try {
+      writeFileSync(path.join(manifestless, 'stray.txt'), 'no package.json here\n');
+      const tar = spawnSync('tar', ['-czf', path.join(dir, 'manifestless.tgz'), '-C', manifestless, 'stray.txt'], {
+        encoding: 'utf8',
+      });
+      expect(tar.status, tar.stderr).toBe(0);
+
+      expect(() => readPackedTarball(path.join(dir, 'manifestless.tgz'))).toThrow(/contains no package.json/);
+    } finally {
+      rmSync(manifestless, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/nmr/src/helpers/__tests__/tarball.test.ts
+++ b/packages/nmr/src/helpers/__tests__/tarball.test.ts
@@ -1,0 +1,186 @@
+import { gzipSync } from 'node:zlib';
+
+import { describe, expect, it } from 'vitest';
+
+import { decodePackedTarball } from '../tarball.ts';
+
+/**
+ * Decoding tests over synthesized archives. The field layouts here replicate what `pnpm pack` was observed
+ * to emit — a deep path split across `prefix`/`name`, and an over-long filename displaced into a PAX header
+ * whose own entry is named `PaxHeader`. `tarball.int.test.ts` is the ground truth that real packers still
+ * produce these encodings; these tests pin how the reader decodes them, and unlike the integration suite
+ * they run under `nmr check:strict`.
+ */
+
+const BLOCK_SIZE = 512;
+const ZERO_BLOCK = Buffer.alloc(BLOCK_SIZE);
+
+describe(decodePackedTarball, () => {
+  it('reads the manifest and the file list', () => {
+    const tarball = tarballOf([
+      entry({ name: 'package/package.json', data: '{"name":"p","version":"1.0.0"}' }),
+      entry({ name: 'package/dist/index.js', data: 'export const value = 1;\n' }),
+    ]);
+
+    const { files, packageJson } = decodePackedTarball(tarball, 'test.tgz');
+
+    expect(packageJson.name).toBe('p');
+    expect(files).toStrictEqual(['package.json', 'dist/index.js']);
+  });
+
+  it('rejoins a path split across the prefix and name fields', () => {
+    // tar splits an over-long path at a `/`, and only the two fields together name the file.
+    const tarball = tarballOf([
+      entry({ name: 'package/package.json', data: '{}' }),
+      entry({ prefix: 'package/dist', name: 'esm/index.d.ts', data: 'export declare const value: number;\n' }),
+    ]);
+
+    const { files } = decodePackedTarball(tarball, 'test.tgz');
+
+    expect(files).toContain('dist/esm/index.d.ts');
+  });
+
+  it('recovers a displaced path from its PAX extended header', () => {
+    // The file entry's own name is the placeholder `PaxHeader`; only the PAX payload carries the real path.
+    const realPath = `package/dist/${'x'.repeat(120)}.d.ts`;
+    const tarball = tarballOf([
+      entry({ name: 'package/package.json', data: '{}' }),
+      entry({ name: 'PaxHeader', typeFlag: 'x', data: paxRecord('path', realPath) }),
+      entry({ name: 'PaxHeader', data: 'export declare const value: number;\n' }),
+    ]);
+
+    const { files } = decodePackedTarball(tarball, 'test.tgz');
+
+    expect(files).toContain(realPath.slice('package/'.length));
+    expect(files).not.toContain('PaxHeader');
+  });
+
+  it('applies a PAX path override to the next entry only', () => {
+    const tarball = tarballOf([
+      entry({ name: 'package/package.json', data: '{}' }),
+      entry({ name: 'PaxHeader', typeFlag: 'x', data: paxRecord('path', 'package/dist/displaced.d.ts') }),
+      entry({ name: 'PaxHeader', data: 'displaced\n' }),
+      entry({ name: 'package/dist/plain.js', data: 'plain\n' }),
+    ]);
+
+    const { files } = decodePackedTarball(tarball, 'test.tgz');
+
+    expect(files).toStrictEqual(['package.json', 'dist/displaced.d.ts', 'dist/plain.js']);
+  });
+
+  it('ignores a PAX header that carries no path record', () => {
+    const tarball = tarballOf([
+      entry({ name: 'package/package.json', data: '{}' }),
+      entry({ name: 'PaxHeader', typeFlag: 'x', data: paxRecord('mtime', '1700000000') }),
+      entry({ name: 'package/dist/index.d.ts', data: 'export declare const value: number;\n' }),
+    ]);
+
+    const { files } = decodePackedTarball(tarball, 'test.tgz');
+
+    expect(files).toContain('dist/index.d.ts');
+  });
+
+  it('skips a global PAX header without consuming the next entry name', () => {
+    const tarball = tarballOf([
+      entry({ name: 'PaxHeader', typeFlag: 'g', data: paxRecord('comment', 'global') }),
+      entry({ name: 'package/package.json', data: '{}' }),
+      entry({ name: 'package/dist/index.d.ts', data: 'export declare const value: number;\n' }),
+    ]);
+
+    const { files } = decodePackedTarball(tarball, 'test.tgz');
+
+    expect(files).toStrictEqual(['package.json', 'dist/index.d.ts']);
+  });
+
+  it('skips entries that are not regular files', () => {
+    const tarball = tarballOf([
+      entry({ name: 'package/dist/', typeFlag: '5' }),
+      entry({ name: 'package/package.json', data: '{}' }),
+    ]);
+
+    const { files } = decodePackedTarball(tarball, 'test.tgz');
+
+    expect(files).toStrictEqual(['package.json']);
+  });
+
+  it('ignores entries outside the package root', () => {
+    const tarball = tarballOf([
+      entry({ name: 'package/package.json', data: '{}' }),
+      entry({ name: 'elsewhere/stray.d.ts', data: 'stray\n' }),
+    ]);
+
+    const { files } = decodePackedTarball(tarball, 'test.tgz');
+
+    expect(files).toStrictEqual(['package.json']);
+  });
+
+  it('stops at the end-of-archive marker rather than reading past it', () => {
+    const tarball = gzipSync(
+      Buffer.concat([
+        entry({ name: 'package/package.json', data: '{}' }),
+        ZERO_BLOCK,
+        ZERO_BLOCK,
+        entry({ name: 'package/dist/after-the-end.d.ts', data: 'unreachable\n' }),
+      ]),
+    );
+
+    const { files } = decodePackedTarball(tarball, 'test.tgz');
+
+    expect(files).toStrictEqual(['package.json']);
+  });
+
+  it('throws for an archive that is not gzipped', () => {
+    expect(() => decodePackedTarball(Buffer.from('not a gzip stream'), 'test.tgz')).toThrow(/Could not read tarball/);
+  });
+
+  it('throws for a tarball carrying no manifest', () => {
+    const tarball = tarballOf([entry({ name: 'package/dist/index.js', data: 'export const value = 1;\n' })]);
+
+    expect(() => decodePackedTarball(tarball, 'test.tgz')).toThrow(/contains no package.json/);
+  });
+});
+
+// region | Helpers
+
+/** Serializes a PAX record, whose length prefix counts the whole `"{length} {key}={value}\n"` line. */
+function paxRecord(key: string, value: string): string {
+  const body = ` ${key}=${value}\n`;
+  let length = body.length + 1;
+  if (String(length).length !== String(length + 1).length) length += 1;
+  return `${length}${body}`;
+}
+
+/** Builds one tar entry: a 512-byte header followed by its data, padded out to a block boundary. */
+function entry(fields: { name: string; prefix?: string; typeFlag?: string; data?: string }): Buffer {
+  const { name, prefix = '', typeFlag = '0', data = '' } = fields;
+  const body = Buffer.from(data, 'utf8');
+
+  const header = Buffer.alloc(BLOCK_SIZE);
+  header.write(name, 0, 100, 'utf8');
+  header.write('0000644\0', 100, 8, 'utf8'); // mode
+  header.write(octal(body.length, 12), 124, 12, 'utf8');
+  header.write(octal(0, 12), 136, 12, 'utf8'); // mtime
+  header.write(' '.repeat(8), 148, 8, 'utf8'); // checksum, summed as spaces
+  header.write(typeFlag, 156, 1, 'utf8');
+  header.write('ustar\0', 257, 6, 'utf8');
+  header.write('00', 263, 2, 'utf8');
+  header.write(prefix, 345, 155, 'utf8');
+
+  const checksum = header.reduce((total, byte) => total + byte, 0);
+  header.write(`${octal(checksum, 7)} `, 148, 8, 'utf8');
+
+  const padding = Buffer.alloc((BLOCK_SIZE - (body.length % BLOCK_SIZE)) % BLOCK_SIZE);
+  return Buffer.concat([header, body, padding]);
+}
+
+/** Encodes a numeric header field as the NUL-terminated octal text tar stores it as. */
+function octal(value: number, width: number): string {
+  return `${value.toString(8).padStart(width - 1, '0')}\0`;
+}
+
+/** Gzips a sequence of entries, closing the archive with the two zero blocks that mark its end. */
+function tarballOf(entries: Buffer[]): Buffer {
+  return gzipSync(Buffer.concat([...entries, ZERO_BLOCK, ZERO_BLOCK]));
+}
+
+// endregion | Helpers

--- a/packages/nmr/src/helpers/__tests__/tarball.test.ts
+++ b/packages/nmr/src/helpers/__tests__/tarball.test.ts
@@ -5,11 +5,9 @@ import { describe, expect, it } from 'vitest';
 import { decodePackedTarball } from '../tarball.ts';
 
 /**
- * Decoding tests over synthesized archives. The field layouts here replicate what `pnpm pack` was observed
- * to emit — a deep path split across `prefix`/`name`, and an over-long filename displaced into a PAX header
- * whose own entry is named `PaxHeader`. `tarball.int.test.ts` is the ground truth that real packers still
- * produce these encodings; these tests pin how the reader decodes them, and unlike the integration suite
- * they run under `nmr check:strict`.
+ * The synthesized layouts here are the ones npm and pnpm were observed to emit, down to the placeholder
+ * `PaxHeader` entry name. Keep them faithful to a real packer rather than to the tar spec's full generality:
+ * an idealized fixture would pass against a reader that no real tarball survives.
  */
 
 const BLOCK_SIZE = 512;

--- a/packages/nmr/src/helpers/package-json.ts
+++ b/packages/nmr/src/helpers/package-json.ts
@@ -9,6 +9,8 @@ export interface PackageJson {
   version?: string;
   packageManager?: string;
   main?: string;
+  types?: string;
+  typings?: string;
   exports?: unknown;
   scripts?: Record<string, string>;
   pnpm?: { overrides?: Record<string, string> };
@@ -18,11 +20,17 @@ export interface PackageJson {
  * Reads and parses a package.json file at the given directory.
  */
 export function readPackageJson(dir: string): PackageJson {
-  const content = readFileSync(path.join(dir, 'package.json'), 'utf8');
+  return parsePackageJson(readFileSync(path.join(dir, 'package.json'), 'utf8'), dir);
+}
+
+/**
+ * Parses package.json content. `source` names the origin (a directory, or a tarball path) for error messages.
+ */
+export function parsePackageJson(content: string, source: string): PackageJson {
   const parsed: unknown = JSON.parse(content);
 
   if (!isObject(parsed)) {
-    throw new TypeError(`Invalid package.json in ${dir}: expected an object`);
+    throw new TypeError(`Invalid package.json in ${source}: expected an object`);
   }
 
   // After isObject guard, we know parsed is Record<string, unknown>.
@@ -33,6 +41,8 @@ export function readPackageJson(dir: string): PackageJson {
   if (typeof parsed.version === 'string') pkg.version = parsed.version;
   if (typeof parsed.packageManager === 'string') pkg.packageManager = parsed.packageManager;
   if (typeof parsed.main === 'string') pkg.main = parsed.main;
+  if (typeof parsed.types === 'string') pkg.types = parsed.types;
+  if (typeof parsed.typings === 'string') pkg.typings = parsed.typings;
   if (parsed.exports !== undefined) pkg.exports = parsed.exports;
   if (isObject(parsed.scripts)) {
     const scripts: Record<string, string> = {};
@@ -65,6 +75,19 @@ export function hasPublishableEntryPoint(pkg: PackageJson): boolean {
 }
 
 /**
+ * Collects every path at which a package declares type declarations: a top-level `types`/`typings`
+ * field, and the target of every `types` condition in `exports`. An empty result means the package
+ * makes no type claim — a valid JavaScript package, and not something to fail.
+ */
+export function getDeclaredTypesPaths(pkg: PackageJson): string[] {
+  const paths: string[] = [];
+  if (pkg.types !== undefined) paths.push(pkg.types);
+  if (pkg.typings !== undefined) paths.push(pkg.typings);
+  collectTypesConditions(pkg.exports, paths);
+  return [...new Set(paths)];
+}
+
+/**
  * Checks if a package.json has pnpm overrides and returns them.
  */
 export function getPnpmOverrides(pkg: PackageJson): Record<string, string> | undefined {
@@ -79,4 +102,43 @@ export function getPnpmOverrides(pkg: PackageJson): Record<string, string> | und
   }
 
   return overrides;
+}
+
+/**
+ * Walks an `exports` value, collecting the target of every `types` condition. A condition key is
+ * exactly `types`; a subpath key such as `"./types"` begins with `.` and is not one.
+ */
+function collectTypesConditions(exportsValue: unknown, paths: string[]): void {
+  if (Array.isArray(exportsValue)) {
+    for (const entry of exportsValue) collectTypesConditions(entry, paths);
+    return;
+  }
+  if (!isObject(exportsValue)) return;
+
+  for (const [key, value] of Object.entries(exportsValue)) {
+    if (key === 'types') {
+      collectConditionTargets(value, paths);
+    } else {
+      collectTypesConditions(value, paths);
+    }
+  }
+}
+
+/**
+ * Collects every path reachable from a condition's target, which may be a bare path, an array of
+ * alternatives, or a further nested condition map (`"types": { "import": …, "require": … }`). A `null`
+ * target — the documented way to withdraw a subpath — contributes nothing.
+ */
+function collectConditionTargets(target: unknown, paths: string[]): void {
+  if (typeof target === 'string') {
+    paths.push(target);
+    return;
+  }
+  if (Array.isArray(target)) {
+    for (const entry of target) collectConditionTargets(entry, paths);
+    return;
+  }
+  if (isObject(target)) {
+    for (const value of Object.values(target)) collectConditionTargets(value, paths);
+  }
 }

--- a/packages/nmr/src/helpers/tarball.ts
+++ b/packages/nmr/src/helpers/tarball.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs';
+import { gunzipSync } from 'node:zlib';
+
+import { type PackageJson, parsePackageJson } from './package-json.ts';
+
+/** Size of a tar header, and of the blocks file data is padded out to. */
+const BLOCK_SIZE = 512;
+
+/** Offsets and widths of the tar header fields this reader depends on. */
+const NAME = { offset: 0, size: 100 };
+const SIZE = { offset: 124, size: 12 };
+const TYPE_FLAG = { offset: 156 };
+const PREFIX = { offset: 345, size: 155 };
+
+/** The directory every entry of an npm/pnpm tarball is nested under. */
+const ROOT = 'package/';
+
+export interface PackedTarball {
+  /** Every regular file in the tarball, relative to the package root (the `package/` prefix removed). */
+  files: string[];
+  /** The package's manifest, as packed — so `publishConfig` rewrites applied at pack time are reflected. */
+  packageJson: PackageJson;
+}
+
+/**
+ * Reads a packed npm/pnpm tarball, returning its file list and its manifest. The tarball is what a
+ * consumer actually installs, so it — not the source tree — is the authority on what the package ships
+ * and what it claims.
+ *
+ * Throws when the archive cannot be decompressed or carries no manifest at its root.
+ */
+export function readPackedTarball(tarballPath: string): PackedTarball {
+  let tar: Buffer;
+  try {
+    tar = gunzipSync(readFileSync(tarballPath));
+  } catch (error) {
+    throw new Error(`Could not read tarball ${tarballPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const files: string[] = [];
+  let manifest: string | undefined;
+
+  // A PAX extended header (type `x`) carries the true path of the entry that follows it, whose own
+  // header holds a truncated name. It applies to that one entry only.
+  let paxPath: string | undefined;
+
+  for (let offset = 0; offset + BLOCK_SIZE <= tar.length;) {
+    const header = tar.subarray(offset, offset + BLOCK_SIZE);
+    if (isZeroBlock(header)) break;
+
+    const size = readOctal(header, SIZE);
+    const typeFlag = String.fromCodePoint(header[TYPE_FLAG.offset] ?? 0);
+    const dataOffset = offset + BLOCK_SIZE;
+    const data = tar.subarray(dataOffset, dataOffset + size);
+    offset = dataOffset + roundUpToBlock(size);
+
+    if (typeFlag === 'x') {
+      paxPath = readPaxPath(data.toString('utf8'));
+      continue;
+    }
+    // A global header (`g`) applies to every following entry, but carries no per-entry path override.
+    if (typeFlag === 'g') continue;
+
+    const name = paxPath ?? readEntryName(header);
+    paxPath = undefined;
+
+    // Only regular files: `0` is the ustar spelling, and NUL the older one.
+    if (typeFlag !== '0' && typeFlag !== '\0') continue;
+    if (!name.startsWith(ROOT)) continue;
+
+    const relativePath = name.slice(ROOT.length);
+    files.push(relativePath);
+    if (relativePath === 'package.json') manifest = data.toString('utf8');
+  }
+
+  if (manifest === undefined) {
+    throw new Error(`Tarball ${tarballPath} contains no package.json`);
+  }
+
+  return { files, packageJson: parsePackageJson(manifest, tarballPath) };
+}
+
+/** Reports whether a header block is all zeroes, which is how a tar archive marks its end. */
+function isZeroBlock(header: Buffer): boolean {
+  return header.every((byte) => byte === 0);
+}
+
+/** Reads a NUL/space-terminated field as text. */
+function readString(header: Buffer, field: { offset: number; size: number }): string {
+  const raw = header.subarray(field.offset, field.offset + field.size);
+  const end = raw.indexOf(0);
+  return raw.subarray(0, end === -1 ? raw.length : end).toString('utf8');
+}
+
+/** Reads a numeric header field, which tar stores as NUL/space-padded octal text. */
+function readOctal(header: Buffer, field: { offset: number; size: number }): number {
+  const text = readString(header, field).trim();
+  const value = Number.parseInt(text, 8);
+  return Number.isNaN(value) ? 0 : value;
+}
+
+/** Joins a ustar header's `prefix` and `name`, which together encode paths too long for `name` alone. */
+function readEntryName(header: Buffer): string {
+  const name = readString(header, NAME);
+  const prefix = readString(header, PREFIX);
+  return prefix === '' ? name : `${prefix}/${name}`;
+}
+
+/**
+ * Extracts the `path` override from a PAX extended header's payload, a sequence of
+ * `"{length} {key}={value}\n"` records. Returns undefined when the payload declares no path.
+ */
+function readPaxPath(payload: string): string | undefined {
+  for (const record of payload.split('\n')) {
+    const match = /^\d+ path=(.*)$/.exec(record);
+    if (match?.[1] !== undefined) return match[1];
+  }
+  return undefined;
+}
+
+/** Rounds a file size up to the block boundary tar pads its data out to. */
+function roundUpToBlock(size: number): number {
+  return Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE;
+}

--- a/packages/nmr/src/helpers/tarball.ts
+++ b/packages/nmr/src/helpers/tarball.ts
@@ -33,12 +33,7 @@ export function readPackedTarball(tarballPath: string): PackedTarball {
   return decodePackedTarball(readFileSync(tarballPath), tarballPath);
 }
 
-/**
- * Decodes a gzipped tarball's bytes. `source` names the archive in error messages.
- *
- * Separate from the file read so the decoding — the part with the failure mode that matters, where a
- * misread path hides a declaration and fails a healthy package — is testable without a filesystem.
- */
+/** Decodes a gzipped tarball's bytes. `source` names the archive in error messages. */
 export function decodePackedTarball(archive: Buffer, source: string): PackedTarball {
   let tar: Buffer;
   try {

--- a/packages/nmr/src/helpers/tarball.ts
+++ b/packages/nmr/src/helpers/tarball.ts
@@ -30,11 +30,21 @@ export interface PackedTarball {
  * Throws when the archive cannot be decompressed or carries no manifest at its root.
  */
 export function readPackedTarball(tarballPath: string): PackedTarball {
+  return decodePackedTarball(readFileSync(tarballPath), tarballPath);
+}
+
+/**
+ * Decodes a gzipped tarball's bytes. `source` names the archive in error messages.
+ *
+ * Separate from the file read so the decoding — the part with the failure mode that matters, where a
+ * misread path hides a declaration and fails a healthy package — is testable without a filesystem.
+ */
+export function decodePackedTarball(archive: Buffer, source: string): PackedTarball {
   let tar: Buffer;
   try {
-    tar = gunzipSync(readFileSync(tarballPath));
+    tar = gunzipSync(archive);
   } catch (error) {
-    throw new Error(`Could not read tarball ${tarballPath}: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error(`Could not read tarball ${source}: ${error instanceof Error ? error.message : String(error)}`);
   }
 
   const files: string[] = [];
@@ -74,10 +84,10 @@ export function readPackedTarball(tarballPath: string): PackedTarball {
   }
 
   if (manifest === undefined) {
-    throw new Error(`Tarball ${tarballPath} contains no package.json`);
+    throw new Error(`Tarball ${source} contains no package.json`);
   }
 
-  return { files, packageJson: parsePackageJson(manifest, tarballPath) };
+  return { files, packageJson: parsePackageJson(manifest, source) };
 }
 
 /** Reports whether a header block is all zeroes, which is how a tar archive marks its end. */

--- a/packages/release-kit/package.json
+++ b/packages/release-kit/package.json
@@ -17,6 +17,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/esm/index.d.ts",
       "import": "./dist/esm/index.js"
     }
   },

--- a/packages/v11y-check/package.json
+++ b/packages/v11y-check/package.json
@@ -24,8 +24,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "types": "./dist/esm/index.d.ts"
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js"
     }
   },
   "bin": {


### PR DESCRIPTION
## What

`nmr attw` now fails a package that claims to ship type declarations but ships none. Such a package used to pass, leaving every TypeScript consumer of it silently typed as `any`.

A package that ships working declarations found only by sitting beside its JavaScript entry point escapes the check, since it declares nothing. Add a `types` entry to bring it under the check.

## Why

A build that emits no declarations, or a `files`/`.npmignore` rule that excludes them, produces a package that claims types and ships none. Every TypeScript consumer of it receives `any`, silently. This is precisely the failure `nmr attw` exists to catch, and it was invisible: attw is a type-_resolution_ checker, so "no types at all" falls outside its scope — it reports such a package and exits 0, unable to tell a broken package from one that is untyped by design.

nmr has strictly more information than attw does. It can read the type _claim_ that attw discards, and crossing that claim with what the tarball actually ships resolves the ambiguity attw cannot.

## Details

### 🎉 Features

- 🚨 **Breaking:** `nmr attw` decides, before attw runs, whether the packed manifest's type claim matches what the tarball ships. A declared-but-missing type surface fails with a non-zero exit naming the declared path; a package that declares nothing and ships nothing is reported and exits 0; anything shipping TypeScript files is handed to attw unchanged.
- The verdict is derived from the tarball rather than from attw's JSON output. That output is suppressed in passthrough mode, so a check keyed on it would fail a package by default and pass the same package under `--verbose`. Deriving it from the tarball is what makes the verdict identical across every output mode.
- Packing moved from `npm pack` to `pnpm pack`. Only pnpm applies `publishConfig` field rewrites, so only its tarball carries the manifest consumers receive; under `npm pack`, a package using the common source-first-`exports` plus `publishConfig`-rewrite pattern was analyzed against its un-rewritten source manifest.
- attw is skipped on the two no-types rows, which costs nothing: attw exits 0 whenever its type analysis is falsy, and its untyped result carries no diagnostics.

### ♻️ Refactoring

- `readPackedTarball` reads a packed tarball in-process — gunzip plus a walk of the tar headers — returning its file list and its manifest. Handles both encodings tar uses for an over-long path: the ustar `prefix`/`name` split, and displacement into a PAX extended header. No new dependency, and no reliance on a `tar` binary.
- `getDeclaredTypesPaths` collects a package's type claim: a top-level `types`/`typings` field, and every `types` condition reachable in `exports`, including nested condition maps and fallback arrays. A `"./types"` subpath is not mistaken for a `types` condition, and a `null` target contributes nothing.
- `nmr`, `nmr-core`, and `release-kit` gained a types-first `types` condition, and `v11y-check`'s moved ahead of `import` — a condition listed after `import` is never consulted. Without this the new check would not have covered the packages that ship it.

### 🧪 Tests

- The tar decoding is covered by two complementary suites. Unit tests decode synthesized archives — both long-path encodings, PAX-override scoping, non-regular entries, the end-of-archive marker — and run under `nmr check:strict`. Integration tests decode tarballs a real `pnpm pack` produced, establishing that packers still emit those encodings, which synthesized bytes cannot.
- An integration test packs a package whose `publishConfig` redirects `exports` from `src` to `dist`. It passes only because the rewrite was applied, and fails under `npm pack` — the falsifiable proof of the packing change.
- The three verdicts are asserted end-to-end through real attw, and the failing verdict is asserted in all three output modes.


Closes #463
